### PR TITLE
Fixes the ugly toggle switch at the config page

### DIFF
--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/config.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/config.html.twig
@@ -7,6 +7,11 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.toggle_extrahead() }}
+    <style>
+        .btn.toggle-on {
+            right: initial;
+        }
+    </style>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This was caused due to the fact that the default "Off" is narrower than "Yes", doing a quick reset of this css property fixes this issue.

Tried it in all my browsers (FF, Opera, and Safari) and it did not cause more issues then were already present. As far as I am aware and could find, this is the only place where this library gets used; so the fixed is placed in the config page instead of modifying `bootstrap-toggle.min.css`.

![image](https://user-images.githubusercontent.com/2218324/56772354-ff384800-67b9-11e9-86af-550b51103711.png)
