### PR TITLE
Shortened `DOMJudgeService` and `EntityManager`

### DIFF
--- a/webapp/src/DOMJudgeBundle/Controller/API/AbstractRestController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AbstractRestController.php
@@ -29,7 +29,7 @@ abstract class AbstractRestController extends FOSRestController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -39,12 +39,12 @@ abstract class AbstractRestController extends FOSRestController
     /**
      * AbstractRestController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService $DOMJudgeService
+     * @param DOMJudgeService $dj
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService, EventLogService $eventLogService)
+    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj, EventLogService $eventLogService)
     {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -129,7 +129,7 @@ abstract class AbstractRestController extends FOSRestController
         $view = $this->view($data);
 
         // Set the DOMjudge service on the context, so we can use it for permissions
-        $view->getContext()->setAttribute('domjudge_service', $this->DOMJudgeService);
+        $view->getContext()->setAttribute('domjudge_service', $this->dj);
 
         $groups = ['Default'];
         if (!$request->query->has('strict')) {
@@ -162,11 +162,11 @@ abstract class AbstractRestController extends FOSRestController
             ->orderBy('c.activatetime');
 
         // Filter on contests this user has access to
-        if (!$this->DOMJudgeService->checkrole('api_reader') && !$this->DOMJudgeService->checkrole('judgehost')) {
-            if ($this->DOMJudgeService->checkrole('team') && $this->DOMJudgeService->getUser()->getTeamid()) {
+        if (!$this->dj->checkrole('api_reader') && !$this->dj->checkrole('judgehost')) {
+            if ($this->dj->checkrole('team') && $this->dj->getUser()->getTeamid()) {
                 $qb->leftJoin('c.teams', 'ct')
                     ->andWhere('ct.teamid = :teamid OR c.public = 1')
-                    ->setParameter(':teamid', $this->DOMJudgeService->getUser()->getTeamid());
+                    ->setParameter(':teamid', $this->dj->getUser()->getTeamid());
             } else {
                 $qb->andWhere('c.public = 1');
             }

--- a/webapp/src/DOMJudgeBundle/Controller/API/AbstractRestController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AbstractRestController.php
@@ -24,7 +24,7 @@ abstract class AbstractRestController extends FOSRestController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -43,7 +43,7 @@ abstract class AbstractRestController extends FOSRestController
      */
     public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj, EventLogService $eventLogService)
     {
-        $this->entityManager   = $entityManager;
+        $this->em   = $entityManager;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -57,7 +57,7 @@ abstract class AbstractRestController extends FOSRestController
     protected function performListAction(Request $request)
     {
         // Make sure we clear the entity manager class, for when this method is called multiple times by internal requests
-        $this->entityManager->clear();
+        $this->em->clear();
         $queryBuilder = $this->getQueryBuilder($request);
 
         if ($request->query->has('ids')) {
@@ -98,7 +98,7 @@ abstract class AbstractRestController extends FOSRestController
     protected function performSingleAction(Request $request, string $id)
     {
         // Make sure we clear the entity manager class, for when this method is called multiple times by internal requests
-        $this->entityManager->clear();
+        $this->em->clear();
         $queryBuilder = $this->getQueryBuilder($request)
             ->andWhere(sprintf('%s = :id', $this->getIdField()))
             ->setParameter(':id', $id);
@@ -147,7 +147,7 @@ abstract class AbstractRestController extends FOSRestController
     protected function getContestQueryBuilder(): QueryBuilder
     {
         $now = Utils::now();
-        $qb  = $this->entityManager->createQueryBuilder();
+        $qb  = $this->em->createQueryBuilder();
         $qb
             ->from('DOMJudgeBundle:Contest', 'c')
             ->select('c')

--- a/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
@@ -104,7 +104,7 @@ class AwardsController extends AbstractRestController
     protected function getAwardsData(Request $request, string $requestedType = null)
     {
         $public   = false;
-        if ($this->DOMJudgeService->checkrole('jury') && $request->query->has('public')) {
+        if ($this->dj->checkrole('jury') && $request->query->has('public')) {
             $public = $request->query->getBoolean('public');
         }
         /** @var Contest $contest */

--- a/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/AwardsController.php
@@ -108,7 +108,7 @@ class AwardsController extends AbstractRestController
             $public = $request->query->getBoolean('public');
         }
         /** @var Contest $contest */
-        $contest       = $this->entityManager->getRepository(Contest::class)->find($this->getContestId($request));
+        $contest       = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
         $isJury        = $this->isGranted('ROLE_JURY');
         $accessAllowed = ($isJury && $contest->getEnabled()) || (!$isJury && $contest->isActive());
         if (!$accessAllowed) {
@@ -118,12 +118,12 @@ class AwardsController extends AbstractRestController
         $scoreboard = $this->scoreboardService->getScoreboard($contest, !$public, null, true);
         $group_winners = $problem_winners = [];
         foreach ($scoreboard->getTeams() as $team) {
-            $teamid = (string)$team->getApiId($this->eventLogService, $this->entityManager);
+            $teamid = (string)$team->getApiId($this->eventLogService, $this->em);
             if ($scoreboard->isBestInCategory($team)) {
                 $group_winners[$team->getCategoryId()][] = $teamid;
             }
             foreach($scoreboard->getProblems() as $problem) {
-                $probid = (string)$problem->getApiId($this->eventLogService, $this->entityManager);
+                $probid = (string)$problem->getApiId($this->eventLogService, $this->em);
                 if ($scoreboard->solvedFirst($team, $problem)) {
                     $problem_winners[$probid][] = $teamid;
                 }
@@ -154,7 +154,7 @@ class AwardsController extends AbstractRestController
         // can we assume this is ordered just walk the first 12+B entries?
         foreach ($scoreboard->getScores() as $teamScore) {
             $rank = $teamScore->getRank();
-            $teamid = (string)$teamScore->getTeam()->getApiId($this->eventLogService, $this->entityManager);
+            $teamid = (string)$teamScore->getTeam()->getApiId($this->eventLogService, $this->em);
             if ($rank === 1) {
                 $overall_winners[] = $teamid;
             }

--- a/webapp/src/DOMJudgeBundle/Controller/API/ClarificationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ClarificationController.php
@@ -71,7 +71,7 @@ class ClarificationController extends AbstractRestController
      */
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Clarification', 'clar')
             ->join('clar.contest', 'c')
             ->leftJoin('clar.in_reply_to', 'reply')

--- a/webapp/src/DOMJudgeBundle/Controller/API/ContestController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ContestController.php
@@ -174,7 +174,7 @@ class ContestController extends AbstractRestController
     public function getContestYamlAction(Request $request, string $id)
     {
         $contest      = $this->getContestWithId($request, $id);
-        $penalty_time = $this->DOMJudgeService->dbconfig_get('penalty_time', 20);
+        $penalty_time = $this->dj->dbconfig_get('penalty_time', 20);
         $response     = new StreamedResponse();
         $response->setCallback(function () use ($contest, $penalty_time) {
             echo "name:                     " . $contest->getName() . "\n";

--- a/webapp/src/DOMJudgeBundle/Controller/API/ExecutableController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ExecutableController.php
@@ -21,15 +21,15 @@ class ExecutableController extends FOSRestController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * ExecutableController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $em)
     {
-        $this->entityManager = $entityManager;
+        $this->em = $em;
     }
 
     /**
@@ -49,7 +49,7 @@ class ExecutableController extends FOSRestController
     public function singleAction(string $id)
     {
         /** @var Executable|null $executable */
-        $executable = $this->entityManager->createQueryBuilder()
+        $executable = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Executable', 'e')
             ->select('e')
             ->andWhere('e.execid = :id')

--- a/webapp/src/DOMJudgeBundle/Controller/API/GeneralInfoController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/GeneralInfoController.php
@@ -36,7 +36,7 @@ class GeneralInfoController extends FOSRestController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -56,20 +56,20 @@ class GeneralInfoController extends FOSRestController
     /**
      * GeneralInfoController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      * @param CheckConfigService     $checkConfigService
      * @param RouterInterface        $router
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService,
         CheckConfigService $checkConfigService,
         RouterInterface $router
     ) {
         $this->entityManager      = $entityManager;
-        $this->DOMJudgeService    = $DOMJudgeService;
+        $this->dj                 = $dj;
         $this->eventLogService    = $eventLogService;
         $this->checkConfigService = $checkConfigService;
         $this->router             = $router;
@@ -144,14 +144,14 @@ class GeneralInfoController extends FOSRestController
      */
     public function getStatusAction()
     {
-        if ($this->DOMJudgeService->checkrole('jury')) {
+        if ($this->dj->checkrole('jury')) {
             $onlyOfTeam = null;
-        } elseif ($this->DOMJudgeService->checkrole('team') && $this->DOMJudgeService->getUser()->getTeamid()) {
-            $onlyOfTeam = $this->DOMJudgeService->getUser()->getTeamid();
+        } elseif ($this->dj->checkrole('team') && $this->dj->getUser()->getTeamid()) {
+            $onlyOfTeam = $this->dj->getUser()->getTeamid();
         } else {
             $onlyOfTeam = -1;
         }
-        $contests = $this->DOMJudgeService->getCurrentContests($onlyOfTeam);
+        $contests = $this->dj->getCurrentContests($onlyOfTeam);
         if (empty($contests)) {
             throw new BadRequestHttpException('No active contest');
         }
@@ -205,7 +205,7 @@ class GeneralInfoController extends FOSRestController
      */
     public function getUserAction()
     {
-        $user = $this->DOMJudgeService->getUser();
+        $user = $this->dj->getUser();
         if ($user === null) {
             throw new HttpException(401, 'Permission denied');
         }
@@ -234,10 +234,10 @@ class GeneralInfoController extends FOSRestController
      */
     public function getDatabaseConfigurationAction(Request $request)
     {
-        $onlypublic = !($this->DOMJudgeService->checkrole('jury') || $this->DOMJudgeService->checkrole('judgehost'));
+        $onlypublic = !($this->dj->checkrole('jury') || $this->dj->checkrole('judgehost'));
         $name       = $request->query->get('name');
 
-        $result = $this->DOMJudgeService->dbconfig_get($name, null, $onlypublic);
+        $result = $this->dj->dbconfig_get($name, null, $onlypublic);
 
         if ($name !== null) {
             return [$name => $result];

--- a/webapp/src/DOMJudgeBundle/Controller/API/GeneralInfoController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/GeneralInfoController.php
@@ -31,7 +31,7 @@ class GeneralInfoController extends FOSRestController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -55,20 +55,20 @@ class GeneralInfoController extends FOSRestController
 
     /**
      * GeneralInfoController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      * @param CheckConfigService     $checkConfigService
      * @param RouterInterface        $router
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService,
         CheckConfigService $checkConfigService,
         RouterInterface $router
     ) {
-        $this->entityManager      = $entityManager;
+        $this->em                 = $em;
         $this->dj                 = $dj;
         $this->eventLogService    = $eventLogService;
         $this->checkConfigService = $checkConfigService;
@@ -159,14 +159,14 @@ class GeneralInfoController extends FOSRestController
         $result = [];
         foreach ($contests as $contest) {
             $resultItem                    = ['cid' => $contest->getCid()];
-            $resultItem['num_submissions'] = (int)$this->entityManager
+            $resultItem['num_submissions'] = (int)$this->em
                 ->createQuery(
                     'SELECT COUNT(s)
                 FROM DOMJudgeBundle:Submission s
                 WHERE s.cid = :cid')
                 ->setParameter(':cid', $contest->getCid())
                 ->getSingleScalarResult();
-            $resultItem['num_queued']      = (int)$this->entityManager
+            $resultItem['num_queued']      = (int)$this->em
                 ->createQuery(
                     'SELECT COUNT(s)
                 FROM DOMJudgeBundle:Submission s
@@ -176,7 +176,7 @@ class GeneralInfoController extends FOSRestController
                 AND s.valid = 1')
                 ->setParameter(':cid', $contest->getCid())
                 ->getSingleScalarResult();
-            $resultItem['num_judging']     = (int)$this->entityManager
+            $resultItem['num_judging']     = (int)$this->em
                 ->createQuery(
                     'SELECT COUNT(s)
                 FROM DOMJudgeBundle:Submission s

--- a/webapp/src/DOMJudgeBundle/Controller/API/GroupController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/GroupController.php
@@ -78,7 +78,7 @@ class GroupController extends AbstractRestController
             ->select('c')
             ->orderBy('c.sortorder');
 
-        if (!$this->DOMJudgeService->checkrole('api_reader') || $request->query->get('public')) {
+        if (!$this->dj->checkrole('api_reader') || $request->query->get('public')) {
             $queryBuilder
                 ->andWhere('c.visible = 1');
         }

--- a/webapp/src/DOMJudgeBundle/Controller/API/GroupController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/GroupController.php
@@ -73,7 +73,7 @@ class GroupController extends AbstractRestController
     {
         // Call getContestId to make sure we have an active contest
         $this->getContestId($request);
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TeamCategory', 'c')
             ->select('c')
             ->orderBy('c.sortorder');

--- a/webapp/src/DOMJudgeBundle/Controller/API/JudgementController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/JudgementController.php
@@ -111,7 +111,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
      */
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Judging', 'j')
             ->select('j, c, s, MAX(jr.runtime) AS maxruntime')
             ->leftJoin('j.contest', 'c')

--- a/webapp/src/DOMJudgeBundle/Controller/API/JudgementController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/JudgementController.php
@@ -37,7 +37,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
     ) {
         parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
 
-        $verdictsConfig = $this->DOMJudgeService->getDomjudgeEtcDir() . '/verdicts.php';
+        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $this->verdicts = include $verdictsConfig;
     }
 
@@ -123,8 +123,8 @@ class JudgementController extends AbstractRestController implements QueryObjectT
             ->groupBy('j.judgingid')
             ->orderBy('j.judgingid');
 
-        $roleAllowsVisibility = $this->DOMJudgeService->checkrole('api_reader')
-            || $this->DOMJudgeService->checkrole('judgehost');
+        $roleAllowsVisibility = $this->dj->checkrole('api_reader')
+            || $this->dj->checkrole('judgehost');
         if ($request->query->has('result')) {
             $queryBuilder
                 ->andWhere('j.result = :result')
@@ -136,7 +136,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
         if (!$roleAllowsVisibility) {
             $queryBuilder
                 ->andWhere('s.teamid = :team')
-                ->setParameter(':team', $this->DOMJudgeService->getUser()->getTeamid());
+                ->setParameter(':team', $this->dj->getUser()->getTeamid());
         }
 
         if ($request->query->has('submission_id')) {
@@ -153,7 +153,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
             $queryBuilder
                 ->andWhere('s.submittime < c.endtime')
                 ->andWhere('j.valid = 1');
-            if ($this->DOMJudgeService->dbconfig_get('verification_required', false)) {
+            if ($this->dj->dbconfig_get('verification_required', false)) {
                 $queryBuilder->andWhere('j.verified = 1');
             }
         }

--- a/webapp/src/DOMJudgeBundle/Controller/API/JudgementTypeController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/JudgementTypeController.php
@@ -95,7 +95,7 @@ class JudgementTypeController extends AbstractRestController
      */
     protected function getJudgementTypes(array $filteredOn = null)
     {
-        $verdictsConfig = $this->DOMJudgeService->getDomjudgeEtcDir() . '/verdicts.php';
+        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $verdicts       = include $verdictsConfig;
 
         $result = [];
@@ -107,7 +107,7 @@ class JudgementTypeController extends AbstractRestController
                 $solved  = true;
             }
             if ($name == 'compiler-error') {
-                $penalty = $this->DOMJudgeService->dbconfig_get('compile_penalty', false);
+                $penalty = $this->dj->dbconfig_get('compile_penalty', false);
             }
             if ($filteredOn !== null && !in_array($label, $filteredOn)) {
                 continue;

--- a/webapp/src/DOMJudgeBundle/Controller/API/LanguageController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/LanguageController.php
@@ -68,7 +68,7 @@ class LanguageController extends AbstractRestController
         // Make sure the contest exists by calling getContestId. Most API endpoints use the contest to filter its
         // queries, but the languages endpoint does not. So we just call it here
         $this->getContestId($request);
-        return $this->entityManager->createQueryBuilder()
+        return $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Language', 'lang')
             ->select('lang')
             ->andWhere('lang.allowSubmit = 1');

--- a/webapp/src/DOMJudgeBundle/Controller/API/OrganizationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/OrganizationController.php
@@ -73,7 +73,7 @@ class OrganizationController extends AbstractRestController
     {
         // Call getContestId to make sure we have an active contest
         $this->getContestId($request);
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TeamAffiliation', 'ta')
             ->select('ta')
             ->orderBy('ta.name');

--- a/webapp/src/DOMJudgeBundle/Controller/API/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ProblemController.php
@@ -66,7 +66,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
     public function listAction(Request $request)
     {
         // Make sure we clear the entity manager class, for when this method is called multiple times by internal requests
-        $this->entityManager->clear();
+        $this->em->clear();
         // This method is overwritten, because we need to add ordinal values
         $queryBuilder = $this->getQueryBuilder($request);
 
@@ -149,7 +149,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
         $files     = $request->files->get('zip') ?: [];
         $contestId = $this->getContestId($request);
         /** @var Contest $contest */
-        $contest     = $this->entityManager->getRepository(Contest::class)->find($contestId);
+        $contest     = $this->em->getRepository(Contest::class)->find($contestId);
         $allMessages = [];
         $probIds     = [];
 
@@ -159,7 +159,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
             if (sizeof($files) != 1) {
                 throw new BadRequestHttpException('Can only take one problem zip if \'problem\' is set.');
             }
-            $problem = $this->entityManager->createQueryBuilder()
+            $problem = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Problem', 'p')
                 ->select('p')
                 ->andWhere(sprintf('%s = :id', $this->getIdField()))
@@ -214,7 +214,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
     public function singleAction(Request $request, string $id)
     {
         // Make sure we clear the entity manager class, for when this method is called multiple times by internal requests
-        $this->entityManager->clear();
+        $this->em->clear();
         // This method is overwritten, because we need to add ordinal values
         $queryBuilder = $this->getQueryBuilder($request);
 
@@ -269,9 +269,9 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
     {
         $contestId = $this->getContestId($request);
         /** @var Contest $contest */
-        $contest = $this->entityManager->getRepository(Contest::class)->find($contestId);
+        $contest = $this->em->getRepository(Contest::class)->find($contestId);
 
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:ContestProblem', 'cp')
             ->join('cp.problem', 'p')
             ->leftJoin('p.testcases', 'tc')

--- a/webapp/src/DOMJudgeBundle/Controller/API/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ProblemController.php
@@ -174,14 +174,14 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
         foreach ($files as $file) {
             $zip = null;
             try {
-                $zip         = $this->DOMJudgeService->openZipFile($file->getRealPath());
+                $zip         = $this->dj->openZipFile($file->getRealPath());
                 $clientName  = $file->getClientOriginalName();
                 $messages    = [];
                 $newProblem  = $this->importProblemService->importZippedProblem($zip, $clientName, null, $contest,
                                                                                 $messages);
                 $allMessages = array_merge($allMessages, $messages);
                 if ($newProblem) {
-                    $this->DOMJudgeService->auditlog('problem', $newProblem->getProbid(), 'upload zip', $clientName);
+                    $this->dj->auditlog('problem', $newProblem->getProbid(), 'upload zip', $clientName);
                     $probIds[] = $newProblem->getProbid();
                 }
             } catch (\Exception $e) {
@@ -283,7 +283,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
             ->groupBy('cp.probid');
 
         // For non-API-reader users, only expose the problems after the contest has started
-        if (!$this->DOMJudgeService->checkrole('api_reader') && $contest->getStartTimeObject()->getTimestamp() > time()) {
+        if (!$this->dj->checkrole('api_reader') && $contest->getStartTimeObject()->getTimestamp() > time()) {
             $queryBuilder->andWhere('1 = 0');
         }
 

--- a/webapp/src/DOMJudgeBundle/Controller/API/RunController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/RunController.php
@@ -34,7 +34,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
     {
         parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
 
-        $verdictsConfig = $this->DOMJudgeService->getDomjudgeEtcDir() . '/verdicts.php';
+        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $this->verdicts = include $verdictsConfig;
     }
 
@@ -157,7 +157,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
             $queryBuilder
                 ->andWhere('s.submittime < c.endtime')
                 ->andWhere('j.rejudgingid IS NULL OR j.valid = 1');
-            if ($this->DOMJudgeService->dbconfig_get('verification_required', false)) {
+            if ($this->dj->dbconfig_get('verification_required', false)) {
                 $queryBuilder->andWhere('j.verified = 1');
             }
         }

--- a/webapp/src/DOMJudgeBundle/Controller/API/RunController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/RunController.php
@@ -120,7 +120,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
      */
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:JudgingRun', 'jr')
             ->leftJoin('jr.judging', 'j')
             ->leftJoin('jr.testcase', 'tc')

--- a/webapp/src/DOMJudgeBundle/Controller/API/ScoreboardController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ScoreboardController.php
@@ -106,8 +106,8 @@ class ScoreboardController extends AbstractRestController
             $filter->setAffiliations([$request->query->get('affiliation')]);
         }
         $allTeams = $request->query->getBoolean('allteams', false);
-        $public   = !$this->DOMJudgeService->checkrole('api_reader');
-        if ($this->DOMJudgeService->checkrole('api_reader') && $request->query->has('public')) {
+        $public   = !$this->dj->checkrole('api_reader');
+        if ($this->dj->checkrole('api_reader') && $request->query->has('public')) {
             $public = $request->query->getBoolean('public');
         }
 
@@ -141,7 +141,7 @@ class ScoreboardController extends AbstractRestController
             'rows' => [],
         ];
 
-        $scoreIsInSecods = (bool)$this->DOMJudgeService->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSecods = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
 
         foreach ($scorebard->getScores() as $teamScore) {
             $row = [

--- a/webapp/src/DOMJudgeBundle/Controller/API/ScoreboardController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/ScoreboardController.php
@@ -112,7 +112,7 @@ class ScoreboardController extends AbstractRestController
         }
 
         /** @var Contest $contest */
-        $contest         = $this->entityManager->getRepository(Contest::class)->find($this->getContestId($request));
+        $contest         = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
         $inactiveAllowed = $this->isGranted('ROLE_API_READER');
         $accessAllowed   = ($inactiveAllowed && $contest->getEnabled()) || (!$inactiveAllowed && $contest->isActive());
         if (!$accessAllowed) {
@@ -122,7 +122,7 @@ class ScoreboardController extends AbstractRestController
         // Get the event for this scoreboard
         // TODO: add support for after_event_id
         /** @var Event $event */
-        $event = $this->entityManager->createQueryBuilder()
+        $event = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Event', 'e')
             ->select('e')
             ->orderBy('e.eventid', 'DESC')
@@ -146,7 +146,7 @@ class ScoreboardController extends AbstractRestController
         foreach ($scorebard->getScores() as $teamScore) {
             $row = [
                 'rank' => $teamScore->getRank(),
-                'team_id' => (string)$teamScore->getTeam()->getApiId($this->eventLogService, $this->entityManager),
+                'team_id' => (string)$teamScore->getTeam()->getApiId($this->eventLogService, $this->em),
                 'score' => [
                     'num_solved' => $teamScore->getNumberOfPoints(),
                     'total_time' => $teamScore->getTotalTime(),
@@ -159,7 +159,7 @@ class ScoreboardController extends AbstractRestController
                 $contestProblem = $scorebard->getProblems()[$problemId];
                 $problem        = [
                     'label' => $contestProblem->getShortname(),
-                    'problem_id' => (string)$contestProblem->getApiId($this->eventLogService, $this->entityManager),
+                    'problem_id' => (string)$contestProblem->getApiId($this->eventLogService, $this->em),
                     'num_judged' => $matrixItem->getNumberOfSubmissions(),
                     'num_pending' => $matrixItem->getNumberOfPendingSubmissions(),
                     'solved' => $matrixItem->isCorrect(),

--- a/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
@@ -169,7 +169,7 @@ class SubmissionController extends AbstractRestController
 
         // Load the problem
         /** @var ContestProblem $problem */
-        $problem = $this->entityManager->createQueryBuilder()
+        $problem = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:ContestProblem', 'cp')
             ->join('cp.problem', 'p')
             ->join('cp.contest', 'c')
@@ -190,7 +190,7 @@ class SubmissionController extends AbstractRestController
 
         // Load the language
         /** @var Language $language */
-        $language = $this->entityManager->createQueryBuilder()
+        $language = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Language', 'lang')
             ->select('lang')
             ->andWhere(sprintf('lang.%s = :language',
@@ -317,7 +317,7 @@ class SubmissionController extends AbstractRestController
      */
     public function getSubmissionSourceCodeAction(Request $request, string $id)
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:SubmissionFile', 'f')
             ->join('f.submission_file_source_code', 'sc')
             ->join('f.submission', 's')
@@ -357,7 +357,7 @@ class SubmissionController extends AbstractRestController
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
         $cid          = $this->getContestId($request);
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Submission', 's')
             ->join('s.contest', 'c')
             ->select('s')

--- a/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
@@ -41,11 +41,11 @@ class SubmissionController extends AbstractRestController
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService,
         SubmissionService $submissionService
     ) {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        parent::__construct($entityManager, $dj, $eventLogService);
         $this->submissionService = $submissionService;
     }
 
@@ -163,7 +163,7 @@ class SubmissionController extends AbstractRestController
             }
         }
 
-        if (!$this->DOMJudgeService->getUser()->getTeam()) {
+        if (!$this->dj->getUser()->getTeam()) {
             throw new BadRequestHttpException(sprintf('User does not belong to a team'));
         }
 
@@ -219,7 +219,7 @@ class SubmissionController extends AbstractRestController
         $files = $request->files->get('code') ?: [];
 
         // Now submit the solution
-        $team       = $this->DOMJudgeService->getUser()->getTeam();
+        $team       = $this->dj->getUser()->getTeam();
         $submission = $this->submissionService->submitSolution($team, $problem, $problem->getContest(), $language,
                                                                $files, null, $entryPoint, null, null, null, $message);
 
@@ -269,7 +269,7 @@ class SubmissionController extends AbstractRestController
         /** @var SubmissionFileWithSourceCode[] $files */
         $files = $submission->getFilesWithSourceCode();
         $zip   = new \ZipArchive;
-        if (!($tmpfname = tempnam($this->DOMJudgeService->getDomjudgeTmpDir(), "submission_file-"))) {
+        if (!($tmpfname = tempnam($this->dj->getDomjudgeTmpDir(), "submission_file-"))) {
             return new Response("Could not create temporary file.", Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 

--- a/webapp/src/DOMJudgeBundle/Controller/API/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/TeamController.php
@@ -103,7 +103,7 @@ class TeamController extends AbstractRestController
                 ->setParameter(':affiliation', $request->query->get('affiliation'));
         }
 
-        if (!$this->DOMJudgeService->checkrole('api_reader') || $request->query->getBoolean('public')) {
+        if (!$this->dj->checkrole('api_reader') || $request->query->getBoolean('public')) {
             $queryBuilder->andWhere('tc.visible = 1');
         }
 

--- a/webapp/src/DOMJudgeBundle/Controller/API/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/TeamController.php
@@ -84,7 +84,7 @@ class TeamController extends AbstractRestController
      */
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Team', 't')
             ->leftJoin('t.affiliation', 'ta')
             ->leftJoin('t.category', 'tc')
@@ -107,7 +107,7 @@ class TeamController extends AbstractRestController
             $queryBuilder->andWhere('tc.visible = 1');
         }
 
-        $contest = $this->entityManager->getRepository(Contest::class)->find($this->getContestId($request));
+        $contest = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
         if (!$contest->getPublic()) {
             $queryBuilder
                 ->andWhere('c.cid = :cid')

--- a/webapp/src/DOMJudgeBundle/Controller/API/TestcaseController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/TestcaseController.php
@@ -26,15 +26,15 @@ class TestcaseController extends FOSRestController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * TestcaseController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $em)
     {
-        $this->entityManager = $entityManager;
+        $this->em = $em;
     }
 
     /**
@@ -55,7 +55,7 @@ class TestcaseController extends FOSRestController
     {
         // First, check if the judging has an endtime, because then we are done
         /** @var Judging $judging */
-        $judging = $this->entityManager->createQueryBuilder()
+        $judging = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Judging', 'j')
             ->join('j.submission', 's')
             ->leftJoin('j.runs', 'jr')
@@ -74,7 +74,7 @@ class TestcaseController extends FOSRestController
             return '';
         }
 
-        $queryBuilder = $this->entityManager->createQueryBuilder()
+        $queryBuilder = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Testcase', 't')
             ->select('t')
             ->andWhere('t.probid = :probid')
@@ -135,7 +135,7 @@ class TestcaseController extends FOSRestController
         }
 
         /** @var TestcaseWithContent|null $testcaseWithContent */
-        $testcaseWithContent = $this->entityManager->createQueryBuilder()
+        $testcaseWithContent = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TestcaseWithContent', 'tcc')
             ->select('tcc')
             ->andWhere('tcc.testcaseid = :id')

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/AnalysisController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/AnalysisController.php
@@ -20,7 +20,7 @@ class AnalysisController extends Controller
     /**
      * @var DOMJudgeService
      */
-    private $DOMJudgeService;
+    private $dj;
 
     const FILTERS = [
         'visiblecat' => 'Teams from visible categories',
@@ -35,9 +35,9 @@ class AnalysisController extends Controller
       $array[$index] = $array[$index] +1;
     }
 
-    public function __construct(DOMJudgeService $DOMJudgeService)
+    public function __construct(DOMJudgeService $dj)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -66,7 +66,7 @@ class AnalysisController extends Controller
     public function indexAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
-        $contest = $this->DOMJudgeService->getCurrentContest();
+        $contest = $this->dj->getCurrentContest();
 
         if ($contest == null) {
           return $this->render('@DOMJudge/jury/error.html.twig', [
@@ -260,7 +260,7 @@ class AnalysisController extends Controller
     public function teamAction(Request $request, Team $team)
     {
         $em = $this->getDoctrine()->getManager();
-        $contest = $this->DOMJudgeService->getCurrentContest();
+        $contest = $this->dj->getCurrentContest();
 
         if ($contest == null) {
           return $this->render('@DOMJudge/jury/error.html.twig', [
@@ -359,7 +359,7 @@ class AnalysisController extends Controller
     public function problemAction(Request $request, Problem $problem)
     {
         $em = $this->getDoctrine()->getManager();
-        $contest = $this->DOMJudgeService->getCurrentContest();
+        $contest = $this->dj->getCurrentContest();
 
         $filterKeys = array_keys(self::FILTERS);
         $view = $request->query->get('view') ?: reset($filterKeys);

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/AuditLogController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/AuditLogController.php
@@ -30,7 +30,7 @@ class AuditLogController extends Controller
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -40,16 +40,16 @@ class AuditLogController extends Controller
     /**
      * AuditLogController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -58,7 +58,7 @@ class AuditLogController extends Controller
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $timeFormat = (string)$this->DOMJudgeService->dbconfig_get('time_format', '%H:%M');
+        $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
 
         $showAll = $request->query->get('showAll', false);
         $page = $request->query->get('page', 1);

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/AuditLogController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/AuditLogController.php
@@ -25,7 +25,7 @@ class AuditLogController extends Controller
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -39,16 +39,16 @@ class AuditLogController extends Controller
 
     /**
      * AuditLogController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -64,7 +64,7 @@ class AuditLogController extends Controller
         $page = $request->query->get('page', 1);
         $limit = 1000;
 
-        $em = $this->entityManager;
+        $em = $this->em;
         $query = $em->createQueryBuilder()
                     ->select('a')
                     ->from('DOMJudgeBundle:AuditLog', 'a')
@@ -173,12 +173,12 @@ class AuditLogController extends Controller
             case 'user':
                 // Pre 6.1, usernames were stored instead of numeric ids
                 if (!is_numeric($id)) {
-                    $user = $this->entityManager->getRepository(User::class)->findOneBy(['username'=>$id]);
+                    $user = $this->em->getRepository(User::class)->findOneBy(['username'=>$id]);
                     $id = $user->getUserId();
                 }
                 return $this->generateUrl('jury_user', ['userId' => $id]);
             case 'testcase':
-                $testcase = $this->entityManager->getRepository(Testcase::class)->find($id);
+                $testcase = $this->em->getRepository(Testcase::class)->find($id);
                 if ($testcase) {
                     return $this->generateUrl('jury_problem_testcases', ['probId' => $testcase->getProbid()]);
                 }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/BalloonController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/BalloonController.php
@@ -24,7 +24,7 @@ class BalloonController extends Controller
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -38,16 +38,16 @@ class BalloonController extends Controller
 
     /**
      * BalloonController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -60,7 +60,7 @@ class BalloonController extends Controller
         $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
         $showPostFreeze = (bool)$this->dj->dbconfig_get('show_balloons_postfreeze', false);
 
-        $em = $this->entityManager;
+        $em = $this->em;
         $query = $em->createQueryBuilder()
             ->select('b', 's.submittime', 'p.probid',
                 't.teamid', 't.name AS teamname', 't.room', 'c.name AS catname',
@@ -196,7 +196,7 @@ class BalloonController extends Controller
      */
     public function setDoneAction(Request $request, int $balloonId)
     {
-        $em = $this->entityManager;
+        $em = $this->em;
         $balloon = $em->getRepository(Balloon::class)->find($balloonId);
         if (!$balloon) {
             throw new NotFoundHttpException('balloon not found');

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/BalloonController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/BalloonController.php
@@ -29,7 +29,7 @@ class BalloonController extends Controller
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -39,16 +39,16 @@ class BalloonController extends Controller
     /**
      * BalloonController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -57,12 +57,12 @@ class BalloonController extends Controller
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $timeFormat = (string)$this->DOMJudgeService->dbconfig_get('time_format', '%H:%M');
-        $showPostFreeze = (bool)$this->DOMJudgeService->dbconfig_get('show_balloons_postfreeze', false);
+        $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
+        $showPostFreeze = (bool)$this->dj->dbconfig_get('show_balloons_postfreeze', false);
 
         $em = $this->entityManager;
         $query = $em->createQueryBuilder()
-            ->select('b', 's.submittime', 'p.probid', 
+            ->select('b', 's.submittime', 'p.probid',
                 't.teamid', 't.name AS teamname', 't.room', 'c.name AS catname',
                 's.cid', 'co.shortname', 'cp.shortname AS probshortname', 'cp.color')
             ->from('DOMJudgeBundle:Balloon', 'b')
@@ -74,7 +74,7 @@ class BalloonController extends Controller
             ->leftJoin('t.category', 'c')
             ->orderBy('b.balloonid', 'DESC');
 
-        $contests = $this->DOMJudgeService->getCurrentContests();
+        $contests = $this->dj->getCurrentContests();
         $frozen_contests = [];
         $freezetimes = [];
         foreach($contests as $cid => $contest) {
@@ -180,7 +180,7 @@ class BalloonController extends Controller
                 'actions' => $balloonactions,
                 'cssclass' => $balloon->getDone() ? 'disabled' : null,
             ];
-        } 
+        }
 
         return $this->render('@DOMJudge/jury/balloons.html.twig', [
             'refresh' => ['after' => 60, 'url' => $this->generateUrl('jury_balloons')],

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ConfigController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ConfigController.php
@@ -26,7 +26,7 @@ class ConfigController extends Controller
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var CheckConfigService
@@ -36,16 +36,16 @@ class ConfigController extends Controller
     /**
      * TeamCategoryController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param CheckConfigService     $checkConfigService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         CheckConfigService $checkConfigService
     ) {
         $this->entityManager      = $entityManager;
-        $this->DOMJudgeService    = $DOMJudgeService;
+        $this->dj                 = $dj;
         $this->checkConfigService = $checkConfigService;
     }
 

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ConfigController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ConfigController.php
@@ -21,7 +21,7 @@ class ConfigController extends Controller
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -35,16 +35,16 @@ class ConfigController extends Controller
 
     /**
      * TeamCategoryController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param CheckConfigService     $checkConfigService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         CheckConfigService $checkConfigService
     ) {
-        $this->entityManager      = $entityManager;
+        $this->em                 = $em;
         $this->dj                 = $dj;
         $this->checkConfigService = $checkConfigService;
     }
@@ -55,7 +55,7 @@ class ConfigController extends Controller
     public function indexAction(Request $request)
     {
         /** @var Configuration[] */
-        $options = $this->entityManager->getRepository('DOMJudgeBundle:Configuration')->findAll();
+        $options = $this->em->getRepository('DOMJudgeBundle:Configuration')->findAll();
         if ($request->getMethod() == 'POST' && $request->request->has('save')) {
             $this->addFlash('scoreboard_refresh', 'After changing specific settings, you might need to refresh the scoreboard.');
             foreach ($options as $option) {
@@ -90,11 +90,11 @@ class ConfigController extends Controller
                 }
             }
 
-            $this->entityManager->flush();
+            $this->em->flush();
             return $this->redirectToRoute('jury_config');
         }
         /** @var Configuration[] */
-        $options = $this->entityManager->getRepository('DOMJudgeBundle:Configuration')->findAll();
+        $options = $this->em->getRepository('DOMJudgeBundle:Configuration')->findAll();
         $categories = array();
         foreach ($options as $option) {
             if (!in_array($option->getCategory(), $categories)) {

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ImportExportController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ImportExportController.php
@@ -49,7 +49,7 @@ class ImportExportController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var ScoreboardService
@@ -73,7 +73,7 @@ class ImportExportController extends BaseController
      * ImportExportController constructor.
      * @param BaylorCmsService       $baylorCmsService
      * @param ImportExportService    $importExportService
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param ScoreboardService      $scoreboardService
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
@@ -82,7 +82,7 @@ class ImportExportController extends BaseController
     public function __construct(
         BaylorCmsService $baylorCmsService,
         ImportExportService $importExportService,
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         ScoreboardService $scoreboardService,
         DOMJudgeService $dj,
         EventLogService $eventLogService,
@@ -90,7 +90,7 @@ class ImportExportController extends BaseController
     ) {
         $this->baylorCmsService    = $baylorCmsService;
         $this->importExportService = $importExportService;
-        $this->entityManager       = $entityManager;
+        $this->em                  = $em;
         $this->scoreboardService   = $scoreboardService;
         $this->dj                  = $dj;
         $this->eventLogService     = $eventLogService;
@@ -145,7 +145,7 @@ class ImportExportController extends BaseController
         }
 
         /** @var TeamCategory[] $teamCategories */
-        $teamCategories = $this->entityManager->createQueryBuilder()
+        $teamCategories = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TeamCategory', 'c', 'c.categoryid')
             ->select('c')
             ->where('c.visible = 1')
@@ -286,7 +286,7 @@ class ImportExportController extends BaseController
     protected function getResultsHtml(Request $request, bool $useIcpcLayout)
     {
         /** @var TeamCategory[] $categories */
-        $categories  = $this->entityManager->createQueryBuilder()
+        $categories  = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TeamCategory', 'c', 'c.categoryid')
             ->select('c')
             ->where('c.visible = 1')
@@ -310,7 +310,7 @@ class ImportExportController extends BaseController
 
         $teamNames = [];
         foreach ($teams as $team) {
-            $teamNames[$team->getApiId($this->eventLogService, $this->entityManager)] = $team->getName();
+            $teamNames[$team->getApiId($this->eventLogService, $this->em)] = $team->getName();
         }
 
         $awarded       = [];
@@ -381,7 +381,7 @@ class ImportExportController extends BaseController
                     $firstToSolve[$problem->getProbid()] = [
                         'problem' => $problem->getShortname(),
                         'problem_name' => $problem->getProblem()->getName(),
-                        'team' => $teamNames[$team->getApiId($this->eventLogService, $this->entityManager)],
+                        'team' => $teamNames[$team->getApiId($this->eventLogService, $this->em)],
                         'time' => Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds),
                     ];
                 }
@@ -451,7 +451,7 @@ class ImportExportController extends BaseController
         }
 
         /** @var Clarification[] $clarifications */
-        $clarifications = $this->entityManager->createQueryBuilder()
+        $clarifications = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Clarification', 'c')
             ->select('c')
             ->andWhere('c.contest = :contest')
@@ -477,7 +477,7 @@ class ImportExportController extends BaseController
         }
 
         /** @var ContestProblem[] $contestProblems */
-        $contestProblems = $this->entityManager->createQueryBuilder()
+        $contestProblems = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:ContestProblem', 'cp', 'cp.probid')
             ->select('cp')
             ->andWhere('cp.contest = :contest')

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ImportExportController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ImportExportController.php
@@ -59,7 +59,7 @@ class ImportExportController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -75,7 +75,7 @@ class ImportExportController extends BaseController
      * @param ImportExportService    $importExportService
      * @param EntityManagerInterface $entityManager
      * @param ScoreboardService      $scoreboardService
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      * @param string                 $domjudgeVersion
      */
@@ -84,7 +84,7 @@ class ImportExportController extends BaseController
         ImportExportService $importExportService,
         EntityManagerInterface $entityManager,
         ScoreboardService $scoreboardService,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService,
         string $domjudgeVersion
     ) {
@@ -92,7 +92,7 @@ class ImportExportController extends BaseController
         $this->importExportService = $importExportService;
         $this->entityManager       = $entityManager;
         $this->scoreboardService   = $scoreboardService;
-        $this->DOMJudgeService     = $DOMJudgeService;
+        $this->dj                  = $dj;
         $this->eventLogService     = $eventLogService;
         $this->domjudgeVersion     = $domjudgeVersion;
     }
@@ -297,12 +297,12 @@ class ImportExportController extends BaseController
             $categoryIds[] = $category->getCategoryid();
         }
 
-        $contest = $this->DOMJudgeService->getCurrentContest();
+        $contest = $this->dj->getCurrentContest();
         if ($contest === null) {
             throw new BadRequestHttpException('No current contest');
         }
 
-        $scoreIsInSeconds = (bool)$this->DOMJudgeService->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSeconds = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
         $filter           = new Filter();
         $filter->setCategories($categoryIds);
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);
@@ -432,18 +432,18 @@ class ImportExportController extends BaseController
      */
     protected function getClarificationsHtml()
     {
-        $contest = $this->DOMJudgeService->getCurrentContest();
+        $contest = $this->dj->getCurrentContest();
         if ($contest === null) {
             throw new BadRequestHttpException('No current contest');
         }
 
-        $queues              = (array)$this->DOMJudgeService->dbconfig_get('clar_queues');
+        $queues              = (array)$this->dj->dbconfig_get('clar_queues');
         $clarificationQueues = [null => 'Unassigned issues'];
         foreach ($queues as $key => $val) {
             $clarificationQueues[$key] = $val;
         }
 
-        $categories = (array)$this->DOMJudgeService->dbconfig_get('clar_categories');
+        $categories = (array)$this->dj->dbconfig_get('clar_categories');
 
         $clarificationCategories = [];
         foreach ($categories as $key => $val) {

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/InternalErrorController.php
@@ -27,12 +27,12 @@ class InternalErrorController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService)
+    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->entityManager = $entityManager;
+        $this->dj            = $dj;
     }
 
     /**
@@ -151,9 +151,9 @@ class InternalErrorController extends BaseController
         $this->entityManager->transactional(function () use ($internalError, $status) {
             $internalError->setStatus($status);
             if ($status === InternalError::STATUS_RESOLVED) {
-                $this->DOMJudgeService->setInternalError($internalError->getDisabled(), $internalError->getContest(),
+                $this->dj->setInternalError($internalError->getDisabled(), $internalError->getContest(),
                                                          true);
-                $this->DOMJudgeService->auditlog('internal_error', $internalError->getErrorid(),
+                $this->dj->auditlog('internal_error', $internalError->getErrorid(),
                                                  sprintf('internal error: %s', $status));
             }
         });

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
@@ -30,12 +30,12 @@ class JudgehostRestrictionController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService)
+    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->entityManager = $entityManager;
+        $this->dj            = $dj;
     }
 
     /**
@@ -183,7 +183,7 @@ class JudgehostRestrictionController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->entityManager->flush();
-            $this->DOMJudgeService->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
+            $this->dj->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
                                              'updated');
             return $this->redirect($this->generateUrl('jury_judgehost_restriction',
                                                       ['restrictionId' => $judgehostRestriction->getRestrictionid()]));
@@ -210,7 +210,7 @@ class JudgehostRestrictionController extends BaseController
         /** @var JudgehostRestriction $judgehostRestriction */
         $judgehostRestriction = $this->entityManager->getRepository(JudgehostRestriction::class)->find($restrictionId);
 
-        return $this->deleteEntity($request, $this->entityManager, $this->DOMJudgeService, $judgehostRestriction, $judgehostRestriction->getName(), $this->generateUrl('jury_judgehost_restrictions'));
+        return $this->deleteEntity($request, $this->entityManager, $this->dj, $judgehostRestriction, $judgehostRestriction->getName(), $this->generateUrl('jury_judgehost_restrictions'));
     }
 
     /**
@@ -230,7 +230,7 @@ class JudgehostRestrictionController extends BaseController
         if ($form->isSubmitted() && $form->isValid()) {
             $this->entityManager->persist($judgehostRestriction);
             $this->entityManager->flush();
-            $this->DOMJudgeService->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
+            $this->dj->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
                                              'added');
             return $this->redirect($this->generateUrl('jury_judgehost_restriction',
                                                       ['restrictionId' => $judgehostRestriction->getRestrictionid()]));

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JudgehostRestrictionController.php
@@ -25,7 +25,7 @@ class JudgehostRestrictionController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -34,8 +34,8 @@ class JudgehostRestrictionController extends BaseController
 
     public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager = $entityManager;
-        $this->dj            = $dj;
+        $this->em = $entityManager;
+        $this->dj = $dj;
     }
 
     /**
@@ -44,7 +44,7 @@ class JudgehostRestrictionController extends BaseController
     public function indexAction(Request $request)
     {
         /** @var JudgehostRestriction[] $judgehostRestrictions */
-        $judgehostRestrictions = $this->entityManager->createQueryBuilder()
+        $judgehostRestrictions = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:JudgehostRestriction', 'jr')
             ->select('jr')
             ->orderBy('jr.restrictionid')
@@ -124,7 +124,7 @@ class JudgehostRestrictionController extends BaseController
     public function viewAction(int $restrictionId)
     {
         /** @var JudgehostRestriction $judgehostRestriction */
-        $judgehostRestriction = $this->entityManager->createQueryBuilder()
+        $judgehostRestriction = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:JudgehostRestriction', 'jr')
             ->leftJoin('jr.judgehosts', 'j')
             ->select('jr', 'j')
@@ -137,21 +137,21 @@ class JudgehostRestrictionController extends BaseController
         }
 
         /** @var Contest[] $contests */
-        $contests = $this->entityManager->createQueryBuilder()
+        $contests = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Contest', 'c', 'c.cid')
             ->select('c')
             ->getQuery()
             ->getResult();
 
         /** @var Problem[] $problems */
-        $problems = $this->entityManager->createQueryBuilder()
+        $problems = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Problem', 'p', 'p.probid')
             ->select('p')
             ->getQuery()
             ->getResult();
 
         /** @var Language[] $languages */
-        $languages = $this->entityManager->createQueryBuilder()
+        $languages = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Language', 'l', 'l.langid')
             ->select('l')
             ->getQuery()
@@ -175,14 +175,14 @@ class JudgehostRestrictionController extends BaseController
     public function editAction(Request $request, int $restrictionId)
     {
         /** @var JudgehostRestriction $judgehostRestriction */
-        $judgehostRestriction = $this->entityManager->getRepository(JudgehostRestriction::class)->find($restrictionId);
+        $judgehostRestriction = $this->em->getRepository(JudgehostRestriction::class)->find($restrictionId);
 
         $form = $this->createForm(JudgehostRestrictionType::class, $judgehostRestriction);
 
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->flush();
+            $this->em->flush();
             $this->dj->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
                                              'updated');
             return $this->redirect($this->generateUrl('jury_judgehost_restriction',
@@ -208,9 +208,9 @@ class JudgehostRestrictionController extends BaseController
     public function deleteAction(Request $request, int $restrictionId)
     {
         /** @var JudgehostRestriction $judgehostRestriction */
-        $judgehostRestriction = $this->entityManager->getRepository(JudgehostRestriction::class)->find($restrictionId);
+        $judgehostRestriction = $this->em->getRepository(JudgehostRestriction::class)->find($restrictionId);
 
-        return $this->deleteEntity($request, $this->entityManager, $this->dj, $judgehostRestriction, $judgehostRestriction->getName(), $this->generateUrl('jury_judgehost_restrictions'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $judgehostRestriction, $judgehostRestriction->getName(), $this->generateUrl('jury_judgehost_restrictions'));
     }
 
     /**
@@ -228,8 +228,8 @@ class JudgehostRestrictionController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->persist($judgehostRestriction);
-            $this->entityManager->flush();
+            $this->em->persist($judgehostRestriction);
+            $this->em->flush();
             $this->dj->auditlog('judgehost_restriction', $judgehostRestriction->getRestrictionid(),
                                              'added');
             return $this->redirect($this->generateUrl('jury_judgehost_restriction',

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JuryMiscController.php
@@ -33,7 +33,7 @@ class JuryMiscController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -47,8 +47,8 @@ class JuryMiscController extends BaseController
      */
     public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager = $entityManager;
-        $this->dj            = $dj;
+        $this->em = $entityManager;
+        $this->dj = $dj;
     }
 
     /**
@@ -78,7 +78,7 @@ class JuryMiscController extends BaseController
     public function ajaxDataAction(Request $request, string $datatype)
     {
         $q  = $request->query->get('q');
-        $qb = $this->entityManager->createQueryBuilder();
+        $qb = $this->em->createQueryBuilder();
 
         if ($datatype === 'problems') {
             $problems = $qb->from('DOMJudgeBundle:Problem', 'p')
@@ -199,7 +199,7 @@ class JuryMiscController extends BaseController
                 $this->dj->auditlog('scoreboard', null, 'refresh cache');
 
                 foreach ($contests as $contest) {
-                    $queryBuilder = $this->entityManager->createQueryBuilder()
+                    $queryBuilder = $this->em->createQueryBuilder()
                         ->from('DOMJudgeBundle:Team', 't')
                         ->select('t')
                         ->orderBy('t.teamid');
@@ -212,7 +212,7 @@ class JuryMiscController extends BaseController
                     /** @var Team[] $teams */
                     $teams = $queryBuilder->getQuery()->getResult();
                     /** @var Problem[] $problems */
-                    $problems = $this->entityManager->createQueryBuilder()
+                    $problems = $this->em->createQueryBuilder()
                         ->from('DOMJudgeBundle:Problem', 'p')
                         ->join('p.contest_problems', 'cp')
                         ->select('p')
@@ -281,7 +281,7 @@ class JuryMiscController extends BaseController
                         ':problemIds' => Connection::PARAM_INT_ARRAY,
                         ':teamIds' => Connection::PARAM_INT_ARRAY,
                     ];
-                    $this->entityManager->getConnection()->executeQuery(
+                    $this->em->getConnection()->executeQuery(
                         'DELETE FROM scorecache WHERE cid = :cid AND probid NOT IN (:problemIds)',
                         $params, $types);
 
@@ -289,10 +289,10 @@ class JuryMiscController extends BaseController
                         ':cid' => $contest->getCid(),
                         ':teamIds' => $teamIds,
                     ];
-                    $this->entityManager->getConnection()->executeQuery(
+                    $this->em->getConnection()->executeQuery(
                         'DELETE FROM scorecache WHERE cid = :cid AND teamid NOT IN (:teamIds)',
                         $params, $types);
-                    $this->entityManager->getConnection()->executeQuery(
+                    $this->em->getConnection()->executeQuery(
                         'DELETE FROM rankcache WHERE cid = :cid AND teamid NOT IN (:teamIds)',
                         $params, $types);
                 }
@@ -323,7 +323,7 @@ class JuryMiscController extends BaseController
         /** @var Submission[] $submissions */
         $submissions = [];
         if ($contests = $this->dj->getCurrentContests()) {
-            $submissions = $this->entityManager->createQueryBuilder()
+            $submissions = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Submission', 's')
                 ->join('s.judgings', 'j', Join::WITH, 'j.valid = 1')
                 ->select('s', 'j')
@@ -406,7 +406,7 @@ class JuryMiscController extends BaseController
             }
         }
 
-        $this->entityManager->flush();
+        $this->em->flush();
 
         return $this->render('@DOMJudge/jury/check_judgings.html.twig', [
             'numChecked' => $numChecked,

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/JuryMiscController.php
@@ -38,17 +38,17 @@ class JuryMiscController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * GeneralInfoController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService)
+    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->entityManager = $entityManager;
+        $this->dj            = $dj;
     }
 
     /**
@@ -67,7 +67,7 @@ class JuryMiscController extends BaseController
      */
     public function updatesAction(Request $request)
     {
-        return $this->json($this->DOMJudgeService->getUpdates());
+        return $this->json($this->dj->getUpdates());
     }
 
     /**
@@ -175,13 +175,13 @@ class JuryMiscController extends BaseController
     {
         // Note: we use a XMLHttpRequest here as Symfony does not support streaming Twig outpit
 
-        $contests = $this->DOMJudgeService->getCurrentContests();
+        $contests = $this->dj->getCurrentContests();
         if ($cid = $request->request->get('cid')) {
             if (!isset($contests[$cid])) {
                 throw new BadRequestHttpException(sprintf('Contest %s not found', $cid));
             }
             $contests = [$cid => $contests[$cid]];
-        } elseif ($request->cookies->has('domjudge_cid') && ($contest = $this->DOMJudgeService->getCurrentContest())) {
+        } elseif ($request->cookies->has('domjudge_cid') && ($contest = $this->dj->getCurrentContest())) {
             $contests = [$contest->getCid() => $contest];
         }
 
@@ -196,7 +196,7 @@ class JuryMiscController extends BaseController
             $response->setCallback(function () use ($contests, $progressReporter, $scoreboardService) {
                 $timeStart = microtime(true);
 
-                $this->DOMJudgeService->auditlog('scoreboard', null, 'refresh cache');
+                $this->dj->auditlog('scoreboard', null, 'refresh cache');
 
                 foreach ($contests as $contest) {
                     $queryBuilder = $this->entityManager->createQueryBuilder()
@@ -322,7 +322,7 @@ class JuryMiscController extends BaseController
     {
         /** @var Submission[] $submissions */
         $submissions = [];
-        if ($contests = $this->DOMJudgeService->getCurrentContests()) {
+        if ($contests = $this->dj->getCurrentContests()) {
             $submissions = $this->entityManager->createQueryBuilder()
                 ->from('DOMJudgeBundle:Submission', 's')
                 ->join('s.judgings', 'j', Join::WITH, 'j.valid = 1')
@@ -434,7 +434,7 @@ class JuryMiscController extends BaseController
         } else {
             $response = $this->redirectToRoute('jury_index');
         }
-        return $this->DOMJudgeService->setCookie('domjudge_cid', (string)$contestId, 0, null, '', false, false,
+        return $this->dj->setCookie('domjudge_cid', (string)$contestId, 0, null, '', false, false,
                                                  $response);
     }
 }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
@@ -26,7 +26,7 @@ class LanguageController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -40,16 +40,16 @@ class LanguageController extends BaseController
 
     /**
      * LanguageController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -59,7 +59,7 @@ class LanguageController extends BaseController
      */
     public function indexAction(Request $request, Packages $assetPackage)
     {
-        $em = $this->entityManager;
+        $em = $this->em;
         /** @var Language[] $languages */
         $languages    = $em->createQueryBuilder()
             ->select('lang')
@@ -156,8 +156,8 @@ class LanguageController extends BaseController
             if ($language->getExtensions()) {
                 $language->setExtensions(array_values($language->getExtensions()));
             }
-            $this->entityManager->persist($language);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $language,
+            $this->em->persist($language);
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $language,
                               $language->getLangid(), true);
             return $this->redirect($this->generateUrl('jury_language',
                                                       ['langId' => $language->getLangid()]));
@@ -180,7 +180,7 @@ class LanguageController extends BaseController
     public function viewAction(Request $request, SubmissionService $submissionService, string $langId)
     {
         /** @var Language $language */
-        $language = $this->entityManager->getRepository(Language::class)->find($langId);
+        $language = $this->em->getRepository(Language::class)->find($langId);
         if (!$language) {
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
@@ -222,13 +222,13 @@ class LanguageController extends BaseController
     public function toggleSubmitAction(Request $request, string $langId)
     {
         /** @var Language $language */
-        $language = $this->entityManager->getRepository(Language::class)->find($langId);
+        $language = $this->em->getRepository(Language::class)->find($langId);
         if (!$language) {
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
 
         $language->setAllowSubmit($request->request->getBoolean('allow_submit'));
-        $this->entityManager->flush();
+        $this->em->flush();
 
         $this->dj->auditlog('language', $langId, 'set allow submit',
                                          $request->request->getBoolean('allow_submit'));
@@ -244,13 +244,13 @@ class LanguageController extends BaseController
     public function toggleJudgeAction(Request $request, string $langId)
     {
         /** @var Language $language */
-        $language = $this->entityManager->getRepository(Language::class)->find($langId);
+        $language = $this->em->getRepository(Language::class)->find($langId);
         if (!$language) {
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
 
         $language->setAllowJudge($request->request->getBoolean('allow_judge'));
-        $this->entityManager->flush();
+        $this->em->flush();
 
         $this->dj->auditlog('language', $langId, 'set allow judge',
                                          $request->request->getBoolean('allow_judge'));
@@ -268,7 +268,7 @@ class LanguageController extends BaseController
     public function editAction(Request $request, string $langId)
     {
         /** @var Language $language */
-        $language = $this->entityManager->getRepository(Language::class)->find($langId);
+        $language = $this->em->getRepository(Language::class)->find($langId);
         if (!$language) {
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
@@ -282,7 +282,7 @@ class LanguageController extends BaseController
             if ($language->getExtensions()) {
                 $language->setExtensions(array_values($language->getExtensions()));
             }
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $language,
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $language,
                               $language->getLangid(), false);
             return $this->redirect($this->generateUrl('jury_language',
                                                       ['langId' => $language->getLangid()]));
@@ -305,11 +305,11 @@ class LanguageController extends BaseController
     public function deleteAction(Request $request, string $langId)
     {
         /** @var Language $language */
-        $language = $this->entityManager->getRepository(Language::class)->find($langId);
+        $language = $this->em->getRepository(Language::class)->find($langId);
         if (!$language) {
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->dj, $language, $language->getName(), $this->generateUrl('jury_languages'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $language, $language->getName(), $this->generateUrl('jury_languages'));
     }
 }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
@@ -31,7 +31,7 @@ class LanguageController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -41,16 +41,16 @@ class LanguageController extends BaseController
     /**
      * LanguageController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -157,7 +157,7 @@ class LanguageController extends BaseController
                 $language->setExtensions(array_values($language->getExtensions()));
             }
             $this->entityManager->persist($language);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $language,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $language,
                               $language->getLangid(), true);
             return $this->redirect($this->generateUrl('jury_language',
                                                       ['langId' => $language->getLangid()]));
@@ -188,7 +188,7 @@ class LanguageController extends BaseController
         $restrictions = ['langid' => $language->getLangid()];
         /** @var Submission[] $submissions */
         list($submissions, $submissionCounts) = $submissionService->getSubmissionList(
-            $this->DOMJudgeService->getCurrentContests(),
+            $this->dj->getCurrentContests(),
             $restrictions
         );
 
@@ -196,7 +196,7 @@ class LanguageController extends BaseController
             'language' => $language,
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
-            'showContest' => count($this->DOMJudgeService->getCurrentContests()) > 1,
+            'showContest' => count($this->dj->getCurrentContests()) > 1,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_language', ['langId' => $language->getLangid()]),
@@ -230,7 +230,7 @@ class LanguageController extends BaseController
         $language->setAllowSubmit($request->request->getBoolean('allow_submit'));
         $this->entityManager->flush();
 
-        $this->DOMJudgeService->auditlog('language', $langId, 'set allow submit',
+        $this->dj->auditlog('language', $langId, 'set allow submit',
                                          $request->request->getBoolean('allow_submit'));
         return $this->redirectToRoute('jury_language', ['langId' => $langId]);
     }
@@ -252,7 +252,7 @@ class LanguageController extends BaseController
         $language->setAllowJudge($request->request->getBoolean('allow_judge'));
         $this->entityManager->flush();
 
-        $this->DOMJudgeService->auditlog('language', $langId, 'set allow judge',
+        $this->dj->auditlog('language', $langId, 'set allow judge',
                                          $request->request->getBoolean('allow_judge'));
         return $this->redirectToRoute('jury_language', ['langId' => $langId]);
     }
@@ -282,7 +282,7 @@ class LanguageController extends BaseController
             if ($language->getExtensions()) {
                 $language->setExtensions(array_values($language->getExtensions()));
             }
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $language,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $language,
                               $language->getLangid(), false);
             return $this->redirect($this->generateUrl('jury_language',
                                                       ['langId' => $language->getLangid()]));
@@ -310,6 +310,6 @@ class LanguageController extends BaseController
             throw new NotFoundHttpException(sprintf('Language with ID %s not found', $langId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->DOMJudgeService, $language, $language->getName(), $this->generateUrl('jury_languages'));
+        return $this->deleteEntity($request, $this->entityManager, $this->dj, $language, $language->getName(), $this->generateUrl('jury_languages'));
     }
 }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/PrintController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/PrintController.php
@@ -32,17 +32,17 @@ class PrintController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * PrintController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService)
+    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
     {
-        $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->entityManager = $entityManager;
+        $this->dj            = $dj;
     }
 
     /**
@@ -53,7 +53,7 @@ class PrintController extends BaseController
      */
     public function showAction(Request $request)
     {
-        if (!$this->DOMJudgeService->dbconfig_get('enable_printing', 0)) {
+        if (!$this->dj->dbconfig_get('enable_printing', 0)) {
             throw new AccessDeniedHttpException("Printing disabled in config");
         }
 

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/PrintController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/PrintController.php
@@ -27,7 +27,7 @@ class PrintController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -36,13 +36,13 @@ class PrintController extends BaseController
 
     /**
      * PrintController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj)
+    public function __construct(EntityManagerInterface $em, DOMJudgeService $dj)
     {
-        $this->entityManager = $entityManager;
-        $this->dj            = $dj;
+        $this->em = $em;
+        $this->dj = $dj;
     }
 
     /**
@@ -82,7 +82,7 @@ class PrintController extends BaseController
         }
 
         /** @var Language[] $languages */
-        $languages = $this->entityManager->createQueryBuilder()
+        $languages = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Language', 'l')
             ->select('l')
             ->andWhere('l.allowSubmit = 1')

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ScoreboardController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ScoreboardController.php
@@ -19,7 +19,7 @@ class ScoreboardController extends Controller
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var ScoreboardService
@@ -28,14 +28,14 @@ class ScoreboardController extends Controller
 
     /**
      * ScoreboardController constructor.
-     * @param DOMJudgeService   $DOMJudgeService
+     * @param DOMJudgeService   $dj
      * @param ScoreboardService $scoreboardService
      */
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         ScoreboardService $scoreboardService
     ) {
-        $this->DOMJudgeService   = $DOMJudgeService;
+        $this->dj                = $dj;
         $this->scoreboardService = $scoreboardService;
     }
 
@@ -49,7 +49,7 @@ class ScoreboardController extends Controller
     {
         $response   = new Response();
         $refreshUrl = $this->generateUrl('jury_scoreboard');
-        $contest    = $this->DOMJudgeService->getCurrentContest();
+        $contest    = $this->dj->getCurrentContest();
         $data       = $this->scoreboardService->getScoreboardTwigData($request, $response, $refreshUrl, true, false,
                                                                       false, $contest);
 

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
@@ -31,7 +31,7 @@ class TeamAffiliationController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -41,16 +41,16 @@ class TeamAffiliationController extends BaseController
     /**
      * TeamCategoryController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -68,7 +68,7 @@ class TeamAffiliationController extends BaseController
             ->groupBy('a.affilid')
             ->getQuery()->getResult();
 
-        $showFlags = $this->DOMJudgeService->dbconfig_get('show_flags', true);
+        $showFlags = $this->dj->dbconfig_get('show_flags', true);
 
         $table_fields = [
             'affilid' => ['title' => 'ID', 'sort' => true],
@@ -171,7 +171,7 @@ class TeamAffiliationController extends BaseController
 
         $data = [
             'teamAffiliation' => $teamAffiliation,
-            'showFlags' => $this->DOMJudgeService->dbconfig_get('show_flags', true),
+            'showFlags' => $this->dj->dbconfig_get('show_flags', true),
             'refresh' => [
                 'after' => 30,
                 'url' => $this->generateUrl('jury_team_affiliation', ['affilId' => $teamAffiliation->getAffilid()]),
@@ -179,14 +179,14 @@ class TeamAffiliationController extends BaseController
             ],
         ];
 
-        if ($currentContest = $this->DOMJudgeService->getCurrentContest()) {
+        if ($currentContest = $this->dj->getCurrentContest()) {
             $data['scoreboard']           = $scoreboardService->getScoreboard($currentContest, true);
-            $data['showFlags']            = $this->DOMJudgeService->dbconfig_get('show_flags', true);
-            $data['showAffiliationLogos'] = $this->DOMJudgeService->dbconfig_get('show_affiliation_logos', false);
-            $data['showAffiliations']     = $this->DOMJudgeService->dbconfig_get('show_affiliations', true);
-            $data['showPending']          = $this->DOMJudgeService->dbconfig_get('show_pending', false);
-            $data['showTeamSubmissions']  = $this->DOMJudgeService->dbconfig_get('show_teams_submissions', true);
-            $data['scoreInSeconds']       = $this->DOMJudgeService->dbconfig_get('score_in_seconds', false);
+            $data['showFlags']            = $this->dj->dbconfig_get('show_flags', true);
+            $data['showAffiliationLogos'] = $this->dj->dbconfig_get('show_affiliation_logos', false);
+            $data['showAffiliations']     = $this->dj->dbconfig_get('show_affiliations', true);
+            $data['showPending']          = $this->dj->dbconfig_get('show_pending', false);
+            $data['showTeamSubmissions']  = $this->dj->dbconfig_get('show_teams_submissions', true);
+            $data['scoreInSeconds']       = $this->dj->dbconfig_get('score_in_seconds', false);
             $data['limitToTeams']         = $teamAffiliation->getTeams();
         }
 
@@ -221,7 +221,7 @@ class TeamAffiliationController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $teamAffiliation,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamAffiliation,
                               $teamAffiliation->getAffilid(), false);
             return $this->redirect($this->generateUrl('jury_team_affiliation',
                                                       ['affilId' => $teamAffiliation->getAffilid()]));
@@ -249,7 +249,7 @@ class TeamAffiliationController extends BaseController
             throw new NotFoundHttpException(sprintf('Team affiliation with ID %s not found', $affilId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->DOMJudgeService, $teamAffiliation,
+        return $this->deleteEntity($request, $this->entityManager, $this->dj, $teamAffiliation,
                                    $teamAffiliation->getName(), $this->generateUrl('jury_team_affiliations'));
     }
 
@@ -270,7 +270,7 @@ class TeamAffiliationController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->entityManager->persist($teamAffiliation);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $teamAffiliation,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamAffiliation,
                               $teamAffiliation->getAffilid(), true);
             return $this->redirect($this->generateUrl('jury_team_affiliation',
                                                       ['affilId' => $teamAffiliation->getAffilid()]));

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
@@ -26,7 +26,7 @@ class TeamAffiliationController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -40,16 +40,16 @@ class TeamAffiliationController extends BaseController
 
     /**
      * TeamCategoryController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -59,7 +59,7 @@ class TeamAffiliationController extends BaseController
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $em               = $this->entityManager;
+        $em               = $this->em;
         $teamAffiliations = $em->createQueryBuilder()
             ->select('a', 'COUNT(t.teamid) AS num_teams')
             ->from('DOMJudgeBundle:TeamAffiliation', 'a')
@@ -164,7 +164,7 @@ class TeamAffiliationController extends BaseController
     public function viewAction(Request $request, ScoreboardService $scoreboardService, int $affilId)
     {
         /** @var TeamAffiliation $teamAffiliation */
-        $teamAffiliation = $this->entityManager->getRepository(TeamAffiliation::class)->find($affilId);
+        $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->find($affilId);
         if (!$teamAffiliation) {
             throw new NotFoundHttpException(sprintf('Team affiliation with ID %s not found', $affilId));
         }
@@ -211,7 +211,7 @@ class TeamAffiliationController extends BaseController
     public function editAction(Request $request, int $affilId)
     {
         /** @var TeamAffiliation $teamAffiliation */
-        $teamAffiliation = $this->entityManager->getRepository(TeamAffiliation::class)->find($affilId);
+        $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->find($affilId);
         if (!$teamAffiliation) {
             throw new NotFoundHttpException(sprintf('Team affiliation with ID %s not found', $affilId));
         }
@@ -221,7 +221,7 @@ class TeamAffiliationController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamAffiliation,
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $teamAffiliation,
                               $teamAffiliation->getAffilid(), false);
             return $this->redirect($this->generateUrl('jury_team_affiliation',
                                                       ['affilId' => $teamAffiliation->getAffilid()]));
@@ -244,12 +244,12 @@ class TeamAffiliationController extends BaseController
     public function deleteAction(Request $request, int $affilId)
     {
         /** @var TeamAffiliation $teamAffiliation */
-        $teamAffiliation = $this->entityManager->getRepository(TeamAffiliation::class)->find($affilId);
+        $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->find($affilId);
         if (!$teamAffiliation) {
             throw new NotFoundHttpException(sprintf('Team affiliation with ID %s not found', $affilId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->dj, $teamAffiliation,
+        return $this->deleteEntity($request, $this->em, $this->dj, $teamAffiliation,
                                    $teamAffiliation->getName(), $this->generateUrl('jury_team_affiliations'));
     }
 
@@ -269,8 +269,8 @@ class TeamAffiliationController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->persist($teamAffiliation);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamAffiliation,
+            $this->em->persist($teamAffiliation);
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $teamAffiliation,
                               $teamAffiliation->getAffilid(), true);
             return $this->redirect($this->generateUrl('jury_team_affiliation',
                                                       ['affilId' => $teamAffiliation->getAffilid()]));

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
@@ -31,7 +31,7 @@ class TeamCategoryController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -41,16 +41,16 @@ class TeamCategoryController extends BaseController
     /**
      * TeamCategoryController constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
 
@@ -152,7 +152,7 @@ class TeamCategoryController extends BaseController
         $restrictions = ['categoryid' => $teamCategory->getCategoryid()];
         /** @var Submission[] $submissions */
         list($submissions, $submissionCounts) = $submissionService->getSubmissionList(
-            $this->DOMJudgeService->getCurrentContests(),
+            $this->dj->getCurrentContests(),
             $restrictions
         );
 
@@ -160,7 +160,7 @@ class TeamCategoryController extends BaseController
             'teamCategory' => $teamCategory,
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
-            'showContest' => count($this->DOMJudgeService->getCurrentContests()) > 1,
+            'showContest' => count($this->dj->getCurrentContests()) > 1,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]),
@@ -198,7 +198,7 @@ class TeamCategoryController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $teamCategory,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamCategory,
                               $teamCategory->getCategoryid(), false);
             $this->addFlash('scoreboard_refresh', 'If the category sort order was changed, it may be necessary to recalculate any cached scoreboards.');
             return $this->redirectToRoute('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]);
@@ -226,7 +226,7 @@ class TeamCategoryController extends BaseController
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->DOMJudgeService, $teamCategory,
+        return $this->deleteEntity($request, $this->entityManager, $this->dj, $teamCategory,
                                    $teamCategory->getName(), $this->generateUrl('jury_team_categories'));
     }
 
@@ -247,7 +247,7 @@ class TeamCategoryController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->entityManager->persist($teamCategory);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $teamCategory,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamCategory,
                               $teamCategory->getCategoryid(), true);
             return $this->redirectToRoute('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]);
         }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
@@ -26,7 +26,7 @@ class TeamCategoryController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -40,16 +40,16 @@ class TeamCategoryController extends BaseController
 
     /**
      * TeamCategoryController constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param EventLogService        $eventLogService
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
     }
@@ -59,7 +59,7 @@ class TeamCategoryController extends BaseController
      */
     public function indexAction(Request $request, Packages $assetPackage)
     {
-        $em             = $this->entityManager;
+        $em             = $this->em;
         $teamCategories = $em->createQueryBuilder()
             ->select('c', 'COUNT(t.teamid) AS num_teams')
             ->from('DOMJudgeBundle:TeamCategory', 'c')
@@ -144,7 +144,7 @@ class TeamCategoryController extends BaseController
     public function viewAction(Request $request, SubmissionService $submissionService, int $categoryId)
     {
         /** @var TeamCategory $teamCategory */
-        $teamCategory = $this->entityManager->getRepository(TeamCategory::class)->find($categoryId);
+        $teamCategory = $this->em->getRepository(TeamCategory::class)->find($categoryId);
         if (!$teamCategory) {
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
@@ -188,7 +188,7 @@ class TeamCategoryController extends BaseController
     public function editAction(Request $request, int $categoryId)
     {
         /** @var TeamCategory $teamCategory */
-        $teamCategory = $this->entityManager->getRepository(TeamCategory::class)->find($categoryId);
+        $teamCategory = $this->em->getRepository(TeamCategory::class)->find($categoryId);
         if (!$teamCategory) {
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
@@ -198,7 +198,7 @@ class TeamCategoryController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamCategory,
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $teamCategory,
                               $teamCategory->getCategoryid(), false);
             $this->addFlash('scoreboard_refresh', 'If the category sort order was changed, it may be necessary to recalculate any cached scoreboards.');
             return $this->redirectToRoute('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]);
@@ -221,12 +221,12 @@ class TeamCategoryController extends BaseController
     public function deleteAction(Request $request, int $categoryId)
     {
         /** @var TeamCategory $teamCategory */
-        $teamCategory = $this->entityManager->getRepository(TeamCategory::class)->find($categoryId);
+        $teamCategory = $this->em->getRepository(TeamCategory::class)->find($categoryId);
         if (!$teamCategory) {
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->dj, $teamCategory,
+        return $this->deleteEntity($request, $this->em, $this->dj, $teamCategory,
                                    $teamCategory->getName(), $this->generateUrl('jury_team_categories'));
     }
 
@@ -246,8 +246,8 @@ class TeamCategoryController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->persist($teamCategory);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $teamCategory,
+            $this->em->persist($teamCategory);
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $teamCategory,
                               $teamCategory->getCategoryid(), true);
             return $this->redirectToRoute('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]);
         }

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/UserController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/UserController.php
@@ -35,7 +35,7 @@ class UserController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    private $DOMJudgeService;
+    private $dj;
 
     /**
      * @var EventLogService
@@ -49,12 +49,12 @@ class UserController extends BaseController
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService,
         TokenStorageInterface $tokenStorage
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
         $this->tokenStorage    = $tokenStorage;
     }
@@ -86,7 +86,7 @@ class UserController extends BaseController
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $users_table      = [];
-        $timeFormat  = (string)$this->DOMJudgeService->dbconfig_get('time_format', '%H:%M');
+        $timeFormat  = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
         foreach ($users as $u) {
             $userdata    = [];
             $useractions = [];
@@ -202,12 +202,12 @@ class UserController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $user,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $user,
                               $user->getUserid(),
                               false);
 
             // If we save the currently logged in used, update the login token
-            if ($user->getUserid() === $this->DOMJudgeService->getUser()->getUserid()) {
+            if ($user->getUserid() === $this->dj->getUser()->getUserid()) {
                 $token = new UsernamePasswordToken(
                     $user,
                     null,
@@ -244,7 +244,7 @@ class UserController extends BaseController
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $userId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->DOMJudgeService, $user, $user->getName(),
+        return $this->deleteEntity($request, $this->entityManager, $this->dj, $user, $user->getName(),
                                    $this->generateUrl('jury_users'));
     }
 
@@ -268,7 +268,7 @@ class UserController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->entityManager->persist($user);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->DOMJudgeService, $user,
+            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $user,
                               $user->getUserid(),
                               true);
             return $this->redirect($this->generateUrl('jury_user',
@@ -323,7 +323,7 @@ class UserController extends BaseController
                 if ( $doit ) {
                     $newpass = Utils::generatePassword();
                     $user->setPlainPassword($newpass);
-                    $this->DOMJudgeService->auditlog('user', $user->getUserid(), 'set password');
+                    $this->dj->auditlog('user', $user->getUserid(), 'set password');
                     $changes[] = [
                             'type' => $role,
                             'id' => $user->getUserid(),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/UserController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/UserController.php
@@ -30,7 +30,7 @@ class UserController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -48,12 +48,12 @@ class UserController extends BaseController
     protected $tokenStorage;
 
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj,
         EventLogService $eventLogService,
         TokenStorageInterface $tokenStorage
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
         $this->tokenStorage    = $tokenStorage;
@@ -67,7 +67,7 @@ class UserController extends BaseController
     public function indexAction()
     {
         /** @var User[] $users */
-        $users = $this->entityManager->createQueryBuilder()
+        $users = $this->em->createQueryBuilder()
             ->select('u', 'r', 't')
             ->from('DOMJudgeBundle:User', 'u')
             ->leftJoin('u.roles', 'r')
@@ -173,7 +173,7 @@ class UserController extends BaseController
     public function viewAction(Request $request, int $userId)
     {
         /** @var User $user */
-        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        $user = $this->em->getRepository(User::class)->find($userId);
         if (!$user) {
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $userId));
         }
@@ -192,7 +192,7 @@ class UserController extends BaseController
     public function editAction(Request $request, int $userId)
     {
         /** @var User $user */
-        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        $user = $this->em->getRepository(User::class)->find($userId);
         if (!$user) {
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $userId));
         }
@@ -202,7 +202,7 @@ class UserController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $user,
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $user,
                               $user->getUserid(),
                               false);
 
@@ -239,12 +239,12 @@ class UserController extends BaseController
     public function deleteAction(Request $request, int $userId)
     {
         /** @var User $user */
-        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        $user = $this->em->getRepository(User::class)->find($userId);
         if (!$user) {
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $userId));
         }
 
-        return $this->deleteEntity($request, $this->entityManager, $this->dj, $user, $user->getName(),
+        return $this->deleteEntity($request, $this->em, $this->dj, $user, $user->getName(),
                                    $this->generateUrl('jury_users'));
     }
 
@@ -259,7 +259,7 @@ class UserController extends BaseController
     {
         $user = new User();
         if ($request->query->has('team')) {
-            $user->setTeam($this->entityManager->getRepository(Team::class)->find($request->query->get('team')));
+            $user->setTeam($this->em->getRepository(Team::class)->find($request->query->get('team')));
         }
 
         $form = $this->createForm(UserType::class, $user);
@@ -267,8 +267,8 @@ class UserController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->persist($user);
-            $this->saveEntity($this->entityManager, $this->eventLogService, $this->dj, $user,
+            $this->em->persist($user);
+            $this->saveEntity($this->em, $this->eventLogService, $this->dj, $user,
                               $user->getUserid(),
                               true);
             return $this->redirect($this->generateUrl('jury_user',
@@ -294,7 +294,7 @@ class UserController extends BaseController
         if ($form->isSubmitted() && $form->isValid()) {
             $groups = $form->get('group')->getData();
 
-            $users = $this->entityManager->getRepository(User::class)->findAll();
+            $users = $this->em->getRepository(User::class)->findAll();
 
             $changes = [];
             foreach ($users as $user) {
@@ -333,7 +333,7 @@ class UserController extends BaseController
                     ];
                 }
             }
-            $this->entityManager->flush();
+            $this->em->flush();
             $response = $this->render('@DOMJudge/jury/tsv/userdata.tsv.twig', [
                 'data' => $changes,
             ]);

--- a/webapp/src/DOMJudgeBundle/Controller/PublicController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/PublicController.php
@@ -39,16 +39,16 @@ class PublicController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     public function __construct(
         DOMJudgeService $dj,
         ScoreboardService $scoreboardService,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $em
     ) {
         $this->dj                = $dj;
         $this->scoreboardService = $scoreboardService;
-        $this->entityManager     = $entityManager;
+        $this->em                = $em;
     }
 
     /**
@@ -145,7 +145,7 @@ class PublicController extends BaseController
      */
     public function teamAction(Request $request, int $teamId)
     {
-        $team             = $this->entityManager->getRepository(Team::class)->find($teamId);
+        $team             = $this->em->getRepository(Team::class)->find($teamId);
         $showFlags        = (bool)$this->dj->dbconfig_get('show_flags', true);
         $showAffiliations = (bool)$this->dj->dbconfig_get('show_affiliations', true);
         $data             = [
@@ -174,7 +174,7 @@ class PublicController extends BaseController
         $defaultMemoryLimit = (int)$this->dj->dbconfig_get('memory_limit', 0);
         $timeFactorDiffers  = false;
         if ($showLimits) {
-            $timeFactorDiffers = $this->entityManager->createQueryBuilder()
+            $timeFactorDiffers = $this->em->createQueryBuilder()
                     ->from('DOMJudgeBundle:Language', 'l')
                     ->select('COUNT(l)')
                     ->andWhere('l.allowSubmit = true')
@@ -185,7 +185,7 @@ class PublicController extends BaseController
 
         $problems = [];
         if ($contest && $contest->getFreezeData()->started()) {
-            $problems = $this->entityManager->createQueryBuilder()
+            $problems = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:ContestProblem', 'cp')
                 ->join('cp.problem', 'p')
                 ->leftJoin('p.testcases', 'tc')
@@ -220,7 +220,7 @@ class PublicController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);
@@ -278,7 +278,7 @@ class PublicController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);
@@ -287,7 +287,7 @@ class PublicController extends BaseController
         }
 
         /** @var TestcaseWithContent $testcase */
-        $testcase = $this->entityManager->createQueryBuilder()
+        $testcase = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TestcaseWithContent', 'tc')
             ->join('tc.problem', 'p')
             ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
@@ -348,7 +348,7 @@ class PublicController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);

--- a/webapp/src/DOMJudgeBundle/Controller/RootController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/RootController.php
@@ -20,15 +20,15 @@ class RootController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * RootController constructor.
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      */
-    public function __construct(DOMJudgeService $DOMJudgeService)
+    public function __construct(DOMJudgeService $dj)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -39,13 +39,13 @@ class RootController extends BaseController
     public function redirectAction(Request $request)
     {
         if ( $this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY') ) {
-            if ( $this->DOMJudgeService->checkrole('jury') ) {
+            if ( $this->dj->checkrole('jury') ) {
                 return $this->redirectToRoute('jury_index');
             }
-            if ( $this->DOMJudgeService->checkrole('team', false) ) {
+            if ( $this->dj->checkrole('team', false) ) {
                 return $this->redirectToRoute('team_index');
             }
-            if ( $this->DOMJudgeService->checkrole('balloon') ) {
+            if ( $this->dj->checkrole('balloon') ) {
                 return $this->redirectToRoute('jury_balloons');
             }
         }

--- a/webapp/src/DOMJudgeBundle/Controller/SecurityController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/SecurityController.php
@@ -18,11 +18,11 @@ class SecurityController extends Controller
     /**
      * @var DOMJudgeService
      */
-    private $DOMJudgeService;
+    private $dj;
 
-    public function __construct(DOMJudgeService $DOMJudgeService)
+    public function __construct(DOMJudgeService $dj)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -40,7 +40,7 @@ class SecurityController extends Controller
             $allowIPAuth = true;
         }
 
-        $ipAutologin = $this->DOMJudgeService->dbconfig_get('ip_autologin', false);
+        $ipAutologin = $this->dj->dbconfig_get('ip_autologin', false);
         if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY') && !$ipAutologin) {
             return $this->redirect($this->generateUrl('root'));
         }
@@ -55,7 +55,7 @@ class SecurityController extends Controller
 
         $em = $this->getDoctrine()->getManager();
 
-        $clientIP = $this->DOMJudgeService->getClientIp();
+        $clientIP = $this->dj->getClientIp();
         $auth_ipaddress_users = [];
         if ($allowIPAuth) {
             $auth_ipaddress_users = $em->getRepository('DOMJudgeBundle:User')->findBy(['ipAddress' => $clientIP]);
@@ -65,7 +65,7 @@ class SecurityController extends Controller
         $response = new Response();
         $response->headers->set('X-Login-Page', $this->generateUrl('login'));
 
-        $registrationCategoryName = $this->DOMJudgeService->dbconfig_get('registration_category_name', '');
+        $registrationCategoryName = $this->dj->dbconfig_get('registration_category_name', '');
         $registrationCategory     = $em->getRepository(TeamCategory::class)->findOneBy(['name' => $registrationCategoryName]);
 
         return $this->render('DOMJudgeBundle:security:login.html.twig', array(
@@ -89,7 +89,7 @@ class SecurityController extends Controller
         }
 
         $em                       = $this->getDoctrine()->getManager();
-        $registrationCategoryName = $this->DOMJudgeService->dbconfig_get('registration_category_name', '');
+        $registrationCategoryName = $this->dj->dbconfig_get('registration_category_name', '');
         $registrationCategory     = $em->getRepository(TeamCategory::class)->findOneBy(['name' => $registrationCategoryName]);
 
         if ($registrationCategory === null) {
@@ -115,7 +115,7 @@ class SecurityController extends Controller
             $team->addUser($user);
             $team->setName($user->getUsername());
             $team->setCategory($registrationCategory);
-            $team->setComments('Registered by ' . $this->DOMJudgeService->getClientIp() . ' on ' . date('r'));
+            $team->setComments('Registered by ' . $this->dj->getClientIp() . ' on ' . date('r'));
 
             $em->persist($user);
             $em->persist($team);

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ClarificationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ClarificationController.php
@@ -38,7 +38,7 @@ class ClarificationController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var EventLogService
@@ -52,12 +52,12 @@ class ClarificationController extends BaseController
 
     public function __construct(
         DOMJudgeService $dj,
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         EventLogService $eventLogService,
         FormFactoryInterface $formFactory
     ) {
         $this->dj              = $dj;
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
         $this->eventLogService = $eventLogService;
         $this->formFactory     = $formFactory;
     }
@@ -77,7 +77,7 @@ class ClarificationController extends BaseController
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
         /** @var Clarification|null $clarification */
-        $clarification = $this->entityManager->createQueryBuilder()
+        $clarification = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Clarification', 'c')
             ->leftJoin('c.problem', 'p')
             ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
@@ -122,7 +122,7 @@ class ClarificationController extends BaseController
             if (!ctype_digit($problemId)) {
                 $category = $problemId;
             } else {
-                $problem = $this->entityManager->getRepository(Problem::class)->find($problemId);
+                $problem = $this->em->getRepository(Problem::class)->find($problemId);
                 $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
@@ -139,8 +139,8 @@ class ClarificationController extends BaseController
                 ->setQueue($queue)
                 ->setBody($formData['message']);
 
-            $this->entityManager->persist($newClarification);
-            $this->entityManager->flush();
+            $this->em->persist($newClarification);
+            $this->em->flush();
 
             $this->dj->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
                                              $contest->getCid());
@@ -168,7 +168,7 @@ class ClarificationController extends BaseController
         foreach ($clarification->getReplies() as $reply) {
             $team->removeUnreadClarification($reply);
         }
-        $this->entityManager->flush();
+        $this->em->flush();
 
         $data = [
             'clarification' => $clarification,
@@ -215,7 +215,7 @@ class ClarificationController extends BaseController
             if (!ctype_digit($problemId)) {
                 $category = $problemId;
             } else {
-                $problem = $this->entityManager->getRepository(Problem::class)->find($problemId);
+                $problem = $this->em->getRepository(Problem::class)->find($problemId);
                 $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
@@ -232,8 +232,8 @@ class ClarificationController extends BaseController
                 ->setQueue($queue)
                 ->setBody($formData['message']);
 
-            $this->entityManager->persist($newClarification);
-            $this->entityManager->flush();
+            $this->em->persist($newClarification);
+            $this->em->flush();
 
             $this->dj->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
                                              $contest->getCid());

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ClarificationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ClarificationController.php
@@ -33,7 +33,7 @@ class ClarificationController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -51,12 +51,12 @@ class ClarificationController extends BaseController
     protected $formFactory;
 
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EntityManagerInterface $entityManager,
         EventLogService $eventLogService,
         FormFactoryInterface $formFactory
     ) {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->entityManager   = $entityManager;
         $this->eventLogService = $eventLogService;
         $this->formFactory     = $formFactory;
@@ -72,10 +72,10 @@ class ClarificationController extends BaseController
      */
     public function viewAction(Request $request, int $clarId)
     {
-        $categories = $this->DOMJudgeService->dbconfig_get('clar_categories');
-        $user       = $this->DOMJudgeService->getUser();
+        $categories = $this->dj->dbconfig_get('clar_categories');
+        $user       = $this->dj->getUser();
         $team       = $user->getTeam();
-        $contest    = $this->DOMJudgeService->getCurrentContest($team->getTeamid());
+        $contest    = $this->dj->getCurrentContest($team->getTeamid());
         /** @var Clarification|null $clarification */
         $clarification = $this->entityManager->createQueryBuilder()
             ->from('DOMJudgeBundle:Clarification', 'c')
@@ -123,7 +123,7 @@ class ClarificationController extends BaseController
                 $category = $problemId;
             } else {
                 $problem = $this->entityManager->getRepository(Problem::class)->find($problemId);
-                $queue   = $this->DOMJudgeService->dbconfig_get('clar_default_problem_queue');
+                $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
                 }
@@ -142,7 +142,7 @@ class ClarificationController extends BaseController
             $this->entityManager->persist($newClarification);
             $this->entityManager->flush();
 
-            $this->DOMJudgeService->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
+            $this->dj->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
                                              $contest->getCid());
             $this->eventLogService->log('clarification', $newClarification->getClarid(), 'create', $contest->getCid());
 
@@ -192,10 +192,10 @@ class ClarificationController extends BaseController
      */
     public function addAction(Request $request)
     {
-        $categories = $this->DOMJudgeService->dbconfig_get('clar_categories');
-        $user       = $this->DOMJudgeService->getUser();
+        $categories = $this->dj->dbconfig_get('clar_categories');
+        $user       = $this->dj->getUser();
         $team       = $user->getTeam();
-        $contest    = $this->DOMJudgeService->getCurrentContest($team->getTeamid());
+        $contest    = $this->dj->getCurrentContest($team->getTeamid());
 
         $formData = [];
         $form     = $this->formFactory
@@ -216,7 +216,7 @@ class ClarificationController extends BaseController
                 $category = $problemId;
             } else {
                 $problem = $this->entityManager->getRepository(Problem::class)->find($problemId);
-                $queue   = $this->DOMJudgeService->dbconfig_get('clar_default_problem_queue');
+                $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
                 }
@@ -235,7 +235,7 @@ class ClarificationController extends BaseController
             $this->entityManager->persist($newClarification);
             $this->entityManager->flush();
 
-            $this->DOMJudgeService->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
+            $this->dj->auditlog('clarification', $newClarification->getClarid(), 'added', null, null,
                                              $contest->getCid());
             $this->eventLogService->log('clarification', $newClarification->getClarid(), 'create', $contest->getCid());
 

--- a/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
@@ -38,7 +38,7 @@ class MiscController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var ScoreboardService
@@ -53,18 +53,18 @@ class MiscController extends BaseController
     /**
      * MiscController constructor.
      * @param DOMJudgeService        $dj
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param ScoreboardService      $scoreboardService
      * @param SubmissionService      $submissionService
      */
     public function __construct(
         DOMJudgeService $dj,
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         ScoreboardService $scoreboardService,
         SubmissionService $submissionService
     ) {
         $this->dj                = $dj;
-        $this->entityManager     = $entityManager;
+        $this->em                = $em;
         $this->scoreboardService = $scoreboardService;
         $this->submissionService = $submissionService;
     }
@@ -104,12 +104,12 @@ class MiscController extends BaseController
             $data['limitToTeams']         = [$team];
             // We need to clear the entity manager, because loading the team scoreboard seems to break getting submission
             // contestproblems for the contest we get the scoreboard for
-            $this->entityManager->clear();
+            $this->em->clear();
             $data['submissions'] = $this->submissionService->getSubmissionList([$contest->getCid() => $contest],
                                                                                ['teamid' => $teamId], 0)[0];
 
             /** @var Clarification[] $clarifications */
-            $clarifications = $this->entityManager->createQueryBuilder()
+            $clarifications = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Clarification', 'c')
                 ->leftJoin('c.problem', 'p')
                 ->leftJoin('c.sender', 's')
@@ -126,7 +126,7 @@ class MiscController extends BaseController
                 ->getResult();
 
             /** @var Clarification[] $clarificationRequests */
-            $clarificationRequests = $this->entityManager->createQueryBuilder()
+            $clarificationRequests = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Clarification', 'c')
                 ->leftJoin('c.problem', 'p')
                 ->leftJoin('c.sender', 's')
@@ -209,7 +209,7 @@ class MiscController extends BaseController
         }
 
         /** @var Language[] $languages */
-        $languages = $this->entityManager->createQueryBuilder()
+        $languages = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Language', 'l')
             ->select('l')
             ->andWhere('l.allowSubmit = 1')

--- a/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
@@ -33,7 +33,7 @@ class MiscController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -52,18 +52,18 @@ class MiscController extends BaseController
 
     /**
      * MiscController constructor.
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EntityManagerInterface $entityManager
      * @param ScoreboardService      $scoreboardService
      * @param SubmissionService      $submissionService
      */
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EntityManagerInterface $entityManager,
         ScoreboardService $scoreboardService,
         SubmissionService $submissionService
     ) {
-        $this->DOMJudgeService   = $DOMJudgeService;
+        $this->dj                = $dj;
         $this->entityManager     = $entityManager;
         $this->scoreboardService = $scoreboardService;
         $this->submissionService = $submissionService;
@@ -78,10 +78,10 @@ class MiscController extends BaseController
      */
     public function homeAction(Request $request)
     {
-        $user    = $this->DOMJudgeService->getUser();
+        $user    = $this->dj->getUser();
         $team    = $user->getTeam();
         $teamId  = $team->getTeamid();
-        $contest = $this->DOMJudgeService->getCurrentContest($teamId);
+        $contest = $this->dj->getCurrentContest($teamId);
 
         $data = [
             'team' => $team,
@@ -94,13 +94,13 @@ class MiscController extends BaseController
         ];
         if ($contest) {
             $data['scoreboard']           = $this->scoreboardService->getTeamScoreboard($contest, $teamId, true);
-            $data['showFlags']            = $this->DOMJudgeService->dbconfig_get('show_flags', true);
-            $data['showAffiliationLogos'] = $this->DOMJudgeService->dbconfig_get('show_affiliation_logos', false);
-            $data['showAffiliations']     = $this->DOMJudgeService->dbconfig_get('show_affiliations', true);
-            $data['showPending']          = $this->DOMJudgeService->dbconfig_get('show_pending', false);
-            $data['showTeamSubmissions']  = $this->DOMJudgeService->dbconfig_get('show_teams_submissions', true);
-            $data['scoreInSeconds']       = $this->DOMJudgeService->dbconfig_get('score_in_seconds', false);
-            $data['verificationRequired'] = $this->DOMJudgeService->dbconfig_get('verification_required', false);
+            $data['showFlags']            = $this->dj->dbconfig_get('show_flags', true);
+            $data['showAffiliationLogos'] = $this->dj->dbconfig_get('show_affiliation_logos', false);
+            $data['showAffiliations']     = $this->dj->dbconfig_get('show_affiliations', true);
+            $data['showPending']          = $this->dj->dbconfig_get('show_pending', false);
+            $data['showTeamSubmissions']  = $this->dj->dbconfig_get('show_teams_submissions', true);
+            $data['scoreInSeconds']       = $this->dj->dbconfig_get('score_in_seconds', false);
+            $data['verificationRequired'] = $this->dj->dbconfig_get('verification_required', false);
             $data['limitToTeams']         = [$team];
             // We need to clear the entity manager, because loading the team scoreboard seems to break getting submission
             // contestproblems for the contest we get the scoreboard for
@@ -143,7 +143,7 @@ class MiscController extends BaseController
 
             $data['clarifications']        = $clarifications;
             $data['clarificationRequests'] = $clarificationRequests;
-            $data['categories']            = $this->DOMJudgeService->dbconfig_get('clar_categories');
+            $data['categories']            = $this->dj->dbconfig_get('clar_categories');
         }
 
         if ($request->isXmlHttpRequest()) {
@@ -168,7 +168,7 @@ class MiscController extends BaseController
         } else {
             $response = $this->redirectToRoute('public_index');
         }
-        return $this->DOMJudgeService->setCookie('domjudge_cid', (string)$contestId, 0, null, '', false, false,
+        return $this->dj->setCookie('domjudge_cid', (string)$contestId, 0, null, '', false, false,
                                                  $response);
     }
 
@@ -180,7 +180,7 @@ class MiscController extends BaseController
      */
     public function printAction(Request $request)
     {
-        if (!$this->DOMJudgeService->dbconfig_get('enable_printing', 0)) {
+        if (!$this->dj->dbconfig_get('enable_printing', 0)) {
             throw new AccessDeniedHttpException("Printing disabled in config");
         }
 
@@ -198,7 +198,7 @@ class MiscController extends BaseController
             $langid   = $data['langid'];
             $username = $this->getUser()->getUsername();
 
-            $team = $this->DOMJudgeService->getUser()->getTeam();
+            $team = $this->dj->getUser()->getTeam();
             $ret  = Printing::send($realfile, $originalfilename, $langid, $username, $team->getName(),
                                    $team->getRoom());
 

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ProblemController.php
@@ -33,17 +33,17 @@ class ProblemController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * ProblemController constructor.
      * @param DOMJudgeService        $dj
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      */
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
     {
-        $this->dj            = $dj;
-        $this->entityManager = $entityManager;
+        $this->dj = $dj;
+        $this->em = $em;
     }
 
     /**
@@ -60,7 +60,7 @@ class ProblemController extends BaseController
         $defaultMemoryLimit = (int)$this->dj->dbconfig_get('memory_limit', 0);
         $timeFactorDiffers  = false;
         if ($showLimits) {
-            $timeFactorDiffers = $this->entityManager->createQueryBuilder()
+            $timeFactorDiffers = $this->em->createQueryBuilder()
                     ->from('DOMJudgeBundle:Language', 'l')
                     ->select('COUNT(l)')
                     ->andWhere('l.allowSubmit = true')
@@ -71,7 +71,7 @@ class ProblemController extends BaseController
 
         $problems = [];
         if ($contest && $contest->getFreezeData()->started()) {
-            $problems = $this->entityManager->createQueryBuilder()
+            $problems = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:ContestProblem', 'cp')
                 ->join('cp.problem', 'p')
                 ->leftJoin('p.testcases', 'tc')
@@ -107,7 +107,7 @@ class ProblemController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);
@@ -166,7 +166,7 @@ class ProblemController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);
@@ -175,7 +175,7 @@ class ProblemController extends BaseController
         }
 
         /** @var TestcaseWithContent $testcase */
-        $testcase = $this->entityManager->createQueryBuilder()
+        $testcase = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:TestcaseWithContent', 'tc')
             ->join('tc.problem', 'p')
             ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
@@ -237,7 +237,7 @@ class ProblemController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
         /** @var ContestProblem $contestProblem */
-        $contestProblem = $this->entityManager->getRepository(ContestProblem::class)->find([
+        $contestProblem = $this->em->getRepository(ContestProblem::class)->find([
                                                                                                'probid' => $probId,
                                                                                                'cid' => $contest->getCid(),
                                                                                            ]);

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ProblemController.php
@@ -28,7 +28,7 @@ class ProblemController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -37,13 +37,13 @@ class ProblemController extends BaseController
 
     /**
      * ProblemController constructor.
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EntityManagerInterface $entityManager
      */
-    public function __construct(DOMJudgeService $DOMJudgeService, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
-        $this->entityManager   = $entityManager;
+        $this->dj            = $dj;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -54,10 +54,10 @@ class ProblemController extends BaseController
      */
     public function problemsAction()
     {
-        $user               = $this->DOMJudgeService->getUser();
-        $contest            = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
-        $showLimits         = (bool)$this->DOMJudgeService->dbconfig_get('show_limits_on_team_page');
-        $defaultMemoryLimit = (int)$this->DOMJudgeService->dbconfig_get('memory_limit', 0);
+        $user               = $this->dj->getUser();
+        $contest            = $this->dj->getCurrentContest($user->getTeamid());
+        $showLimits         = (bool)$this->dj->dbconfig_get('show_limits_on_team_page');
+        $defaultMemoryLimit = (int)$this->dj->dbconfig_get('memory_limit', 0);
         $timeFactorDiffers  = false;
         if ($showLimits) {
             $timeFactorDiffers = $this->entityManager->createQueryBuilder()
@@ -101,8 +101,8 @@ class ProblemController extends BaseController
      */
     public function problemTextAction(int $probId)
     {
-        $user    = $this->DOMJudgeService->getUser();
-        $contest = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $user    = $this->dj->getUser();
+        $contest = $this->dj->getCurrentContest($user->getTeamid());
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
@@ -160,8 +160,8 @@ class ProblemController extends BaseController
      */
     public function sampleTestcaseAction(int $probId, int $index, string $type)
     {
-        $user    = $this->DOMJudgeService->getUser();
-        $contest = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $user    = $this->dj->getUser();
+        $contest = $this->dj->getCurrentContest($user->getTeamid());
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
@@ -231,8 +231,8 @@ class ProblemController extends BaseController
      */
     public function sampleZipAction(int $probId)
     {
-        $user    = $this->DOMJudgeService->getUser();
-        $contest = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $user    = $this->dj->getUser();
+        $contest = $this->dj->getCurrentContest($user->getTeamid());
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
@@ -245,7 +245,7 @@ class ProblemController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
 
-        $zipFilename    = $this->DOMJudgeService->getSamplesZip($contestProblem);
+        $zipFilename    = $this->dj->getSamplesZip($contestProblem);
         $outputFilename = sprintf('samples-%s.zip', $contestProblem->getShortname());
 
         $response = new StreamedResponse();

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ScoreboardController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ScoreboardController.php
@@ -26,7 +26,7 @@ class ScoreboardController extends BaseController
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var ScoreboardService
@@ -40,16 +40,16 @@ class ScoreboardController extends BaseController
 
     /**
      * ScoreboardController constructor.
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param ScoreboardService      $scoreboardService
      * @param EntityManagerInterface $entityManager
      */
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         ScoreboardService $scoreboardService,
         EntityManagerInterface $entityManager
     ) {
-        $this->DOMJudgeService   = $DOMJudgeService;
+        $this->dj                = $dj;
         $this->scoreboardService = $scoreboardService;
         $this->entityManager     = $entityManager;
     }
@@ -62,9 +62,9 @@ class ScoreboardController extends BaseController
      */
     public function scoreboardAction(Request $request)
     {
-        $user       = $this->DOMJudgeService->getUser();
+        $user       = $this->dj->getUser();
         $response   = new Response();
-        $contest    = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $contest    = $this->dj->getCurrentContest($user->getTeamid());
         $refreshUrl = $this->generateUrl('team_scoreboard');
         $data       = $this->scoreboardService->getScoreboardTwigData($request, $response, $refreshUrl, false, false,
                                                                       false, $contest);
@@ -85,8 +85,8 @@ class ScoreboardController extends BaseController
     public function teamAction(Request $request, int $teamId)
     {
         $team             = $this->entityManager->getRepository(Team::class)->find($teamId);
-        $showFlags        = (bool)$this->DOMJudgeService->dbconfig_get('show_flags', true);
-        $showAffiliations = (bool)$this->DOMJudgeService->dbconfig_get('show_affiliations', true);
+        $showFlags        = (bool)$this->dj->dbconfig_get('show_flags', true);
+        $showAffiliations = (bool)$this->dj->dbconfig_get('show_affiliations', true);
         $data             = [
             'team' => $team,
             'showFlags' => $showFlags,

--- a/webapp/src/DOMJudgeBundle/Controller/Team/ScoreboardController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/ScoreboardController.php
@@ -36,22 +36,22 @@ class ScoreboardController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * ScoreboardController constructor.
      * @param DOMJudgeService        $dj
      * @param ScoreboardService      $scoreboardService
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      */
     public function __construct(
         DOMJudgeService $dj,
         ScoreboardService $scoreboardService,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $em
     ) {
         $this->dj                = $dj;
         $this->scoreboardService = $scoreboardService;
-        $this->entityManager     = $entityManager;
+        $this->em                = $em;
     }
 
     /**
@@ -84,7 +84,7 @@ class ScoreboardController extends BaseController
      */
     public function teamAction(Request $request, int $teamId)
     {
-        $team             = $this->entityManager->getRepository(Team::class)->find($teamId);
+        $team             = $this->em->getRepository(Team::class)->find($teamId);
         $showFlags        = (bool)$this->dj->dbconfig_get('show_flags', true);
         $showAffiliations = (bool)$this->dj->dbconfig_get('show_affiliations', true);
         $data             = [

--- a/webapp/src/DOMJudgeBundle/Controller/Team/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/SubmissionController.php
@@ -31,7 +31,7 @@ class SubmissionController extends BaseController
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var SubmissionService
@@ -49,12 +49,12 @@ class SubmissionController extends BaseController
     protected $formFactory;
 
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         SubmissionService $submissionService,
         DOMJudgeService $dj,
         FormFactoryInterface $formFactory
     ) {
-        $this->entityManager     = $entityManager;
+        $this->em                = $em;
         $this->submissionService = $submissionService;
         $this->dj                = $dj;
         $this->formFactory       = $formFactory;
@@ -132,7 +132,7 @@ class SubmissionController extends BaseController
         $team             = $user->getTeam();
         $contest          = $this->dj->getCurrentContest($team->getTeamid());
         /** @var Judging $judging */
-        $judging = $this->entityManager->createQueryBuilder()
+        $judging = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Judging', 'j')
             ->join('j.submission', 's')
             ->join('s.contest_problem', 'cp')
@@ -150,13 +150,13 @@ class SubmissionController extends BaseController
         // Update seen status when viewing submission
         if ($judging && $judging->getSubmission()->getSubmittime() < $contest->getEndtime() && (!$verificationRequired || $judging->getVerified())) {
             $judging->setSeen(true);
-            $this->entityManager->flush();
+            $this->em->flush();
         }
 
         /** @var Testcase[] $runs */
         $runs = [];
         if ($showSampleOutput && $judging && $judging->getResult() !== 'compiler-error') {
-            $runs = $this->entityManager->createQueryBuilder()
+            $runs = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Testcase', 't')
                 ->join('t.testcase_content', 'tc')
                 ->leftJoin('t.judging_runs', 'jr', Join::WITH, 'jr.judging = :judging')

--- a/webapp/src/DOMJudgeBundle/EventListener/ProfilerDisableListener.php
+++ b/webapp/src/DOMJudgeBundle/EventListener/ProfilerDisableListener.php
@@ -21,7 +21,7 @@ class ProfilerDisableListener
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var Profiler
@@ -31,22 +31,22 @@ class ProfilerDisableListener
     /**
      * ProfilerDisableListener constructor.
      * @param KernelInterface $kernel
-     * @param DOMJudgeService $DOMJudgeService
+     * @param DOMJudgeService $dj
      * @param Profiler        $profiler
      */
-    public function __construct(KernelInterface $kernel, DOMJudgeService $DOMJudgeService, Profiler $profiler)
+    public function __construct(KernelInterface $kernel, DOMJudgeService $dj, Profiler $profiler)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
-        $this->profiler        = $profiler;
-        $this->kernel          = $kernel;
+        $this->dj       = $dj;
+        $this->profiler = $profiler;
+        $this->kernel   = $kernel;
     }
 
     public function onKernelRequest()
     {
-        // Disable the profiler for users with the judgehost permission but not the admin one, unless DEBUG contains DEBUG_JUDGE
-        if ($this->DOMJudgeService->checkrole('judgehost') && !$this->DOMJudgeService->checkrole('admin')) {
-            require_once $this->DOMJudgeService->getDomjudgeEtcDir() . '/common-config.php';
-
+        // Disable the profiler for users with the judgehost permission but not the admin one,
+        // unless DEBUG contains DEBUG_JUDGE.
+        if ($this->dj->checkrole('judgehost') && !$this->dj->checkrole('admin')) {
+            require_once $this->dj->getDomjudgeEtcDir() . '/common-config.php';
             if (!(DEBUG & DEBUG_JUDGE)) {
                 $this->profiler->disable();
             }

--- a/webapp/src/DOMJudgeBundle/Form/Type/JudgehostRestrictionType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/JudgehostRestrictionType.php
@@ -20,11 +20,11 @@ class JudgehostRestrictionType extends AbstractType
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $em)
     {
-        $this->entityManager = $entityManager;
+        $this->em = $em;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -35,7 +35,7 @@ class JudgehostRestrictionType extends AbstractType
 
         // Note that we can not use the normal EntityType form type, because these are not Doctrine associations
 
-        $contests       = $this->entityManager->getRepository(Contest::class)->findAll();
+        $contests       = $this->em->getRepository(Contest::class)->findAll();
         $contestChoices = [];
         foreach ($contests as $contest) {
             $contestChoices[$contest->getName()] = $contest->getCid();
@@ -46,7 +46,7 @@ class JudgehostRestrictionType extends AbstractType
             'choices' => $contestChoices,
         ]);
 
-        $problems       = $this->entityManager->getRepository(Problem::class)->findAll();
+        $problems       = $this->em->getRepository(Problem::class)->findAll();
         $problemChoices = [];
         foreach ($problems as $problem) {
             $problemChoices[$problem->getName()] = $problem->getProbid();
@@ -57,7 +57,7 @@ class JudgehostRestrictionType extends AbstractType
             'choices' => $problemChoices,
         ]);
 
-        $languages       = $this->entityManager->getRepository(Language::class)->findAll();
+        $languages       = $this->em->getRepository(Language::class)->findAll();
         $languageChoices = [];
         foreach ($languages as $language) {
             $languageChoices[$language->getName()] = $language->getLangid();

--- a/webapp/src/DOMJudgeBundle/Form/Type/PrintType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/PrintType.php
@@ -14,16 +14,16 @@ class PrintType extends AbstractType
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $em)
     {
-        $this->entityManager = $entityManager;
+        $this->em = $em;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $languages       = $this->entityManager->getRepository(Language::class)->findAll();
+        $languages       = $this->em->getRepository(Language::class)->findAll();
         $languageChoices = [];
         foreach ($languages as $language) {
             $languageChoices[$language->getName()] = $language->getLangid();

--- a/webapp/src/DOMJudgeBundle/Form/Type/RejudgingType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/RejudgingType.php
@@ -24,15 +24,15 @@ class RejudgingType extends AbstractType
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * RejudgingType constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $em)
     {
-        $this->entityManager = $entityManager;
+        $this->em = $em;
     }
 
     /**
@@ -126,7 +126,7 @@ class RejudgingType extends AbstractType
 
         $formProblemModifier = function (FormInterface $form, $contests = []) {
             /** @var Contest[] $contests */
-            $problems = $this->entityManager->createQueryBuilder()
+            $problems = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Problem', 'p')
                 ->join('p.contest_problems', 'cp')
                 ->select('p')
@@ -145,7 +145,7 @@ class RejudgingType extends AbstractType
                 'choices' => $problems,
             ]);
 
-            $teamsQueryBuilder = $this->entityManager->createQueryBuilder()
+            $teamsQueryBuilder = $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Team', 't')
                 ->select('t')
                 ->andWhere('t.enabled = 1')

--- a/webapp/src/DOMJudgeBundle/Form/Type/SubmitProblemType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/SubmitProblemType.php
@@ -26,12 +26,12 @@ class SubmitProblemType extends AbstractType
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
     {
-        $this->dj            = $dj;
-        $this->entityManager = $entityManager;
+        $this->dj = $dj;
+        $this->em = $em;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/webapp/src/DOMJudgeBundle/Form/Type/SubmitProblemType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/SubmitProblemType.php
@@ -21,24 +21,24 @@ class SubmitProblemType extends AbstractType
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
      */
     protected $entityManager;
 
-    public function __construct(DOMJudgeService $DOMJudgeService, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
-        $this->entityManager   = $entityManager;
+        $this->dj            = $dj;
+        $this->entityManager = $entityManager;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $allowMultipleFiles = $this->DOMJudgeService->dbconfig_get('sourcefiles_limit', 100) > 1;
-        $user               = $this->DOMJudgeService->getUser();
-        $contest            = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $allowMultipleFiles = $this->dj->dbconfig_get('sourcefiles_limit', 100) > 1;
+        $user               = $this->dj->getUser();
+        $contest            = $this->dj->getCurrentContest($user->getTeamid());
 
         $builder->add('code', BootstrapFileType::class, [
             'label' => 'Source file' . ($allowMultipleFiles ? 's' : ''),

--- a/webapp/src/DOMJudgeBundle/Form/Type/TeamClarificationType.php
+++ b/webapp/src/DOMJudgeBundle/Form/Type/TeamClarificationType.php
@@ -14,11 +14,11 @@ class TeamClarificationType extends AbstractType
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
-    public function __construct(DOMJudgeService $DOMJudgeService)
+    public function __construct(DOMJudgeService $dj)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -36,9 +36,9 @@ class TeamClarificationType extends AbstractType
 
         $subjects = [];
         /** @var string[] $categories */
-        $categories = $this->DOMJudgeService->dbconfig_get('clar_categories');
-        $user       = $this->DOMJudgeService->getUser();
-        $contest    = $this->DOMJudgeService->getCurrentContest($user->getTeamid());
+        $categories = $this->dj->dbconfig_get('clar_categories');
+        $user       = $this->dj->getUser();
+        $contest    = $this->dj->getCurrentContest($user->getTeamid());
         foreach ($categories as $categoryId => $categoryName) {
             $subjects[$categoryName] = sprintf('%d-%s', $contest->getCid(), $categoryId);
         }

--- a/webapp/src/DOMJudgeBundle/Security/UserStateUpdater.php
+++ b/webapp/src/DOMJudgeBundle/Security/UserStateUpdater.php
@@ -18,12 +18,12 @@ class UserStateUpdater
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
     {
-        $this->dj            = $dj;
-        $this->entityManager = $entityManager;
+        $this->dj = $dj;
+        $this->em = $em;
     }
 
     public function updateUserState(AuthenticationEvent $event)
@@ -36,7 +36,7 @@ class UserStateUpdater
                 $user->getTeam()->setTeampageFirstVisited(Utils::now());
             }
 
-            $this->entityManager->flush();
+            $this->em->flush();
         }
     }
 }

--- a/webapp/src/DOMJudgeBundle/Security/UserStateUpdater.php
+++ b/webapp/src/DOMJudgeBundle/Security/UserStateUpdater.php
@@ -13,24 +13,24 @@ class UserStateUpdater
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
      */
     protected $entityManager;
 
-    public function __construct(DOMJudgeService $DOMJudgeService, EntityManagerInterface $entityManager)
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $entityManager)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
-        $this->entityManager   = $entityManager;
+        $this->dj            = $dj;
+        $this->entityManager = $entityManager;
     }
 
     public function updateUserState(AuthenticationEvent $event)
     {
         if ($event->getAuthenticationToken() && ($user = $event->getAuthenticationToken()->getUser()) && $user instanceof User) {
             $user->setLastLogin(Utils::now());
-            $user->setLastIpAddress($this->DOMJudgeService->getClientIp());
+            $user->setLastIpAddress($this->dj->getClientIp());
 
             if ($user->getTeam() && !$user->getTeam()->getTeampageFirstVisited()) {
                 $user->getTeam()->setTeampageFirstVisited(Utils::now());

--- a/webapp/src/DOMJudgeBundle/Serializer/ContestVisitor.php
+++ b/webapp/src/DOMJudgeBundle/Serializer/ContestVisitor.php
@@ -17,15 +17,15 @@ class ContestVisitor implements EventSubscriberInterface
     /**
      * @var DOMJudgeService
      */
-    private $DOMJudgeService;
+    private $dj;
 
     /**
      * ContestVisitor constructor.
-     * @param DOMJudgeService $DOMJudgeService
+     * @param DOMJudgeService $dj
      */
-    public function __construct(DOMJudgeService $DOMJudgeService)
+    public function __construct(DOMJudgeService $dj)
     {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -51,6 +51,6 @@ class ContestVisitor implements EventSubscriberInterface
     {
         /** @var JsonSerializationVisitor $visitor */
         $visitor = $event->getVisitor();
-        $visitor->setData('penalty_time', (int)$this->DOMJudgeService->dbconfig_get('penalty_time',20));
+        $visitor->setData('penalty_time', (int)$this->dj->dbconfig_get('penalty_time',20));
     }
 }

--- a/webapp/src/DOMJudgeBundle/Serializer/SubmissionVisitor.php
+++ b/webapp/src/DOMJudgeBundle/Serializer/SubmissionVisitor.php
@@ -20,7 +20,7 @@ class SubmissionVisitor implements EventSubscriberInterface
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EventLogService
@@ -39,17 +39,17 @@ class SubmissionVisitor implements EventSubscriberInterface
 
     /**
      * SubmissionVisitor constructor.
-     * @param DOMJudgeService $DOMJudgeService
+     * @param DOMJudgeService $dj
      * @param EventLogService $eventLogService
      * @param RouterInterface $router
      */
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EventLogService $eventLogService,
         RouterInterface $router,
         EntityManagerInterface $entityManager
     ) {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
         $this->router          = $router;
         $this->entityManager   = $entityManager;
@@ -76,7 +76,7 @@ class SubmissionVisitor implements EventSubscriberInterface
      */
     public function onPostSerialize(ObjectEvent $event)
     {
-        if ($this->DOMJudgeService->checkrole('jury')) {
+        if ($this->dj->checkrole('jury')) {
             /** @var JsonSerializationVisitor $visitor */
             $visitor = $event->getVisitor();
             /** @var Submission $submission */

--- a/webapp/src/DOMJudgeBundle/Serializer/SubmissionVisitor.php
+++ b/webapp/src/DOMJudgeBundle/Serializer/SubmissionVisitor.php
@@ -35,7 +35,7 @@ class SubmissionVisitor implements EventSubscriberInterface
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * SubmissionVisitor constructor.
@@ -47,12 +47,12 @@ class SubmissionVisitor implements EventSubscriberInterface
         DOMJudgeService $dj,
         EventLogService $eventLogService,
         RouterInterface $router,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $em
     ) {
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
         $this->router          = $router;
-        $this->entityManager   = $entityManager;
+        $this->em              = $em;
     }
 
     /**
@@ -84,9 +84,9 @@ class SubmissionVisitor implements EventSubscriberInterface
             $filesRoute         = $this->router->generate('submission_files',
                                                           [
                                                               'cid' => $submission->getContest()->getApiId($this->eventLogService,
-                                                                                                           $this->entityManager),
+                                                                                                           $this->em),
                                                               'id' => $submission->getApiId($this->eventLogService,
-                                                                                            $this->entityManager)
+                                                                                            $this->em)
                                                           ]);
             $apiRootRoute       = $this->router->generate('api_root');
             $relativeFilesRoute = substr(

--- a/webapp/src/DOMJudgeBundle/Service/BalloonService.php
+++ b/webapp/src/DOMJudgeBundle/Service/BalloonService.php
@@ -18,19 +18,19 @@ class BalloonService
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * BalloonService constructor.
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService
+        DOMJudgeService $dj
     ) {
         $this->entityManager   = $entityManager;
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
     }
 
     /**
@@ -57,7 +57,7 @@ class BalloonService
 
         // Also make sure it is verified if this is required
         if (!$judging->getVerified() &&
-            $this->DOMJudgeService->dbconfig_get('verification_required', false)) {
+            $this->dj->dbconfig_get('verification_required', false)) {
             return;
         }
 

--- a/webapp/src/DOMJudgeBundle/Service/BalloonService.php
+++ b/webapp/src/DOMJudgeBundle/Service/BalloonService.php
@@ -13,7 +13,7 @@ class BalloonService
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var DOMJudgeService
@@ -22,14 +22,14 @@ class BalloonService
 
     /**
      * BalloonService constructor.
-     * @param EntityManagerInterface $entityManager
+     * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      */
     public function __construct(
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         DOMJudgeService $dj
     ) {
-        $this->entityManager   = $entityManager;
+        $this->em = $em;
         $this->dj = $dj;
     }
 
@@ -62,7 +62,7 @@ class BalloonService
         }
 
         // prevent duplicate balloons in case of multiple correct submissions
-        $numCorrect = $this->entityManager->createQueryBuilder()
+        $numCorrect = $this->em->createQueryBuilder()
             ->from('DOMJudgeBundle:Balloon', 'b')
             ->select('COUNT(b.submitid) AS numBallons')
             ->join('b.submission', 's')
@@ -80,9 +80,9 @@ class BalloonService
             if ($contest->getProcessBalloons()) {
                 $balloon = new Balloon();
                 $balloon->setSubmission(
-                    $this->entityManager->getReference(Submission::class, $submission->getSubmitid()));
-                $this->entityManager->persist($balloon);
-                $this->entityManager->flush();
+                    $this->em->getReference(Submission::class, $submission->getSubmitid()));
+                $this->em->persist($balloon);
+                $this->em->flush();
             }
         }
     }

--- a/webapp/src/DOMJudgeBundle/Service/BaylorCmsService.php
+++ b/webapp/src/DOMJudgeBundle/Service/BaylorCmsService.php
@@ -20,7 +20,7 @@ class BaylorCmsService
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -34,16 +34,16 @@ class BaylorCmsService
 
     /**
      * BaylorCmsService constructor.
-     * @param DOMJudgeService        $DOMJudgeService
+     * @param DOMJudgeService        $dj
      * @param EntityManagerInterface $entityManager
      * @param                        $domjudgeVersion
      */
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EntityManagerInterface $entityManager,
         $domjudgeVersion
     ) {
-        $this->DOMJudgeService = $DOMJudgeService;
+        $this->dj = $dj;
         $this->entityManager   = $entityManager;
         $this->client          = new Client(
             [
@@ -88,7 +88,7 @@ class BaylorCmsService
         }
 
         $body = (string)$response->getBody();
-        $json = $this->DOMJudgeService->jsonDecode((string)$body);
+        $json = $this->dj->jsonDecode((string)$body);
 
         if ($json === null) {
             $message = sprintf('Error retrieving API data. API gave us: %s', $body);
@@ -211,7 +211,7 @@ class BaylorCmsService
             return null;
         }
 
-        $body = $this->DOMJudgeService->jsonDecode((string)$response->getBody());
+        $body = $this->dj->jsonDecode((string)$response->getBody());
         return $body['access_token'];
     }
 }

--- a/webapp/src/DOMJudgeBundle/Service/EventLogService.php
+++ b/webapp/src/DOMJudgeBundle/Service/EventLogService.php
@@ -130,7 +130,7 @@ class EventLogService implements ContainerAwareInterface
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -143,13 +143,13 @@ class EventLogService implements ContainerAwareInterface
     protected $logger;
 
     public function __construct(
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         EntityManagerInterface $entityManager,
         LoggerInterface $logger
     ) {
-        $this->DOMJudgeService = $DOMJudgeService;
-        $this->entityManager   = $entityManager;
-        $this->logger          = $logger;
+        $this->dj            = $dj;
+        $this->entityManager = $entityManager;
+        $this->logger        = $logger;
 
         foreach ($this->apiEndpoints as $endpoint => $data) {
             if (!array_key_exists(self::KEY_URL, $data)) {
@@ -256,7 +256,7 @@ class EventLogService implements ContainerAwareInterface
         }
 
         if ($ids === [null] && $json !== null) {
-            $data = $this->DOMJudgeService->jsonDecode($json);
+            $data = $this->dj->jsonDecode($json);
             if (!empty($data['id'])) {
                 $ids = [$data['id']];
             }
@@ -306,7 +306,7 @@ class EventLogService implements ContainerAwareInterface
             } elseif ($type === 'teams') {
                 $expectedEvents = 0;
                 foreach ($dataIds as $dataId) {
-                    $contests        = $this->DOMJudgeService->getCurrentContests($dataId);
+                    $contests        = $this->dj->getCurrentContests($dataId);
                     $contestIdsForId = array_map(function (Contest $contest) {
                         return $contest->getCid();
                     }, $contests);
@@ -322,7 +322,7 @@ class EventLogService implements ContainerAwareInterface
                 }
                 $contestId = $contestIds[0];
             } else {
-                $contests       = $this->DOMJudgeService->getCurrentContests();
+                $contests       = $this->dj->getCurrentContests();
                 $contestIds     = array_map(function (Contest $contest) {
                     return $contest->getCid();
                 }, $contests);
@@ -355,8 +355,8 @@ class EventLogService implements ContainerAwareInterface
                 $query = ['ids' => $ids];
             }
 
-            $this->DOMJudgeService->withAllRoles(function () use ($query, $url, &$json) {
-                $json = $this->DOMJudgeService->internalApiRequest($url, Request::METHOD_GET, $query);
+            $this->dj->withAllRoles(function () use ($query, $url, &$json) {
+                $json = $this->dj->internalApiRequest($url, Request::METHOD_GET, $query);
             });
 
             if ($json === null) {
@@ -381,7 +381,7 @@ class EventLogService implements ContainerAwareInterface
         $now = sprintf('%.3f', microtime(true));
 
         if ($jsonPassed) {
-            $json = $this->DOMJudgeService->jsonDecode($json);
+            $json = $this->dj->jsonDecode($json);
         }
 
         // TODO: can this be wrapped into a single query?
@@ -503,7 +503,7 @@ class EventLogService implements ContainerAwareInterface
         if ($endpointData[self::KEY_ALWAYS_USE_EXTERNAL_ID] ?? false) {
             $lookupExternalid = true;
         } else {
-            $dataSource = $this->DOMJudgeService->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
+            $dataSource = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
 
             if ($dataSource !== DOMJudgeService::DATA_SOURCE_LOCAL) {
                 $endpointType = $endpointData[self::KEY_TYPE];

--- a/webapp/src/DOMJudgeBundle/Service/RejudgingService.php
+++ b/webapp/src/DOMJudgeBundle/Service/RejudgingService.php
@@ -25,7 +25,7 @@ class RejudgingService
     /**
      * @var DOMJudgeService
      */
-    protected $DOMJudgeService;
+    protected $dj;
 
     /**
      * @var ScoreboardService
@@ -52,13 +52,13 @@ class RejudgingService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
-        DOMJudgeService $DOMJudgeService,
+        DOMJudgeService $dj,
         ScoreboardService $scoreboardService,
         EventLogService $eventLogService,
         BalloonService $balloonService
     ) {
         $this->entityManager     = $entityManager;
-        $this->DOMJudgeService   = $DOMJudgeService;
+        $this->dj                = $dj;
         $this->scoreboardService = $scoreboardService;
         $this->eventLogService   = $eventLogService;
         $this->balloonService    = $balloonService;
@@ -78,7 +78,7 @@ class RejudgingService
     {
         // This might take a while
         ini_set('max_execution_time', '300');
-        
+
         if ($rejudging->getEndtime()) {
             $error = sprintf('Rejudging already %s.', $rejudging->getValid() ? 'applied' : 'canceled');
             if ($progressReporter) {
@@ -136,7 +136,7 @@ class RejudgingService
             ->getQuery()
             ->getResult();
 
-        $this->DOMJudgeService->auditlog('rejudging', $rejudgingId, $action . 'ing rejudge', '(start)');
+        $this->dj->auditlog('rejudging', $rejudgingId, $action . 'ing rejudge', '(start)');
 
         // This loop uses direct queries instead of Doctrine classes to speed it up drastically
 
@@ -227,14 +227,14 @@ class RejudgingService
         // Update the rejudging itself
         /** @var Rejudging $rejudging */
         $rejudging = $this->entityManager->getRepository(Rejudging::class)->find($rejudgingId);
-        $user      = $this->entityManager->getRepository(User::class)->find($this->DOMJudgeService->getUser()->getUserid());
+        $user      = $this->entityManager->getRepository(User::class)->find($this->dj->getUser()->getUserid());
         $rejudging
             ->setEndtime(Utils::now())
             ->setFinishUser($user)
             ->setValid($action === self::ACTION_APPLY);
         $this->entityManager->flush();
 
-        $this->DOMJudgeService->auditlog('rejudging', $rejudgingId, $action . 'ing rejudge', '(end)');
+        $this->dj->auditlog('rejudging', $rejudgingId, $action . 'ing rejudge', '(end)');
 
         return true;
     }

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -25,7 +25,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
     /**
      * @var EntityManagerInterface
      */
-    protected $entityManager;
+    protected $em;
 
     /**
      * @var SubmissionService
@@ -44,13 +44,13 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
 
     public function __construct(
         DOMJudgeService $dj,
-        EntityManagerInterface $entityManager,
+        EntityManagerInterface $em,
         SubmissionService $submissionService,
         EventLogService $eventLogService,
         KernelInterface $kernel
     ) {
         $this->dj                = $dj;
-        $this->entityManager     = $entityManager;
+        $this->em                = $em;
         $this->submissionService = $submissionService;
         $this->eventLogService   = $eventLogService;
         $this->kernel            = $kernel;
@@ -120,7 +120,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             'ext_ccs_url' => defined('EXT_CCS_URL') ? EXT_CCS_URL : null,
             'current_team_contest' => $team ? $this->dj->getCurrentContest($user->getTeamid()) : null,
             'current_team_contests' => $team ? $this->dj->getCurrentContests($user->getTeamid()) : null,
-            'submission_languages' => $this->entityManager->createQueryBuilder()
+            'submission_languages' => $this->em->createQueryBuilder()
                 ->from('DOMJudgeBundle:Language', 'l')
                 ->select('l')
                 ->andWhere('l.allowSubmit = 1')
@@ -297,7 +297,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
         $judging   = $submission->getJudgings()->first();
         $judgingId = $judging ? $judging->getJudgingid() : null;
         $probId    = $submission->getProbid();
-        $testcases = $this->entityManager->getConnection()->fetchAll(
+        $testcases = $this->em->getConnection()->fetchAll(
             'SELECT r.runresult, t.rank, t.description
                   FROM testcase t
                   LEFT JOIN judging_run r ON (r.testcaseid = t.testcaseid

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -20,7 +20,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
     /**
      * @var DOMJudgeService
      */
-    protected $domjudge;
+    protected $dj;
 
     /**
      * @var EntityManagerInterface
@@ -43,13 +43,13 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
     protected $kernel;
 
     public function __construct(
-        DOMJudgeService $domjudge,
+        DOMJudgeService $dj,
         EntityManagerInterface $entityManager,
         SubmissionService $submissionService,
         EventLogService $eventLogService,
         KernelInterface $kernel
     ) {
-        $this->domjudge          = $domjudge;
+        $this->dj                = $dj;
         $this->entityManager     = $entityManager;
         $this->submissionService = $submissionService;
         $this->eventLogService   = $eventLogService;
@@ -100,26 +100,26 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
 
     public function getGlobals()
     {
-        $refresh_cookie = $this->domjudge->getCookie("domjudge_refresh");
+        $refresh_cookie = $this->dj->getCookie("domjudge_refresh");
         $refresh_flag   = ($refresh_cookie == null || (bool)$refresh_cookie);
 
         require_once $this->domjudge->getDomjudgeEtcDir() . '/domserver-config.php';
 
-        $user = $this->domjudge->getUser();
+        $user = $this->dj->getUser();
         $team = $user ? $user->getTeam() : null;
 
         // These variables mostly exist for the header template
         return [
-            'current_contest' => $this->domjudge->getCurrentContest(),
-            'current_contests' => $this->domjudge->getCurrentContests(),
-            'current_public_contest' => $this->domjudge->getCurrentContest(-1),
-            'current_public_contests' => $this->domjudge->getCurrentContests(-1),
-            'have_printing' => $this->domjudge->dbconfig_get('enable_printing', 0),
+            'current_contest' => $this->dj->getCurrentContest(),
+            'current_contests' => $this->dj->getCurrentContests(),
+            'current_public_contest' => $this->dj->getCurrentContest(-1),
+            'current_public_contests' => $this->dj->getCurrentContests(-1),
+            'have_printing' => $this->dj->dbconfig_get('enable_printing', 0),
             'refresh_flag' => $refresh_flag,
             'icat_url' => defined('ICAT_URL') ? ICAT_URL : null,
             'ext_ccs_url' => defined('EXT_CCS_URL') ? EXT_CCS_URL : null,
-            'current_team_contest' => $team ? $this->domjudge->getCurrentContest($user->getTeamid()) : null,
-            'current_team_contests' => $team ? $this->domjudge->getCurrentContests($user->getTeamid()) : null,
+            'current_team_contest' => $team ? $this->dj->getCurrentContest($user->getTeamid()) : null,
+            'current_team_contests' => $team ? $this->dj->getCurrentContests($user->getTeamid()) : null,
             'submission_languages' => $this->entityManager->createQueryBuilder()
                 ->from('DOMJudgeBundle:Language', 'l')
                 ->select('l')
@@ -153,7 +153,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
         if ($datetime === null) {
             $datetime = Utils::now();
         }
-        if ($contest !== null && $this->domjudge->dbconfig_get('show_relative_time', false)) {
+        if ($contest !== null && $this->dj->dbconfig_get('show_relative_time', false)) {
             $relativeTime = $contest->getContestTime((float)$datetime);
             $sign         = ($relativeTime < 0 ? -1 : 1);
             $relativeTime *= $sign;
@@ -176,7 +176,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             }
         } else {
             if ($format === null) {
-                $format = $this->domjudge->dbconfig_get('time_format', '%H:%M');
+                $format = $this->dj->dbconfig_get('time_format', '%H:%M');
             }
             return Utils::printtime($datetime, $format);
         }
@@ -724,7 +724,7 @@ JS;
             SUBMITDIR . '/' . $newsourcefile,
             $oldFile,
             SUBMITDIR . '/' . $oldsourcefile,
-            $this->domjudge->getDomjudgeTmpDir()
+            $this->dj->getDomjudgeTmpDir()
         );
 
         return $this->parseSourceDiff($difftext);
@@ -807,7 +807,7 @@ JS;
      */
     public function scoreTime($time)
     {
-        return Utils::scoretime($time, (bool)$this->domjudge->dbconfig_get('score_in_seconds', false));
+        return Utils::scoretime($time, (bool)$this->dj->dbconfig_get('score_in_seconds', false));
     }
 
     /**
@@ -819,8 +819,8 @@ JS;
      */
     public function calculatePenaltyTime(bool $solved, int $num_submissions)
     {
-        return Utils::calcPenaltyTime($solved, $num_submissions, (int)$this->domjudge->dbconfig_get('penalty_time', 20),
-                                      (bool)$this->domjudge->dbconfig_get('score_in_seconds', false));
+        return Utils::calcPenaltyTime($solved, $num_submissions, (int)$this->dj->dbconfig_get('penalty_time', 20),
+                                      (bool)$this->dj->dbconfig_get('score_in_seconds', false));
     }
 
     /**

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -103,7 +103,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
         $refresh_cookie = $this->dj->getCookie("domjudge_refresh");
         $refresh_flag   = ($refresh_cookie == null || (bool)$refresh_cookie);
 
-        require_once $this->domjudge->getDomjudgeEtcDir() . '/domserver-config.php';
+        require_once $this->dj->getDomjudgeEtcDir() . '/domserver-config.php';
 
         $user = $this->dj->getUser();
         $team = $user ? $user->getTeam() : null;
@@ -419,7 +419,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
      */
     public function externalCcsUrl(Submission $submission)
     {
-        require_once $this->domjudge->getDomjudgeEtcDir() . '/domserver-config.php';
+        require_once $this->dj->getDomjudgeEtcDir() . '/domserver-config.php';
 
         if (defined('EXT_CCS_URL')) {
             if ($submission->getExternalid()) {
@@ -717,7 +717,7 @@ JS;
                                                                          'filename' => $oldFile->getFilename()
                                                                      ]);
 
-        require_once $this->domjudge->getDomjudgeEtcDir() . '/domserver-static.php';
+        require_once $this->dj->getDomjudgeEtcDir() . '/domserver-static.php';
 
         $difftext = Utils::createDiff(
             $newFile,


### PR DESCRIPTION
The current webapp contains many references to `DOMJudgeService` and `EntityManager`, most if not all of these occurrences (attributes and variables) have been replaced with `dj` and `em` respectively.