### PR TITLE
Split up contest.public in contest.public and contest.open_to_all_teams.

### DIFF
--- a/lib/lib.misc.php
+++ b/lib/lib.misc.php
@@ -32,7 +32,7 @@ function getCurContests(
     if ($onlyofteam !== null && $onlyofteam > 0) {
         $contests = $DB->q("SELECT * FROM contest
                             LEFT JOIN contestteam USING (cid)
-                            WHERE (contestteam.teamid = %i OR contest.public = 1)
+                            WHERE (contestteam.teamid = %i OR contest.open_to_all_teams = 1)
                             AND enabled = 1 ${extra}
                             AND ( deactivatetime IS NULL OR
                                   deactivatetime > UNIX_TIMESTAMP() )

--- a/sql/mysql_db_structure.sql
+++ b/sql/mysql_db_structure.sql
@@ -106,6 +106,7 @@ CREATE TABLE `contest` (
   `starttime_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1 COMMENT 'If disabled, starttime is not used, e.g. to delay contest start',
   `process_balloons` tinyint(1) UNSIGNED DEFAULT 1 COMMENT 'Will balloons be processed for this contest?',
   `public` tinyint(1) UNSIGNED DEFAULT 1 COMMENT 'Is this contest visible for the public and non-associated teams?',
+  `open_to_all_teams` tinyint(1) UNSIGNED DEFAULT 1 COMMENT 'Is this contest open to all teams?',
   PRIMARY KEY (`cid`),
   UNIQUE KEY `externalid` (`externalid`(190)),
   UNIQUE KEY `shortname` (`shortname`(190)),

--- a/sql/upgrade/upgrade_7.0.0_7.1.0.sql
+++ b/sql/upgrade/upgrade_7.0.0_7.1.0.sql
@@ -8,12 +8,16 @@
 --
 
 -- @UPGRADE-CHECK@
-CREATE TABLE `external_judgement` (`extjudgementid` varchar (255));
-DROP TABLE `external_judgement`;
+ALTER TABLE `contest` ADD  COLUMN `open_to_all_teams` tinyint(1);
+ALTER TABLE `contest` DROP COLUMN `open_to_all_teams`;
 
 --
 -- Create additional structures
 --
+
+ALTER TABLE `contest`
+  CHANGE COLUMN `public` `public` tinyint(1) UNSIGNED DEFAULT '1' COMMENT 'Is this contest visible for the public?',
+  ADD    COLUMN `open_to_all_teams` tinyint(1) UNSIGNED DEFAULT '1' COMMENT 'Is this contest open to all teams?' AFTER `public`;
 
 -- Create external judgement/run tables
 CREATE TABLE `external_judgement` (
@@ -81,6 +85,8 @@ INSERT INTO `testcase_content` (`testcaseid`, `input`, `output`, `image`, `image
 INSERT INTO `judging_run_output` (`runid`, `output_run`, `output_diff`, `output_error`, `output_system`)
     SELECT `runid`, `output_run`, `output_diff`, `output_error`, `output_system` FROM `judging_run`;
 
+UPDATE `contest` SET `open_to_all_teams` = `public`;
+
 --
 -- Add/remove sample/initial contents
 --
@@ -91,7 +97,6 @@ INSERT INTO `configuration` (`name`, `value`, `type`, `public`, `category`, `des
 --
 -- Finally remove obsolete structures after moving data
 --
-
 
 ALTER TABLE `submission`
     DROP COLUMN `externalresult`;

--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -978,7 +978,7 @@ class ImportEventFeedCommand extends Command
         // Also check if this is a private contest. If so, we need to add the team to the contest
         /** @var Contest $contest */
         $contest = $this->em->getRepository(Contest::class)->find($this->contestId);
-        if (!$contest->getPublic()) {
+        if (!$contest->isOpenToAllTeams()) {
             if (!$contest->getTeams()->contains($team)) {
                 $contest->addTeam($team);
             }

--- a/webapp/src/Controller/API/AbstractRestController.php
+++ b/webapp/src/Controller/API/AbstractRestController.php
@@ -165,7 +165,7 @@ abstract class AbstractRestController extends AbstractFOSRestController
         if (!$this->dj->checkrole('api_reader') && !$this->dj->checkrole('judgehost')) {
             if ($this->dj->checkrole('team') && $this->dj->getUser()->getTeamid()) {
                 $qb->leftJoin('c.teams', 'ct')
-                    ->andWhere('ct.teamid = :teamid OR c.public = 1')
+                    ->andWhere('ct.teamid = :teamid OR c.openToAllTeams = 1')
                     ->setParameter(':teamid', $this->dj->getUser()->getTeamid());
             } else {
                 $qb->andWhere('c.public = 1');

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -108,7 +108,7 @@ class TeamController extends AbstractRestController
         }
 
         $contest = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
-        if (!$contest->getPublic()) {
+        if (!$contest->isOpenToAllTeams()) {
             $queryBuilder
                 ->andWhere('c.cid = :cid')
                 ->setParameter(':cid', $contest->getCid());

--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -110,7 +110,7 @@ class AnalysisController extends AbstractController
 
         // Next select information about the teams
         $teams = [];
-        if ($contest->getPublic()) {
+        if ($contest->isOpenToAllTeams()) {
             $teams = $this->applyFilter($em->createQueryBuilder()
                                             ->select('t', 'ts', 'j', 'lang', 'a')
                                             ->from(Team::class, 't')

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -209,6 +209,7 @@ class ContestController extends BaseController
 
         $table_fields = array_merge($table_fields, [
             'process_balloons' => ['title' => 'process<br/>balloons?', 'sort' => true],
+            'public' => ['title' => 'public?', 'sort' => true],
             'num_teams' => ['title' => '# teams', 'sort' => true],
             'num_problems' => ['title' => '# problems', 'sort' => true],
         ]);
@@ -253,7 +254,8 @@ class ContestController extends BaseController
             }
 
             $contestdata['process_balloons'] = ['value' => $contest->getProcessBalloons() ? 'yes' : 'no'];
-            if ($contest->getPublic()) {
+            $contestdata['public'] = ['value' => $contest->getPublic() ? 'yes' : 'no'];
+            if ($contest->isOpenToAllTeams()) {
                 $contestdata['num_teams'] = ['value' => '<i>all</i>'];
             } else {
                 $contestdata['num_teams'] = ['value' => $contestData['num_teams']];

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -224,7 +224,7 @@ class JuryMiscController extends BaseController
                         ->from(Team::class, 't')
                         ->select('t')
                         ->orderBy('t.teamid');
-                    if (!$contest->getPublic()) {
+                    if (!$contest->isOpenToAllTeams()) {
                         $queryBuilder
                             ->join('t.contests', 'c')
                             ->andWhere('c.cid = :cid')

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -85,13 +85,13 @@ class TeamController extends BaseController
             ->addOrderBy('t.name', 'ASC')
             ->getQuery()->getResult();
 
-        $contests             = $this->dj->getCurrentContests();
-        $num_public_contests  = $this->em->createQueryBuilder()
+        $contests                       = $this->dj->getCurrentContests();
+        $num_open_to_all_teams_contests = $this->em->createQueryBuilder()
             ->select('count(c.cid) as num_contests')
             ->from(Contest::class, 'c')
-            ->andWhere('c.public = 1')
+            ->andWhere('c.openToAllTeams = 1')
             ->getQuery()->getSingleResult()['num_contests'];
-        $teams_that_submitted = $this->em->createQueryBuilder()
+        $teams_that_submitted   = $this->em->createQueryBuilder()
             ->select('t.teamid as teamid, count(t.teamid) as num_submitted')
             ->from(Team::class, 't')
             ->join('t.submissions', 's')
@@ -99,7 +99,7 @@ class TeamController extends BaseController
             ->andWhere('s.contest in (:contests)')
             ->setParameter('contests', $contests)
             ->getQuery()->getResult();
-        $teams_that_submitted = array_column($teams_that_submitted, 'num_submitted', 'teamid');
+        $teams_that_submitted   = array_column($teams_that_submitted, 'num_submitted', 'teamid');
 
         $teams_that_solved = $this->em->createQueryBuilder()
             ->select('t.teamid as teamid, count(t.teamid) as num_correct')
@@ -208,7 +208,7 @@ class TeamController extends BaseController
 
             // merge in the rest of the data
             $teamdata = array_merge($teamdata, [
-                'num_contests' => ['value' => (int)($t->getContests()->count()) + $num_public_contests],
+                'num_contests' => ['value' => (int)($t->getContests()->count()) + $num_open_to_all_teams_contests],
                 'status' => [
                     'value' => $status,
                     'title' => $statustitle,

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -225,11 +225,17 @@ class Contest extends BaseApiEntity
 
     /**
      * @var boolean
-     * @ORM\Column(type="boolean", name="public", options={"comment"="Is this contest visible for the public and
-     *                             non-associated teams?"}, nullable=false)
+     * @ORM\Column(type="boolean", name="public", options={"comment"="Is this contest visible for the public?"}, nullable=false)
      * @Serializer\Exclude()
      */
     private $public = true;
+
+    /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="open_to_all_teams", options={"comment"="Are all teams automatically part of this contest?"}, nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $openToAllTeams = true;
 
     /**
      * @ORM\ManyToMany(targetEntity="Team", inversedBy="contests")
@@ -856,9 +862,6 @@ class Contest extends BaseApiEntity
     public function setPublic($public)
     {
         $this->public = $public;
-        if ($this->public) {
-            $this->teams->clear();
-        }
 
         return $this;
     }
@@ -871,6 +874,33 @@ class Contest extends BaseApiEntity
     public function getPublic()
     {
         return $this->public;
+    }
+
+    /**
+     * Set open to all teams
+     *
+     * @param boolean $openToAllTeams
+     *
+     * @return Contest
+     */
+    public function setOpenToAllTeams($openToAllTeams)
+    {
+        $this->openToAllTeams = $openToAllTeams;
+        if ($this->openToAllTeams) {
+            $this->teams->clear();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get open to all teams
+     *
+     * @return boolean
+     */
+    public function isOpenToAllTeams()
+    {
+        return $this->openToAllTeams;
     }
 
     /**

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -63,6 +63,15 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,
+            'label' => 'Contest visible on public scoreboard',
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+        ]);
+        $builder->add('openToAllTeams', ChoiceType::class, [
+            'expanded' => true,
+            'label' => 'Contest open to all teams',
             'choices' => [
                 'Yes' => true,
                 'No' => false,

--- a/webapp/src/Form/Type/RejudgingType.php
+++ b/webapp/src/Form/Type/RejudgingType.php
@@ -151,15 +151,15 @@ class RejudgingType extends AbstractType
                 ->andWhere('t.enabled = 1')
                 ->addOrderBy('t.name');
 
-            $anyPublic = false;
+            $selectAllTeams = false;
             foreach ($contests as $contest) {
-                if ($contest->getPublic()) {
-                    $anyPublic = true;
+                if ($contest->isOpenToAllTeams()) {
+                    $selectAllTeams = true;
                     break;
                 }
             }
 
-            if (!$anyPublic) {
+            if (!$selectAllTeams) {
                 $teamsQueryBuilder
                     ->join('t.contests', 'c')
                     ->andWhere('c IN (:contests)')

--- a/webapp/src/Form/Type/TeamType.php
+++ b/webapp/src/Form/Type/TeamType.php
@@ -80,7 +80,7 @@ class TeamType extends AbstractExternalIdEntityType
             'multiple' => true,
             'by_reference' => false,
             'query_builder' => function (EntityRepository $er) {
-                return $er->createQueryBuilder('c')->where('c.public = false')->orderBy('c.name');
+                return $er->createQueryBuilder('c')->where('c.openToAllTeams = false')->orderBy('c.name');
             },
         ]);
         $builder->add('enabled', ChoiceType::class, [

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -163,11 +163,11 @@ class DOMJudgeService
         $qb->select('c')->from(Contest::class, 'c', 'c.cid');
         if ($onlyofteam !== null && $onlyofteam > 0) {
             $qb->leftJoin('c.teams', 'ct')
-                ->andWhere('ct.teamid = :teamid OR c.public = 1')
+                ->andWhere('ct.teamid = :teamid OR c.openToAllTeams = 1')
                 ->setParameter(':teamid', $onlyofteam);
             // $contests = $DB->q("SELECT * FROM contest
             //                     LEFT JOIN contestteam USING (cid)
-            //                     WHERE (contestteam.teamid = %i OR contest.public = 1)
+            //                     WHERE (contestteam.teamid = %i OR contest.openToAllTeams = 1)
             //                     AND enabled = 1 ${extra}
             //                     AND ( deactivatetime IS NULL OR
             //                           deactivatetime > UNIX_TIMESTAMP() )

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -611,7 +611,7 @@ class ScoreboardService
             ->orderBy('cat.name')
             ->addOrderBy('affil.name');
 
-        if (!$contest->getPublic()) {
+        if (!$contest->isOpenToAllTeams()) {
             $queryBuilder
                 ->join('t.contests', 'c')
                 ->andWhere('c = :contest')
@@ -685,7 +685,7 @@ class ScoreboardService
                 ->join('a.teams', 't')
                 ->andWhere('t.category IN (:categories)')
                 ->setParameter(':categories', $categories);
-            if (!$contest->getPublic()) {
+            if (!$contest->isOpenToAllTeams()) {
                 $queryBuilder
                     ->join('t.contests', 'c')
                     ->andWhere('c = :contest')
@@ -783,7 +783,7 @@ class ScoreboardService
             ->select('t, tc, ta')
             ->andWhere('t.enabled = 1');
 
-        if (!$contest->getPublic()) {
+        if (!$contest->isOpenToAllTeams()) {
             $queryBuilder
                 ->join('t.contests', 'c')
                 ->andWhere('c.cid = :cid')

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -84,13 +84,17 @@
                     <td>{{ contest.processBalloons | printYesNo }}</td>
                 </tr>
                 <tr>
-                    <th>Public</th>
+                    <th>Publicly visible</th>
                     <td>{{ contest.public | printYesNo }}</td>
+                </tr>
+                <tr>
+                    <th>Open to all teams</th>
+                    <td>{{ contest.openToAllTeams | printYesNo }}</td>
                 </tr>
                 <tr>
                     <th>Teams</th>
                     <td>
-                        {% if contest.public %}
+                        {% if contest.openToAllTeams %}
                             <em>all teams</em>
                         {% else %}
                             {% for team in contest.teams %}

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -19,6 +19,7 @@
         {{ form_row(form.deactivatetimeString) }}
         {{ form_row(form.processBalloons) }}
         {{ form_row(form.public) }}
+        {{ form_row(form.openToAllTeams) }}
         <div data-teams-field>
             {{ form_row(form.teams) }}
         </div>
@@ -120,14 +121,14 @@
 
     $(function () {
         function showHideTeams() {
-            if ($('#contest_public_1').is(':checked')) {
+            if ($('#contest_openToAllTeams_1').is(':checked')) {
                 $('[data-teams-field]').show();
             } else {
                 $('[data-teams-field]').hide();
             }
         }
 
-        $('#contest_public_1, #contest_public_0').on('change', showHideTeams);
+        $('#contest_openToAllTeams_1, #contest_openToAllTeams_0').on('change', showHideTeams);
         showHideTeams();
     })
 </script>


### PR DESCRIPTION
This should do the trick of splitting up public visibility and whether all teams are part of a contest.

I tested a little around with public-not-all-teams, private-all-teams and the two modes we already supported and it seems to work, but of course I might have missed some edge case.