### PR TITLE
When uploading judging runs fails, do not crash judgedaemon but add an internal error on the problem

### DIFF
--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -355,7 +355,7 @@ class ContestController extends AbstractRestController
                 unset($toCheck['teamcategories']);
                 unset($toCheck['teamaffiliations']);
                 unset($toCheck['contestproblems']);
-                
+
                 foreach ($toCheck as $plural => $class) {
                     $serializerMetadata = $metadataFactory->getMetadataForClass($class);
                     /** @var PropertyMetadata $propertyMetadata */


### PR DESCRIPTION
Crashing judgedaemons are never what we want. It is better to not judge the problem anymore and notify the admins.
This would happen in two instances:
* When PHP's post_max_size is too low.
* When using nginx and client_max_body_size is too low.

Screenshots of the internal error in these two cases:

<img width="1627" alt="Screenshot 2019-09-23 at 20 29 53" src="https://user-images.githubusercontent.com/550145/65452358-62013e80-de41-11e9-9c0a-6c323f9f9179.png">
<img width="1631" alt="Screenshot 2019-09-23 at 20 30 08" src="https://user-images.githubusercontent.com/550145/65452359-6299d500-de41-11e9-8f7c-6284e564c54a.png">
