### PR TITLE
Implement a secure hashing algorithm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 		"jumbojett/openid-connect-php": "0.1.*",
 		"mustangostang/spyc": "0.5.*",
 		"php": ">= 5.4",
+		"ircmaxell/password-compat": "*",
 		"twig/twig": "~1.0"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,51 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a2d4835c07166d5a4d431ecc5813f394",
-    "content-hash": "d954248015e978366ade9f46dc5d04c1",
+    "hash": "422b11f9511af576f6fe868b10e969fb",
+    "content-hash": "c136ca5847e64d970f6d05f337ba746b",
     "packages": [
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20 16:49:30"
+        },
         {
             "name": "jumbojett/openid-connect-php",
             "version": "0.1.0",
@@ -184,16 +226,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.1",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512"
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3566d311a92aae4deec6e48682dc5a4528c4a512",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
                 "shasum": ""
             },
             "require": {
@@ -206,7 +248,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "1.27-dev"
                 }
             },
             "autoload": {
@@ -241,7 +283,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-05-30 09:11:59"
+            "time": "2016-10-25 19:17:17"
         }
     ],
     "packages-dev": [],

--- a/etc/common-config.php
+++ b/etc/common-config.php
@@ -18,6 +18,8 @@ define('DEBUG_JUDGE',      8); // Display judging scripts debug info
 
 define('DEBUG', 1);
 
+define('PASSWORD_HASH_COST', 10); // Cost for hashing function. Increase for more secure hashes and decrease for speed.
+
 // By default report all PHP errors, except notices.
 error_reporting(E_ALL & ~E_NOTICE);
 

--- a/lib/www/auth.php
+++ b/lib/www/auth.php
@@ -347,10 +347,11 @@ function do_login_native($user, $pass)
 	global $DB, $userdata, $username;
 
 	$userdata = $DB->q('MAYBETUPLE SELECT * FROM user
-	                    WHERE username = %s AND password = %s AND enabled = 1',
-	                   $user, md5($user."#".$pass));
+	                    WHERE username = %s AND enabled = 1',
+	                   $user);
 
