### PR TITLE
Take into account pending submissions in the freeze.

### DIFF
--- a/webapp/src/DOMJudgeBundle/Entity/Submission.php
+++ b/webapp/src/DOMJudgeBundle/Entity/Submission.php
@@ -469,7 +469,7 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
      */
     public function getRelativeSubmitTime()
     {
-        return Utils::relTime($this->getSubmittime() - $this->getContest()->getStarttime());
+        return Utils::relTime($this->getContest()->getContestTime((float)$this->getSubmittime()));
     }
 
     /**


### PR DESCRIPTION
After a discussion with @deboer-tim we came to the conclusion that we leaked some info to the public during the freeze.

Please please double-triple check my code.

To explain what this tries to fix, here are two scenario's:

# Scenario 1

Imagine the following: we have a team, say team `X`, and a problem, say `A`. Now imagine the team does two submissions, both after the freeze. The first one is a `compiler-error` and the second one is `correct`. `compile_penalty` is set to `false`.
Our previous code would show `1 try` for this team to the public, while the team actually did try two times. Showing `1 try` gives something away, namely that one of the submissions was not 'counted'. It doesn't necessarily mean it was a compiler-error, because of the second scenario below.
Moreover, until the first submission has actually been judged, we would show `1 try`. Then after the judging is done, we show no tries. This *clearly* gives away the fact that this submission was a `compiler-error` (or it was ignored by the jury).
The new code will show `2 tries` until we unfreeze, then we show `1 try` with the score of the last try.

# Scenario 2

Imagine the following: we have a team, say team `X`, and a problem, say `A`. Now imagine the team does two submissions, both after the freeze. The first one is `correct` and the second one is `wrong-answer`.
Our previous code would show `1 try` for this team to the public, because we stopped checking submissions after the first correct one. Again, this gives away info, because we again ignore one of the submissions.
The same holds for the state *during* judging. We would show `2 tries` until the second submission is done and then it would jump back to `1 try`.
The new code will also show `2 tries` until we unfreeze, then we show `1 try` with the score of the first try, ignoring the second one.

# Rationale

The rationale to change this is that the [Contest API spec](https://clics.ecs.baylor.edu/index.php?title=Contest_API_2019#Access_restrictions_at_WF_11) regulates that judgements *during* the freeze will not be shown to the public. Hence we should not leak information from these judgements during the freeze to the public.

# Testing

I tested this by using a copy of the DOMjudge online contest, where team DerBaer had two during-freeze-submissions on problem G, the first of which was correct and the second was compiler-error. I played a bit with these submissions to get different scenario's. Let's call these submissions `S1` and `S2`.

The results after this change are:
* `S1 = correct, S2 = compiler-error, S1.time < S2.time`: frozen scoreboard shows `2 tries`, jury shows `1 try` and correct with time of S1.
* `S1 = correct, S2 = compiler-error, S1.time > S2.time` (i.e. swapping them) with `compile_penalty` set to `false`: frozen scoreboard shows `2 tries`, jury shows `1 try` and correct with time of S2.
* `S1 = correct, S2 = compiler-error, S1.time > S2.time` (i.e. swapping them) with `compile_penalty` set to `true`: frozen scoreboard shows `2 tries`, jury shows `2 tries` and correct with time of S2 + 20.
* `S1 = correct, S2 = wrong-answer, S1.time > S2.time` (i.e. swapping them and changing the outcome of S2): frozen scoreboard shows `2 tries`, jury shows `2 tries` and correct with time of S2 + 20.
* `S1 = correct, S2 = correct, S1.time < S2.time` )i.e. changing the outcome of S2 to correct0: frozen scoreboard shows `2 tries`, jury shows `1 try` and correct with time of S1.