### PR TITLE
[EXPERIMENT] Add new script to build chroot from a docker image

### DIFF
--- a/misc-tools/Makefile
+++ b/misc-tools/Makefile
@@ -11,7 +11,7 @@ SUBST_DOMSERVER = save_sources2file restore_sources2db \
                   simulate_contest create_accounts multi_rejudge \
                   eventdaemon
 
-SUBST_JUDGEHOST = create_cgroups dj_make_chroot dj_run_chroot
+SUBST_JUDGEHOST = create_cgroups dj_make_chroot dj_run_chroot dj_make_chroot_docker
 
 SUBST_FILES = $(SUBST_DOMSERVER) $(SUBST_JUDGEHOST)
 

--- a/misc-tools/dj_make_chroot_docker.in
+++ b/misc-tools/dj_make_chroot_docker.in
@@ -1,0 +1,147 @@
+#!/bin/bash
+# @configure_input@
+#
+# Script to generate a chroot environment from a docker image
+#
+# The space required is dependent on the docker image you use.
+# Dependencies: curl, tar, kernel 3.10; xzutils?
+#
+# Part of the DOMjudge Programming Contest Jury System and licenced
+# under the GNU GPL. See README and COPYING for details.
+
+# Abort when a single command fails(or uninitialized variable is accessed):
+set -eu
+
+# Default directory where to build the chroot tree:
+CHROOTDIR="@judgehost_chrootdir@"
+
+usage()
+{
+	cat <<EOF
+Usage: $0 [options]...
+Creates a chroot environment from a docker image
+
+Options:
+  -i <image>:<tag>   Docker image to build chroot from
+  -d <dir>           Directory where to build the chroot environment.
+  -y                 Force overwriting the chroot dir and downloading debootstrap.
+  -h                 Display this help.
+
+This script must be run as root, <chrootdir> is the non-existing
+target location of the chroot (unless '-y' is specified). The
+default chrootdir is '@judgehost_chrootdir@'.
+
+EOF
+}
+
+error()
+{
+    echo "Error: $*"
+    echo
+    usage
+    exit 1
+}
+
+# Read command-line parameters:
+SHOWHELP=0
+FORCEYES=0
+IMAGE=""
+while getopts 'i:d:yh' OPT ; do
+	case $OPT in
+		i) IMAGE=$OPTARG ;;
+		d) CHROOTDIR=$OPTARG ;;
+		y) FORCEYES=1 ;;
+		h) SHOWHELP=1 ;;
+		\?) error "Could not parse options." ;;
+	esac
+done
+shift $((OPTIND-1))
+if [ $# -gt 0 ]; then
+	error "Additional arguments specified."
+fi
+
+if [ "$SHOWHELP" -eq "1" ]; then
+	usage
+	exit 0
+fi
+
+if [ "$(id -u)" != 0 ]; then
+    echo "Warning: you probably need to run this program as root."
+fi
+
+[ -z "$CHROOTDIR" ] && error "No chroot directory given or default known."
+[ -z "$IMAGE" ] && error "No docker image specified(-i image:tag)"
+
+if [ -e "$CHROOTDIR" ]; then
+	if [ ! "$FORCEYES" ]; then
+		printf "'%s' already exists. Remove? (y/N) " "$CHROOTDIR"
+		read -r yn
+		if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
+			error "Chrootdir already exists, exiting."
+		fi
+	fi
+	cleanup
+	rm -rf "$CHROOTDIR"
+fi
+
+mkdir -p "$CHROOTDIR"
+cd "$CHROOTDIR"
+CHROOTDIR="$PWD"
+
+
+WORKDIR="$(mktemp -d)"
+DOCKER_BINARY_PATH="$WORKDIR/docker-binary"
+mkdir "$DOCKER_BINARY_PATH"
+
+echo "Downloading and extracting docker binaries"
+curl https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz | tar -C $DOCKER_BINARY_PATH --strip-components=1 -xzf -
+echo "{}" > "$WORKDIR/docker-config.json"
+
+echo "Launching docker daemon so we can download/extract files"
+export PATH="$DOCKER_BINARY_PATH:$PATH"
+$DOCKER_BINARY_PATH/dockerd \
+  --data-root $WORKDIR/docker-data \
+  --exec-root $WORKDIR/docker-exec \
+  --pidfile $WORKDIR/docker.pid \
+  --config-file $WORKDIR/docker-config.json \
+  --host unix://$WORKDIR/docker.sock \
+  --group root \
+  --iptables=false \
+  --bridge=none &
+
+DOCKER="$DOCKER_BINARY_PATH/docker -H unix://$WORKDIR/docker.sock"
+
+echo "Running docker to download/extract the contents of an image"
+container="$($DOCKER create $IMAGE)"
+$DOCKER export "$container" | tar -C $CHROOTDIR -xf -
+
+echo "Shutting down docker daemon"
+kill -9 "$(cat $WORKDIR/docker.pid)"
+
+# Unmount anything mounted there(docker leaves some things behind)
+awk "\$2 ~ \"^$WORKDIR\" { print \$2 }" /proc/mounts | while read -r mountpoint; do
+    umount $mountpoint
+done
+
+rm -rf "$WORKDIR" || true
+
+
+# Do some final domjudge specific set up of the chroot
+rm -f "$CHROOTDIR/etc/resolv.conf"
+cp /etc/resolv.conf /etc/hosts /etc/hostname "$CHROOTDIR/etc" || true
+cp /etc/ssl/certs/ca-certificates.crt "$CHROOTDIR/etc/ssl/certs/" || true
+cp -r /usr/share/ca-certificates/* "$CHROOTDIR/usr/share/ca-certificates" || true
+cp -r /usr/local/share/ca-certificates/* "$CHROOTDIR/usr/local/share/ca-certificates" || true
+
+# Disable root account
+sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
+
+# Create a dummy file to test that in the judging environment no
+# access to group root readable files is available:
+echo "This file should not be readable inside the judging environment!" \
+	> "$CHROOTDIR/etc/root-permission-test.txt"
+chmod 0640 "$CHROOTDIR/etc/root-permission-test.txt"
+
+
+echo "Done building chroot in $CHROOTDIR"
+exit 0

--- a/travis.sh
+++ b/travis.sh
@@ -79,7 +79,7 @@ sudo bin/create_cgroups
 
 # build chroot(randomly pick which script to use)
 cd ${DIR}/misc-tools
-FLIP=$(($(($RANDOM%10))%2))
+FLIP=$((RANDOM % 2))
 if [ $FLIP -eq 1 ]; then
   time sudo ./dj_make_chroot -a amd64
 else

--- a/travis.sh
+++ b/travis.sh
@@ -77,10 +77,14 @@ sudo cp /opt/domjudge/judgehost/etc/sudoers-domjudge /etc/sudoers.d/
 sudo chmod 400 /etc/sudoers.d/sudoers-domjudge
 sudo bin/create_cgroups
 
-# build chroot
+# build chroot(randomly pick which script to use)
 cd ${DIR}/misc-tools
-# sudo ./dj_make_chroot -a amd64
-time sudo ./dj_make_chroot_docker -i ubergeek42/domjudge-chroot:latest
+FLIP=$(($(($RANDOM%10))%2))
+if [ $FLIP -eq 1 ]; then
+  time sudo ./dj_make_chroot -a amd64
+else
+  time sudo ./dj_make_chroot_docker -i domjudge/default-judgehost-chroot:latest
+fi
 
 # download domjudge-scripts for API check
 cd $HOME

--- a/travis.sh
+++ b/travis.sh
@@ -79,7 +79,8 @@ sudo bin/create_cgroups
 
 # build chroot
 cd ${DIR}/misc-tools
-sudo ./dj_make_chroot -a amd64
+# sudo ./dj_make_chroot -a amd64
+time sudo ./dj_make_chroot_docker -i ubergeek42/domjudge-chroot:latest
 
 # download domjudge-scripts for API check
 cd $HOME


### PR DESCRIPTION
This is an experiment to see if we can make the chroot build process a bit better. My thinking was that docker images are much simpler to make, so maybe we could just take the root filesystem from them, extract it, and use it as our chroot. Turns out it isn't super difficult to do just that, so I wrote a new make_chroot script to do so.

I then built and uploaded a simple docker image that should approximate what `dj_make_chroot` gives you(See dockerfile at the bottom). I configured travis to use it, and it seems to work ok.

I'm also thinking it might be nice to have per language chroots; so maybe our chroot dir ends up looking like:
```
/chroot/domjudge/c++/<a chroot for running c++ programs>
/chroot/domjudge/java/<a chroot for running java programs>
```

I think we could switch to using it for compilation as well, and then things get a lot simpler. E.g. how do you support weird/random versions of kotlin? Just use the official go docker image + do whatever modifications we need for domjudge.

What do you all think? Is this something you'd like to see done/continued/polished?


```Dockerfile
FROM ubuntu:18.04
ENV DEBIAN_FRONTEND=noninteractive
RUN apt-get update && apt-get -y install \
  ca-certificates default-jre-headless pypy locales \
  software-properties-common \
  && rm -rf /var/lib/apt/lists/*

RUN chmod a-s \
  /usr/bin/wall \
  /usr/bin/newgrp \
  /usr/bin/chage \
  /usr/bin/chfn \
  /usr/bin/chsh \
  /usr/bin/expiry \
  /usr/bin/gpasswd \
  /usr/bin/passwd \
  /bin/su \
  /bin/mount \
  /bin/umount \
  /sbin/unix_chkpwd \
  || true

```