-	if ( !$userdata ) {
+	if ( !$userdata || !password_verify($userdata['password'])) {
+		$userdata = false;
 		sleep(1);
 		show_failed_login("Invalid username or password supplied. " .
 		                  "Please try again or contact a staff member.");
@@ -496,7 +497,7 @@ function do_register() {
 		// Associate a user with the team we just made
         $i = array();
         $i['username'] = $login;
-        $i['password'] = md5($login."#".$pass);
+        $i['password'] = generate_password_hash($pass);
         $i['name'] = $login;
         $i['teamid'] = $teamid;
         $newid = $DB->q("RETURNID INSERT INTO user SET %S", $i);
@@ -564,4 +565,9 @@ function get_user_roles($userid)
 	return $DB->q('COLUMN SELECT role.role FROM userrole
 	               LEFT JOIN role USING (roleid)
 	               WHERE userrole.userid = %s', $userid);
+}
+
+function generate_password_hash($password)
+{
+	return password_hash($password, PASSWORD_DEFAULT, ['cost' => PASSWORD_HASH_COST]);
 }

--- a/lib/www/auth.php
+++ b/lib/www/auth.php
@@ -350,7 +350,7 @@ function do_login_native($user, $pass)
 	                    WHERE username = %s AND enabled = 1',
 	                   $user);
 
-	if ( !$userdata || !password_verify($userdata['password'])) {
+	if ( !$userdata || !password_verify($pass, $userdata['password'])) {
 		$userdata = false;
 		sleep(1);
 		show_failed_login("Invalid username or password supplied. " .

--- a/lib/www/checkers.jury.php
+++ b/lib/www/checkers.jury.php
@@ -73,7 +73,7 @@ function check_user($data, $keydata = null)
 		ch_error("Email not valid.");
 	}
 	if ( !empty($data['password']) ) {
-		$data['password'] = md5("$id#".$data['password']);
+		$data['password'] = generate_password_hash($data['password']);
 	} else {
 		unset($data['password']);
 	}

--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -137,7 +137,7 @@ INSERT INTO `team` (`teamid`, `name`, `categoryid`, `affilid`, `hostname`, `room
 --
 
 INSERT INTO `user` (`userid`, `username`, `name`, `password`) VALUES
-(1, 'admin', 'Administrator', MD5('admin#admin')),
+(1, 'admin', 'Administrator', '$2y$10$WkXRuj/UgoMGF80BaqhOJ.b1HW8KcGrUcWV3uAvGrQlp6Ia8w/dgO'), -- Is a hash for 'admin'
 (2, 'judgehost', 'User for judgedaemons', NULL);
 
 --

--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -531,7 +531,7 @@ CREATE TABLE `user` (
   `email` varchar(255) DEFAULT NULL COMMENT 'Email address',
   `last_login` decimal(32,9) unsigned DEFAULT NULL COMMENT 'Time of last successful login',
   `last_ip_address` varchar(255) DEFAULT NULL COMMENT 'Last IP address of successful login',
-  `password` varchar(32) DEFAULT NULL COMMENT 'Password hash',
+  `password` varchar(255) DEFAULT NULL COMMENT 'Password hash',
   `ip_address` varchar(255) DEFAULT NULL COMMENT 'IP Address used to autologin',
   `enabled` tinyint(1) unsigned NOT NULL DEFAULT '1' COMMENT 'Whether the user is able to log in',
   `teamid` int(4) unsigned DEFAULT NULL COMMENT 'Team associated with',

--- a/travis.sh
+++ b/travis.sh
@@ -33,7 +33,7 @@ sudo make install-domserver install-judgehost
 # setup database and add special user
 cd /opt/domjudge/domserver
 sudo bin/dj_setup_database install
-echo "INSERT INTO user (userid, username, name, password, teamid) VALUES (3, 'dummy', 'dummy user for example team', MD5('dummy#dummy'), 2)" | sudo mysql domjudge
+echo "INSERT INTO user (userid, username, name, password, teamid) VALUES (3, 'dummy', 'dummy user for example team', '\$2y\$10\$0d0sPmeAYTJ/Ya7rvA.kk.zvHu758ScyuHAjps0A6n9nm3eFmxW2K', 2)" | sudo mysql domjudge
 echo "INSERT INTO userrole (userid, roleid) VALUES (3, 2);" | sudo mysql domjudge
 echo "INSERT INTO userrole (userid, roleid) VALUES (3, 3);" | sudo mysql domjudge
 echo "machine localhost login dummy password dummy" > ~/.netrc

--- a/www/jury/genpasswds.php
+++ b/www/jury/genpasswds.php
@@ -37,7 +37,7 @@ function genpw($users, $group, $format) {
 		}
 		$pass = genrandpasswd();
 		// update the user table with a password
-		$DB->q('UPDATE user SET password = %s WHERE username = %s', md5($user['username'].'#'.$pass), $user['username']);
+		$DB->q('UPDATE user SET password = %s WHERE username = %s', generate_password_hash($pass), $user['username']);
 		auditlog('user', $user['username'], 'set password');
 		$line = implode("\t",
 			array($group, $group == 'team' ? $user['teamid'] : '',

--- a/www/jury/impexp_tsv.php
+++ b/www/jury/impexp_tsv.php
@@ -198,7 +198,7 @@ function tsv_accounts_prepare($content)
 			'user' => array (
 				'name' => $line[1],
 				'username' => $line[2],
-				'password' => md5($line[2].'#'.$line[3]),
+				'password' => generate_password_hash($line[3]),
 				'teamid' => $teamid
 				),
 			'userrole' => array (


### PR DESCRIPTION
Implement the feature suggested in #237.

The password hashing algorithm now used is `PASSWORD_DEFAULT` (which currently is PASSWORD_BCRYPT) for future compatibility. The `ircmaxell/password-compat` library is used to remain backwards compatible with PHP 5.4.

The cost for the hashing function is configurable in `common-config.php`.

Note that this patch invalidates all current passwords. The default data has been updated to reflect the new hash style.