### PR TITLE
Add SAST to GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,8 @@ stages:
   - test
 
 include:
-  template: Dependency-Scanning.gitlab-ci.yml
+  - template: Dependency-Scanning.gitlab-ci.yml
+  - template: SAST.gitlab-ci.yml
 
 integration:
   stage: test


### PR DESCRIPTION
This will add SAST checking to GitLab.

I also created this PR to test LabHub, which will run the CI on pull requests that are not on the main repo but on forks.