### PR TITLE
Consider earlier pendings in first to solve

### DIFF
--- a/doc/admin/admin-manual.sgml
+++ b/doc/admin/admin-manual.sgml
@@ -1269,6 +1269,9 @@ conservative in adding and upgrading SQL data, so check that e.g. new
 compile scripts are present or add them manually, and check the
 upgrade scripts manually for any other data upgraded.
 
+If you have any active contests, it may be advisable to run
+"Refresh scoreboard cache" from the DOMjudge web interface after
+the upgrade.
 
 <chapt>Setting up a contest <label id="contestsetup">
 <p>

--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -399,6 +399,7 @@ CREATE TABLE `scorecache` (
   `pending_public` int(4) unsigned NOT NULL DEFAULT '0' COMMENT 'Number of submissions pending judgement (public)',
   `solvetime_public` decimal(32,9) NOT NULL DEFAULT '0.000000000' COMMENT 'Seconds into contest when problem solved (public)',
   `is_correct_public` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Has there been a correct submission? (public)',
+  `is_first_to_solve` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Is this the first solution to this problem?',
   PRIMARY KEY (`cid`,`teamid`,`probid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Scoreboard cache';
 

--- a/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
+++ b/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
@@ -20,6 +20,8 @@ ALTER TABLE `configuration`
 ALTER TABLE `problem`
   ADD COLUMN `combined_run_compare` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Use the exit code of the run script to compute the verdict' AFTER `special_compare_args`;
 
+ALTER TABLE `scorecache`
+  ADD COLUMN `is_first_to_solve` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Is this the first solution to this problem?';
 
 --
 -- Transfer data from old to new structure

--- a/webapp/src/DOMJudgeBundle/Entity/ScoreCache.php
+++ b/webapp/src/DOMJudgeBundle/Entity/ScoreCache.php
@@ -65,7 +65,12 @@ class ScoreCache
      */
     private $solvetime_public;
 
-
+    /**
+     * @var boolean
+     *
+     * @ORM\Column(type="boolean", name="is_first_to_solve", options={"comment"="Is this team the first to solve for this problem,sortorder?"}, nullable=false)
+     */
+    private $is_first_to_solve = false;
 
     /**
      * @ORM\Id
@@ -278,6 +283,30 @@ class ScoreCache
     public function getSolvetimePublic()
     {
         return $this->solvetime_public;
+    }
+
+    /**
+     * Set isFirstToSolve
+     *
+     * @param boolean $isFirstToSolve
+     *
+     * @return ScoreCache
+     */
+    public function setIsFirstToSolve(bool $isFirstToSolve)
+    {
+        $this->is_first_to_solve = $isFirstToSolve;
+
+        return $this;
+    }
+
+    /**
+     * Get isFirstToSolve
+     *
+     * @return boolean
+     */
+    public function getIsFirstToSolve() : bool
+    {
+        return $this->is_first_to_solve;
     }
 
     /**

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ProblemSummary.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ProblemSummary.php
@@ -114,8 +114,6 @@ class ProblemSummary
      */
     public function updateBestTime(int $sortorder, $bestTime)
     {
-        if (!isset($this->bestTimes[$sortorder]) || $bestTime < $this->bestTimes[$sortorder]) {
-            $this->bestTimes[$sortorder] = $bestTime;
-        }
+        $this->bestTimes[$sortorder] = $bestTime;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/Scoreboard.php
@@ -234,6 +234,7 @@ class Scoreboard
 
             $this->matrix[$scoreRow->getTeam()->getTeamid()][$scoreRow->getProblem()->getProbid()] = new ScoreboardMatrixItem(
                 $scoreRow->getIsCorrect($this->restricted),
+                $scoreRow->getIsFirstToSolve(),
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
@@ -291,7 +292,7 @@ class Scoreboard
                 $problemId = $contestProblem->getProbid();
                 // Provide default scores when nothing submitted for this team + problem yet
                 if (!isset($this->matrix[$teamId][$problemId])) {
-                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0);
+                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0);
                 }
 
                 $problemMatrixItem = $this->matrix[$teamId][$problemId];
@@ -300,7 +301,7 @@ class Scoreboard
                 $problemSummary->addNumberOfPendingSubmissions($sortOrder,
                                                                $problemMatrixItem->getNumberOfPendingSubmissions());
                 $problemSummary->addNumberOfCorrectSubmissions($sortOrder, $problemMatrixItem->isCorrect() ? 1 : 0);
-                if ($problemMatrixItem->isCorrect()) {
+                if ($problemMatrixItem->isFirst()) {
                     $problemSummary->updateBestTime($sortOrder, $problemMatrixItem->getTime());
                 }
             }
@@ -490,20 +491,6 @@ class Scoreboard
      */
     public function solvedFirst(Team $team, ContestProblem $problem): bool
     {
-        if (!$this->matrix[$team->getTeamid()][$problem->getProbid()]->isCorrect()) {
-            return false;
-        }
-        $teamTime       = $this->matrix[$team->getTeamid()][$problem->getProbid()]->getTime();
-        $sortOrder      = $team->getCategory()->getSortorder();
-        $problemSummary = $this->summary->getProblem($problem->getProbid());
-        if ($problemSummary === null) {
-            return false;
-        }
-        $problemTimes = $this->summary->getProblem($problem->getProbid())->getBestTimes();
-        if (!isset($problemTimes[$sortOrder])) {
-            return false;
-        }
-        $eps = 0.0000001;
-        return $teamTime - $eps <= $problemTimes[$sortOrder];
+        return $this->matrix[$team->getTeamid()][$problem->getProbid()]->isFirst();
     }
 }

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -10,6 +10,11 @@ class ScoreboardMatrixItem
     protected $isCorrect;
 
     /**
+     * @var bool
+     */
+    protected $isFirst;
+
+    /**
      * @var int
      */
     protected $numberOfSubmissions;
@@ -32,14 +37,16 @@ class ScoreboardMatrixItem
     /**
      * ScoreboardMatrixItem constructor.
      * @param bool $isCorrect
+     * @param bool $isFirst
      * @param int $numberOfSubmissions
      * @param int $numberOfPendingSubmissions
      * @param float|string $time
      * @param int $penaltyTime
      */
-    public function __construct(bool $isCorrect, int $numberOfSubmissions, int $numberOfPendingSubmissions, $time, int $penaltyTime)
+    public function __construct(bool $isCorrect, bool $isFirst, int $numberOfSubmissions, int $numberOfPendingSubmissions, $time, int $penaltyTime)
     {
         $this->isCorrect                  = $isCorrect;
+        $this->isFirst                    = $isFirst;
         $this->numberOfSubmissions        = $numberOfSubmissions;
         $this->numberOfPendingSubmissions = $numberOfPendingSubmissions;
         $this->time                       = $time;
@@ -52,6 +59,14 @@ class ScoreboardMatrixItem
     public function isCorrect(): bool
     {
         return $this->isCorrect;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFirst(): bool
+    {
+        return $this->isFirst;
     }
 
     /**

--- a/webapp/src/DOMJudgeBundle/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/DOMJudgeBundle/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -100,6 +100,7 @@ class SingleTeamScoreboard extends Scoreboard
 
             $this->matrix[$scoreRow->getTeam()->getTeamid()][$scoreRow->getProblem()->getProbid()] = new ScoreboardMatrixItem(
                 $scoreRow->getIsCorrect($this->restricted),
+                $scoreRow->getIsFirstToSolve(),
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
@@ -113,7 +114,7 @@ class SingleTeamScoreboard extends Scoreboard
             $teamId    = $this->team->getTeamid();
             $problemId = $contestProblem->getProbid();
             if (!isset($this->matrix[$teamId][$problemId])) {
-                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, 0, 0, 0, 0);
+                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0);
             }
         }
     }


### PR DESCRIPTION
This is a new approach, because the previous PR had become quite stale given all the source changes in between, and I opted to solve it in yet another way now.

This moves all logic to determine what constitutes a first to solve to one place, calculation of the score row. When refreshing a row, and the judgement is correct, determine whether there are any earlier
submissions for this contest, problem, sort order that are either correct or still pending. If this is the case, this submission is not (yet) the first to solve.

Advantage is that this extra complexity and time is spent in updating the cache. Every _display_ of the scoreboard or team row is now even simpler than before so remains fast. Drawback is that a change of
sortorder information now also requires recalculating of the cache. It should likely be in the release notes that after upgrading you need to recalculate the scores.