### PR TITLE
Handle runguard errors and crashes gracefully.

### DIFF
--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -155,7 +155,7 @@ if [ $exitcode -ne 0 ]; then
 	echo "Compiling failed with exitcode $exitcode, compiler output:" >compile.out
 	cat compile.tmp >>compile.out
 	if [ ! -s compile.meta ]; then
-		echo "\n--------------------------------------------------------------------------------\n" >> compile.out
+		printf "\n--------------------------------------------------------------------------------\n\n" >> compile.out
 		echo "Since the file 'compile.meta' is empty, above error is most likely caused by a crash in runguard." >> compile.out
 		echo "internal-error: runguard crash" > compile.meta
 	fi

--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -154,6 +154,11 @@ fi
 if [ $exitcode -ne 0 ]; then
 	echo "Compiling failed with exitcode $exitcode, compiler output:" >compile.out
 	cat compile.tmp >>compile.out
+	if [ ! -s compile.meta ]; then
+		echo "\n--------------------------------------------------------------------------------\n" >> compile.out
+		echo "Since the file 'compile.meta' is empty, above error is most likely caused by a crash in runguard." >> compile.out
+		echo "internal-error: runguard crash" > compile.meta
+	fi
 	cleanexit ${E_COMPILER_ERROR:--1}
 fi
 if [ ! -f compile/program ] || [ ! -x compile/program ]; then

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -262,6 +262,9 @@ void error(int errnum, const char *format, ...)
 	va_end(ap);
 
 	write_meta("internal-error","%s: %d - %s","runguard error", errnum, format);
+	if ( outputmeta && metafile != NULL && fclose(metafile)!=0 ) {
+		fprintf(stderr,"\nError writing to metafile '%s'.\n",metafilename);
+	}
 
 	/* Make sure that all children are killed before terminating */
 	if ( child_pid > 0) {

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -261,7 +261,7 @@ void error(int errnum, const char *format, ...)
 	fprintf(stderr,"\nTry `%s --help' for more information.\n",progname);
 	va_end(ap);
 
-	write_meta("internal-error","%s: %d - %s","runguard error", errnum, format);
+	write_meta("internal-error","%s - %d - %s","runguard error", errnum, format);
 	if ( outputmeta && metafile != NULL && fclose(metafile)!=0 ) {
 		fprintf(stderr,"\nError writing to metafile '%s'.\n",metafilename);
 	}

--- a/www/api/v4/index.php
+++ b/www/api/v4/index.php
@@ -1832,7 +1832,7 @@ function internal_error_POST($args)
 	$disabled = dj_json_decode($args['disabled']);
 	// disable what needs to be disabled
 	set_internal_error($disabled, $cid, 0);
-	if ( in_array($disabled['kind'], array('problem', 'language')) ) {
+	if ( in_array($disabled['kind'], array('problem', 'language', 'judgehost'))  && isset($args['judgingid']) ) {
 		// give back judging if we have to
 		give_back_judging($args['judgingid']);
 	}


### PR DESCRIPTION
E.g. you forget to run misc-tools/create_cgroups. Then it stops compiling on that judgehost until you fix the error.