### PR TITLE
Add screen to show shadow differences in a matrix view. Fixes #210.

### DIFF
--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -662,6 +662,7 @@ class ImportEventFeedCommand extends Command
         $verdict         = $event['data']['id'];
         $verdictsFlipped = array_flip($this->verdicts);
         if (!isset($verdictsFlipped[$verdict])) {
+            // TODO: we should handle this. Kattis has JE (judge error) which we do not have but want to show
             $this->logger->error(sprintf('Judgement type %s does not exist in DOMjudge', $verdict));
         } else {
             $penalty = true;

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -1,0 +1,207 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\Jury;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Join;
+use App\Controller\BaseController;
+use App\Entity\ExternalJudgement;
+use App\Entity\Judging;
+use App\Entity\Submission;
+use App\Service\DOMJudgeService;
+use App\Service\SubmissionService;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/jury/shadow-differences")
+ * @IsGranted("ROLE_ADMIN")
+ */
+class ShadowDifferencesController extends BaseController
+{
+    /**
+     * @var DOMJudgeService
+     */
+    protected $dj;
+
+    /**
+     * @var SubmissionService
+     */
+    protected $submissions;
+
+    /**
+     * @var SessionInterface
+     */
+    protected $session;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $em;
+
+    public function __construct(
+        DOMJudgeService $dj,
+        SubmissionService $submissions,
+        SessionInterface $session,
+        EntityManagerInterface $em
+    ) {
+        $this->dj          = $dj;
+        $this->submissions = $submissions;
+        $this->session     = $session;
+        $this->em          = $em;
+    }
+
+    /**
+     * @Route("", name="jury_shadow_differences")
+     */
+    public function indexAction(Request $request)
+    {
+        $shadowMode = DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
+        $dataSource = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
+        if ($dataSource != $shadowMode) {
+            $this->addFlash('danger', sprintf(
+                'Shadow differences only supported when data_source is %d',
+                $shadowMode
+            ));
+            return $this->redirectToRoute('jury_index');
+        }
+
+        // Close the session, as this might take a while and we don't need the session below
+        $this->session->save();
+
+        $contest        = $this->dj->getCurrentContest();
+        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
+        $verdicts       = array_merge(['judging' => 'JU'], include $verdictsConfig);
+
+        $used         = [];
+        $verdictTable = [];
+        // pre-fill $verdictTable to get a consistent ordering
+        foreach ($verdicts as $verdict => $abbrev) {
+            foreach ($verdicts as $verdict2 => $abbrev2) {
+                $verdictTable[$verdict][$verdict2] = [];
+            }
+        }
+
+        /** @var Submission[] $submissions */
+        $submissions = $this->em->createQueryBuilder()
+            ->from(Submission::class, 's', 's.submitid')
+            ->leftJoin('s.external_judgements', 'ej', Join::WITH, 'ej.valid = 1')
+            ->leftJoin('s.judgings', 'j', Join::WITH, 'j.valid = 1')
+            ->select('s', 'ej', 'j')
+            ->andWhere('s.contest = :contest')
+            ->setParameter(':contest', $contest)
+            ->getQuery()
+            ->getResult();
+
+        // Helper function to add verdicts
+        $addVerdict = function ($unknownVerdict) use ($verdicts, &$verdictTable) {
+            // add column to existing rows
+            foreach ($verdicts as $verdict => $abbreviation) {
+                $verdictTable[$verdict][$unknownVerdict] = [];
+            }
+            // add verdict to known verdicts
+            $verdicts[$unknownVerdict] = $unknownVerdict;
+            // add row
+            $verdictTable[$unknownVerdict] = [];
+            foreach ($verdicts as $verdict => $abbreviation) {
+                $verdictTable[$unknownVerdict][$verdict] = [];
+            }
+        };
+
+        // Build up the verdict matrix
+        foreach ($submissions as $submitid => $submission) {
+            /** @var ExternalJudgement|null $externalJudgement */
+            $externalJudgement = $submission->getExternalJudgements()->first();
+            /** @var Judging|null $localJudging */
+            $localJudging = $submission->getJudgings()->first();
+
+            if ($localJudging && $localJudging->getResult()) {
+                $localResult = $localJudging->getResult();
+            } else {
+                $localResult = 'judging';
+            }
+
+            if ($externalJudgement && $externalJudgement->getResult()) {
+                $externalResult = $externalJudgement->getResult();
+            } else {
+                $externalResult = 'judging';
+            }
+
+            // add verdicts to data structures if they are unknown up to now
+            foreach ([$externalResult, $localResult] as $result) {
+                if (!array_key_exists($result, $verdicts)) {
+                    $addVerdict($result);
+                }
+            }
+
+            // mark them as used, so we can filter out unused cols/rows later
+            $used[$externalResult] = true;
+            $used[$localResult]    = true;
+
+            // append submitid to list of orig->new verdicts
+            $verdictTable[$externalResult][$localResult][] = $submitid;
+        }
+
+        $viewTypes = [0 => 'unjudged local', 1 => 'unjudged external', 2 => 'diff', 3 => 'all'];
+        $view      = 2;
+        if ($request->query->has('view')) {
+            $index = array_search($request->query->get('view'), $viewTypes);
+            if ($index !== false) {
+                $view = $index;
+            }
+        }
+
+        $restrictions = [];
+        if ($viewTypes[$view] == 'unjudged local') {
+            $restrictions['judged'] = 0;
+        }
+        if ($viewTypes[$view] == 'unjudged external') {
+            $restrictions['externally_judged'] = 0;
+        }
+        if ($viewTypes[$view] == 'diff') {
+            $restrictions['external_diff'] = 1;
+        }
+        if ($request->query->get('external', 'all') !== 'all') {
+            $restrictions['external_result'] = $request->query->get('external');
+        }
+        if ($request->query->get('local', 'all') !== 'all') {
+            $restrictions['result'] = $request->query->get('local');
+        }
+
+        $contests = [$contest->getCid() => $contest];
+
+        /** @var Submission[] $submissions */
+        list($submissions, $submissionCounts) = $this->submissions->getSubmissionList(
+            $contests, $restrictions, 0, true
+        );
+
+        $data = [
+            'verdicts' => $verdicts,
+            'used' => $used,
+            'verdictTable' => $verdictTable,
+            'viewTypes' => $viewTypes,
+            'view' => $view,
+            'submissions' => $submissions,
+            'submissionCounts' => $submissionCounts,
+            'external' => $request->query->get('external', 'all'),
+            'local' => $request->query->get('local', 'all'),
+            'showExternalResult' => true,
+            'showContest' => false,
+            'showTestcases' => true,
+            'showExternalTestcases' => true,
+            'refresh' => [
+                'after' => 15,
+                'url' => $request->getRequestUri(),
+                'ajax' => true,
+            ],
+        ];
+        if ($request->isXmlHttpRequest()) {
+            $data['ajax'] = true;
+            return $this->render('jury/partials/shadow_submissions.html.twig', $data);
+        } else {
+            return $this->render('jury/shadow_differences.html.twig', $data);
+        }
+    }
+}

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -165,6 +165,32 @@ class SubmissionService
             }
         }
 
