### PR TITLE
Various makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,7 @@ ifneq "$(FHS_ENABLED)" "yes"
 	-$(INSTALL_WEBSITE) -m 0770 -d $(DESTDIR)$(domserver_tmpdir)
 endif
 # Fix permissions and ownership for password files:
-# FIXME: installing restapi.secret with website group is a quick hack
-# to fix eventlog() to query the REST API, see issue #283.
-	-$(INSTALL_WEBSITE) -m 0640 -t $(DESTDIR)$(domserver_etcdir) \
+	-$(INSTALL_USER) -m 0600 -t $(DESTDIR)$(domserver_etcdir) \
 		etc/restapi.secret
 	-$(INSTALL_WEBSITE) -m 0640 -t $(DESTDIR)$(domserver_etcdir) \
 		etc/dbpasswords.secret
@@ -265,9 +263,6 @@ maintainer-install: build domserver-create-dirs judgehost-create-dirs
 
 maintainer-postinstall-permissions:
 	setfacl    -m   u:$(WEBSERVER_GROUP):r    $(CURDIR)/etc/dbpasswords.secret
-# FIXME: this is a quick hack to fix eventlog() to query the REST API,
-# see issue #283.
-	setfacl    -m   u:$(WEBSERVER_GROUP):r    $(CURDIR)/etc/restapi.secret
 	setfacl -R -m d:u:$(WEBSERVER_GROUP):rwx  $(CURDIR)/webapp/var
 	setfacl -R -m   u:$(WEBSERVER_GROUP):rwx  $(CURDIR)/webapp/var
 	setfacl -R -m d:u:$(DOMJUDGE_USER):rwx    $(CURDIR)/webapp/var

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,12 @@ endif
 # Fix permissions and ownership for password files:
 	-$(INSTALL_USER) -m 0600 -t $(DESTDIR)$(domserver_etcdir) \
 		etc/restapi.secret
+	-$(INSTALL_USER) -m 0600 -t $(DESTDIR)$(domserver_etcdir) \
+		etc/initial_admin_password.secret
 	-$(INSTALL_WEBSITE) -m 0640 -t $(DESTDIR)$(domserver_etcdir) \
 		etc/dbpasswords.secret
-	-$(INSTALL_WEBSITE) -m 0600 -t $(DESTDIR)$(domserver_etcdir) \
-		etc/initial_admin_password.secret
+	-$(INSTALL_WEBSITE) -m 0640 -t $(DESTDIR)$(domserver_webappdir)/app/config \
+		webapp/app/config/parameters.yml
 	@echo ""
 	@echo "Domserver install complete. Admin web interface password can be found in:"
 	@echo "$(DESTDIR)$(domserver_etcdir)/initial_admin_password.secret"

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ install-domserver-l:
 	-$(INSTALL_USER)    -m 0700 -d $(DESTDIR)$(domserver_logdir)
 	-$(INSTALL_USER)    -m 0700 -d $(DESTDIR)$(domserver_rundir)
 	-$(INSTALL_WEBSITE) -m 0770 -d $(DESTDIR)$(domserver_submitdir)
+	-for d in cache logs sessions ; do \
+		$(INSTALL_WEBSITE) -m 0775 -d $(DESTDIR)$(domserver_webappdir)/var/$$d ; \
+	done
+	-$(INSTALL_WEBSITE) -t $(DESTDIR)$(domserver_webappdir)/var var/*.php var/*.cache
 # Special case create tmpdir here, only when FHS not enabled:
 ifneq "$(FHS_ENABLED)" "yes"
 	-$(INSTALL_WEBSITE) -m 0770 -d $(DESTDIR)$(domserver_tmpdir)

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -44,8 +44,7 @@ install-domserver:
 			ln -s $$realtarget $$link ; \
 		fi \
 	done
-	cp        -t $(DESTDIR)$(domserver_webappdir) phpunit.xml.dist
-	chmod a+r    $(DESTDIR)$(domserver_webappdir)/phpunit.xml.dist
+	$(INSTALL_DATA) -t $(DESTDIR)$(domserver_webappdir) phpunit.xml.dist
 
 install-docs:
 	$(INSTALL_DATA) -T web/images/countries/README    $(DESTDIR)$(domjudge_docdir)/README.country_flags

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -44,10 +44,6 @@ install-domserver:
 			ln -s $$realtarget $$link ; \
 		fi \
 	done
-	-for d in cache logs sessions ; do \
-		$(INSTALL_WEBSITE) -m 0775 -d $(DESTDIR)$(domserver_webappdir)/var/$$d ; \
-	done
-	-$(INSTALL_WEBSITE) -t $(DESTDIR)$(domserver_webappdir)/var var/*.php var/*.cache
 	cp        -t $(DESTDIR)$(domserver_webappdir) phpunit.xml.dist
 	chmod a+r    $(DESTDIR)$(domserver_webappdir)/phpunit.xml.dist
 

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -17,15 +17,16 @@ clear-cache:
 copy-bundle-assets:
 # We can not use bin/console here, as when using a fakeroot,
 # the include paths are broken. We just copy in the data we need
+	-rm -rf web/bundles/nelmioapidoc
 	mkdir -p web/bundles/nelmioapidoc
 	cp -R ../lib/vendor/nelmio/api-doc-bundle/Resources/public/* web/bundles/nelmioapidoc/
 
 clean-l:
 	-rm -r web/bundles/nelmioapidoc
 
-domserver: copy-bundle-assets
-
 install-domserver:
+# This must be done first to install with the rest.
+	$(MAKE) copy-bundle-assets
 	$(INSTALL_DIR) $(DESTDIR)$(domserver_webappdir);
 # KLUDGE: how to install a tree of files with correct permissions?
 	for d in app bin src web tests ; do \


### PR DESCRIPTION
These fix #601 and clean up the special ownership installation a bit: by consolidating those in the root Makefile, we easily which commands fail and need to be rerun when not installing as root.

Also reverts a dirty hack to install `restapi.secret` with webserver group, from when we hadn't fully moved to Symfony yet. @nickygerritsen can you double check this is ok to revert?