### PR TITLE
Fixing crashes with compile.meta

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -644,7 +644,7 @@ function read_metadata(string $filename)
     if (!is_readable($filename)) return null;
 
     // Don't quite treat it as YAML, but simply key/value pairs.
-    $contents = preg_replace('/: (.*)$/', ': "$1"', dj_file_get_contents($filename));
+    $contents = preg_replace('/: (.*)$/m', ': "$1"', dj_file_get_contents($filename));
 
     return spyc_load($contents);
 }


### PR DESCRIPTION
During judging process, the following compile.meta file was created:
[compile.meta.txt](https://github.com/DOMjudge/domjudge/files/2764465/compile.meta.txt)

Preparing the compile.meta file does not work as intended and results
in crashes of the judgedaemon. By default, preg_replace does not match
newlines with $-sign. And therefore only the last line was surrounded with quotes. The regex option /m is required for multiline support.

(This happened on an Ubuntu 16.04 machine with PHP 7.0.30)