+        if (isset($restrictions['externally_judged'])) {
+            if ($restrictions['externally_judged']) {
+                $queryBuilder->andWhere('ej.result IS NOT NULL');
+            } else {
+                $queryBuilder->andWhere('ej.result IS NULL OR ej.endtime IS NULL');
+            }
+        }
+
+        if (isset($restrictions['external_diff'])) {
+            if ($restrictions['external_diff']) {
+                $queryBuilder->andWhere('j.result != ej.result');
+            } else {
+                $queryBuilder->andWhere('j.result = ej.result');
+            }
+        }
+
+        if (isset($restrictions['external_result'])) {
+            if ($restrictions['external_result'] === 'judging') {
+                $queryBuilder->andWhere('ej.result IS NULL or ej.endtime IS NULL');
+            } else {
+                $queryBuilder
+                    ->andWhere('ej.result = :externalresult')
+                    ->setParameter(':externalresult', $restrictions['external_result']);
+            }
+        }
+
         if (isset($restrictions['teamid'])) {
             $queryBuilder
                 ->andWhere('s.teamid = :teamid')
@@ -196,9 +222,13 @@ class SubmissionService
         }
 
         if (isset($restrictions['result'])) {
-            $queryBuilder
-                ->andWhere('j.result = :result')
-                ->setParameter(':result', $restrictions['result']);
+            if ($restrictions['result'] === 'judging') {
+                $queryBuilder->andWhere('j.result IS NULL OR j.endtime IS NULL');
+            } else {
+                $queryBuilder
+                    ->andWhere('j.result = :result')
+                    ->setParameter(':result', $restrictions['result']);
+            }
         }
 
         if ($this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -60,7 +60,7 @@
                         <li><a href="{{ path('jury_scoreboard') }}">Scoreboard</a></li>
                         <li><a href="{{ path('analysis_index') }}">Statistics/Analysis</a></li>
                         <li><a href="{{ path('jury_submissions') }}">Submissions</a></li>
-                        {% if is_granted('ROLE_ADMIN') and data_source == constant('App\\Service\\DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL') %}
+                        {% if show_shadow_differences %}
                             <li><a href="{{ path('jury_shadow_differences') }}">Shadow Differences</a></li>
                         {% endif %}
                     {% endif %}

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -60,6 +60,9 @@
                         <li><a href="{{ path('jury_scoreboard') }}">Scoreboard</a></li>
                         <li><a href="{{ path('analysis_index') }}">Statistics/Analysis</a></li>
                         <li><a href="{{ path('jury_submissions') }}">Submissions</a></li>
+                        {% if is_granted('ROLE_ADMIN') and data_source == constant('App\\Service\\DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL') %}
+                            <li><a href="{{ path('jury_shadow_differences') }}">Shadow Differences</a></li>
+                        {% endif %}
                     {% endif %}
                 </ul>
             </div>

--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -41,6 +41,12 @@
                     <a class="nav-link" href="{{ path('jury_submissions') }}"><i class="fas fa-file-code"></i> submissions</a>
                 </li>
 
+                {% if is_granted('ROLE_ADMIN') and data_source == constant('App\\Service\\DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL') %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ path('jury_shadow_differences') }}"><i class="fas fa-not-equal"></i> shadow differences</a>
+                    </li>
+                {% endif %}
+
                 <li class="nav-item">
                     <a class="nav-link" href="{{ path('jury_rejudgings') }}" id="menu_rejudgings"><i class="fas fa-sync"></i> rejudgings <span class="badge badge-info" id="num-alerts-rejudgings"></span></a>
                 </li>

