### PR TITLE
allows filter for room/affiliation in balloon page, fixes #251

### DIFF
--- a/www/jury/balloons.php
+++ b/www/jury/balloons.php
@@ -86,17 +86,21 @@ echo addForm($pagename, 'get') . "<p>\n" .
     addEndForm();
 
 
+$contestids = $cids;
+if ( $cid !== null ) {
+	$contestids = array($cid);
+}
+
 // Filtering by affiliation or room
 $affils = $DB->q('TABLE SELECT affilid,
-				  team_affiliation.name, room
-				  FROM team_affiliation
-				  LEFT JOIN team t USING (affilid)
-				  INNER JOIN contest c ON (c.cid = %i)
-				  LEFT JOIN contestteam ct ON (ct.teamid = t.teamid AND ct.cid = c.cid)
-				  WHERE c.cid = %i AND
-				  (c.public = 1 OR ct.teamid IS NOT NULL)
-				  GROUP BY affilid, room',
-				 $cdata['cid'], $cdata['cid']);
+                  team_affiliation.name, room
+                  FROM team t
+                  INNER JOIN team_affiliation USING (affilid)
+                  INNER JOIN contest c ON (c.cid IN (%Ai))
+                  LEFT JOIN contestteam ct ON (ct.teamid = t.teamid AND ct.cid = c.cid)
+                  WHERE c.public = 1 OR ct.teamid IS NOT NULL
+                  GROUP BY affilid, room',
+                 $contestids);
 
 // all possible filter values for the select field
 $affilids  = array();
@@ -140,11 +144,6 @@ collapse("filter");
 // -->
 </script>
 		<?php
-
-$contestids = $cids;
-if ( $cid !== null ) {
-	$contestids = array($cid);
-}
 
 // Problem metadata: colours and names.
 if ( empty($cids) ) {
@@ -190,7 +189,7 @@ if ( !empty($contestids) ) {
 	               WHERE s.cid IN (%Ai) $freezecond" .
 	               (isset($filter['affilid']) ? ' AND t.affilid IN (%As) ' : ' %_') .
 	               (isset($filter['room']) ? ' AND t.room IN (%As) ' : ' %_') .
-	               "ORDER BY done ASC, balloonid DESC",
+	               " ORDER BY done ASC, balloonid DESC",
 	              $contestids, @$filter['affilid'], @$filter['room']);
 }
 

--- a/www/jury/balloons.php
+++ b/www/jury/balloons.php
@@ -95,7 +95,7 @@ if ( $cid !== null ) {
 $affils = $DB->q('TABLE SELECT affilid,
                   team_affiliation.name, room
                   FROM team t
-                  INNER JOIN team_affiliation USING (affilid)
+                  LEFT JOIN team_affiliation USING (affilid)
                   INNER JOIN contest c ON (c.cid IN (%Ai))
                   LEFT JOIN contestteam ct ON (ct.teamid = t.teamid AND ct.cid = c.cid)
                   WHERE c.public = 1 OR ct.teamid IS NOT NULL
@@ -106,9 +106,12 @@ $affils = $DB->q('TABLE SELECT affilid,
 $affilids  = array();
 $rooms = array();
 foreach( $affils as $affil ) {
-	$affilids[$affil['affilid']] = $affil['name'];
-	if ( isset($affil['room']) ) $rooms[$affil['room']] = $affil['room'];
+	if ( isset($affil['affilid']) ) $affilids[$affil['affilid']] = $affil['name'];
+	if ( isset($affil['room']) ) $rooms[] = $affil['room'];
 }
+$rooms = array_unique($rooms);
+natcasesort($rooms);
+natcasesort($affilids);
 
 // the 'filtered on' text
 $filteron = array();
@@ -131,8 +134,8 @@ if ( sizeof($filteron) > 0 ) {
 <?php
 
 		echo addForm($pagename, 'get') .
-			( count($affilids) > 1 ? addSelect('affilid[]',    $affilids,  @$filter['affilid'],    TRUE,  8) : "" ) .
-			( count($rooms) > 1 ? addSelect('room[]',    $rooms,  @$filter['room'],    TRUE,  8) : "" ) .
+			( count($affilids) > 1 ? addSelect('affilid[]', $affilids, @$filter['affilid'], TRUE,   8) : "" ) .
+			( count($rooms)    > 1 ? addSelect('room[]',    $rooms,    @$filter['room'],    FALSE,  8) : "" ) .
 			addSubmit('filter', 'filter') . addSubmit('clear', 'clear') .
 			addEndForm();
 		?>


### PR DESCRIPTION
Allows filtering the balloon page by affiliation and/or room for multi site contests.
More or less the same code as the scoreboard filter.