### PR TITLE
Enable federated login with SimpleSAMLphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
 		"angel-vladov/select2-bootstrap-theme": "0.2.0-beta.2",
 		"twig/extensions": "^1.5",
 		"guzzlehttp/guzzle": "^6.3",
-		"sgomez/ssp-guard-bundle": "^0.10.0"
+		"sgomez/ssp-guard-bundle": "^0.11.0"
 	},
 	"require-dev": {
 		"sensio/generator-bundle": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
 		"select2/select2": "4.*",
 		"angel-vladov/select2-bootstrap-theme": "0.2.0-beta.2",
 		"twig/extensions": "^1.5",
-		"guzzlehttp/guzzle": "^6.3"
+		"guzzlehttp/guzzle": "^6.3",
+		"sgomez/ssp-guard-bundle": "^0.10.0"
 	},
 	"require-dev": {
 		"sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d04e33cbd281abf76731921ccab49542",
+    "content-hash": "d019aa656d766b50310cbed41f958c8e",
     "packages": [
         {
             "name": "angel-vladov/select2-bootstrap-theme",

--- a/composer.lock
+++ b/composer.lock
@@ -2911,16 +2911,16 @@
         },
         {
             "name": "sgomez/ssp-guard-bundle",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sgomez/SSPGuardBundle.git",
-                "reference": "7d507f5d88df46319cf3543a58350935b108f750"
+                "reference": "9655bfdb62e0321b9929209587f5eaab8cc6a38b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sgomez/SSPGuardBundle/zipball/7d507f5d88df46319cf3543a58350935b108f750",
-                "reference": "7d507f5d88df46319cf3543a58350935b108f750",
+                "url": "https://api.github.com/repos/sgomez/SSPGuardBundle/zipball/9655bfdb62e0321b9929209587f5eaab8cc6a38b",
+                "reference": "9655bfdb62e0321b9929209587f5eaab8cc6a38b",
                 "shasum": ""
             },
             "require": {
@@ -2953,7 +2953,7 @@
                 "guard",
                 "simplesamlphp"
             ],
-            "time": "2018-10-15T06:29:21+00:00"
+            "time": "2019-04-25T20:58:58+00:00"
         },
         {
             "name": "symfony/monolog-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -2910,6 +2910,52 @@
             "time": "2018-02-28T22:10:01+00:00"
         },
         {
+            "name": "sgomez/ssp-guard-bundle",
+            "version": "0.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sgomez/SSPGuardBundle.git",
+                "reference": "7d507f5d88df46319cf3543a58350935b108f750"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sgomez/SSPGuardBundle/zipball/7d507f5d88df46319cf3543a58350935b108f750",
+                "reference": "7d507f5d88df46319cf3543a58350935b108f750",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/config": "~2.8|~3.0|^4.0",
+                "symfony/framework-bundle": "~2.8|~3.0|^4.0",
+                "symfony/routing": "~2.8|~3.0|^4.0",
+                "symfony/security-guard": "~2.8|~3.0|^4.0",
+                "twig/twig": "~1.14,>=1.14.2|~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sgomez\\Bundle\\SSPGuardBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sergio Gómez",
+                    "email": "sergio@uco.es"
+                }
+            ],
+            "description": "SimpleSAMLphp Integration for Symfony",
+            "keywords": [
+                "Authentication",
+                "guard",
+                "simplesamlphp"
+            ],
+            "time": "2018-10-15T06:29:21+00:00"
+        },
+        {
             "name": "symfony/monolog-bundle",
             "version": "v3.3.0",
             "source": {

--- a/webapp/app/AppKernel.php
+++ b/webapp/app/AppKernel.php
@@ -19,6 +19,7 @@ class AppKernel extends Kernel
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new Nelmio\ApiDocBundle\NelmioApiDocBundle(),
+            new Sgomez\Bundle\SSPGuardBundle\SSPGuardBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/webapp/app/config/config.yml
+++ b/webapp/app/config/config.yml
@@ -270,3 +270,10 @@ nelmio_api_doc:
                 items:
                     type: string
                     description: A single ID
+
+ssp_guard:
+    installation_path: /srv/simplesamlphp
+    auth_sources:
+        surfconext:
+            title: "Log in at your university"
+            user_id: eduPersonPrincipalName

--- a/webapp/app/config/routing.yml
+++ b/webapp/app/config/routing.yml
@@ -1,3 +1,6 @@
+ssp_bundle:
+    resource: "@SSPGuardBundle/Resources/config/routing/connect.xml"
+
 domjudge:
     resource: '@DOMJudgeBundle/Controller/'
     type: annotation

--- a/webapp/app/config/security.yml
+++ b/webapp/app/config/security.yml
@@ -53,6 +53,7 @@ security:
               authenticators:
                 - DOMJudgeBundle\Security\DOMJudgeXHeadersAuthenticator
                 - DOMJudgeBundle\Security\DOMJudgeIPAuthenticator
+                - DOMJudgeBundle\Security\SimpleSAMLAuthenticator
               entry_point: DOMJudgeBundle\Security\DOMJudgeXHeadersAuthenticator
             anonymous: ~
             form_login:
@@ -68,6 +69,7 @@ security:
     access_control:
       - { path: ^/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+      - { path: ^/connect, roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/register, roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/public, roles: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/api, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/webapp/app/config/services.yml
+++ b/webapp/app/config/services.yml
@@ -64,3 +64,6 @@ services:
     DOMJudgeBundle\Controller\Jury\ImportExportController:
         arguments:
             $domjudgeVersion: '%domjudge.version%'
+
+    DOMJudgeBundle\Security\SimpleSAMLAuthenticator:
+        arguments: ["@router", "@ssp.guard.registry", "surfconext"]

--- a/webapp/app/config/services.yml
+++ b/webapp/app/config/services.yml
@@ -66,4 +66,4 @@ services:
             $domjudgeVersion: '%domjudge.version%'
 
     DOMJudgeBundle\Security\SimpleSAMLAuthenticator:
-        arguments: ["@router", "@ssp.guard.registry", "surfconext"]
+        arguments: ["@router", "@ssp.guard.registry", "dummy"]

--- a/webapp/src/DOMJudgeBundle/Resources/views/security/login.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/security/login.html.twig
@@ -9,10 +9,13 @@
 {% block messages %}{% endblock %}
 {% block body %}
 
-    {% set hasaltmethods =
-        ("xheaders" in allowed_authmethods and auth_xheaders_present) or
-        ("ipaddress" in allowed_authmethods and auth_ipaddress_users|length > 0) %}
-    {% set showregular = not hasaltmethods or error %}
+{% set hasfederated = ssp_auth_sources()|length > 0 %}
+{% set hasaltmethods =
+    ("xheaders" in allowed_authmethods and auth_xheaders_present) or
+    ("ipaddress" in allowed_authmethods and auth_ipaddress_users|length > 0) or
+    hasfederated
+%}
+{% set showregular = not hasaltmethods or hasfederated or error %}
 
     <div class="form-signin" id="loginform">
         <img class="mb-4" src="{{ asset('images/DOMjudgelogo.png') }}" alt="DOMjudge" width="72">
@@ -81,7 +84,20 @@
                         });
                     </script>
                 {% endif %}
-            </div>
+
+                {% if hasfederated %}
+                    <div class="login-content">
+                    You can log in with the following external identity provider.</div>
+                    {% for source in ssp_auth_sources() %}
+
+                        {% set item = ssp_auth_source(source) %}
+                        <a class="btn btn-lg btn-success btn-block"
+                            href="{{ path('ssp_guard_connect', {'authSource': source}) }}">
+                            {{ item.title }}
+                        </a>
+                    {% endfor %}
+                {% endif %}
+  </div>
 
             <div class="vertical-line regularLoginform{% if not showregular %} d-none{% endif %}"></div>
         {% endif %}

--- a/webapp/src/DOMJudgeBundle/Security/SimpleSAMLAuthenticator.php
+++ b/webapp/src/DOMJudgeBundle/Security/SimpleSAMLAuthenticator.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace DOMJudgeBundle\Security;
+
+use Sgomez\Bundle\SSPGuardBundle\Security\Authenticator\SSPGuardAuthenticator;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class SimpleSAMLAuthenticator extends SSPGuardAuthenticator
+{
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new RedirectResponse($this->router->generate('login'));
+    }
+    
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        return $userProvider->loadUserByUsername($credentials[$this->authSource->getUserId()][0]);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        $this->saveAuthenticationErrorToSession($request, $exception);
+
+        return new RedirectResponse($this->router->generate('login'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        $targetPath = $this->getTargetPath($request, $providerKey);
+
+        if (!$targetPath) {
+            $targetPath = $this->router->generate('root');
+        }
+
+        return new RedirectResponse($targetPath);
+    }
+}

--- a/webapp/src/DOMJudgeBundle/Security/SimpleSAMLAuthenticator.php
+++ b/webapp/src/DOMJudgeBundle/Security/SimpleSAMLAuthenticator.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class SimpleSAMLAuthenticator extends SSPGuardAuthenticator
@@ -38,5 +39,20 @@ class SimpleSAMLAuthenticator extends SSPGuardAuthenticator
         }
 
         return new RedirectResponse($targetPath);
+    }
+
+    // override supports() not to require a fixed authsource id
+    public function supports(Request $request)
+    {
+        $match = $this->router->match($request->getPathInfo());
+        return 'ssp_guard_check' === $match['_route'];
+    }
+
+    // override getCredentials() not to require a fixed authsource id
+    public function getCredentials(Request $request)
+    {
+        $match = $this->router->match($request->getPathInfo());
+        $this->authSource = $this->authSourceRegistry->getAuthSource($match['authSource']);
+        return $this->authSource->getCredentials();
     }
 }


### PR DESCRIPTION
Initial setup for allowing federated authentication with DOMjudge.

This is an approach to solve #546 but in a better way, since really you do not want LDAP auth directly in your app any more, nowadays you'd want to use SAML or CAS or OpenID Conect or ...

I've chosen integration with SimpleSAMLphp. It does require installing that as well, but big advantage is that it has many authentication sources and is highly configurable. So this is a very flexible solution. You can configure it against SAML 2.0 IdP's, a CAS server, ICPC-ID or if you insist, an LDAP server.

To try it out:
- https://djdev.pt-48.utr.surfcloud.nl/domjudge/
- log in with the button
- type "diy" (SURFconext test IdP) and select it
- log in with user "student7" password "student7"

It works but it's not complete yet, at least I'm thinking of:
- Only works when account of the right name is already present - if registration enabled, trigger account creation based on the attributes?
- Does not seem to support dependency injection, not sure why or how to do that.
- Document how to set this up.