### PR TITLE
Report freeze duration of "00:00:00" if not set.

### DIFF
--- a/webapp/src/DOMJudgeBundle/Entity/Contest.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Contest.php
@@ -1105,7 +1105,7 @@ class Contest
      */
     public function getScoreboardFreezeDuration()
     {
-        if (!empty($this->getFreezetime()) {
+        if (!empty($this->getFreezetime())) {
             return Utils::relTime($this->getEndtime() - $this->getFreezetime());
         } else {
             return Utils::relTime(0);

--- a/webapp/src/DOMJudgeBundle/Entity/Contest.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Contest.php
@@ -1105,7 +1105,11 @@ class Contest
      */
     public function getScoreboardFreezeDuration()
     {
-        return Utils::relTime($this->getEndtime() - $this->getFreezetime());
+        if (!empty($this->getFreezetime()) {
+            return Utils::relTime($this->getEndtime() - $this->getFreezetime());
+        } else {
+            return Utils::relTime(0);
+        }
     }
 
     /**


### PR DESCRIPTION
Leaves Contest::getDuration alone because it isn't as clear-cut what to do there.

Fixes #477