### PR TITLE
Implemented max-width for team-, affiliate-names

### DIFF
--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -59,7 +59,8 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('openid_clientid', '""', 'string', '0','Misc', 'OpenID Connect client id'),
 ('openid_clientsecret', '""', 'string', '0', 'Misc', 'OpenID Connect client secret'),
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
-('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.');
+('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.'),
+('team_column_width', '0', 'int', '0', 'Misc', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.');
 
 
 --

--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -51,6 +51,7 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('time_format', '"%H:%M"', 'string', '0', 'Display', 'The format used to print times. For formatting options see the PHP \'strftime\' function.'),
 ('thumbnail_size', '128', 'int', '0', 'Display', 'Maximum width/height of a thumbnail for uploaded testcase images.'),
 ('show_limits_on_team_page', '0', 'bool', '1', 'Display', 'Show time and memory limit on the team problems page'),
+('team_column_width', '0', 'int', '0', 'Display', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.'),
 ('enable_printing', '0', 'bool', '1', 'Misc', 'Enable teams and jury to send source code to a printer via the DOMjudge web interface.'),
 ('registration_category_name', '""', 'string', '1', 'Misc', 'Team category for users that register themselves with the system. Disabled if empty.'),
 ('allow_openid_auth', '0', 'bool', '1', 'Misc', 'Allow users to log in using OpenID'),
@@ -59,8 +60,7 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('openid_clientid', '""', 'string', '0','Misc', 'OpenID Connect client id'),
 ('openid_clientsecret', '""', 'string', '0', 'Misc', 'OpenID Connect client secret'),
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
-('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.'),
-('team_column_width', '0', 'int', '0', 'Misc', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.');
+('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.');
 
 
 --

--- a/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
+++ b/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
@@ -62,7 +62,8 @@ UPDATE `configuration` SET `category` = 'Misc' WHERE `name` IN (
 INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `description`) VALUES
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
 ('update_judging_seconds', '0', 'int', '0', 'Judging', 'Post updates to a judging every X seconds. Set to 0 to update after each judging_run.'),
-('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.');
+('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.'),
+('team_column_width', '0', 'int', '0', 'Misc', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.');
 
 UPDATE `configuration` SET `name` = 'registration_category_name',
   `value` = IF(`value` = '0', '""', '"Self-Registered"'),

--- a/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
+++ b/sql/upgrade/upgrade_6.0.0_6.1.0DEV.sql
@@ -63,7 +63,7 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
 ('update_judging_seconds', '0', 'int', '0', 'Judging', 'Post updates to a judging every X seconds. Set to 0 to update after each judging_run.'),
 ('ip_autologin', '0', 'bool', '0', 'Misc', 'Enable to skip the login page when using IP authentication.'),
-('team_column_width', '0', 'int', '0', 'Misc', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.');
+('team_column_width', '0', 'int', '0', 'Display', 'Maximum width of team column on scoreboard. Leave 0 for no maximum.');
 
 UPDATE `configuration` SET `name` = 'registration_category_name',
   `value` = IF(`value` = '0', '""', '"Self-Registered"'),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamAffiliationController.php
@@ -177,6 +177,7 @@ class TeamAffiliationController extends BaseController
                 'url' => $this->generateUrl('jury_team_affiliation', ['affilId' => $teamAffiliation->getAffilid()]),
                 'ajax' => true,
             ],
+            'maxWidth' => $this->dj->dbconfig_get('team_column_width', 0),
         ];
 
         if ($currentContest = $this->dj->getCurrentContest()) {

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
@@ -249,6 +249,7 @@ class TeamController extends BaseController
             'showAffiliations' => (bool)$this->dj->dbconfig_get('show_affiliations', true),
             'showFlags' => (bool)$this->dj->dbconfig_get('show_flags', true),
             'showContest' => count($this->dj->getCurrentContests()) > 1,
+            'maxWidth' => $this->dj->dbconfig_get("team_column_width", 0),
         ];
 
         $currentContest = $this->dj->getCurrentContest();

--- a/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/MiscController.php
@@ -91,6 +91,7 @@ class MiscController extends BaseController
                 'url' => $this->generateUrl('team_index'),
                 'ajax' => true,
             ],
+            'maxWidth' => $this->dj->dbconfig_get('team_column_width', 0),
         ];
         if ($contest) {
             $data['scoreboard']           = $this->scoreboardService->getTeamScoreboard($contest, $teamId, true);

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -14,6 +14,14 @@
     {% set static = false %}
 {% endif %}
 
+{% if maxWidth > 0 %}
+    <style>
+        .forceWidth {
+            max-width: {{ maxWidth }}px;
+        }
+    </style>
+{% endif %}
+
 <table class="scoreboard center {% if jury %}scoreboard_jury{% endif %}">
 
     {# output table column groups (for the styles) #}
@@ -89,6 +97,7 @@
     <tbody>
     {% set previousSortOrder = -1 %}
     {% set previousTeam = null %}
+    {% set backgroundColors = {"FFFFFF": 1} %}
     {% for score in scoreboard.scores if (limitToTeams is null or score.team.teamid in limitToTeamIds) %}
         {% set classes = [] %}
         {% if score.team.category.sortorder != previousSortOrder %}
@@ -163,8 +172,13 @@
                     {% endif %}
                 </td>
             {% endif %}
-            <td class="scoretn"
-                {% if color is not null %}style="background: {{ color }};"{% endif %} {% if jury %}title="{{ score.team.name }}"{% endif %}>
+            {% if color is null %}
+                {% set color = "FFFFFF" %}
+            {% else %}
+                {% set color = color|trim("#") %}
+                {% set backgroundColors = backgroundColors|merge({(''~color): 1}) %}
+            {% endif %}
+            <td class="scoretn cl{{ color }}" {% if jury %}title="{{ score.team.name }}"{% endif %}>
                 {% set link = null %}
                 {% set extra = null %}
                 {% if not static %}
@@ -184,10 +198,11 @@
                             {{ score.team.category.name }}
                         </span>
                     {% endif %}
-                    {{ score.team.name }}
+                    <span class="forceWidth">
+                        {{ score.team.name }}
+                    </span>
                     {% if showAffiliations %}
-                        <br/>
-                        <span class="univ">
+                        <span class="univ forceWidth">
                             {% if score.team.affiliation %}
                                 {{ score.team.affiliation.name }}
                             {% endif %}
@@ -300,7 +315,6 @@
             {% endfor %}
             </tbody>
         </table>
-        &nbsp;
     {% endif %}
 
     {% if showTeamSubmissions or jury %}
@@ -323,3 +337,49 @@
         </table>
     {% endif %}
 {% endif %}
+
+<style>
+    {% for color,i in backgroundColors %}
+    {% set cssColor = "#"~color %}
+
+    .cl{{ color }} {
+        background-color: {{ cssColor }}
+    }
+
+    {% set cMin = cssColor|hexColorToRGBA(0) %}
+    {% set cMid = cssColor|hexColorToRGBA(0.7) %}
+    {% set cMax = cssColor|hexColorToRGBA(1) %}
+
+    .cl{{ color }} .forceWidth.toolong:after {
+        background: -moz-linear-gradient(left,
+            {{ cMin }} 0%,
+            {{ cMax }} 96%);
+        background: -webkit-gradient(linear, left top, right top,
+            color-stop(0%, {{ cMin }}),
+            color-stop(96%, {{ cMax }}));
+        background: -webkit-linear-gradient(left,
+            {{ cMin }} 0%,
+            {{ cMax }} 96%);
+        background: -o-linear-gradient(left,
+            {{ cMin }} 0%,
+            {{ cMax }} 96%);
+        background: -ms-linear-gradient(left,
+            {{ cMin }} 0%,
+            {{ cMax }} 96%);
+        background: linear-gradient(left,
+            {{ cMin }} 0%,
+            {{ cMax }} 96%);
+            filter: progid:DXImageTransform.Microsoft.gradient(
+                startColorstr='#00{{ color }}',
+                endColorstr='#FF{{ color }}',
+                GradientType=1);
+    }
+    {% endfor %}
+</style>
+<script>
+    document.querySelectorAll(".forceWidth:not(.toolong").forEach(el => {
+        if (el instanceof Element && el.scrollWidth > el.offsetWidth) {
+            el.classList.add("toolong");
+        }
+    });
+</script>

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -178,7 +178,7 @@
                 {% set color = color|trim("#") %}
                 {% set backgroundColors = backgroundColors|merge({(''~color): 1}) %}
             {% endif %}
-            <td class="scoretn cl{{ color }}" {% if jury %}title="{{ score.team.name }}"{% endif %}>
+            <td class="scoretn cl{{ color }}" title="{{ score.team.name }}">
                 {% set link = null %}
                 {% set extra = null %}
                 {% if not static %}

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -340,40 +340,39 @@
 
 <style>
     {% for color,i in backgroundColors %}
-    {% set cssColor = "#"~color %}
+        {% set cssColor = "#"~color %}
 
-    .cl{{ color }} {
-        background-color: {{ cssColor }}
-    }
+        .cl{{ color }} {
+            background-color: {{ cssColor }}
+        }
 
-    {% set cMin = cssColor|hexColorToRGBA(0) %}
-    {% set cMid = cssColor|hexColorToRGBA(0.7) %}
-    {% set cMax = cssColor|hexColorToRGBA(1) %}
+        {% set cMin = cssColor|hexColorToRGBA(0) %}
+        {% set cMax = cssColor|hexColorToRGBA(1) %}
 
-    .cl{{ color }} .forceWidth.toolong:after {
-        background: -moz-linear-gradient(left,
-            {{ cMin }} 0%,
-            {{ cMax }} 96%);
-        background: -webkit-gradient(linear, left top, right top,
-            color-stop(0%, {{ cMin }}),
-            color-stop(96%, {{ cMax }}));
-        background: -webkit-linear-gradient(left,
-            {{ cMin }} 0%,
-            {{ cMax }} 96%);
-        background: -o-linear-gradient(left,
-            {{ cMin }} 0%,
-            {{ cMax }} 96%);
-        background: -ms-linear-gradient(left,
-            {{ cMin }} 0%,
-            {{ cMax }} 96%);
-        background: linear-gradient(left,
-            {{ cMin }} 0%,
-            {{ cMax }} 96%);
-            filter: progid:DXImageTransform.Microsoft.gradient(
-                startColorstr='#00{{ color }}',
-                endColorstr='#FF{{ color }}',
-                GradientType=1);
-    }
+        .cl{{ color }} .forceWidth.toolong:after {
+            background: -moz-linear-gradient(left,
+                {{ cMin }} 0%,
+                {{ cMax }} 96%);
+            background: -webkit-gradient(linear, left top, right top,
+                color-stop(0%, {{ cMin }}),
+                color-stop(96%, {{ cMax }}));
+            background: -webkit-linear-gradient(left,
+                {{ cMin }} 0%,
+                {{ cMax }} 96%);
+            background: -o-linear-gradient(left,
+                {{ cMin }} 0%,
+                {{ cMax }} 96%);
+            background: -ms-linear-gradient(left,
+                {{ cMin }} 0%,
+                {{ cMax }} 96%);
+            background: linear-gradient(left,
+                {{ cMin }} 0%,
+                {{ cMax }} 96%);
+                filter: progid:DXImageTransform.Microsoft.gradient(
+                    startColorstr='#00{{ color }}',
+                    endColorstr='#FF{{ color }}',
+                    GradientType=1);
+        }
     {% endfor %}
 </style>
 <script>

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -377,7 +377,7 @@
     {% endfor %}
 </style>
 <script>
-    document.querySelectorAll(".forceWidth:not(.toolong").forEach(el => {
+    document.querySelectorAll(".forceWidth:not(.toolong)").forEach(el => {
         if (el instanceof Element && el.scrollWidth > el.offsetWidth) {
             el.classList.add("toolong");
         }

--- a/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
+++ b/webapp/src/DOMJudgeBundle/Service/ScoreboardService.php
@@ -706,6 +706,7 @@ class ScoreboardService
             $data['showPending']          = $this->dj->dbconfig_get('show_pending', false);
             $data['showTeamSubmissions']  = $this->dj->dbconfig_get('show_teams_submissions', true);
             $data['scoreInSeconds']       = $this->dj->dbconfig_get('score_in_seconds', false);
+            $data['maxWidth']             = $this->dj->dbconfig_get('team_column_width', 0);
         }
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -95,6 +95,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             new \Twig_SimpleFilter('statusIcon', [$this, 'statusIcon']),
             new \Twig_SimpleFilter('descriptionExpand', [$this, 'descriptionExpand'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('wrapUnquoted', [$this, 'wrapUnquoted']),
+            new \Twig_SimpleFilter('hexColorToRGBA', [$this, 'hexColorToRGBA']),
         ];
     }
 
@@ -892,5 +893,33 @@ EOF;
         $result .= wordwrap(rtrim($unquoted), $width);
 
         return $result;
+    }
+
+    /**
+     * Convert a hex color to RGBA
+     * @param string $text
+     * @param float  $opacity
+     * @return string
+     */
+    public function hexColorToRGBA(string $text, float $opacity = 1): string
+    {
+        $col = Utils::convertToHex($text);
+        preg_match_all("/[0-9A-Fa-f]{2}/", $col,$m);
+        if (!count($m)) {
+            return $text;
+        }
+
+        $m = current($m);
+        switch (count($m)){
+            case 4:
+                // We also have opacity; load that
+                $opacity = hexdec(array_pop($m));
+            case 3:
+                $vals = array_map("hexdec", $m);
+                $vals[] = $opacity;
+                return "rgba(" . implode(",", $vals).")";
+        }
+
+        return $text;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -904,20 +904,21 @@ EOF;
     public function hexColorToRGBA(string $text, float $opacity = 1): string
     {
         $col = Utils::convertToHex($text);
-        preg_match_all("/[0-9A-Fa-f]{2}/", $col,$m);
+        preg_match_all("/[0-9A-Fa-f]{2}/", $col, $m);
         if (!count($m)) {
             return $text;
         }
 
         $m = current($m);
-        switch (count($m)){
+        switch (count($m)) {
             case 4:
                 // We also have opacity; load that
                 $opacity = hexdec(array_pop($m));
             case 3:
                 $vals = array_map("hexdec", $m);
                 $vals[] = $opacity;
-                return "rgba(" . implode(",", $vals).")";
+
+                return "rgba(" . implode(",", $vals) . ")";
         }
 
         return $text;

--- a/webapp/web/style_domjudge.css
+++ b/webapp/web/style_domjudge.css
@@ -177,7 +177,7 @@ del {
 }
 .toolong:after {
     content: "";
-    width: calc(100% * 0.3);
+    width: 30%;
     position: absolute;
     top: 0;
     right: 0;

--- a/webapp/web/style_domjudge.css
+++ b/webapp/web/style_domjudge.css
@@ -170,6 +170,19 @@ del {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+.forceWidth {
+    position: relative;
+    display: block;
+    overflow: hidden;
+}
+.toolong:after {
+    content: "";
+    width: calc(100% * 0.3);
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
 .scoreboard .scoreaf { white-space: nowrap; border: 0; text-align: center; }
 .scoreboard .scoreaf img { vertical-align: middle; }
 .univ {


### PR DESCRIPTION
Added a configuration option to set the max-width for the affiliation and team names. When set to 0, it does not apply a maximum width. Some JS adds a class when the contents are too wide, which adds a slot that houses the gradient, this gradient overlaps with the rightmost 30% of the field. It has been tested in Webkit browsers (opera, safari) and Firefox

Old:
<img width="980" alt="old" src="https://user-images.githubusercontent.com/2218324/55760158-3c2edb80-5a53-11e9-9f2a-37cfce817dd7.png">

New:
![new](https://user-images.githubusercontent.com/2218324/55760242-6d0f1080-5a53-11e9-9f55-bfc1988b0b12.png)


Fixes #431

