### PR TITLE
Also wait for child after terminating it (due to SIGALRM/timelimit).

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -1321,7 +1321,7 @@ int main(int argc, char **argv)
 			r = pselect(nfds+1, &readfds, NULL, NULL, NULL, &emptymask);
 			if ( r==-1 && errno!=EINTR ) error(errno,"waiting for child data");
 
-			if ( received_SIGCHLD ) {
+			if ( received_SIGCHLD || received_signal == SIGALRM ) {
 				if ( (pid = wait(&status))<0 ) error(errno,"waiting on child");
 				if ( pid==child_pid ) break;
 			}


### PR DESCRIPTION
This fixes a bug with interactive problems where the judgedaemon got
stuck on simple forever loops.

Partly addresses #465.