### PR TITLE
Update URL in manual to About page on domjudge.org

### DIFF
--- a/doc/domjudge-overview-inc.sgml
+++ b/doc/domjudge-overview-inc.sgml
@@ -34,7 +34,7 @@ A global overview of the features that DOMjudge provides:
 </itemize>
 
 DOMjudge has been used in many live contests
-(see <url url="https://www.domjudge.org/intro"> for an overview) and
+(see <url url="https://www.domjudge.org/about"> for an overview) and
 is Open Source, Free Software.
 
 <![ %admin; [


### PR DESCRIPTION
I was reading the judge manual on your website (https://www.domjudge.org/docs/judge-manual.pdf) and noticed that the URL that linked to the About page did not exist anymore.
It seems that it has been moved, hence this update.