### PR TITLE
Use FontAwesome icons on new jury pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,20 @@
 	"description": "DOMjudge Programming Contest Control System",
 	"homepage": "https://www.domjudge.org",
 	"license": "GPL-2.0+",
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "fortawesome/font-awesome",
+				"version": "5.4.2",
+				"source": {
+					"url": "https://github.com/FortAwesome/Font-Awesome.git",
+					"type": "git",
+					"reference": "5.4.2"
+				}
+			}
+		}
+	],
 	"require": {
 		"ext-curl": "*",
 		"ext-json": "*",
@@ -31,7 +45,8 @@
 		"novus/nvd3": "^1.8",
 		"components/jquery": "^3.3",
 		"nelmio/api-doc-bundle": "^3.3",
-		"datatables/datatables": "^1.10"
+		"datatables/datatables": "^1.10",
+		"fortawesome/font-awesome": "5.*"
 	},
 	"require-dev": {
 		"sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee05df0561e50e9ca5e08902411d0375",
+    "content-hash": "9e84085a42bb56764af1cb9231dd4897",
     "packages": [
         {
             "name": "components/jquery",
@@ -992,6 +992,16 @@
                 "rest"
             ],
             "time": "2016-10-17T18:31:11+00:00"
+        },
+        {
+            "name": "fortawesome/font-awesome",
+            "version": "5.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "reference": "5.4.2"
+            },
+            "type": "library"
         },
         {
             "name": "friendsofsymfony/rest-bundle",

--- a/webapp/app/Resources/views/base_bootstrap.html.twig
+++ b/webapp/app/Resources/views/base_bootstrap.html.twig
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="{{asset("css/octicons/octicons.css")}}">
 
   <link rel="stylesheet" href="{{asset("css/bootstrap.min.css")}}">
+  <link rel="stylesheet" href="{{asset("css/fontawesome-all.min.css")}}">
   <script src="{{asset("js/jquery.min.js")}}"></script>
   <script src="{{asset("js/popper.min.js")}}"></script>
   <script src="{{asset("js/bootstrap.min.js")}}"></script>

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ExecutableController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ExecutableController.php
@@ -60,8 +60,8 @@ class ExecutableController extends Controller
         ];
         if ($this->isGranted('ROLE_ADMIN')) {
           $table_fields = array_merge($table_fields, [
-            'save'        => [ 'title' => '',            'sort' => false,  ],
-            'edit'        => [ 'title' => '',            'sort' => false,  ],
+            'save'        => [ 'title' => '',            'sort' => false, ],
+            'edit'        => [ 'title' => '',            'sort' => false, ],
             'delete'      => [ 'title' => '',            'sort' => false, ],
           ]);
         }
@@ -78,20 +78,20 @@ class ExecutableController extends Controller
           }
 
 
-          $editvalue = '<img src="' . $assetPackage->getUrl('images/edit.png') . '" alt="edit" title="edit this executable" class="picto">';
+          $editvalue = '<i class="fas fa-edit" title="edit this executable"></i>';
           $editlink = $this->generateUrl('legacy.jury_executable', [
             'cmd'=>'edit',
             'id'=>$e->getExecid(),
             'referrer' => 'executables/'
           ]);
-          $deletevalue = '<img src="' . $assetPackage->getUrl('images/delete.png') . '" alt="delete" title="delete this executable" class="picto">';
+          $deletevalue = '<i class="fas fa-trash-alt" title="delete this executable"></i>';
           $deletelink = $this->generateUrl('legacy.jury_delete', [
             'table'=>'executable',
             'execid'=>$e->getExecid(),
             'referrer' => '',
             'desc' => $e->getDescription(),
           ]);
-          $savevalue = '<img src="' . $assetPackage->getUrl('images/b_save.png') . '" alt="edit" title="edit this executable" class="picto">';
+          $savevalue = '<i class="fas fa-file-download" title="download this executable"></i>';
           $savelink = $this->generateUrl('legacy.jury_executable', [
             'fetch'=>'',
             'id'=>$e->getExecid(),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
@@ -127,20 +127,20 @@ class TeamController extends Controller
           }
 
           // Create action links
-          $editvalue = '<img src="' . $assetPackage->getUrl('images/edit.png') . '" alt="edit" title="edit this team" class="picto">';
+          $editvalue = '<i class="fas fa-edit" title="edit this team"></i>';
           $editlink = $this->generateUrl('legacy.jury_team', [
             'cmd'=>'edit',
             'id'=>$t->getTeamId(),
             'referrer' => 'teams/'
           ]);
-          $deletevalue = '<img src="' . $assetPackage->getUrl('images/delete.png') . '" alt="delete" title="delete this team" class="picto">';
+          $deletevalue = '<i class="fas fa-trash-alt" title="delete this team"></i>';
           $deletelink = $this->generateUrl('legacy.jury_delete', [
             'table'=>'team',
             'teamid'=>$t->getTeamId(),
             'referrer' => '',
             'desc' => $t->getName(),
           ]);
-          $sendvalue = '<span class="octicon octicon-mail"></span>';
+          $sendvalue = '<i class="fas fa-envelope" title="send clarification to this team"></i>';
           $sendlink = $this->generateUrl('legacy.jury_clarification', [
             'teamto'=>$t->getTeamId(),
           ]);

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/executables.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/executables.html.twig
@@ -15,7 +15,7 @@
 
 {{ macros.table(executables, table_fields) }}
 
-<p><a href="{{ path('legacy.jury_executable', {'cmd': 'add'}) }}"><img src="{{ asset('images/add.png') }}" alt="add" title="add new executable" class="picto"></a></p>
+<p><a href="{{ path('legacy.jury_executable', {'cmd': 'add'}) }}"><i class="fas fa-plus-square" title="add new executable"></i></a></p>
 <form style="display:inline;" action="{{ path('legacy.jury_executable') }}" method="post" enctype="multipart/form-data">
 Executable archive(s): <select name="type" id="type">
 <option value="compare">compare</option>

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/teams.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/teams.html.twig
@@ -15,5 +15,5 @@
 
 {{ macros.table(teams, table_fields) }}
 
-<p><a href="{{path('legacy.jury_team', {cmd: 'add'})}}"><img src="{{asset('images/add.png')}}" alt="add" title="add new team" class="picto"></a></p>
+<p><a href="{{path('legacy.jury_team', {cmd: 'add'})}}"><i class="fas fa-plus-square" title="add new team"></i></a></p>
 {% endblock %}

--- a/webapp/web/css/fontawesome-all.min.css
+++ b/webapp/web/css/fontawesome-all.min.css
@@ -1,0 +1,1 @@
+../../../lib/vendor/fortawesome/font-awesome/web-fonts-with-css/css/fontawesome-all.min.css

--- a/webapp/web/webfonts
+++ b/webapp/web/webfonts
@@ -1,0 +1,1 @@
+../../lib/vendor/fortawesome/font-awesome/web-fonts-with-css/webfonts


### PR DESCRIPTION
As a 'trial' I replaced the edit/delete/etc icons in tables in the new interface with FontAwesome glyphs. FontAwesome is GPL-compliant and works in IE 10/11 and modern browsers, so that shouldn't be a problem. They have not registered a 5.x version of their package for Composer, so I use a git URL directly.

See this screenshot:
<img width="1794" alt="screenshot 2018-10-28 at 16 52 39" src="https://user-images.githubusercontent.com/550145/47618366-5642b600-dad2-11e8-8647-fe7b47c7cfa9.png">
(We might consider making the icons a bit lighter. Also we might want to change the blue + button to black or something; it now uses the default link color; or even change it to a `<button>`?)

Any thoughts?