### PR TITLE
404 instead of 500 internal error for non-existing entities

### DIFF
--- a/webapp/src/DOMJudgeBundle/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/InternalErrorController.php
@@ -9,6 +9,7 @@ use DOMJudgeBundle\Entity\InternalError;
 use DOMJudgeBundle\Service\DOMJudgeService;
 use DOMJudgeBundle\Utils\Utils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -96,6 +97,9 @@ class InternalErrorController extends BaseController
     {
         /** @var InternalError $internalError */
         $internalError = $this->entityManager->getRepository(InternalError::class)->find($errorId);
+        if (!$internalError) {
+            throw new NotFoundHttpException(sprintf('Internal Error with ID %s not found', $errorId));
+        }
 
         $disabled     = $internalError->getDisabled();
         $affectedLink = $affectedText = null;

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostController.php
@@ -11,6 +11,7 @@ use DOMJudgeBundle\Service\DOMJudgeService;
 use DOMJudgeBundle\Utils\Utils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
@@ -207,6 +208,10 @@ class JudgehostController extends BaseController
             ->setParameter(':hostname', $hostname)
             ->getQuery()
             ->getOneOrNullResult();
+
+        if (!$judgehost) {
+            throw new NotFoundHttpException(sprintf('Judgehost with hostname %s not found', $hostname));
+        }
 
         $reltime = floor(Utils::difftime(Utils::now(), (float)$judgehost->getPolltime()));
         if ($reltime < $this->DOMJudgeService->dbconfig_get('judgehost_warning', 30)) {

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
@@ -12,6 +12,7 @@ use DOMJudgeBundle\Form\Type\JudgehostRestrictionType;
 use DOMJudgeBundle\Service\DOMJudgeService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -131,6 +132,9 @@ class JudgehostRestrictionController extends BaseController
             ->setParameter(':restrictionId', $restrictionId)
             ->getQuery()
             ->getOneOrNullResult();
+        if (!$judgehostRestriction) {
+            throw new NotFoundHttpException(sprintf('Judgehost restriction with ID %s not found', $restrictionId));
+        }
 
         /** @var Contest[] $contests */
         $contests = $this->entityManager->createQueryBuilder()

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Annotation\Route;
@@ -174,6 +175,9 @@ class RejudgingController extends Controller
             ->getQuery()
             ->getOneOrNullResult();
 
+        if (!$rejudging) {
+            throw new NotFoundHttpException(sprintf('Rejudging with ID %s not found', $rejudgingId));
+        }
         $todo = $this->entityManager->createQueryBuilder()
             ->from('DOMJudgeBundle:Submission', 's')
             ->select('COUNT(s)')


### PR DESCRIPTION
some pages give a 500 Internal error when using the viewAction with a non-existing ID. Those that missed a check are: judgehost, judgehost restriction, internal error.
Rejudging page shows a "canceld" rejudging which is not intuitive as well.