### PR TITLE
Only show problem as First To Solve if there are no earlier pending submissions

### DIFF
--- a/lib/www/scoreboard.php
+++ b/lib/www/scoreboard.php
@@ -258,6 +258,7 @@ function renderScoreBoardTable(
     $prevsortorder = -1;
     $usedCategories = array();
     $bestInCat = array();
+    $firsttosolveknown = [];
     foreach ($scores as $team => $totals) {
         // skip if we have limitteams and the team is not listed
         if (!empty($limitteams) && !in_array($team, $limitteams)) {
@@ -405,6 +406,7 @@ function renderScoreBoardTable(
                         @$summary['problems'][$prob]['best_time_sort'][$totals['sortorder']]
                     )) {
                         $score_css_class .= ' score_first';
+                        $firsttosolveknown[] = $prob;
                     }
                 } elseif ($matrix[$team][$prob]['num_pending'] > 0 && $SHOW_PENDING) {
                     $score_css_class = 'score_pending';
@@ -490,7 +492,7 @@ function renderScoreBoardTable(
                     $summary['problems'][$prob]['num_pending'] .
                     '</span>';
                 $best = @$summary['problems'][$prob]['best_time_sort'][0];
-                $best = empty($best) ? 'n/a' : ((int)($best/60)) . 'min';
+                $best = !in_array($prob, $firsttosolveknown) ? 'n/a' : ((int)($best/60)) . 'min';
                 $best = '<i class="fas fa-clock fa-fw"> </i>' .
                     '<span style="font-size:90%;" title="first solved"> ' . $best . '</span>';
 

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -86,6 +86,7 @@
     <tbody>
     {% set previousSortOrder = -1 %}
     {% set previousTeam = null %}
+    {% set firsttosolveknown = [] %}
     {% for score in scoreboard.scores if (limitToTeams is null or score.team.teamid in limitToTeamIds) %}
         {% set classes = [] %}
         {% if score.team.category.sortorder != previousSortOrder %}
@@ -201,6 +202,7 @@
                         {% set scoreCssClass = 'score_correct' %}
                         {% if scoreboard.solvedFirst(score.team, problem) %}
                             {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
+                            {% set firsttosolveknown = firsttosolveknown|merge([problem.probid]) %}
                         {% endif %}
                     {% elseif showPending and scoreboard.matrix[score.team.teamid][problem.probid].numberOfPendingSubmissions > 0 %}
                         {% set scoreCssClass = 'score_pending' %}
@@ -302,7 +304,7 @@
 
                             <i class="fas fa-clock fa-fw"></i>
                             <span style="font-size:90%;" title="first solved">
-                                {% if scoreboard.summary.problem(problem.probid).bestTimeInMinutes(0) is not null %}
+                                {% if problem.probid in firsttosolveknown %}
                                     {{ scoreboard.summary.problem(problem.probid).bestTimeInMinutes(0) }}min
                                 {% else %}
                                     n/a

--- a/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
+++ b/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
@@ -323,6 +323,10 @@ class ScoreboardService
         $correctJury     = false;
         $correctPubl     = false;
 
+        // Loop over the submissions to find whether it is correct
+        // and update the times/scores. We stop the loop at the
+        // first correct solution, as we don't want to count any
+        // submissions after that.
         foreach ($submissions as $submission) {
             /** @var Judging|null $judging */
             $judging    = $submission->getJudgings()->first() ?: null;

--- a/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
+++ b/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
@@ -328,6 +328,10 @@ class ScoreboardService
             $judging    = $submission->getJudgings()->first() ?: null;
             $submitTime = $contest->getContestTime((float)$submission->getSubmittime());
 
+            $timeJury    = $submitTime;
+            if (!$submission->isAfterFreeze()) {
+                $timePubl    = $submitTime;
+            }
             // Check if this submission has a publicly visible judging result:
             if ($judging === null || ($verificationRequired && !$judging->getVerified()) || empty($judging->getResult())) {
                 $pendingJury++;
@@ -347,10 +351,8 @@ class ScoreboardService
             // if correct, don't look at any more submissions after this one
             if ($judging->getResult() == Judging::RESULT_CORRECT) {
                 $correctJury = true;
-                $timeJury    = $submitTime;
                 if (!$submission->isAfterFreeze()) {
                     $correctPubl = true;
-                    $timePubl    = $submitTime;
                 }
                 // stop counting after a first correct submission
                 break;

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
@@ -213,7 +213,7 @@ class Scoreboard
     }
 
     /**
-     * Calculate the scoreboard data, filling the summary, matrix and scores properteis
+     * Calculate the scoreboard data, filling the summary, matrix and scores properties
      */
     protected function calculateScoreboard()
     {
@@ -298,7 +298,7 @@ class Scoreboard
                 $problemSummary->addNumberOfSubmissions($problemMatrixItem->getNumberOfSubmissions());
                 $problemSummary->addNumberOfPendingSubmissions($problemMatrixItem->getNumberOfPendingSubmissions());
                 $problemSummary->addNumberOfCorrectSubmissions($problemMatrixItem->isCorrect() ? 1 : 0);
-                if ($problemMatrixItem->isCorrect()) {
+                if ($problemMatrixItem->isCorrect() || $problemMatrixItem->getNumberOfPendingSubmissions()) {
                     $problemSummary->updateBestTime($teamScore->getTeam()->getCategory()->getSortorder(),
                                                     $problemMatrixItem->getTime());
                 }


### PR DESCRIPTION
The time in scorecache is now set to the time of the earliest pending
or correct submission, while before it was only set for the earliest.

We can use this to determine if we are ready to award the first-to-solve
prize yet. We update the summary of the minimum time for any cell which
has a correct or pending submission. We only show that summary line
when a dark green cell has actually been awarded.