### PR TITLE
Use cgroup base directory to detect cgroup support instead of grub commandline

### DIFF
--- a/misc-tools/create_cgroups.in
+++ b/misc-tools/create_cgroups.in
@@ -9,21 +9,31 @@
 JUDGEHOSTUSER=@DOMJUDGE_USER@
 CGROUPBASE=@judgehost_cgroupdir@
 
-if ! grep -Eq 'cgroup_enable.+memory' /proc/cmdline || ! grep -Eq 'swapaccount.+1' /proc/cmdline; then
-        echo "Error: cgroup support missing from running kernel. Unable to continue.
-
-        To fix this, please make the following changes:
-        1. In /etc/default/grub, add 'cgroup_enable=memory swapaccount=1' to GRUB_CMDLINE_LINUX_DEFAULT
-        2. Run update-grub
-        3. Reboot" >&2
-        exit 1
-fi
-
 for i in cpuset memory; do
-	mkdir -p $CGROUPBASE/$i
-	mount -t cgroup -o$i $i $CGROUPBASE/$i/
-	mkdir -p $CGROUPBASE/$i/domjudge
+    mkdir -p $CGROUPBASE/$i
+    if [ ! -d $CGROUPBASE/$i/ ]; then
+        if ! mount -t cgroup -o$i $i $CGROUPBASE/$i/; then
+            echo "Error: Can not mount $i cgroup. Probably cgroup support is missing from running kernel. Unable to continue.
+
+            To fix this, please make the following changes:
+            1. In /etc/default/grub, add 'cgroup_enable=memory swapaccount=1' to GRUB_CMDLINE_LINUX_DEFAULT
+            2. Run update-grub
+            3. Reboot" >&2
+            exit 1
+        fi
+    fi
+    mkdir -p $CGROUPBASE/$i/domjudge
 done
+
+if [ ! -f $CGROUPBASE/memory/memory.limit_in_bytes ] || [ ! -f $CGROUPBASE/memory/memory.memsw.limit_in_bytes ]; then
+    echo "Error: cgroup support missing memory features in running kernel. Unable to continue.
+
+    To fix this, please make the following changes:
+    1. In /etc/default/grub, add 'cgroup_enable=memory swapaccount=1' to GRUB_CMDLINE_LINUX_DEFAULT
+    2. Run update-grub
+    3. Reboot" >&2
+    exit 1
+fi
 
 chown -R $JUDGEHOSTUSER $CGROUPBASE/*/domjudge
 


### PR DESCRIPTION
I'm not committing this directly as I'd like input from you guys.

Both Docker on my macOS machine as well as my Ubuntu 18.04 machine do have cgroups enabled, even for memory and including swap accounting, but don't have it in the grub commandline.

Although I can easily add it on my Ubuntu 18.04 machine, it is way harder to add this on Docker on my Mac.

I *think* this should also detect whether cgroups are enabled while not looking at the grub commandline.

Thoughts?