### PR TITLE
fix the default api URL in judgehost

### DIFF
--- a/etc/genrestapicredentials
+++ b/etc/genrestapicredentials
@@ -8,6 +8,6 @@ set -e
 
 echo "# Format: '<ID> <API url> <user> <password>'"
 
-printf "default\thttp://localhost/domjudge/api\tjudgehost\t"
+printf "default\thttp://localhost/domjudge/domserver/www/api/index.php\tjudgehost\t"
         head -c12 /dev/urandom | base64 | head -c16 | tr '/+' 'Aa'
 echo


### PR DESCRIPTION
This API URL makes more sense because of the following two reasons:
1. As the the default commands given in the documentation install the domserver inside `$HOME/domjudge/domserver`.
2. The URL  should be appended with `index.php` otherwise `$_SERVER['PATH_INFO']` variable won't be set. See : http://stackoverflow.com/questions/5629683/serverpath-info-and-serverorig-path-info-in-php
