### PR TITLE
Implement IP authentication autologin

### DIFF
--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -58,7 +58,8 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('openid_provider', '"https://accounts.google.com"', 'string', '1', 'Misc', 'OpenID Provider URL'),
 ('openid_clientid', '""', 'string', '0','Misc', 'OpenID Connect client id'),
 ('openid_clientsecret', '""', 'string', '0', 'Misc', 'OpenID Connect client secret'),
-('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external');
+('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
+('ip_autologin', '0', 'bool', '0', 'Misc', 'IP authentication still requires a button to be pressed, enable this option to skip this step');
 
 
 --

--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -59,7 +59,7 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('openid_clientid', '""', 'string', '0','Misc', 'OpenID Connect client id'),
 ('openid_clientsecret', '""', 'string', '0', 'Misc', 'OpenID Connect client secret'),
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
-('ip_autologin', '0', 'bool', '0', 'Misc', 'IP authentication still requires a button to be pressed, enable this option to skip this step');
+('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.');
 
 
 --

--- a/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
+++ b/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
@@ -61,7 +61,8 @@ UPDATE `configuration` SET `category` = 'Misc' WHERE `name` IN (
 
 INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `description`) VALUES
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
-('update_judging_seconds', '0', 'int', '0', 'Judging', 'Post updates to a judging every X seconds. Set to 0 to update after each judging_run.');
+('update_judging_seconds', '0', 'int', '0', 'Judging', 'Post updates to a judging every X seconds. Set to 0 to update after each judging_run.'),
+('ip_autologin', '0', 'bool', '0', 'Misc', 'IP authentication still requires a button to be pressed, enable this option to skip this step');
 
 UPDATE `configuration` SET `name` = 'registration_category_name',
   `value` = IF(`value` = '0', '""', '"Self-Registered"'),

--- a/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
+++ b/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
@@ -62,7 +62,7 @@ UPDATE `configuration` SET `category` = 'Misc' WHERE `name` IN (
 INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `description`) VALUES
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
 ('update_judging_seconds', '0', 'int', '0', 'Judging', 'Post updates to a judging every X seconds. Set to 0 to update after each judging_run.'),
-('ip_autologin', '0', 'bool', '0', 'Misc', 'IP authentication still requires a button to be pressed, enable this option to skip this step');
+('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.');
 
 UPDATE `configuration` SET `name` = 'registration_category_name',
   `value` = IF(`value` = '0', '""', '"Self-Registered"'),

--- a/webapp/src/DOMJudgeBundle/Controller/SecurityController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/SecurityController.php
@@ -35,12 +35,13 @@ class SecurityController extends Controller
         if ($this->container->hasParameter('domjudge.authmethods')) {
             $authmethods = $this->container->getParameter('domjudge.authmethods');
         }
+
         if (in_array('ipaddress', $authmethods)) {
             $allowIPAuth = true;
         }
 
-        $clientIP = $this->DOMJudgeService->getClientIp();
-        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        $ipAutologin = $this->DOMJudgeService->dbconfig_get('ip_autologin', false);
+        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY') && !$ipAutologin) {
             return $this->redirect($this->generateUrl('root'));
         }
 
@@ -54,6 +55,7 @@ class SecurityController extends Controller
 
         $em = $this->getDoctrine()->getManager();
 
+        $clientIP = $this->DOMJudgeService->getClientIp();
         $auth_ipaddress_users = [];
         if ($allowIPAuth) {
             $auth_ipaddress_users = $em->getRepository('DOMJudgeBundle:User')->findBy(['ipAddress' => $clientIP]);


### PR DESCRIPTION
In the old implementation, when IP authentication was enabled, you still needed to click a button to actually log in. This commit makes a configuration option available `ip_autologin` (default off) which immediately logs in the user.

Furthermore, after login; you can now visit `/login` to log in with a different user.