### PR TITLE
Implement awards endpoint

### DIFF
--- a/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
@@ -85,7 +85,7 @@ class AwardsController extends AbstractRestController
         $group_winners = $problem_winners = [];
         foreach ($scoreboard->getTeams() as $team) {
             $teamid = (string)($teamuseextid ? $team->getExternalid() : $team->getTeamid());
-            if ( $scoreboard->isBestInCategory($team) ) {
+            if ($scoreboard->isBestInCategory($team)) {
                 $group_winners[$team->getCategoryId()][] = $teamid;
             }
             foreach($scoreboard->getProblems() as $problem) {
@@ -97,22 +97,22 @@ class AwardsController extends AbstractRestController
         }
 
         $results = [];
-        foreach($group_winners as $id => $team_ids) {
+        foreach ($group_winners as $id => $team_ids) {
             $type = 'group-winner-' . $id;
             $result = [ 'id' => $type,
                 'citation' => 'Winner(s) of group ' . $id,
                 'team_ids' => $team_ids];
-            if ( $requestedType === $type ) {
+            if ($requestedType === $type) {
                 return $result;
             }
             $results[] = $result;
         }
-        foreach($problem_winners as $id => $team_ids) {
+        foreach ($problem_winners as $id => $team_ids) {
             $type = 'first-to-solve-' . $id;
             $result = [ 'id' => $type,
                 'citation' => 'First to solve problem ' . $id,
                 'team_ids' => $team_ids];
-            if ( $requestedType === $type ) {
+            if ($requestedType === $type) {
                 return $result;
             }
             $results[] = $result;
@@ -136,29 +136,29 @@ class AwardsController extends AbstractRestController
             }
         }
 
-        if ( count($overall_winners) > 0 ) {
+        if (count($overall_winners) > 0) {
             $type = 'winner';
             $result = ['id' => $type,
                 'citation' => 'Contest winner',
                 'team_ids' => $overall_winners ];
-            if ( $requestedType === $type ) {
+            if ($requestedType === $type) {
                 return $result;
             }
             $results[] = $result;
         }
-        foreach($medal_winners as $metal => $team_ids) {
+        foreach ($medal_winners as $metal => $team_ids) {
             $type = $metal . '-medal';
             $result = ['id' => $metal . '-medal',
                 'citation' => ucfirst($metal) . ' medal winner',
                 'team_ids' => $team_ids ];
-            if ( $requestedType === $type ) {
+            if ($requestedType === $type) {
                 return $result;
             }
             $results[] = $result;
         }
 
         // Specific type was requested, but not found above.
-        if ( !is_null($requestedType) ) {
+        if (!is_null($requestedType)) {
             return [];
         }
 

--- a/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
@@ -73,8 +73,8 @@ class AwardsController extends AbstractRestController
             throw new AccessDeniedHttpException();
         }
 
-        $probuseextid = !empty($this->eventLogService->externalIdFieldForEntity(Problem::class));
-        $teamuseextid = !empty($this->eventLogService->externalIdFieldForEntity(Team::class));
+        $probuseextid = !is_null($this->eventLogService->externalIdFieldForEntity(Problem::class));
+        $teamuseextid = !is_null($this->eventLogService->externalIdFieldForEntity(Team::class));
 
         $additionalBronzeMedals = $contest->getB() ?? 0;
 
@@ -82,12 +82,12 @@ class AwardsController extends AbstractRestController
 
         $group_winners = $problem_winners = [];
         foreach ($scoreboard->getTeams() as $team) {
-            $teamid = $teamuseextid ? $team->getExternalid() : $team->getTeamid();
+            $teamid = (string)($teamuseextid ? $team->getExternalid() : $team->getTeamid());
             if ( $scoreboard->isBestInCategory($team) ) {
                 $group_winners[$team->getCategoryId()][] = $teamid;
             }
             foreach($scoreboard->getProblems() as $problem) {
-                $probid = $probuseextid ? $problem->getExternalid() : $problem->getProbid();
+                $probid = (string)($probuseextid ? $problem->getExternalid() : $problem->getProbid());
                 if ($scoreboard->solvedFirst($team, $problem)) {
                     $problem_winners[$probid][] = $teamid;
                 }
@@ -98,7 +98,7 @@ class AwardsController extends AbstractRestController
         // can we assume this is ordered just walk the first 12+B entries?
         foreach ($scoreboard->getScores() as $teamScore) {
             $rank = $teamScore->getRank();
-            $teamid = $teamuseextid ? $teamScore->getTeam()->getExternalid() : $teamScore->getTeam()->getTeamid();
+            $teamid = (string)($teamuseextid ? $teamScore->getTeam()->getExternalid() : $teamScore->getTeam()->getTeamid());
 
             if ($rank === 1) {
                 $overall_winners[] = $teamid;

--- a/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+namespace DOMJudgeBundle\Controller\API;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use DOMJudgeBundle\Entity\Contest;
+use DOMJudgeBundle\Entity\Problem;
+use DOMJudgeBundle\Entity\Team;
+use DOMJudgeBundle\Service\DOMJudgeService;
+use DOMJudgeBundle\Service\EventLogService;
+use DOMJudgeBundle\Service\ScoreboardService;
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Swagger\Annotations as SWG;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @Rest\Route("/api/v4/contests/{cid}/awards", defaults={ "_format" = "json" })
+ * @Rest\Prefix("/api/contests/{cid}/awards")
+ * @Rest\NamePrefix("scoreboard_")
+ * @SWG\Tag(name="Scoreboard")
+ * @SWG\Parameter(ref="#/parameters/cid")
+ * @SWG\Response(response="404", ref="#/definitions/NotFound")
+ * @SWG\Response(response="401", ref="#/definitions/Unauthorized")
+ */
+class AwardsController extends AbstractRestController
+{
+    /**
+     * @var ScoreboardService
+     */
+    protected $scoreboardService;
+
+    /**
+     * ScoreboardController constructor.
+     * @param EntityManagerInterface $entityManager
+     * @param DOMJudgeService        $DOMJudgeService
+     * @param EventLogService        $eventLogService
+     * @param ScoreboardService      $scoreboardService
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DOMJudgeService $DOMJudgeService,
+        EventLogService $eventLogService,
+        ScoreboardService $scoreboardService
+    ) {
+        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        $this->scoreboardService = $scoreboardService;
+    }
+
+    /**
+     * Get the awards standings for this contest
+     * @param Request $request
+     * @return array
+     * @Rest\Get("")
+     * @SWG\Response(
+     *     response="200",
+     *     description="Returns the current teams qualifying for each award"
+     * )
+     * @throws \Exception
+     */
+    public function getAwardsAction(Request $request)
+    {
+        $public   = false;
+        if ($this->DOMJudgeService->checkrole('jury') && $request->query->has('public')) {
+            $public = $request->query->getBoolean('public');
+        }
+
+        $contest       = $this->entityManager->getRepository(Contest::class)->find($this->getContestId($request));
+        $isJury        = $this->isGranted('ROLE_JURY');
+        $accessAllowed = ($isJury && $contest->getEnabled()) || (!$isJury && $contest->isActive());
+        if (!$accessAllowed) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $b = $contest->getB() ?? 0;
+
+        $scoreboard = $this->scoreboardService->getScoreboard($contest, !$public, null, true);
+
+        $group_winners = $problem_winners = [];
+        foreach ($scoreboard->getTeams() as $team) {
+            if ( $scoreboard->isBestInCategory($team) ) {
+                $group_winners[$team->getCategoryId()][] = $team->getTeamid();
+            }
+            foreach($scoreboard->getProblems() as $problem) {
+                if ($scoreboard->solvedFirst($team, $problem)) {
+                    $problem_winners[$problem->getProbid()][] = $team->getTeamid();
+                }
+            }
+        }
+
+        $overall_winners = $medal_winners = [];
+        // can we assume this is ordered just walk the first 12+B entries?
+        foreach ($scoreboard->getScores() as $teamScore) {
+            $rank = $teamScore->getRank();
+            $teamid = $teamScore->getTeam()->getTeamid();
+
+            if ($rank === 1) {
+                $overall_winners[] = $teamid();
+            }
+            if ($rank <= 4 ) {
+                $medal_winners['gold'][] = $teamid;
+            } elseif ($rank <= 8 ) {
+                $medal_winners['silver'][] = $teamid;
+            } elseif ($rank <= 12 + $b ) {
+                $medal_winners['bronze'][] = $teamid;
+            }
+        }
+
+        $results = [];
+        foreach($group_winners as $id => $team_ids) {
+                $results[] = [ 'id' => 'group-winner-' . $id,
+                        'citation' => 'Winner(s) of group ' . $id,
+                        'team_ids' => $team_ids];
+        }
+        foreach($problem_winners as $id => $team_ids) {
+                $results[] = [ 'id' => 'first-to-solve-' . $id,
+                        'citation' => 'First to solve problem ' . $id,
+                        'team_ids' => $team_ids];
+        }
+        if ( count($overall_winners) > 0 ) {
+                $results[] = ['id' => 'winner',
+                        'citation' => 'Contest winner',
+                        'team_ids' => $overall_winners ];
+        }
+        foreach($medal_winners as $metal => $team_ids) {
+                $results[] = ['id' => $metal . '-medal',
+                        'citation' => ucfirst($metal) . ' medal winner',
+                        'team_ids' => $team_ids ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getQueryBuilder(Request $request): QueryBuilder
+    {
+        // Not used for awards endpoint
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getIdField(): string
+    {
+        // Not used for awaards endpoint
+        return '';
+    }
+}

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
@@ -489,7 +489,7 @@ class Scoreboard
      */
     public function solvedFirst(Team $team, ContestProblem $problem): bool
     {
-        if ( ! $this->matrix[$team->getTeamid()][$problem->getProbid()]->isCorrect() ) {
+        if (!$this->matrix[$team->getTeamid()][$problem->getProbid()]->isCorrect()) {
             return false;
         }
         $teamTime       = $this->matrix[$team->getTeamid()][$problem->getProbid()]->getTime();

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
@@ -482,13 +482,16 @@ class Scoreboard
     }
 
     /**
-     * Determine whether this team solved this problem first
+     * Determine whether this team was the first team to solve this problem
      * @param Team           $team
      * @param ContestProblem $problem
      * @return bool
      */
     public function solvedFirst(Team $team, ContestProblem $problem): bool
     {
+        if ( ! $this->matrix[$team->getTeamid()][$problem->getProbid()]->isCorrect() ) {
+            return false;
+        }
         $teamTime       = $this->matrix[$team->getTeamid()][$problem->getProbid()]->getTime();
         $sortOrder      = $team->getCategory()->getSortorder();
         $problemSummary = $this->summary->getProblem($problem->getProbid());


### PR DESCRIPTION
This is an attempt to implement the awards endpoint as requested in #300.

It currently only does the `/contests/<id>/awards` endpoint, not yet  `/contests/<id>/awards/<id>` but that is easy to add if the general approach is deemed OK.

The spec gives as an example the `organization-winner` award, since we do not have that concept in DOMjudge, and it's an example, I think it's fine not to output that.
