### PR TITLE
External judgements runs

### DIFF
--- a/etc/domserver-config.php
+++ b/etc/domserver-config.php
@@ -37,7 +37,3 @@ define('ALLOW_REMOVED_INTERVALS', false);
 // Specify URL of the iCAT webinterface. Uncommenting this will enable
 // the ICPC Analytics iCAT integration for jury members.
 //define('ICAT_URL', 'http://icat.example.com/icat/');
-
-// Specify URL to external CCS's submission page for linking external
-// submission IDs. The external ID is appended to the URL below.
-//define('EXT_CCS_URL', 'https://ccs.example.com/submissions/');

--- a/sql/mysql_db_defaultdata.sql
+++ b/sql/mysql_db_defaultdata.sql
@@ -55,6 +55,7 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 ('enable_printing', '0', 'bool', '1', 'Misc', 'Enable teams and jury to send source code to a printer via the DOMjudge web interface.'),
 ('registration_category_name', '""', 'string', '1', 'Misc', 'Team category for users that register themselves with the system. Self-registration is disabled if this field is left empty.'),
 ('data_source', '0', 'int', '0', 'Misc', 'Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external'),
+('external_ccs_submission_url', '""', 'string', '0', 'Misc', 'URL of a submission detail page on the external CCS. Placeholder :id: will be replaced by submission ID. Leave empty to not display links to external CCS'),
 ('auth_methods', '[]', 'array_val', '0', 'Authentication', 'List of allowed additional authentication methods. Supported values are \'ipaddress\', and \'xheaders\''),
 ('allow_openid_auth', '0', 'bool', '1', 'Authentication', 'Allow users to log in using OpenID'),
 ('openid_autocreate_team', '1', 'bool', '1', 'Authentication', 'Create a team for each user that logs in with OpenID'),

--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -179,6 +179,39 @@ CREATE TABLE `executable` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Compile, compare, and run script executable bundles';
 
 --
