### PR TITLE
add missing port and socket params before flags

### DIFF
--- a/lib/lib.database.php
+++ b/lib/lib.database.php
@@ -306,7 +306,7 @@ class db
 		}
 
 		$this->_connection = mysqli_init();
-		@mysqli_real_connect($this->_connection, $pers.$this->host, $this->user, $this->password, $this->database, $this->flags);
+		@mysqli_real_connect($this->_connection, $pers.$this->host, $this->user, $this->password, $this->database, NULL, NULL, $this->flags);
 
 		if(mysqli_connect_error() || !$this->_connection) {
 			throw new RuntimeException("Could not connect to database server "


### PR DESCRIPTION
Trying SSL support I found that the call to `mysql_real_connect` was 2 params short before _flags_. After this change both the judgedaemon and the domserver were able to connect to the mysql server via SSL.

See the [PHP manual](http://www.php.net/manual/en/mysqli.real-connect.php) details for confirmation.
