### PR TITLE
Use external judgements for scoreboard calculation when shadowing.

### DIFF
--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -1487,6 +1487,13 @@ class ImportEventFeedCommand extends Command
 
         $this->em->flush();
 
+        // Now we need to update the scoreboard cache for this cell to get this judgement result in
+        $this->em->clear();
+        $contest = $this->em->getRepository(Contest::class)->find($submission->getCid());
+        $team    = $this->em->getRepository(Team::class)->find($submission->getTeamid());
+        $problem = $this->em->getRepository(Problem::class)->find($submission->getProbid());
+        $this->scoreboardService->calculateScoreRow($contest, $team, $problem);
+
         $this->processPendingEvents('judgement', $judgement->getExternalid());
     }
 


### PR DESCRIPTION
I think @meisterT came up with this idea: when we are shadowing, we should use the external judgements to calculate our scoreboard, instead of using our own judgings.

I tested this by shadowing our online contest and comparing scoreboards afterwards. They are 100% the same.