+-- Table structure for table `external_judgement`
+--
+
+CREATE TABLE `external_judgement` (
+  `extjudgementid` varchar (255) NOT NULL COMMENT 'Unique external judgement ID',
+  `submitid` int(4) unsigned NOT NULL COMMENT 'Submission ID being judged by external system',
+  `result` varchar(32) DEFAULT NULL COMMENT 'Result string as obtained from external system. null if not finished yet',
+  `starttime` decimal(32,9) unsigned NOT NULL COMMENT 'Time judging started',
+  `endtime` decimal(32,9) unsigned DEFAULT NULL COMMENT 'Time judging ended, null = still busy',
+  PRIMARY KEY  (`extjudgementid`),
+  KEY `submitid` (`submitid`),
+  CONSTRAINT `external_judgement_ibfk_1` FOREIGN KEY (`submitid`) REFERENCES `submission` (`submitid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Judgement in external system';
+
+--
+-- Table structure for table `external_run`
+--
+
+CREATE TABLE `external_run` (
+  `extrunid` varchar (255) NOT NULL COMMENT 'Unique external run ID',
+  `extjudgementid` varchar(255) NOT NULL COMMENT 'Judging ID this run belongs to',
+  `testcaseid` int(4) unsigned NOT NULL COMMENT 'Testcase ID',
+  `result` varchar(32) NOT NULL COMMENT 'Result string as obtained from external system',
+  `endtime` decimal(32,9) unsigned NOT NULL COMMENT 'Time run ended',
+  `runtime` float NOT NULL COMMENT 'Running time on this testcase',
+  PRIMARY KEY  (`extjudgementid`),
+  KEY `extjudgementid` (`extjudgementid`),
+  KEY `testcaseid` (`testcaseid`),
+  CONSTRAINT `external_run_ibfk_1` FOREIGN KEY (`extjudgementid`) REFERENCES `external_judgement` (`extjudgementid`) ON DELETE CASCADE,
+  CONSTRAINT `external_run_ibfk_2` FOREIGN KEY (`testcaseid`) REFERENCES `testcase` (`testcaseid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Run in external system';
+
+--
 -- Table structure for table `internal_error`
 --
 

--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -451,7 +451,6 @@ CREATE TABLE `submission` (
   `rejudgingid` int(4) unsigned DEFAULT NULL COMMENT 'Rejudging ID (if rejudge)',
   `expected_results` varchar(255) DEFAULT NULL COMMENT 'JSON encoded list of expected results - used to validate jury submissions',
   `externalid` varchar(255) DEFAULT NULL COMMENT 'Specifies ID of submission if imported from external CCS, e.g. Kattis',
-  `externalresult` varchar(32) DEFAULT NULL COMMENT 'Result string as returned from external CCS, e.g. Kattis',
   `entry_point` varchar(255) DEFAULT NULL COMMENT 'Optional entry point. Can be used e.g. for java main class.',
   PRIMARY KEY  (`submitid`),
   UNIQUE KEY `externalid` (`cid`,`externalid`(190)),

--- a/sql/upgrade/upgrade_7.0.0_7.1.0.sql
+++ b/sql/upgrade/upgrade_7.0.0_7.1.0.sql
@@ -51,7 +51,8 @@ CREATE TABLE `external_run` (
 -- Add/remove sample/initial contents
 --
 
-
+INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `description`) VALUES
+('external_ccs_submission_url', '""', 'string', '0', 'Misc', 'URL of a submission detail page on the external CCS. Placeholder :id: will be replaced by submission ID. Leave empty to not display links to external CCS');
 
 --
 -- Finally remove obsolete structures after moving data

--- a/sql/upgrade/upgrade_7.0.0_7.1.0.sql
+++ b/sql/upgrade/upgrade_7.0.0_7.1.0.sql
@@ -1,0 +1,60 @@
+-- This script upgrades table structure, data, and privileges
+-- from/to the exact version numbers specified in the filename.
+
+--
+-- First execute a check whether this upgrade should apply. The check
+-- below should fail if this upgrade has already been applied, but
+-- keep everything unchanged if not.
+--
+
+-- @UPGRADE-CHECK@
+CREATE TABLE `external_judgement` (`extjudgementid` varchar (255));
+DROP TABLE `external_judgement`;
+
+--
+-- Create additional structures
+--
+
+-- Create external judgement/run tables
+CREATE TABLE `external_judgement` (
+  `extjudgementid` varchar (255) NOT NULL COMMENT 'Unique external judgement ID',
+  `submitid` int(4) unsigned NOT NULL COMMENT 'Submission ID being judged by external system',
+  `result` varchar(32) DEFAULT NULL COMMENT 'Result string as obtained from external system. null if not finished yet',
+  `starttime` decimal(32,9) unsigned NOT NULL COMMENT 'Time judging started',
+  `endtime` decimal(32,9) unsigned DEFAULT NULL COMMENT 'Time judging ended, null = still busy',
+  PRIMARY KEY  (`extjudgementid`),
+  KEY `submitid` (`submitid`),
+  CONSTRAINT `external_judgement_ibfk_1` FOREIGN KEY (`submitid`) REFERENCES `submission` (`submitid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Judgement in external system';
+
+CREATE TABLE `external_run` (
+  `extrunid` varchar (255) NOT NULL COMMENT 'Unique external run ID',
+  `extjudgementid` varchar(255) NOT NULL COMMENT 'Judging ID this run belongs to',
+  `testcaseid` int(4) unsigned NOT NULL COMMENT 'Testcase ID',
+  `result` varchar(32) NOT NULL COMMENT 'Result string as obtained from external system',
+  `endtime` decimal(32,9) unsigned NOT NULL COMMENT 'Time run ended',
+  `runtime` float NOT NULL COMMENT 'Running time on this testcase',
+  PRIMARY KEY  (`extjudgementid`),
+  KEY `extjudgementid` (`extjudgementid`),
+  KEY `testcaseid` (`testcaseid`),
+  CONSTRAINT `external_run_ibfk_1` FOREIGN KEY (`extjudgementid`) REFERENCES `external_judgement` (`extjudgementid`) ON DELETE CASCADE,
+  CONSTRAINT `external_run_ibfk_2` FOREIGN KEY (`testcaseid`) REFERENCES `testcase` (`testcaseid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Run in external system';
+
+--
+-- Transfer data from old to new structure
+--
+
+
+
+--
+-- Add/remove sample/initial contents
+--
+
+
+
+--
+-- Finally remove obsolete structures after moving data
+--
+
+

--- a/sql/upgrade/upgrade_7.0.0_7.1.0.sql
+++ b/sql/upgrade/upgrade_7.0.0_7.1.0.sql
@@ -58,3 +58,5 @@ CREATE TABLE `external_run` (
 --
 
 
+ALTER TABLE `submission`
+    DROP COLUMN `externalresult`;

--- a/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
+++ b/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
@@ -205,6 +205,13 @@ class ImportEventFeedCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // Disable SQL logging if we do not run explicitly in debug mode.
+        // This would cause a serious memory leak otherwise since this is a
+        // long runnning process.
+        if (!$this->getContainer()->getParameter('kernel.debug')) {
+            $this->em->getConnection()->getConfiguration()->setSQLLogger(null);
+        }
+
         // Set up logger
         $verbosityLevelMap = [
             LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,

--- a/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
+++ b/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
@@ -222,7 +222,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
         pcntl_signal(SIGTERM, [$this, 'stopCommand']);
         pcntl_signal(SIGINT, [$this, 'stopCommand']);
 
-        $dataSource = (int)$this->dj->dbconfig_get('data_source');
+        $dataSource = (int)$this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
         if ($dataSource !== DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL) {
             if ($input->getOption('force')) {
                 $this->logger->warning(sprintf('data_source configuration setting is set to %d; --force given so continuing...',

--- a/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/API/SubmissionController.php
@@ -221,7 +221,7 @@ class SubmissionController extends AbstractRestController
         // Now submit the solution
         $team       = $this->dj->getUser()->getTeam();
         $submission = $this->submissionService->submitSolution($team, $problem, $problem->getContest(), $language,
-                                                               $files, null, $entryPoint, null, null, null, $message);
+                                                               $files, null, $entryPoint, null, null, $message);
 
         if (!$submission) {
             throw new BadRequestHttpException($message);

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
@@ -197,6 +197,7 @@ class LanguageController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_language', ['langId' => $language->getLangid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/LanguageController.php
@@ -197,7 +197,8 @@ class LanguageController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+                DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_language', ['langId' => $language->getLangid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ProblemController.php
@@ -477,6 +477,7 @@ class ProblemController extends BaseController
             'defaultRunExecutable' => (string)$this->dj->dbconfig_get('default_run'),
             'defaultCompareExecutable' => (string)$this->dj->dbconfig_get('default_compare'),
             'showContest' => count($this->dj->getCurrentContests()) > 1,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_problem', ['probId' => $problem->getProbid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/ProblemController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/ProblemController.php
@@ -477,7 +477,8 @@ class ProblemController extends BaseController
             'defaultRunExecutable' => (string)$this->dj->dbconfig_get('default_run'),
             'defaultCompareExecutable' => (string)$this->dj->dbconfig_get('default_compare'),
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+                DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_problem', ['probId' => $problem->getProbid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
@@ -348,7 +348,8 @@ class RejudgingController extends BaseController
             'submissionCounts' => $submissionCounts,
             'oldverdict' => $request->query->get('oldverdict', 'all'),
             'newverdict' => $request->query->get('newverdict', 'all'),
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+                DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,
                 'url' => $request->getRequestUri(),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/RejudgingController.php
@@ -348,6 +348,7 @@ class RejudgingController extends BaseController
             'submissionCounts' => $submissionCounts,
             'oldverdict' => $request->query->get('oldverdict', 'all'),
             'newverdict' => $request->query->get('newverdict', 'all'),
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
             'refresh' => [
                 'after' => 15,
                 'url' => $request->getRequestUri(),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/SubmissionController.php
@@ -172,7 +172,8 @@ class SubmissionController extends BaseController
             'filteredProblems' => $filteredProblems,
             'filteredLanguages' => $filteredLanguages,
             'filteredTeams' => $filteredTeams,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+                DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
         ];
 
         // For ajax requests, only return the submission list partial

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/SubmissionController.php
@@ -172,6 +172,7 @@ class SubmissionController extends BaseController
             'filteredProblems' => $filteredProblems,
             'filteredLanguages' => $filteredLanguages,
             'filteredTeams' => $filteredTeams,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
         ];
 
         // For ajax requests, only return the submission list partial

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
@@ -161,7 +161,8 @@ class TeamCategoryController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+                DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamCategoryController.php
@@ -161,6 +161,7 @@ class TeamCategoryController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
+            'showExternalResult' => $this->dj->dbconfig_get('data_source', 0) == 2,
             'refresh' => [
                 'after' => 15,
                 'url' => $this->generateUrl('jury_team_category', ['categoryId' => $teamCategory->getCategoryid()]),

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
@@ -300,9 +300,10 @@ class TeamController extends BaseController
         $restrictions['teamid'] = $teamId;
         list($submissions, $submissionCounts) = $submissionService->getSubmissionList($this->dj->getCurrentContests(),
                                                                                       $restrictions);
-        $data['restrictionText']  = $restrictionText;
-        $data['submissions']      = $submissions;
-        $data['submissionCounts'] = $submissionCounts;
+        $data['restrictionText']    = $restrictionText;
+        $data['submissions']        = $submissions;
+        $data['submissionCounts']   = $submissionCounts;
+        $data['showExternalResult'] = $this->dj->dbconfig_get('data_source', 0) == 2;
 
         if ($request->isXmlHttpRequest()) {
             $data['displayRank'] = true;

--- a/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Jury/TeamController.php
@@ -303,7 +303,8 @@ class TeamController extends BaseController
         $data['restrictionText']    = $restrictionText;
         $data['submissions']        = $submissions;
         $data['submissionCounts']   = $submissionCounts;
-        $data['showExternalResult'] = $this->dj->dbconfig_get('data_source', 0) == 2;
+        $data['showExternalResult'] = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+            DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
 
         if ($request->isXmlHttpRequest()) {
             $data['displayRank'] = true;

--- a/webapp/src/DOMJudgeBundle/Controller/Team/SubmissionController.php
+++ b/webapp/src/DOMJudgeBundle/Controller/Team/SubmissionController.php
@@ -93,7 +93,7 @@ class SubmissionController extends BaseController
                 $entryPoint = $form->get('entry_point')->getData() ?: null;
                 $submission = $this->submissionService->submitSolution($team, $problem->getProbid(), $contest,
                                                                        $language, $files, null, $entryPoint, null, null,
-                                                                       null, $message);
+                                                                       $message);
 
                 if ($submission) {
                     $this->dj->auditlog('submission', $submission->getSubmitid(), 'added', 'via teampage',

--- a/webapp/src/DOMJudgeBundle/Entity/ExternalJudgement.php
+++ b/webapp/src/DOMJudgeBundle/Entity/ExternalJudgement.php
@@ -1,0 +1,226 @@
+<?php declare(strict_types=1);
+
+namespace DOMJudgeBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Judgement in external system
+ * @ORM\Table(name="external_judgement",
+ *             indexes={@ORM\Index(name="submitid", columns={"submitid"})},
+ *             options={"comment":"Judgement in external system"})
+ * @ORM\Entity
+ */
+class ExternalJudgement
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="extjudgementid", type="string", length=255, nullable=false,
+     *              options={"comment": "Unique external judgement ID"})
+     * @ORM\Id
+     */
+    private $extjudgementid;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="result", type="string", length=32, nullable=true)
+     */
+    private $result = null;
+
+    /**
+     * @var double
+     *
+     * @ORM\Column(type="decimal", precision=32, scale=9, name="starttime",
+     *              options={"comment"="Time judging started", "unsigned"=true},
+     *              nullable=false)
+     */
+    private $starttime;
+
+    /**
+     * @var double
+     *
+     * @ORM\Column(type="decimal", precision=32, scale=9, name="endtime",
+     *              options={"comment"="Time judging ended, null = stil busy", "unsigned"=true},
+     *              nullable=true)
+     */
+    private $endtime = null;
+
+    /**
+     * @var Submission
+     *
+     * @ORM\ManyToOne(targetEntity="Submission", inversedBy="external_judgements")
+     * @ORM\JoinColumn(name="submitid", referencedColumnName="submitid", onDelete="CASCADE")
+     */
+    private $submission;
+
+    /**
+     * @ORM\OneToMany(targetEntity="ExternalRun", mappedBy="external_judgement")
+     */
+    private $external_runs;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->external_runs = new ArrayCollection();
+    }
+
+    /**
+     * Set extjudgementid
+     *
+     * @param string $extjudgementid
+     *
+     * @return ExternalJudgement
+     */
+    public function setExtjudgementid($extjudgementid): ExternalJudgement
+    {
+        $this->extjudgementid = $extjudgementid;
+
+        return $this;
+    }
+
+    /**
+     * Get extjudgementid
+     *
+     * @return string
+     */
+    public function getExtjudgementid()
+    {
+        return $this->extjudgementid;
+    }
+
+    /**
+     * Set result
+     *
+     * @param string|null $result
+     *
+     * @return ExternalJudgement
+     */
+    public function setResult($result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * Get result
+     *
+     * @return string|null
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * Set starttime
+     *
+     * @param double $starttime
+     *
+     * @return ExternalJudgement
+     */
+    public function setStarttime($starttime)
+    {
+        $this->starttime = $starttime;
+
+        return $this;
+    }
+
+    /**
+     * Get starttime
+     *
+     * @return double
+     */
+    public function getStarttime()
+    {
+        return $this->starttime;
+    }
+
+    /**
+     * Set endtime
+     *
+     * @param double $endtime
+     *
+     * @return ExternalJudgement
+     */
+    public function setEndtime($endtime)
+    {
+        $this->endtime = $endtime;
+
+        return $this;
+    }
+
+    /**
+     * Get endtime
+     *
+     * @return double
+     */
+    public function getEndtime()
+    {
+        return $this->endtime;
+    }
+
+    /**
+     * Set submission
+     *
+     * @param Submission $submission
+     *
+     * @return ExternalJudgement
+     */
+    public function setSubmission(Submission $submission)
+    {
+        $this->submission = $submission;
+
+        return $this;
+    }
+
+    /**
+     * Get submission
+     *
+     * @return Submission
+     */
+    public function getSubmission()
+    {
+        return $this->submission;
+    }
+
+    /**
+     * Add externalRun
+     *
+     * @param ExternalRun $externalRun
+     *
+     * @return ExternalJudgement
+     */
+    public function addExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs[] = $externalRun;
+
+        return $this;
+    }
+
+    /**
+     * Remove externalRun
+     *
+     * @param ExternalRun $externalRun
+     */
+    public function removeExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs->removeElement($externalRun);
+    }
+
+    /**
+     * Get externalRuns
+     *
+     * @return Collection
+     */
+    public function getExternalRuns()
+    {
+        return $this->external_runs;
+    }
+}

--- a/webapp/src/DOMJudgeBundle/Entity/ExternalRun.php
+++ b/webapp/src/DOMJudgeBundle/Entity/ExternalRun.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+
+namespace DOMJudgeBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Run in external system
+ * @ORM\Table(name="external_run",
+ *             indexes={@ORM\Index(name="extjudgementid", columns={"extjudgementid"}),
+ *                      @ORM\Index(name="testcaseid", columns={"testcaseid"})},
+ *             options={"comment":"Run in external system"})
+ * @ORM\Entity
+ */
+class ExternalRun
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="extrunid", type="string", length=255, nullable=false,
+     *              options={"comment": "Unique external run ID"})
+     * @ORM\Id
+     */
+    private $extrunid;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="result", type="string", length=32,
+     *              options={"comment"="Result string as obtained from external system"},
+     *              nullable=false)
+     */
+    private $result;
+
+    /**
+     * @var double
+     *
+     * @ORM\Column(type="decimal", precision=32, scale=9, name="endtime",
+     *              options={"comment"="Time run ende", "unsigned"=true},
+     *              nullable=false)
+     */
+    private $endtime;
+
+    /**
+     * @var double
+     *
+     * @ORM\Column(type="float", name="runtime",
+     *              options={"comment"="Running time on this testcase"}, nullable=false)
+     */
+    private $runtime;
+
+    /**
+     * @var ExternalJudgement
+     *
+     * @ORM\ManyToOne(targetEntity="ExternalJudgement", inversedBy="external_runs")
+     * @ORM\JoinColumn(name="extjudgementid", referencedColumnName="extjudgementid")
+     */
+    private $external_judgement;
+
+    /**
+     * @var Testcase
+     *
+     * @ORM\ManyToOne(targetEntity="Testcase", inversedBy="external_runs")
+     * @ORM\JoinColumn(name="testcaseid", referencedColumnName="testcaseid")
+     */
+    private $testcase;
+
+    /**
+     * Set extrunid
+     *
+     * @param string $extrunid
+     *
+     * @return ExternalRun
+     */
+    public function setExtrunid($extrunid)
+    {
+        $this->extrunid = $extrunid;
+
+        return $this;
+    }
+
+    /**
+     * Get extrunid
+     *
+     * @return string
+     */
+    public function getExtrunid()
+    {
+        return $this->extrunid;
+    }
+
+    /**
+     * Set result
+     *
+     * @param string $result
+     *
+     * @return ExternalRun
+     */
+    public function setResult($result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * Get result
+     *
+     * @return string
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * Set endtime
+     *
+     * @param double $endtime
+     *
+     * @return ExternalRun
+     */
+    public function setEndtime($endtime)
+    {
+        $this->endtime = $endtime;
+
+        return $this;
+    }
+
+    /**
+     * Get endtime
+     *
+     * @return double
+     */
+    public function getEndtime()
+    {
+        return $this->endtime;
+    }
+
+    /**
+     * Set runtime
+     *
+     * @param double $runtime
+     *
+     * @return ExternalRun
+     */
+    public function setRuntime($runtime)
+    {
+        $this->runtime = $runtime;
+
+        return $this;
+    }
+
+    /**
+     * Get runtime
+     *
+     * @return double
+     */
+    public function getRuntime()
+    {
+        return $this->runtime;
+    }
+
+    /**
+     * Set externalJudgement
+     *
+     * @param ExternalJudgement $externalJudgement
+     *
+     * @return ExternalRun
+     */
+    public function setExternalJudgement(ExternalJudgement $externalJudgement)
+    {
+        $this->external_judgement = $externalJudgement;
+
+        return $this;
+    }
+
+    /**
+     * Get externalJudgement
+     *
+     * @return ExternalJudgement
+     */
+    public function getExternalJudgement()
+    {
+        return $this->external_judgement;
+    }
+
+    /**
+     * Set testcase
+     *
+     * @param Testcase $testcase
+     *
+     * @return ExternalRun
+     */
+    public function setTestcase(Testcase $testcase)
+    {
+        $this->testcase = $testcase;
+
+        return $this;
+    }
+
+    /**
+     * Get testcase
+     *
+     * @return Testcase
+     */
+    public function getTestcase()
+    {
+        return $this->testcase;
+    }
+}

--- a/webapp/src/DOMJudgeBundle/Entity/Submission.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Submission.php
@@ -174,6 +174,12 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     private $judgings;
 
     /**
+     * @ORM\OneToMany(targetEntity="DOMJudgeBundle\Entity\ExternalJudgement", mappedBy="submission")
+     * @Serializer\Exclude()
+     */
+    private $external_judgements;
+
+    /**
      * @var ArrayCollection
      * @ORM\OneToMany(targetEntity="SubmissionFile", mappedBy="submission")
      * @Serializer\Exclude()
@@ -625,6 +631,7 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         $this->files                  = new ArrayCollection();
         $this->files_with_source_code = new ArrayCollection();
         $this->resubmissions          = new ArrayCollection();
+        $this->external_judgements    = new ArrayCollection();
     }
 
     /**
@@ -1013,5 +1020,39 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         }
 
         return !empty($judging->getResult()) && empty($judging->getEndtime()) && !$this->isAborted();
+    }
+
+    /**
+     * Add externalJudgement
+     *
+     * @param ExternalJudgement $externalJudgement
+     *
+     * @return Submission
+     */
+    public function addExternalJudgement(ExternalJudgement $externalJudgement)
+    {
+        $this->external_judgements[] = $externalJudgement;
+
+        return $this;
+    }
+
+    /**
+     * Remove externalJudgement
+     *
+     * @param ExternalJudgement $externalJudgement
+     */
+    public function removeExternalJudgement(ExternalJudgement $externalJudgement)
+    {
+        $this->external_judgements->removeElement($externalJudgement);
+    }
+
+    /**
+     * Get externalJudgements
+     *
+     * @return Collection
+     */
+    public function getExternalJudgements()
+    {
+        return $this->external_judgements;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Entity/Submission.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Submission.php
@@ -35,13 +35,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     protected $externalid;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", name="externalresult", length=255, options={"comment"="Result string as returned from external CCS, e.g. Kattis"}, nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $externalresult;
-
-    /**
      * @var int
      *
      * @ORM\Column(type="integer", name="origsubmitid", options={"comment"="If set, specifies original submission in case of edit/resubmit"}, nullable=true)
@@ -270,30 +263,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     public function getExternalid()
     {
         return $this->externalid;
-    }
-
-    /**
-     * Set externalresult
-     *
-     * @param string $externalresult
-     *
-     * @return Submission
-     */
-    public function setExternalresult($externalresult)
-    {
-        $this->externalresult = $externalresult;
-
-        return $this;
-    }
-
-    /**
-     * Get externalresult
-     *
-     * @return string
-     */
-    public function getExternalresult()
-    {
-        return $this->externalresult;
     }
 
     /**

--- a/webapp/src/DOMJudgeBundle/Entity/Testcase.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Testcase.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace DOMJudgeBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -75,6 +77,12 @@ class Testcase
     private $judging_runs;
 
     /**
+     * @ORM\OneToMany(targetEntity="ExternalRun", mappedBy="testcase")
+     * @Serializer\Exclude()
+     */
+    private $external_runs;
+
+    /**
      * @ORM\ManyToOne(targetEntity="Problem", inversedBy="testcases")
      * @ORM\JoinColumn(name="probid", referencedColumnName="probid", onDelete="CASCADE")
      * @Serializer\Exclude()
@@ -94,7 +102,8 @@ class Testcase
      */
     public function __construct()
     {
-        $this->judging_runs = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->judging_runs = new ArrayCollection();
+        $this->external_runs = new ArrayCollection();
     }
 
     /**
@@ -308,7 +317,7 @@ class Testcase
     /**
      * Get judgingRuns
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getJudgingRuns()
     {
@@ -372,5 +381,39 @@ class Testcase
     public function getTestcaseContent()
     {
         return $this->testcase_content;
+    }
+
+    /**
+     * Add externalRun
+     *
+     * @param ExternalRun $externalRun
+     *
+     * @return Testcase
+     */
+    public function addExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs[] = $externalRun;
+
+        return $this;
+    }
+
+    /**
+     * Remove externalRun
+     *
+     * @param ExternalRun $externalRun
+     */
+    public function removeExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs->removeElement($externalRun);
+    }
+
+    /**
+     * Get externalRuns
+     *
+     * @return Collection
+     */
+    public function getExternalRuns()
+    {
+        return $this->external_runs;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Entity/TestcaseWithContent.php
+++ b/webapp/src/DOMJudgeBundle/Entity/TestcaseWithContent.php
@@ -3,6 +3,7 @@
 namespace DOMJudgeBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -107,6 +108,12 @@ class TestcaseWithContent
      * @Serializer\Exclude()
      */
     private $judging_runs;
+
+    /**
+     * @ORM\OneToMany(targetEntity="ExternalRun", mappedBy="testcase")
+     * @Serializer\Exclude()
+     */
+    private $external_runs;
 
     /**
      * @ORM\ManyToOne(targetEntity="Problem", inversedBy="testcases")
@@ -472,5 +479,39 @@ class TestcaseWithContent
     public function getProblem()
     {
         return $this->problem;
+    }
+
+    /**
+     * Add externalRun
+     *
+     * @param ExternalRun $externalRun
+     *
+     * @return Testcase
+     */
+    public function addExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs[] = $externalRun;
+
+        return $this;
+    }
+
+    /**
+     * Remove externalRun
+     *
+     * @param ExternalRun $externalRun
+     */
+    public function removeExternalRun(ExternalRun $externalRun)
+    {
+        $this->external_runs->removeElement($externalRun);
+    }
+
+    /**
+     * Get externalRuns
+     *
+     * @return Collection
+     */
+    public function getExternalRuns()
+    {
+        return $this->external_runs;
     }
 }

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/partials/submission_list.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/partials/submission_list.html.twig
@@ -1,4 +1,5 @@
 {# Render a list of submissions for a jury page #}
+{# @var \DOMJudgeBundle\Entity\ExternalJudgement externalJudgement #}
 
 {% if submissions is empty %}
     <div class="alert alert-warning">No submissions</div>
@@ -17,6 +18,9 @@
             <th scope="col">problem</th>
             <th scope="col">lang</th>
             <th scope="col">result</th>
+            {% if showExternalResult | default(false) %}
+                <th scope="col">external result</th>
+            {% endif %}
             <th scope="col">verified</th>
             <th scope="col">by</th>
             {%- if rejudging is defined %}
@@ -58,23 +62,37 @@
                                       title="{{ submission.language.name }}">{{ submission.langid }}</a></td>
                 <td><a href="{{ link }}">
                         {%- if submission.submittime > submission.contest.endtime %}
-                            {{ 'too-late' | printResult(true, true) }}
+                            {{ 'too-late' | printValidJuryResult }}
                             {%- if submission.judgings.first is not empty and submission.judgings.first.result is not empty %}
-                                ({{ submission.judgings.first.result | printResult(true, true) }})
+                                ({{ submission.judgings.first.result | printValidJuryResult }})
                             {%- endif %}
                         {%- elseif submission.judgings.first is empty or submission.judgings.first.result is empty %}
                             {%- if submission.judgehost %}
-                                {{- '' | printResult(true, true) -}}
+                                {{- '' | printValidJuryResult -}}
                             {%- else %}
-                                {{- 'queued' | printResult(true, true) -}}
+                                {{- 'queued' | printValidJuryResult -}}
                             {%- endif %}
                         {%- else %}
-                            {{- submission.judgings.first.result | printResult(true, true) -}}
+                            {{- submission.judgings.first.result | printValidJuryResult -}}
                         {%- endif %}
                         {%- if submission.stillBusy -%}
                             (&hellip;)
                         {%- endif -%}
                 </a></td>
+                {% if showExternalResult | default(false) %}
+                    {% if submission.externalJudgements.empty %}
+                        {% set externalJudgement = null %}
+                    {% else %}
+                        {% set externalJudgement = submission.externalJudgements.first %}
+                    {% endif %}
+                    <td><a href="{{ link }}">
+                            {% if externalJudgement is null or externalJudgement.result is empty %}
+                                {{- 'pending' | printValidJuryResult -}}
+                            {% else %}
+                                {{- externalJudgement.result | printValidJuryResult -}}
+                            {% endif %}
+                    </a></td>
+                {% endif %}
                 {%- set claim = false %}
                 {%- if submission.judgings.first is empty or submission.judgings.first.result is empty -%}
                     {%- set verified = '' %}
@@ -116,7 +134,7 @@
                 {%- if rejudging is defined %}
 
                     <td><a href="{{ path('jury_submission', {submitId: submission.submitid}) }}">
-                            {{ submission.oldResult | printResult(true, true) }}
+                            {{ submission.oldResult | printValidJuryResult }}
                     </a></td>
                 {%- endif %}
                 {%- if showTestcases is defined and showTestcases %}

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
@@ -139,11 +139,11 @@
             </a>
         </span>
 
-        {% if ext_ccs_url is not null and submission.externalid is null %}
+        {% if external_ccs_submission_url is not empty %}
             <span>
                 <i class="fas fa-link"></i>
                 <a href="{{ submission | externalCcsUrl }}" target="_blank">
-                    View in Kattis
+                    View in external CCS
                 </a>
             </span>
         {% endif %}
@@ -152,7 +152,7 @@
     {% if submission.externalid %}
         <div class="mb-2">
             External ID:
-            {% if ext_ccs_url is null %}
+            {% if external_ccs_submission_url is empty %}
                 {{- submission.externalid -}}
             {% else %}
                 <a href="{{ submission | externalCcsUrl }}" target="_blank">
@@ -169,7 +169,7 @@
             <hr>
             <p>
                 This submission was judged as
-                {% if ext_ccs_url is null %}
+                {% if external_ccs_submission_url is empty %}
                     {{ externalJudgement.result | printResult(true, true) }} by the external CCS
                 {% else %}
                     <a href="{{ submission | externalCcsUrl }}" target="_blank">

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
@@ -159,7 +159,7 @@
                     {{- submission.externalid -}}
                 </a>
             {% endif -%}
-            , {{ externalJudgement.result | printResult(true, true) }}
+            , {{ externalJudgement.result | printValidJuryResult }}
         </div>
     {% endif %}
 
@@ -170,13 +170,13 @@
             <p>
                 This submission was judged as
                 {% if external_ccs_submission_url is empty %}
-                    {{ externalJudgement.result | printResult(true, true) }} by the external CCS
+                    {{ externalJudgement.result | printValidJuryResult }} by the external CCS
                 {% else %}
                     <a href="{{ submission | externalCcsUrl }}" target="_blank">
-                        {{ externalJudgement.result | printResult(true, true) }} by the external CCS
+                        {{ externalJudgement.result | printValidJuryResult }} by the external CCS
                     </a>
                 {% endif -%}
-                , but as {{ selectedJudging.result | printResult(true, true) }}
+                , but as {{ selectedJudging.result | printValidJuryResult }}
                 by DOMjudge.
             </p>
         </div>

--- a/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/jury/submission.html.twig
@@ -1,3 +1,4 @@
+{# @var \DOMJudgeBundle\Entity\ExternalJudgement externalJudgement #}
 {% extends "@DOMJudge/jury/base.html.twig" %}
 {% import _self as self %}
 
@@ -22,6 +23,12 @@
 {% endblock %}
 
 {% block content %}
+
+    {% if submission.externalJudgements.empty %}
+        {% set externalJudgement = null %}
+    {% else %}
+        {% set externalJudgement = submission.externalJudgements.first %}
+    {% endif %}
 
     {% if claimWarning %}
         <div class="alert alert-warning">
@@ -142,24 +149,34 @@
         {% endif %}
     </div>
 
-    {% if ext_ccs_url is not null and submission.externalid %}
+    {% if submission.externalid %}
         <div class="mb-2">
             External ID:
-            <a href="{{ submission | externalCcsUrl }}" target="_blank">
+            {% if ext_ccs_url is null %}
                 {{- submission.externalid -}}
-            </a>, {{ submission.externalresult | printResult(true, true) }}
+            {% else %}
+                <a href="{{ submission | externalCcsUrl }}" target="_blank">
+                    {{- submission.externalid -}}
+                </a>
+            {% endif -%}
+            , {{ externalJudgement.result | printResult(true, true) }}
         </div>
     {% endif %}
 
-    {% if submission.externalresult is not empty and selectedJudging is not null and submission.externalresult != selectedJudging.result and ext_ccs_url is not null %}
+    {% if externalJudgement is not null and externalJudgement.result is not empty and selectedJudging is not null and externalJudgement.result != selectedJudging.result %}
         <div class="alert alert-danger">
             <strong>Results differ!</strong>
             <hr>
             <p>
                 This submission was judged as
-                <a href="{{ submission | externalCcsUrl }}" target="_blank">
-                    {{ submission.externalresult | printResult(true, true) }}
-                    by the external CCS</a>, but as {{ selectedJudging.result | printResult(true, true) }}
+                {% if ext_ccs_url is null %}
+                    {{ externalJudgement.result | printResult(true, true) }} by the external CCS
+                {% else %}
+                    <a href="{{ submission | externalCcsUrl }}" target="_blank">
+                        {{ externalJudgement.result | printResult(true, true) }} by the external CCS
+                    </a>
+                {% endif -%}
+                , but as {{ selectedJudging.result | printResult(true, true) }}
                 by DOMjudge.
             </p>
         </div>

--- a/webapp/src/DOMJudgeBundle/Resources/views/team/partials/submission.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/team/partials/submission.html.twig
@@ -38,7 +38,7 @@
         {% if judging.result != 'compiler-error' %}
             <div class="d-flex flex-row">
                 <div class="p-2">
-                    Run result: {{ judging.result | printResult(true) }}
+                    Run result: {{ judging.result | printResult }}
                 </div>
             </div>
         {% endif %}

--- a/webapp/src/DOMJudgeBundle/Resources/views/team/partials/submission_list.html.twig
+++ b/webapp/src/DOMJudgeBundle/Resources/views/team/partials/submission_list.html.twig
@@ -46,13 +46,13 @@
                 <td>
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
                         {%- if submission.submittime > submission.contest.endtime %}
-                            {{ 'too-late' | printResult(true, false) }}
+                            {{ 'too-late' | printResult }}
                         {%- elseif submission.judgings.first is empty or submission.judgings.first.result is empty %}
-                            {{- '' | printResult(true, false) -}}
+                            {{- '' | printResult -}}
                         {%- elseif verificationRequired and not submission.judgings.first.verified %}
-                            {{- '' | printResult(true, false) -}}
+                            {{- '' | printResult -}}
                         {%- else %}
-                            {{- submission.judgings.first.result | printResult(true, false) -}}
+                            {{- submission.judgings.first.result | printResult -}}
                         {%- endif %}
                     </a>
                 </td>

--- a/webapp/src/DOMJudgeBundle/Service/ImportProblemService.php
+++ b/webapp/src/DOMJudgeBundle/Service/ImportProblemService.php
@@ -628,7 +628,7 @@ class ImportProblemService
                             ]);
                         $submission     = $this->submissionService->submitSolution($team, $contestProblem, $contest,
                                                                                    $languageToUse, $filesToSubmit, null,
-                                                                                   '__auto__', null, null, null,
+                                                                                   '__auto__', null, null,
                                                                                    $submissionMessage);
                         if (!$submission) {
                             $errorMessage = $submissionMessage;

--- a/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
+++ b/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
@@ -197,7 +197,8 @@ class SubmissionService
                 ->setParameter(':result', $restrictions['result']);
         }
 
-        if ($this->dj->dbconfig_get('data_source', 0) == 2) {
+        if ($this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+            DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL) {
             // When we are shadow, also load the external results
             $queryBuilder
                 ->leftJoin('s.external_judgements', 'ej')

--- a/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
+++ b/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
@@ -197,6 +197,18 @@ class SubmissionService
                 ->setParameter(':result', $restrictions['result']);
         }
 
+        if ($this->dj->dbconfig_get('data_source', 0) == 2) {
+            // When we are shadow, also load the external results
+            $queryBuilder
+                ->leftJoin('s.external_judgements', 'ej')
+                // We want the external judgement that was started the latest, because that is the
+                // current valid one. We do this by left-joining on external judgements again, bot
+                // only for ones that started later. This should then give no result, hence we add
+                // a andWhere below for ej2.extjudgementid IS NULL
+                ->leftJoin('s.external_judgements', 'ej2', Join::WITH, 'ej2.starttime > ej.starttime')
+                ->andWhere('ej2.extjudgementid IS NULL');
+        }
+
         $submissions = $queryBuilder->getQuery()->getResult();
         if (isset($restrictions['rejudgingid'])) {
             // Doctrine will return an array for each item. At index '0' will be the submission and at

--- a/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
+++ b/webapp/src/DOMJudgeBundle/Service/SubmissionService.php
@@ -292,7 +292,6 @@ class SubmissionService
      * @param string|null         $entryPoint
      * @param string|null         $externalId
      * @param float|null          $submitTime
-     * @param string|null         $externalResult
      * @param string|null         $message
      * @return Submission|null
      * @throws \Doctrine\DBAL\DBALException
@@ -307,7 +306,6 @@ class SubmissionService
         string $entryPoint = null,
         $externalId = null,
         float $submitTime = null,
-        $externalResult = null,
         string &$message = null
     ) {
         if (!$team instanceof Team) {
@@ -444,8 +442,7 @@ class SubmissionService
             ->setSubmittime($submitTime)
             ->setOriginalSubmission($originalSubmission)
             ->setEntryPoint($entryPoint)
-            ->setExternalid($externalId)
-            ->setExternalresult($externalResult);
+            ->setExternalid($externalId);
 
         // Add expected results from source. We only do this for jury submissions
         // to prevent accidental auto-verification of team submissions.

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -418,15 +418,17 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
      * Return the URL to an external CCS for the given submission if available
      * @param Submission $submission
      * @return string|null
+     * @throws \Exception
      */
     public function externalCcsUrl(Submission $submission)
     {
         require_once $this->dj->getDomjudgeEtcDir() . '/domserver-config.php';
 
         if (defined('EXT_CCS_URL')) {
-            if ($submission->getExternalid()) {
+            $dataSource = $this->dj->dbconfig_get('data_source', 0);
+            if ($dataSource == 2) {
                 return sprintf('%s%s', EXT_CCS_URL, $submission->getExternalid());
-            } else {
+            } elseif ($dataSource == 1) {
                 return sprintf('%s%s', EXT_CCS_URL, $submission->getSubmitid());
             }
         }

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -72,6 +72,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             new \Twig_SimpleFilter('printtime', [$this, 'printtime']),
             new \Twig_SimpleFilter('printtimeHover', [$this, 'printtimeHover'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('printResult', [$this, 'printResult'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFilter('printValidJuryResult', [$this, 'printValidJuryResult'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('printHost', [$this, 'printHost'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('printYesNo', [$this, 'printYesNo']),
             new \Twig_SimpleFilter('printSize', [Utils::class, 'printSize'], ['is_safe' => ['html']]),
@@ -399,6 +400,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             // no break
             case 'judging':
             case 'queued':
+            case 'pending':
                 if (!$jury) {
                     $result = 'pending';
                 }
@@ -412,6 +414,16 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
         }
 
         return sprintf('<span class="sol %s">%s</span>', $valid ? $style : 'disabled', $result);
+    }
+
+    /**
+     * Print the given result for the jury, assuming it is valid
+     * @param string $result
+     * @return string
+     */
+    public function printValidJuryResult($result): string
+    {
+        return $this->printResult($result, true, true);
     }
 
     /**

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -438,7 +438,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
 
         $extCcsUrl = $this->dj->dbconfig_get('external_ccs_submission_url', '');
         if (!empty($extCcsUrl)) {
-            $dataSource = $this->dj->dbconfig_get('data_source', 0);
+            $dataSource = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
             if ($dataSource == 2) {
                 return str_replace(':id:', $submission->getExternalid(), $extCcsUrl);
             } elseif ($dataSource == 1) {

--- a/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
+++ b/webapp/src/DOMJudgeBundle/Twig/TwigExtension.php
@@ -118,7 +118,7 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
             'have_printing' => $this->dj->dbconfig_get('enable_printing', 0),
             'refresh_flag' => $refresh_flag,
             'icat_url' => defined('ICAT_URL') ? ICAT_URL : null,
-            'ext_ccs_url' => defined('EXT_CCS_URL') ? EXT_CCS_URL : null,
+            'external_ccs_submission_url' => $this->dj->dbconfig_get('external_ccs_submission_url', ''),
             'current_team_contest' => $team ? $this->dj->getCurrentContest($user->getTeamid()) : null,
             'current_team_contests' => $team ? $this->dj->getCurrentContests($user->getTeamid()) : null,
             'submission_languages' => $this->em->createQueryBuilder()
@@ -424,12 +424,13 @@ class TwigExtension extends \Twig\Extension\AbstractExtension implements \Twig\E
     {
         require_once $this->dj->getDomjudgeEtcDir() . '/domserver-config.php';
 
-        if (defined('EXT_CCS_URL')) {
+        $extCcsUrl = $this->dj->dbconfig_get('external_ccs_submission_url', '');
+        if (!empty($extCcsUrl)) {
             $dataSource = $this->dj->dbconfig_get('data_source', 0);
             if ($dataSource == 2) {
-                return sprintf('%s%s', EXT_CCS_URL, $submission->getExternalid());
+                return str_replace(':id:', $submission->getExternalid(), $extCcsUrl);
             } elseif ($dataSource == 1) {
-                return sprintf('%s%s', EXT_CCS_URL, $submission->getSubmitid());
+                return str_replace(':id:', $submission->getSubmitid(), $extCcsUrl);
             }
         }
 


### PR DESCRIPTION
So, here it is: we now store external judgements and runs in separate tables, so we can later show more info from them, like timing and per-testcase results.

I also already modified the submission lists to show the external result, as that was an easy change.

Further improvements, like the nice matrix page and indeed showing external runs on the submission page, will be done at a later stage.

Note that I make the assumption that the judgement with the latest `start_time` is the valid one for each submssion and that is also the one that will be loaded automatically with each submission. If the spec at some point will add the `valid` field as suggested by @meisterT this would make the query to get the valid judgement easier.