### PR TITLE
   If the validator of a combined run/compare script exits first with WA, override TLE.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -855,18 +855,24 @@ function judge(array $row)
         $hardtimelimit = $row['maxruntime'] +
                          overshoot_time($row['maxruntime'], $overshoot);
 
-        list($compare_runpath, $error) = fetch_executable($workdirpath, $row['compare'], $row['compare_md5sum']);
-        if (isset($error)) {
-            logmsg(LOG_ERR, "fetching executable failed for compare script '" . $row['compare'] . "':" . $error);
-            disable('problem', 'probid', $row['probid'], $error, $row['judgingid'], $row['cid']);
-            return;
-        }
-
         list($run_runpath, $error) = fetch_executable($workdirpath, $row['run'], $row['run_md5sum']);
         if (isset($error)) {
             logmsg(LOG_ERR, "fetching executable failed for run script '" . $row['run'] . "':" . $error);
             disable('problem', 'probid', $row['probid'], $error, $row['judgingid'], $row['cid']);
             return;
+        }
+
+        if ($row['combined_run_compare']) {
+            // set to empty string to signal the testcase_run script that the
+            // run script also acts as compare script
+            $compare_runpath = '';
+        } else {
+            list($compare_runpath, $error) = fetch_executable($workdirpath, $row['compare'], $row['compare_md5sum']);
+            if (isset($error)) {
+                logmsg(LOG_ERR, "fetching executable failed for compare script '" . $row['compare'] . "':" . $error);
+                disable('problem', 'probid', $row['probid'], $error, $row['judgingid'], $row['cid']);
+                return;
+            }
         }
 
         system(LIBJUDGEDIR . "/testcase_run.sh $cpuset_opt $tcfile[input] $tcfile[output] " .

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -311,9 +311,21 @@ resourceinfo="\
 runtime: ${program_cputime}s cpu, ${program_walltime}s wall
 memory used: ${memory_bytes} bytes"
 if grep '^time-result: .*timelimit' program.meta >/dev/null 2>&1 ; then
-	echo "Timelimit exceeded." >>system.out
-	echo "$resourceinfo" >>system.out
-	cleanexit ${E_TIMELIMIT:-1}
+	if [ $COMBINED_RUN_COMPARE -eq 1 ] && grep '^exitcode: 43' compare.meta > /dev/null 2>&1 ; then
+		# For interactive problems with combined run/compare scripts, a
+		# WA may override TLE.
+		# FIXME: For now, we only write to compare.meta if the
+		# validator exited first, but we should always write the meta
+		# file and include information about which exited first and
+		# when.
+		echo "Timelimit exceeded, but validator exited first with WA." >>system.out
+		echo "$resourceinfo" >>system.out
+		cleanexit ${E_WRONG_ANSWER:-1}
+	else
+		echo "Timelimit exceeded." >>system.out
+		echo "$resourceinfo" >>system.out
+		cleanexit ${E_TIMELIMIT:-1}
+	fi
 fi
 if [ "$program_exit" != "0" ]; then
 	echo "Non-zero exitcode $program_exit" >>system.out

--- a/webapp/src/DOMJudgeBundle/Controller/API/JudgehostController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/JudgehostController.php
@@ -396,7 +396,8 @@ class JudgehostController extends FOSRestController
             'run' => $submission->getProblem()->getSpecialRun(),
             'compare' => $submission->getProblem()->getSpecialCompare(),
             'compare_args' => $submission->getProblem()->getSpecialCompareArgs(),
-            'compile_script' => $submission->getLanguage()->getCompileScript()
+            'compile_script' => $submission->getLanguage()->getCompileScript(),
+            'combined_run_compare' => $submission->getProblem()->getCombinedRunCompare()
         ];
 
         // Merge defaults


### PR DESCRIPTION
    
    See
    https://github.com/Kattis/problemtools/pull/77
    for an in-depth discussion.
    
    With this, all test submissions of the example guess problem give the
    expected answer, but we need to do some cleanup and UI/import changes
    before we can close #465.
