### PR TITLE
Fix syntax of linear-gradient() and clean up all others.

### DIFF
--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -345,35 +345,16 @@
         {% set hexColor = color | colorToHex | trim('#') %}
 
         .cl{{ colorClass }} {
-            background-color: {{ color }}
+            background-color: {{ color }};
         }
 
         {% set cMin = color|hexColorToRGBA(0) %}
         {% set cMax = color|hexColorToRGBA(1) %}
 
         .cl{{ colorClass }} .forceWidth.toolong:after {
-            background: -moz-linear-gradient(left,
+            background: linear-gradient(to right,
                 {{ cMin }} 0%,
                 {{ cMax }} 96%);
-            background: -webkit-gradient(linear, left top, right top,
-                color-stop(0%, {{ cMin }}),
-                color-stop(96%, {{ cMax }}));
-            background: -webkit-linear-gradient(left,
-                {{ cMin }} 0%,
-                {{ cMax }} 96%);
-            background: -o-linear-gradient(left,
-                {{ cMin }} 0%,
-                {{ cMax }} 96%);
-            background: -ms-linear-gradient(left,
-                {{ cMin }} 0%,
-                {{ cMax }} 96%);
-            background: linear-gradient(left,
-                {{ cMin }} 0%,
-                {{ cMax }} 96%);
-                filter: progid:DXImageTransform.Microsoft.gradient(
-                    startColorstr='#00{{ hexColor }}',
-                    endColorstr='#FF{{ hexColor }}',
-                    GradientType=1);
         }
     {% endfor %}
 </style>

--- a/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/partials/scoreboard_table.html.twig
@@ -342,7 +342,6 @@
 <style>
     {% for color,i in backgroundColors %}
         {% set colorClass = color | replace({"#": "_"}) %}
-        {% set hexColor = color | colorToHex | trim('#') %}
 
         .cl{{ colorClass }} {
             background-color: {{ color }};

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -95,7 +95,6 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             new \Twig_SimpleFilter('statusIcon', [$this, 'statusIcon']),
             new \Twig_SimpleFilter('descriptionExpand', [$this, 'descriptionExpand'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('wrapUnquoted', [$this, 'wrapUnquoted']),
-            new \Twig_SimpleFilter('colorToHex', [Utils::class, 'convertToHex']),
             new \Twig_SimpleFilter('hexColorToRGBA', [$this, 'hexColorToRGBA']),
         ];
     }


### PR DESCRIPTION
We really need not support century old browsers. Just use the W3C
standard. Also so we know whether we use it correctly.