--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -41,7 +41,7 @@
                     <a class="nav-link" href="{{ path('jury_submissions') }}"><i class="fas fa-file-code"></i> submissions</a>
                 </li>
 
-                {% if is_granted('ROLE_ADMIN') and data_source == constant('App\\Service\\DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL') %}
+                {% if show_shadow_differences %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ path('jury_shadow_differences') }}"><i class="fas fa-not-equal"></i> shadow differences</a>
                     </li>

--- a/webapp/templates/jury/partials/shadow_matrix.html.twig
+++ b/webapp/templates/jury/partials/shadow_matrix.html.twig
@@ -1,0 +1,41 @@
+<div class="mt-2">
+    <table class="rejudgetable">
+        <tr>
+            <th title="external vs. local verdicts">e\l</th>
+            {% for verdict, abbreviation in verdicts %}
+                {% if used[verdict] is defined %}
+                    <th title="{{ verdict }} (local)">{{ abbreviation }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+
+        {% for externalVerdict, localVerdicts in verdictTable %}
+            {% if used[externalVerdict] is defined %}
+                <tr>
+                    <th title="{{ externalVerdict }} (external)">{{ verdicts[externalVerdict] }}</th>
+                    {% for localVerdict, submitIds in localVerdicts %}
+                        {% if used[localVerdict] is defined %}
+                            {% set numSubmissions = submitIds | length %}
+                            {% set link = null %}
+                            {% if externalVerdict == localVerdict %}
+                                {% set class = 'identical' %}
+                            {% elseif numSubmissions == 0 %}
+                                {% set class = 'zero' %}
+                            {% else %}
+                                {% set class = 'changed' %}
+                                {% set link = path('jury_shadow_differences', {view: 'all', external: externalVerdict, local: localVerdict}) %}
+                            {% endif %}
+                            <td class="{{ class }}">
+                                {% if link is not null %}
+                                    <a href="{{ link }}">{{ numSubmissions }}</a>
+                                {% else %}
+                                    {{ numSubmissions }}
+                                {% endif %}
+                            </td>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endif %}
+        {% endfor %}
+    </table>
+</div>

