### PR TITLE
WIP - Pump pipes validator

### DIFF
--- a/judge/runpipe.c
+++ b/judge/runpipe.c
@@ -27,6 +27,7 @@
 #endif
 
 #include <sys/select.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
@@ -106,7 +107,7 @@ void verb(const char *format, ...)
 	va_list ap;
 	va_start(ap,format);
 
-	if ( be_verbose ) {
+	if ( be_verbose || 1 == 1 ) {
 		fprintf(stderr,"%s: verbose: ",progname);
 		vfprintf(stderr,format,ap);
 		fprintf(stderr,"\n");
@@ -162,6 +163,7 @@ void set_fd_close_exec(int fd, int value)
 
 	fdflags = fcntl(fd, F_GETFD);
 	if ( fdflags==-1 ) error(errno,"reading filedescriptor flags");
+	verb("fd=%d: fdflags: %lo\n", fd, fdflags);
 	if ( value ) {
 		fdflags = fdflags | FD_CLOEXEC;
 	} else {
@@ -211,28 +213,38 @@ void resize_pipe(int fd)
 }
 #endif
 
-void pump_pipes(int *fd_out, int *fd_in)
+void pump_pipes(int *fd_out, int *fd_in, int from_val)
 {
 	ssize_t nread, to_write, nwritten;
 	fd_set readfds;
 	char buf[BUF_SIZE+1];
 	int r;
+	struct timeval tv;
+	warning(0, "pump from %d to %d", *fd_out, *fd_in);
 
 	if ( *fd_out<0 ) return;
 
 	FD_ZERO(&readfds);
 	FD_SET(*fd_out, &readfds);
 
-	r = select(*fd_out+1, &readfds, NULL, NULL, NULL);
+	tv.tv_sec = 0;
+	tv.tv_usec = 1000; /* FIXME: this is just in order to not block */
+	r = select(*fd_out+1, &readfds, NULL, NULL, &tv);
 	if ( r==-1 && errno!=EINTR ) error(errno,"waiting for child data");
 
 	if ( FD_ISSET(*fd_out, &readfds) ) {
+		warning(0, "there should be data here on %d", *fd_out);
 		nread = read(*fd_out, buf, BUF_SIZE);
 		verb("read %d bytes from program #2, fd %d", (int)nread, *fd_out);
 		if ( nread>0 ) {
 			buf[nread] = 0;
 			/* First write to file. */
 			errno = 0;
+			if (from_val) {
+				fwrite("> ", 1, 2, progoutfile);
+			} else {
+				fwrite("< ", 1, 2, progoutfile);
+			}
 			nwritten = fwrite(buf, 1, nread, progoutfile);
 			if ( nwritten<nread ) {
 				error(errno,"writing to `%s'", progoutfilename);
@@ -275,6 +287,8 @@ void pump_pipes(int *fd_out, int *fd_in)
 			*fd_out = -1;
 			*fd_in  = -1;
 		}
+	} else {
+		warning(0, "no data here on %d", *fd_out);
 	}
 }
 
@@ -289,7 +303,7 @@ int main(int argc, char **argv)
 	char *arg;
 	int   i, r, fd_out, newcmd, argsize = 0;
 	int   pipe_fd[MAX_CMDS][2];
-	int   progout_pipe_fd[2];
+	int   progout_pipe_fd[MAX_CMDS][2];
 
 	progname = argv[0];
 
@@ -388,6 +402,7 @@ int main(int argc, char **argv)
 	   executing a forked subcommand, required ones are reset below. */
 	for(i=0; i<ncmds; i++) {
 		if ( pipe(pipe_fd[i])!=0 ) error(errno,"creating pipes");
+		verb("command #%d: read fd=%d, write fd=%d", i, pipe_fd[i][0], pipe_fd[i][1]);
 		set_fd_close_exec(pipe_fd[i][0], 1);
 		set_fd_close_exec(pipe_fd[i][1], 1);
 #ifdef PROC_MAX_PIPE_SIZE
@@ -400,22 +415,25 @@ int main(int argc, char **argv)
 		if ( (progoutfile = fopen(progoutfilename,"w"))==NULL ) {
 			error(errno,"cannot open `%s'",progoutfilename);
 		}
-		if ( pipe(progout_pipe_fd)!=0 ) error(errno,"creating pipes");
-		set_fd_close_exec(progout_pipe_fd[0], 1);
-		set_fd_close_exec(progout_pipe_fd[1], 1);
+		for(i=0; i<ncmds; i++) {
+			if ( pipe(progout_pipe_fd[i])!=0 ) error(errno,"creating pipes");
+			set_fd_close_exec(progout_pipe_fd[i][0], 1);
+			set_fd_close_exec(progout_pipe_fd[i][1], 1);
 #ifdef PROC_MAX_PIPE_SIZE
-		resize_pipe(progout_pipe_fd[1]);
+			resize_pipe(progout_pipe_fd[i][1]);
 #endif
-		verb("writing program #2 output via pipe %d -> %d",
-		     progout_pipe_fd[1], progout_pipe_fd[0]);
+			verb("writing program #%d output via pipe %d -> %d",
+			     i, progout_pipe_fd[i][1], progout_pipe_fd[i][0]);
+		}
 	}
 
 	/* Execute commands as subprocesses and connect pipes as required. */
 	for(i=0; i<ncmds; i++) {
-		fd_out = ( i==1 && write_progout ? progout_pipe_fd[1] : pipe_fd[1-i][1] );
+		fd_out = write_progout ? progout_pipe_fd[i][1] : pipe_fd[1-i][1];
 		cmd_fds[i][0] = pipe_fd[i][0];
 		cmd_fds[i][1] = fd_out;
 		cmd_fds[i][2] = FDREDIR_NONE;
+		verb("pipes for command #%d are %d and %d", i, cmd_fds[i][0], cmd_fds[i][1]);
 
 		set_fd_close_exec(pipe_fd[i][0], 0);
 		set_fd_close_exec(fd_out, 0);
@@ -432,9 +450,9 @@ int main(int argc, char **argv)
 
 	if ( write_progout ) {
 		if ( close(pipe_fd[1][0])!=0 ) error(errno,"closing pipe read end");
-		if ( close(pipe_fd[1][1])!=0 ) error(errno,"closing pipe write end");
 		if ( close(pipe_fd[0][0])!=0 ) error(errno,"closing pipe read end");
-		if ( close(progout_pipe_fd[1])!=0 ) error(errno,"closing pipe write end");
+		if ( close(progout_pipe_fd[0][1])!=0 ) error(errno,"closing pipe write end");
+		if ( close(progout_pipe_fd[1][1])!=0 ) error(errno,"closing pipe write end");
 	} else {
 		for(i=0; i<ncmds; i++) {
 			if ( close(pipe_fd[i][0])!=0 ) error(errno,"closing pipe read end");
@@ -446,7 +464,11 @@ int main(int argc, char **argv)
 	while ( 1 ) {
 
 		if ( write_progout ) {
-			pump_pipes(&progout_pipe_fd[0], &pipe_fd[0][1]);
+			for(i=0; i<ncmds; i++) {
+				if ( cmd_exit[i]==-1 ) {
+					pump_pipes(&progout_pipe_fd[i][0], &pipe_fd[i][1], 1-i);
+				}
+			}
 
 			pid = 0;
 			for(i=0; i<ncmds; i++) {
@@ -495,16 +517,18 @@ int main(int argc, char **argv)
 	};
 
 	/* Reset pipe filedescriptors to use blocking I/O. */
-	if ( write_progout && progout_pipe_fd[0]>=0 ) {
-		r = fcntl(progout_pipe_fd[0], F_GETFL);
-		if (r == -1) error(errno, "fcntl, getting flags");
+	for(i=0; i<ncmds; i++) {
+		if ( write_progout && progout_pipe_fd[i][0]>=0 ) {
+			r = fcntl(progout_pipe_fd[i][0], F_GETFL);
+			if (r == -1) error(errno, "fcntl, getting flags");
 
-		r = fcntl(progout_pipe_fd[0], F_SETFL, r ^ O_NONBLOCK);
-		if (r == -1) error(errno, "fcntl, setting flags");
+			r = fcntl(progout_pipe_fd[i][0], F_SETFL, r ^ O_NONBLOCK);
+			if (r == -1) error(errno, "fcntl, setting flags");
 
-		do {
-			pump_pipes(&progout_pipe_fd[0], &pipe_fd[0][1]);
-		} while ( progout_pipe_fd[0]>=0 );
+			do {
+				pump_pipes(&progout_pipe_fd[i][0], &pipe_fd[1-i][1], 1-i);
+			} while ( progout_pipe_fd[i][0]>=0 );
+		}
 	}
 
 	/* Check exit status of commands and report back the exit code of the first. */

--- a/judge/runpipe.c
+++ b/judge/runpipe.c
@@ -228,7 +228,7 @@ void pump_pipes(int *fd_out, int *fd_in, int from_val)
 	FD_SET(*fd_out, &readfds);
 
 	tv.tv_sec = 0;
-	tv.tv_usec = 1000; /* FIXME: this is just in order to not block */
+	tv.tv_usec = 10000; /* FIXME: this is just in order to not block */
 	r = select(*fd_out+1, &readfds, NULL, NULL, &tv);
 	if ( r==-1 && errno!=EINTR ) error(errno,"waiting for child data");
 
@@ -465,9 +465,7 @@ int main(int argc, char **argv)
 
 		if ( write_progout ) {
 			for(i=0; i<ncmds; i++) {
-				if ( cmd_exit[i]==-1 ) {
-					pump_pipes(&progout_pipe_fd[i][0], &pipe_fd[i][1], 1-i);
-				}
+				pump_pipes(&progout_pipe_fd[i][0], &pipe_fd[1-i][1], 1-i);
 			}
 
 			pid = 0;


### PR DESCRIPTION
    Also write validator output to the same file (with different prefixes)
    and generalize pipe setup for that.
    
    This step is not only useful for debugging but it will allow us to
    detect whether the validator exited first before the submission crashes
    (as a result of the validator exiting).