### PR TITLE
Set the PATH for running debootstrap

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -249,7 +249,7 @@ fi
 echo "Running debootstrap to install base system, this may take a while..."
 
 # shellcheck disable=SC2086
-eval $BOOTSTRAP_COMMAND $INCLUDEOPT $EXCLUDEOPT \
+eval PATH=$PATH:/bin:/sbin:/usr/sbin $BOOTSTRAP_COMMAND $INCLUDEOPT $EXCLUDEOPT \
 	--variant=minbase --arch "$ARCH" "$RELEASE" "$CHROOTDIR" "$DEBMIRROR"
 
 rm -f "$CHROOTDIR/etc/resolv.conf"


### PR DESCRIPTION
This is required when running debootstrap on CentOS and other systems where the PATH
is different from what debootstrap needs.