### PR TITLE
Fix a bug that "solved" value is always true.

### DIFF
--- a/www/api/index.php
+++ b/www/api/index.php
@@ -1085,7 +1085,7 @@ function scoreboard($args)
 			                           'num_judged'  => $pdata['num_submissions'],
 			                           'num_pending' => $pdata['num_pending'],
 						   'time'        => $pdata['time'],
-						   'solved'      => isset($pdata['is_correct']));
+						   'solved'      => $pdata['is_correct']);
 		}
 		$res[] = $row;
 	}


### PR DESCRIPTION
Currently, scoreboard API says every team solved all problems.
