### PR TITLE
Do not check dependent events while applying rejudgings

### DIFF
--- a/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
+++ b/webapp/src/DOMJudgeBundle/Command/ImportEventFeedCommand.php
@@ -99,19 +99,19 @@ class ImportEventFeedCommand extends ContainerAwareCommand
     protected $verdicts = [];
 
     /**
-     * This array will hold all events that are waiting on a dependant event because it has an ID
+     * This array will hold all events that are waiting on a dependent event because it has an ID
      * that does not exist yet. According to the official spec this can not happen, but in practice
      * it does happen. We handle this by storing these events here and checking whether there are
-     * any after saving any dependant event.
+     * any after saving any dependent event.
      *
      * This array is three dimensional:
-     * - The first dimension is the type of the dependant event type
-     * - The second dimension is the (external) ID of the dependant event
+     * - The first dimension is the type of the dependent event type
+     * - The second dimension is the (external) ID of the dependent event
      * - The third dimension contains an array of all events that should be processed
      * @var array
      */
     protected $pendingEvents = [
-        // Initialize it with all types that can be a dependant event. Note that Language is not here, as they should exist already
+        // Initialize it with all types that can be a dependent event. Note that Language is not here, as they should exist already
         'team' => [],
         'group' => [],
         'organization' => [],
@@ -304,12 +304,12 @@ class ImportEventFeedCommand extends ContainerAwareCommand
         }
 
         if (!empty(array_filter($this->pendingEvents))) {
-            $this->logger->warning(sprintf('Some events could not be processed, because they still have missing dependant events:'));
+            $this->logger->warning(sprintf('Some events could not be processed, because they still have missing dependent events:'));
         }
         foreach ($this->pendingEvents as $type => $eventData) {
             foreach ($eventData as $id => $events) {
                 foreach ($events as $event) {
-                    $this->logger->warning(sprintf('Could not process %s event %s, because it is dependant on missing %s event %s',
+                    $this->logger->warning(sprintf('Could not process %s event %s, because it is dependent on missing %s event %s',
                                                    $event['type'], $event['id'], $type, $id));
                 }
             }
@@ -890,7 +890,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
             $action = EventLogService::ACTION_CREATE;
         }
 
-        // Now check if we have all dependant data
+        // Now check if we have all dependent data
 
         $groupIds = $event['data']['group_ids'] ?? [];
         $category = null;
@@ -989,7 +989,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
             $action = EventLogService::ACTION_CREATE;
         }
 
-        // Now check if we have all dependant data
+        // Now check if we have all dependent data
 
         $fromTeamId = $event['data']['from_team_id'] ?? null;
         $fromTeam   = null;
@@ -1380,7 +1380,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
             $persist = true;
         }
 
-        // Now check if we have all dependant data
+        // Now check if we have all dependent data
 
         $submissionId = $event['data']['submission_id'] ?? null;
         /** @var Submission $submission */
@@ -1482,7 +1482,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
             $persist = true;
         }
 
-        // Now check if we have all dependant data
+        // Now check if we have all dependent data
 
         $judgementId = $event['data']['judgement_id'] ?? null;
         /** @var ExternalJudgement $externalJudgement */
@@ -1571,7 +1571,7 @@ class ImportEventFeedCommand extends ContainerAwareCommand
      */
     protected function addPendingEvent(string $type, $id, array $event)
     {
-        $this->logger->warning(sprintf('Can not currently import %s event %s, because it is dependant on %s %s',
+        $this->logger->warning(sprintf('Can not currently import %s event %s, because it is dependent on %s %s',
                                        $event['type'], $event['id'], $type, $id));
         if (!isset($this->pendingEvents[$type][$id])) {
             $this->pendingEvents[$type][$id] = [];


### PR DESCRIPTION
We should test this on a large rejudging, but on my test with ~20 submissions it went from ~22 seconds to ~1 second in production mode, where there is also an initial overhead for fetching the submissions to apply.

It should now be as fast again as it was when we ported this code to Symfony, after we replaced Doctrine calls with direct SQL queries and I think we benchmarked that and concluded it was good enough (for now).

But I don't have a database where I have a rejudging ready with that many submissions currently, so hopefully someone else can create one to test the speed.