### PR TITLE
Prevent spurious cases where not all program output was captured.

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -1345,6 +1345,7 @@ int main(int argc, char **argv)
 			}
 		}
 
+		use_splice = 0;
 		do {
 			total_data = data_passed[1] + data_passed[2];
 			pump_pipes(readfds, data_read, data_passed);

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -640,6 +640,7 @@ void terminate(int sig)
 
 static void child_handler(int sig)
 {
+	verbose("child handler: sig = %d", sig);
 	received_SIGCHLD = 1;
 }
 
@@ -1246,11 +1247,16 @@ int main(int argc, char **argv)
 				}
 			}
 
+			errno = 0;
+			verbose("calling pselect, nfds = %d", nfds);
 			r = pselect(nfds+1, &readfds, NULL, NULL, NULL, &emptymask);
+			verbose("pselect done, r = %d, errno = %d = %s", r, errno, strerror(errno));
+
 			if ( r==-1 && errno!=EINTR ) error(errno,"waiting for child data");
 
 			if ( received_SIGCHLD ) {
 				if ( (pid = wait(&status))<0 ) error(errno,"waiting on child");
+				verbose("received_SIGCHLD for pid = %d", pid);
 				if ( pid==child_pid ) break;
 			}
 

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -884,7 +884,7 @@ void pump_pipes(fd_set readfds, size_t data_read[], size_t data_passed[])
 				if ( use_splice ) {
 					nread = splice(child_pipefd[i][PIPE_OUT], NULL,
 					               child_redirfd[i], NULL,
-					               to_read, SPLICE_F_MOVE);
+					               to_read, SPLICE_F_MOVE | SPLICE_F_NONBLOCK);
 
 					if ( nread==-1 && errno==EINVAL ) {
 						use_splice = 0;
@@ -1345,7 +1345,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		use_splice = 0;
+		use_splice = 1;
 		do {
 			total_data = data_passed[1] + data_passed[2];
 			pump_pipes(readfds, data_read, data_passed);

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -861,8 +861,8 @@ void setrestrictions()
 
 void pump_pipes(fd_set readfds, size_t data_read[], size_t data_passed[])
 {
-	ssize_t nread;
-	size_t to_read;
+	ssize_t nread, nwritten;
+	size_t to_read, to_write;
 	int i;
 
 	/* Check to see if data is available and pass it on */
@@ -895,7 +895,15 @@ void pump_pipes(fd_set readfds, size_t data_read[], size_t data_passed[])
 				} else {
 					nread = read(child_pipefd[i][PIPE_OUT], buf, to_read);
 					if ( nread>0 ) {
-						nread = write(child_redirfd[i], buf, nread);
+						to_write = nread;
+						while ( to_write>0 ) {
+							nwritten = write(child_redirfd[i], buf, to_write);
+							if ( nwritten==-1 ) {
+								nread = -1;
+								break;
+							}
+							to_write -= nwritten;
+						}
 					}
 				}
 

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -162,7 +162,7 @@ FILE *child_stderr;
 int child_pipefd[3][2];
 int child_redirfd[3];
 
-struct timeval starttime, endtime;
+struct timeval progstarttime, starttime, endtime;
 struct tms startticks, endticks;
 
 struct option const long_opts[] = {
@@ -212,9 +212,14 @@ void verbose(const char *format, ...)
 {
 	va_list ap;
 	va_start(ap,format);
+	struct timeval currtime;
+	double runtime;
 
 	if ( ! be_quiet && be_verbose ) {
-		fprintf(stderr,"%s: verbose: ",progname);
+		gettimeofday(&currtime,NULL);
+		runtime = (currtime.tv_sec  - progstarttime.tv_sec ) +
+		          (currtime.tv_usec - progstarttime.tv_usec)*1E-6;
+		fprintf(stderr,"%s [%d @ %10.6lf]: verbose: ",progname,getpid(),runtime);
 		vfprintf(stderr,format,ap);
 		fprintf(stderr,"\n");
 	}
@@ -879,6 +884,8 @@ int main(int argc, char **argv)
 	struct sigaction sigact;
 
 	progname = argv[0];
+
+	if ( gettimeofday(&progstarttime,NULL) ) error(errno,"getting time");
 
 	/* Parse command-line options */
 	use_root = use_walltime = use_cputime = use_user = no_coredump = 0;


### PR DESCRIPTION
This was likely a race condition where after reading data from
the pipes, some more data was pushed and then the program exited
and a SIGCHLD was raised and captured, leaving unread data in the
pipes. To fix this, read from the pipes once more after SIGCHILD.

Also rename variable sigmask_empty and only initialize it once.