### PR TITLE
Clean up judgements API.

### DIFF
--- a/webapp/src/DOMJudgeBundle/Entity/Judging.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Judging.php
@@ -89,7 +89,6 @@ class Judging implements ExternalRelationshipEntityInterface
     /**
      * @var boolean
      * @ORM\Column(type="boolean", name="valid", options={"comment"="Old judging is marked as invalid when rejudging"}, nullable=false)
-     * @Serializer\Exclude()
      */
     private $valid = true;
 


### PR DESCRIPTION
In particular follow the intention of
e909f3e92629e8f17bb6abf2c9c05e7ed8f849ea.

- Only show valid judgings to teams. Note that in progress judgings are
  always valid, so no need to filter for rejudgingid=NULL
- Clean up restrictions to make them easier to understand.
- Add valid attribute to judgings to easier understand which judging for
  a submission counts. In long term, we should probably standardize
  this. Note that we expose valid=true for all judgements in the API.
  Other judgements are not visible anyway. Since this is an additional
  attribute, it doesn't hurt but we might want to either filter out it
  in the future or update it to false for the previously valid
  judgement.