### PR TITLE
Allow eventlog and API to have more than one primary key

### DIFF
--- a/lib/www/restapi.php
+++ b/lib/www/restapi.php
@@ -119,7 +119,8 @@ class RestApi {
 		if ( strpos($name, "/") !== FALSE ) {
 			list($name, $primary_key) = preg_split('/\/+/', $name, 2);
 			if ( isset($primary_key) && $primary_key!=='' ) {
-				$arguments['__primary_key'] = $primary_key;
+				// Primary key can either be one or multiple ID's joined by ",", so split them
+				$arguments['__primary_key'] = explode(',', $primary_key);
 			}
 		}
 		$name = $name . '#' . $_SERVER['REQUEST_METHOD'];
@@ -155,7 +156,7 @@ class RestApi {
 		// Arguments
 		$args = array();
 		$valid_args = array_merge($func['optArgs'], array(
-			'__primary_key' => 'ID of single element endpoint',
+			'__primary_key' => 'ID of single element endpoint or multiple ID\'s separated by a comma',
 			'strict'        => 'Strictly follow Contest API specification',
 		));
 		foreach ( $arguments as $key => $value ) {
@@ -186,12 +187,13 @@ class RestApi {
 			$this->createResponse($response);
 			return;
 		}
-		// If a single element was requested, return an object:
+		// If a single element was requested, return an object, but only for non-multiple requests:
 		if  ( isset($arguments['__primary_key']) &&
+		      count($arguments['__primary_key']) === 1 &&
 		      $_SERVER['REQUEST_METHOD']==='GET' ) {
 			if ( count($response)!=1 ) {
 				$this->createError("Found " . count($response) .
-				                   " elements with ID '" . $arguments['__primary_key'] .
+				                   " elements with ID '" . implode(',', $arguments['__primary_key']) .
 				                   "' for function '" . $name . "'.", NOT_FOUND);
 				return;
 
@@ -272,7 +274,7 @@ class RestApi {
 	public function createError($message, $code = BAD_REQUEST)
 	{
 		$protocol = (isset($_SERVER['SERVER_PROTOCOL']) ?
-		             $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
+			     $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
 		header($protocol . " " . $code);
 		$this->createResponse(array('error' => $message));
 	}

--- a/lib/www/restapi.php
+++ b/lib/www/restapi.php
@@ -267,15 +267,21 @@ class RestApi {
 
 	private function createResponse($response)
 	{
-		header('Content-Type: application/json');
+		// Only send headers if not done already. Headers might be sent if calling the API internally
+		if (!headers_sent()) {
+			header('Content-Type: application/json');
+		}
 		print dj_json_encode($response) . "\n";
 	}
 
 	public function createError($message, $code = BAD_REQUEST)
 	{
-		$protocol = (isset($_SERVER['SERVER_PROTOCOL']) ?
-			     $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
-		header($protocol . " " . $code);
+		// Only send headers if not done already. Headers might be sent if calling the API internally
+		if (!headers_sent()) {
+			$protocol = (isset($_SERVER['SERVER_PROTOCOL']) ?
+			             $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
+			header($protocol . " " . $code);
+		}
 		$this->createResponse(array('error' => $message));
 	}
 }

--- a/lib/www/restapi.php
+++ b/lib/www/restapi.php
@@ -120,6 +120,7 @@ class RestApi {
 			list($name, $primary_key) = preg_split('/\/+/', $name, 2);
 			if ( isset($primary_key) && $primary_key!=='' ) {
 				// Primary key can either be one or multiple ID's joined by ",", so split them
+				// TODO: if some ID's contain a comma, this breaks
 				$arguments['__primary_key'] = explode(',', $primary_key);
 			}
 		}

--- a/www/jury/rejudging.php
+++ b/www/jury/rejudging.php
@@ -48,9 +48,12 @@ if ( isset($_REQUEST['apply']) || isset($_REQUEST['cancel']) ) {
 	$time_start = microtime(TRUE);
 
 	// no output buffering... we want to see what's going on real-time
+	header('X-Accel-Buffering: no');
 	echo "<br/><p>Applying rejudge may take some time, please be patient:</p>\n";
+	while (ob_get_level()) {
+		ob_end_flush();
+	}
 	ob_implicit_flush(true);
-	ob_end_flush();
 
 	// clear GET array because otherwise the eventlog subrequest will still include the rejudging id
 	$_GET = array();
@@ -59,6 +62,9 @@ if ( isset($_REQUEST['apply']) || isset($_REQUEST['cancel']) ) {
 	rejudging_finish($id, $request, $userdata['userid'], TRUE);
 
 	echo "\n</p>\n";
+
+	// Start output buffering again to not crash the FallbackController
+	ob_start();
 
 	$time_end = microtime(TRUE);
 


### PR DESCRIPTION
The previous, hacky version was so hacky because there were two code paths in both the `eventlog` function as well as in the only API endpoint supporting it (`runs`).

I have now modified all V4 API endpoints to allow passing more than one ID in __primary_key and changed `restapi.php` to turn `__primary_key` into an array. Although this still results in quite some changes in the API, there are almost no extra code paths anymore. Only the `eventlog` function has a check whether one or more ID's are passed, as that results in getting back an array of objects or only one object from the API.

I have locally called all API endpoints I modified to see if the correct data is still returned and that seems to be the case.

There is one endpoint which is a little bit more work to fix: the `contest` endpoint. This one is already in the Symfony `APIController` and it will always return a single contest.
I think we should accept this for now and make sure we do not call `eventlog` for contests with more than one ID.
In the future, when we have all endpoints in Symfony, I think we can come up with a better way to log events anyway; one that does not go through the API, but uses the Doctrine entities directly.