### PR TITLE
Consider earlier submitted but still pending commits in solvedFirst()

### DIFF
--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
@@ -291,7 +291,7 @@ class Scoreboard
                 $problemId = $contestProblem->getProbid();
                 // Provide default scores when nothing submitted for this team + problem yet
                 if (!isset($this->matrix[$teamId][$problemId])) {
-                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0);
+                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0, 0);
                 }
 
                 $problemMatrixItem = $this->matrix[$teamId][$problemId];

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -30,6 +30,11 @@ class ScoreboardMatrixItem
     protected $penaltyTime;
 
     /**
+     * @var int
+     */
+    protected $sortOrder;
+
+    /**
      * ScoreboardMatrixItem constructor.
      * @param bool $isCorrect
      * @param int $numberOfSubmissions
@@ -37,13 +42,14 @@ class ScoreboardMatrixItem
      * @param float|string $time
      * @param int $penaltyTime
      */
-    public function __construct(bool $isCorrect, int $numberOfSubmissions, int $numberOfPendingSubmissions, $time, int $penaltyTime)
+    public function __construct(bool $isCorrect, int $numberOfSubmissions, int $numberOfPendingSubmissions, $time, int $penaltyTime, int $sortOrder)
     {
         $this->isCorrect                  = $isCorrect;
         $this->numberOfSubmissions        = $numberOfSubmissions;
         $this->numberOfPendingSubmissions = $numberOfPendingSubmissions;
         $this->time                       = $time;
         $this->penaltyTime                = $penaltyTime;
+        $this->sortOrder                  = $sortOrder;
     }
 
     /**
@@ -84,5 +90,13 @@ class ScoreboardMatrixItem
     public function getPenaltyTime(): int
     {
         return $this->penaltyTime;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getSortOrder(): int
+    {
+        return $this->sortOrder;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -103,7 +103,8 @@ class SingleTeamScoreboard extends Scoreboard
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
-                $penalty
+                $penalty,
+                $scoreRow->getTeam()->getCategory()->getSortOrder()
             );
         }
 
@@ -113,7 +114,7 @@ class SingleTeamScoreboard extends Scoreboard
             $teamId    = $this->team->getTeamid();
             $problemId = $contestProblem->getProbid();
             if (!isset($this->matrix[$teamId][$problemId])) {
-                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0);
+                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0, 0);
             }
         }
     }


### PR DESCRIPTION
It has been noted that it would be nice if we only marked something as 'first to solve' (darkgreen color in scoreboard and in the awards api) if there are no earlier submitted but still pending submissions for this problem.

This is one (first) attempt at solving that. It has an additonal cost of keeping the sortorder in the score matrix and looping over the matrix rows so we can check for each other team whether they indeed have earlier pending submissions. This in contrast to the earlier solution that used the scoreboard summary to determine whether this team was the one submitting the fast solution.

Other solutions may be possible. This PR is to see what we think of this, the added cost and whether that's worth it, or that there are better solutions to the problem.