--- a/webapp/templates/jury/partials/shadow_submissions.html.twig
+++ b/webapp/templates/jury/partials/shadow_submissions.html.twig
@@ -1,0 +1,7 @@
+{% if ajax is defined and ajax %}
+    <div class="d-none" data-new-shadow-matrix>
+        {% include 'jury/partials/shadow_matrix.html.twig' %}
+    </div>
+{% endif %}
+
+{%- include 'jury/partials/submission_list.html.twig' %}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -1,6 +1,18 @@
 {# Render a list of submissions for a jury page #}
 {# @var \App\Entity\ExternalJudgement externalJudgement #}
 
+{% if showExternalResult is not defined %}
+    {% set showExternalResult = false %}
+{% endif %}
+{% if showExternalTestcases is not defined %}
+    {% set showExternalTestcases = false %}
+{% endif %}
+
+{% set rowSpan = 1 %}
+{% if showExternalResult and showExternalTestcases %}
+    {% set rowSpan = 2 %}
+{% endif %}
+
 {% if submissions is empty %}
     <div class="alert alert-warning">No submissions</div>
 {% else %}
@@ -17,12 +29,18 @@
             <th scope="col">team</th>
             <th scope="col">problem</th>
             <th scope="col">lang</th>
-            <th scope="col">result</th>
-            {% if showExternalResult | default(false) %}
+            {% if showExternalResult and showExternalTestcases %}
+                <th scope="col" colspan="2">result</th>
+            {% else %}
+                <th scope="col">result</th>
+            {% endif %}
+            {% if showExternalResult and not showExternalTestcases %}
                 <th scope="col">external result</th>
             {% endif %}
             <th scope="col">verified</th>
-            <th scope="col">by</th>
+            {% if not showExternalResult or not showExternalTestcases %}
+                <th scope="col">by</th>
+            {% endif %}
             {%- if rejudging is defined %}
 
                 <th scope="col">old result</th>
@@ -47,20 +65,37 @@
                 data-team-id="{{ submission.teamid }}"
                 data-language-id="{{ submission.langid }}"
                 data-submission-id="{{ submission.submitid }}">
-                <td><a href="{{ link }}">s{{ submission.submitid }}</a></td>
+                <td rowspan="{{ rowSpan }}">
+                    <a href="{{ link }}">s{{ submission.submitid }}</a>
+                </td>
                 {%- if showContest %}
                     <td><a href="{{ link }}">c{{ submission.cid }}</a></td>
                 {%- endif %}
 
-                <td><a href="{{ link }}">{{ submission.submittime | printtime(null, submission.contest) }}</a></td>
-                <td><a href="{{ link }}" title="t{{ submission.teamid }}">{{ submission.team.name | truncate(30) }}</a>
+                <td rowspan="{{ rowSpan }}">
+                    <a href="{{ link }}">{{ submission.submittime | printtime(null, submission.contest) }}</a>
                 </td>
-                <td class="probid"><a href="{{ link }}"
-                                      title="{{ submission.problem.name }}">{{ submission.contestProblem.shortname }}</a>
+                <td rowspan="{{ rowSpan }}">
+                    <a href="{{ link }}"
+                       title="t{{ submission.teamid }}">{{ submission.team.name | truncate(30) }}</a>
                 </td>
-                <td class="langid"><a href="{{ link }}"
-                                      title="{{ submission.language.name }}">{{ submission.langid }}</a></td>
-                <td><a href="{{ link }}">
+                <td class="probid" rowspan="{{ rowSpan }}">
+                    <a href="{{ link }}"
+                       title="{{ submission.problem.name }}">{{ submission.contestProblem.shortname }}</a>
+                </td>
+                <td class="langid" rowspan="{{ rowSpan }}">
+                    <a href="{{ link }}"
+                       title="{{ submission.language.name }}">{{ submission.langid }}</a>
+                </td>
+                {% if showExternalResult and showExternalTestcases %}
+                    <td>
+                        <a href="{{ link }}">
+                            Local
+                        </a>
+                    </td>
+                {% endif %}
+                <td>
+                    <a href="{{ link }}">
                         {%- if submission.submittime > submission.contest.endtime %}
                             {{ 'too-late' | printValidJuryResult }}
                             {%- if submission.judgings.first is not empty and submission.judgings.first.result is not empty %}
@@ -78,20 +113,23 @@
                         {%- if submission.stillBusy -%}
                             (&hellip;)
                         {%- endif -%}
-                </a></td>
-                {% if showExternalResult | default(false) %}
+                    </a>
+                </td>
+                {% if showExternalResult and not showExternalTestcases %}
                     {% if submission.externalJudgements.empty %}
                         {% set externalJudgement = null %}
                     {% else %}
                         {% set externalJudgement = submission.externalJudgements.first %}
                     {% endif %}
-                    <td><a href="{{ link }}">
+                    <td>
+                        <a href="{{ link }}">
                             {% if externalJudgement is null or externalJudgement.result is empty %}
                                 {{- 'pending' | printValidJuryResult -}}
                             {% else %}
                                 {{- externalJudgement.result | printValidJuryResult -}}
                             {% endif %}
-                    </a></td>
+                        </a>
+                    </td>
                 {% endif %}
                 {%- set claim = false %}
                 {%- if submission.judgings.first is empty or submission.judgings.first.result is empty -%}
@@ -115,8 +153,58 @@
                 {%- else %}
                     {%- set claimArg = {unclaim: 1} %}
                 {%- endif %}
-
                 <td><a href="{{ link }}">{{ verified }}</a></td>
+                {% if not showExternalResult or not showExternalTestcases %}
+                    <td>
+                        {%- if rejudging is defined %}
+                            {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid, rejudgingid: rejudging.rejudgingid})) %}
+                        {%- else %}
+                            {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid})) %}
+                        {%- endif %}
+                        {%- if claim -%}
+                            <a class="btn btn-outline-secondary btn-sm"
+                               href="{{ claimLink }}">claim</a>
+                        {%- elseif (not submission.judgings.first or not submission.judgings.first.verified) and juryMember == app.user.username -%}
+                            <a class="btn btn-info btn-sm" href="{{ claimLink }}">unclaim</a>
+                        {%- else -%}
+                            <a href="{{ link }}">{{ juryMember }}</a>
+                        {%- endif -%}
+                    </td>
+                {% endif %}
+                {%- if rejudging is defined %}
+
+                    <td><a href="{{ path('jury_submission', {submitId: submission.submitid}) }}">
+                            {{ submission.oldResult | printValidJuryResult }}
+                        </a></td>
+                {%- endif %}
+                {%- if showTestcases is defined and showTestcases %}
+
+                    <td class="testcase-results">
+                        {{- submission | testcaseResults -}}
+                    </td>
+                {%- endif %}
+
+            </tr>
+            {% if showExternalResult and showExternalTestcases %}
+                {% if submission.externalJudgements.empty %}
+                    {% set externalJudgement = null %}
+                {% else %}
+                    {% set externalJudgement = submission.externalJudgements.first %}
+                {% endif %}
+                <td>
+                    <a href="{{ link }}">
+                        External
+                    </a>
+                </td>
+                <td>
+                    <a href="{{ link }}">
+                        {% if externalJudgement is null or externalJudgement.result is empty %}
+                            {{- 'pending' | printValidJuryResult -}}
+                        {% else %}
+                            {{- externalJudgement.result | printValidJuryResult -}}
+                        {% endif %}
+                    </a>
+                </td>
                 <td>
                     {%- if rejudging is defined %}
                         {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid, rejudgingid: rejudging.rejudgingid})) %}
