### PR TITLE
Fix bug with cancelling file uploads

### DIFF
--- a/www/jury/edit.php
+++ b/www/jury/edit.php
@@ -107,16 +107,15 @@ if ( ! isset($_POST['cancel']) ) {
 			}
 		}
 	}
-}
-
-// If the form contained uploadable files, process these now.
-if ( isset($_FILES['data']) ) {
-	foreach($_FILES['data']['tmp_name'] as $id => $tmpnames) {
-		foreach($tmpnames as $field => $tmpname) {
-			if ( !empty ($tmpname) ) {
-				checkFileUpload($_FILES['data']['error'][$id][$field]);
-				$itemdata = array($field => file_get_contents($tmpname));
-				$DB->q("UPDATE $t SET %S WHERE %S", $itemdata, $prikey);
+	// If the form contained uploadable files, process these now.
+	if ( isset($_FILES['data']) ) {
+		foreach($_FILES['data']['tmp_name'] as $id => $tmpnames) {
+			foreach($tmpnames as $field => $tmpname) {
+				if ( !empty ($tmpname) ) {
+					checkFileUpload($_FILES['data']['error'][$id][$field]);
+					$itemdata = array($field => file_get_contents($tmpname));
+					$DB->q("UPDATE $t SET %S WHERE %S", $itemdata, $prikey);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If you choose a file(for example, on the edit problem page for "problem text"), and then choose cancel, the file upload will attempt to happen but since it won't have the primary key ID to write to(and since you don't actually want it to happen), you get a nice sql error due to the missing WHERE clause.

This simple fix just moves that block inside the check for the cancel button, which solves this problem.
