### PR TITLE
Fix link to "Developer information" documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If you are interested in starting to contribute to DOMjudge, then the
 following are some pointers.
 
 First, install and configure the development version of DOMjudge.
-Either directly from the git reposity, see the [developer information](https://www.domjudge.org/docs/admin-manual-10.html)
+Either directly from the git reposity, see the [developer information](https://www.domjudge.org/docs/admin-manual-11.html)
 section in the admin manual, or via the [contributor docker image](https://github.com/DOMjudge/domjudge-packaging/tree/master/docker-contributor).
 If you follow the admin manual for installation, this is also a great
 way to verify that the documentation is clear and complete, and to


### PR DESCRIPTION
https://www.domjudge.org/docs/admin-manual-11.html is the current place for "Developer information"