### PR TITLE
Allow Jury members to Override the Validator's Decision on a Given Submission

### DIFF
--- a/www/jury/override.php
+++ b/www/jury/override.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Change the judging result of a given judging.
+ *
+ * Part of the DOMjudge Programming Contest Jury System and licenced
+ * under the GNU GPL. See README and COPYING for details.
+ */
+
+require('init.php');
+$id      = @$_POST['id'];
+$val     = @$_POST['val'];
+if ( empty($id) ) error("No judging ID passed to mark (in)correct.");
+
+$jury_member = $username;
+
+// Explicitly unset jury_member when unmarking verified: otherwise this
+// judging would be marked as "claimed".
+$cnt = $DB->q('RETURNAFFECTED UPDATE judging' .
+              ' SET verified = 1, verify_comment = "", result = %s, jury_member = ' . ($val ? '%s ' : 'NULL %_ ') .
+              ' WHERE judgingid = %i',
+              ($val == "1")?"correct":"wrong-answer", $jury_member, $id);
+auditlog("override", 'j'.$id, $val ? "overrode correct" : "overrode incorrect");
+
+if ( $cnt == 0 ) {
+	error("Judging '$id' not found or nothing changed.");
+} else if ( $cnt > 1 ) {
+	error("Overrode more than one judging.");
+}
+
+$jdata = $DB->q('TUPLE SELECT j.result, s.submitid, s.cid, s.teamid, s.probid, s.langid
+                 FROM judging j
+                 LEFT JOIN submission s USING (submitid)
+                 WHERE judgingid = %i', $id);
+
+if ( dbconfig_get('verification_required', 0) ) {
+	calcScoreRow($jdata['cid'], $jdata['teamid'], $jdata['probid']);
+
+	// log to event table (case of no verification required is handled
+	// in the REST API function judging_runs_POST)
+	$DB->q('INSERT INTO event (eventtime, cid, teamid, langid, probid, submitid, description)
+	        VALUES (%s, %i, %s, %s, %s, %i, "problem result overridden")',
+	       now(), $jdata['cid'], $jdata['teamid'], $jdata['langid'],
+	       $jdata['probid'], $jdata['submitid']);
+
+	if ( $jdata['result'] == 'correct' ) {
+		$balloons_enabled = (bool)$DB->q("VALUE SELECT process_balloons FROM contest WHERE cid = %i", $jdata['cid']);
+		if ( $balloons_enabled ) {
+			$DB->q('INSERT INTO balloon (submitid) VALUES(%i)',
+			       $jdata['submitid']);
+		}
+	}
+}
+
+/* redirect to referrer page after verification
+ * or back to submission page when unverifying. */
+if ( $val ) {
+	$redirect = @$_POST['redirect'];
+	if ( empty($redirect) ) $redirect = 'submissions.php';
+	header('Location: '.$redirect);
+}

--- a/www/jury/submission.php
+++ b/www/jury/submission.php
@@ -633,6 +633,20 @@ if ( !empty($jud['result']) ) {
 			echo ' with comment "'.specialchars($jud['verify_comment']).'"';
 		}
 	}
+	
+	// Display options for overriding validator.
+	if ( ! $jud['verified'] ) {
+	  echo addForm('override.php') .
+	  		addHidden('id', $jud['judgingid']);
+	  if ( $jud['result'] == "correct" ) {
+	    echo addHidden('val', 0) .
+	    		addSubmit('mark incorrect', 'override');
+	  } else {
+	  	echo addHidden('val', 1) .
+	  			addSubmit('mark correct', 'override');
+	  }
+		echo addEndForm();
+	}
 
 	if ( $verify_change_allowed ) {
 		echo '; ' . addSubmit(($val ? '' : 'un') . 'mark verified', 'verify');


### PR DESCRIPTION
This creates buttons on the submission page which show whenever the submission is not marked as verified, to allow the jury to override the validator's decision as to whether an answer is correct or not.