@@ -131,20 +219,10 @@
                         <a href="{{ link }}">{{ juryMember }}</a>
                     {%- endif -%}
                 </td>
-                {%- if rejudging is defined %}
-
-                    <td><a href="{{ path('jury_submission', {submitId: submission.submitid}) }}">
-                            {{ submission.oldResult | printValidJuryResult }}
-                    </a></td>
-                {%- endif %}
-                {%- if showTestcases is defined and showTestcases %}
-
-                    <td class="testcase-results">
-                        {{- submission | testcaseResults -}}
-                    </td>
-                {%- endif %}
-
-            </tr>
+                <td class="testcase-results">
+                    {{- submission | testcaseResults(true) -}}
+                </td>
+            {% endif %}
         {%- endfor %}
 
         </tbody>

--- a/webapp/templates/jury/shadow_differences.html.twig
+++ b/webapp/templates/jury/shadow_differences.html.twig
@@ -1,0 +1,96 @@
+{% extends "jury/base.html.twig" %}
+{% import "jury/jury_macros.twig" as macros %}
+
+{% block title %}Shadow differences - {{ parent() }}{% endblock %}
+
+{% block extrahead %}
+    {{ parent() }}
+    {{ macros.table_extrahead() }}
+    {{ macros.select2_extrahead() }}
+{% endblock %}
+
+{% block content %}
+
+    <h1>Shadow differences</h1>
+
+    <div data-shadow-matrix>
+        {% include 'jury/partials/shadow_matrix.html.twig' %}
+    </div>
+
+    <h2 class="mt-4">Details</h2>
+
+    Show submissions:
+    <div class="btn-group btn-group-toggle btn-group-sm mb-3" data-toggle="buttons">
+        {%- for idx, type in viewTypes %}
+
+            <label class="btn btn-secondary {% if idx == view %}active{% endif %}">
+                <input type="radio" name="viewtype" autocomplete="off" value="{{ type }}"
+                       {% if idx == view %}checked{% endif %}> {{ type }}
+            </label>
+        {%- endfor %}
+    </div>
+
+    <form action="{{ path('jury_shadow_differences') }}" method="get">
+        <input type="hidden" name="view" value="{{ viewTypes[view] }}"/>
+        <div class="form-row">
+            <div class="form-group col-md-4">
+                <label for="oldverdict">External verdict</label>
+                <select style="width: 100%" class="select2 form-control" name="external"
+                        id="external">
+                    <option value="all" {% if external == 'all' %}selected{% endif %}>all</option>
+                    {%- for verdict, abbreviation in verdicts %}
+                        <option value="{{ verdict }}"
+                                {% if external == verdict %}selected{% endif %}>
+                            {{ verdict }}
+                        </option>
+                    {%- endfor %}
+
+                </select>
+            </div>
+            <div class="form-group col-md-4">
+                <label for="newverdict">Local verdict</label>
+                <select style="width: 100%" class="select2 form-control" name="local" id="local">
+                    <option value="all" {% if local == 'all' %}selected{% endif %}>all</option>
+                    {%- for verdict, abbreviation in verdicts %}
+                        <option value="{{ verdict }}" {% if local == verdict %}selected{% endif %}>
+                            {{ verdict }}
+                        </option>
+                    {%- endfor %}
+
+                </select>
+            </div>
+            <div class="form-group col-md-2">
+                <label>&nbsp;</label>
+                <input class="btn btn-primary form-control" type="submit" value="Filter"/>
+            </div>
+            <div class="form-group col-md-2">
+                <label>&nbsp;</label>
+                <a href="{{ path('jury_shadow_differences', {view: viewTypes[view]}) }}"
+                   class="btn btn-secondary form-control">Clear</a>
+            </div>
+        </div>
+    </form>
+
+    <div data-ajax-refresh-target data-ajax-refresh-after="updateMatrix">
+        {% include 'jury/partials/shadow_submissions.html.twig' %}
+    </div>
+
+{% endblock %}
+
+{% block extrafooter %}
+    <script>
+        $(function () {
+            $('input[name=viewtype]').on('change', function () {
+                window.location = '{{ path('jury_shadow_differences', {view: 'REPLACE_ME', external: external, local: local}) }}'.replace('REPLACE_ME', $(this).val());
+            });
+
+            $('.select2').select2();
+
+            window.updateMatrix = function () {
+                var $matrixData = $('[data-new-shadow-matrix]');
+                var $matrix = $('[data-shadow-matrix]');
+                $matrix.html($matrixData.children());
+            }
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
This is the first version of a matrix-style view for shadow differences.

Some screenshots:

All submissions with a differences between local and external:
<img width="1666" alt="Screenshot 2019-05-19 at 16 13 09" src="https://user-images.githubusercontent.com/550145/57983456-614f3a80-7a52-11e9-9fe7-9d7fcd15eb12.png">
Note that this will *not* show submissions that are still pending either locally or externally. I think this makes the most sense. There are separate buttons to view them


After clicking on the `3` in the `JU/AC` cell, I get all submissions that are accepted externally but still judging locally:
<img width="1672" alt="Screenshot 2019-05-19 at 16 15 07" src="https://user-images.githubusercontent.com/550145/57983476-9a87aa80-7a52-11e9-9424-81b140d36269.png">

The view might be improved. I am open for (simple) UI improvements in this PR, but if we want bigger changes I'd propose to merge this first and let someone like @thijskh do the UI changes.

Technically it is very similar to the rejudging view, where I build up a matrix, a set of buttons and a submission list.
Notable changes I made:
* The shadow matrix also contains a column/row for 'judging' submissions, to see them quickly.
* I added some restrictions to the submission retrieval function to filter on external judgements.
* The submission list twig partial has gotten an extra option to show external testcases. When enabled, it will use two columns for some of the table fields, such that it can display the local and external result and testcase results below each other.