### PR TITLE
Should update the length of `action` column in `auditlog` table due t…

### DIFF
--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -16,7 +16,7 @@ CREATE TABLE `auditlog` (
   `user` varchar(255) DEFAULT NULL COMMENT 'User who performed this action',
   `datatype` varchar(25) DEFAULT NULL COMMENT 'Reference to DB table associated to this entry',
   `dataid` varchar(50) DEFAULT NULL COMMENT 'Identifier in reference table',
-  `action` varchar(30) DEFAULT NULL COMMENT 'Description of action performed',
+  `action` varchar(32) DEFAULT NULL COMMENT 'Description of action performed',
   `extrainfo` varchar(255) DEFAULT NULL COMMENT 'Optional additional description of the entry',
   PRIMARY KEY (`logid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Log of all actions performed';


### PR DESCRIPTION
…o this error.

error: SQL error, Error#1406: Data too long for column 'action' at row 1, query: 'INSERT INTO auditlog (logtime, cid, user, datatype, dataid, action, extrainfo) VALUES("1509614985.217912", null, "admin", "configuration", null, "update show_balloons_postfreeze", "1")'

This error occurs when I trying to change "Configuration settings" in web interface.