### PR TITLE
Don't use number of times updateClock function is called when calculating clock

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -128,8 +128,7 @@ function togglelastruns()
 // start (and end?).
 function updateClock()
 {
-	var curtime = initial+offset;
-	date.setTime(curtime*1000);
+	var curtime = Math.round((new Date().getTime() - clientOffset) / 1000);
 
 	var fmt = "";
 	if ( timeleftelt.innerHTML=='start delayed' || timeleft.innerHTML == 'no contest' ) { // FIXME
@@ -166,7 +165,6 @@ function updateClock()
 	}
 
 	timeleftelt.innerHTML = what + fmt;
-	offset++;
 }
 
 function setCookie(name, value)

--- a/webapp/templates/partials/menu_countdown.html.twig
+++ b/webapp/templates/partials/menu_countdown.html.twig
@@ -14,11 +14,11 @@
 
 <script>
     var initial = {{ now }};
+    var localInitial = new Date().getTime();
     var activatetime = {{ contest.activatetime|default(-1) }};
     var starttime = {{ contest.starttime|default(-1) }};
     var endtime = {{ contest.endtime|default(-1) }};
-    var offset = 0;
-    var date = new Date(initial * 1000);
+    var clientOffset = localInitial - new Date(initial * 1000).getTime();
     var timeleftelt = document.getElementById("timeleft");
 
     setInterval(function () {


### PR DESCRIPTION
As reported by @ubergeek42 (and I also noticed this before), the clock on the upper right corner gets skewed quite a bit if you wait long enough, especially when the browser window/tab is not active.

I think this is becasue we use `setInterval` and add `1` to a variable each time. However if the interval does not get called exactly every second, you will have a skew.

The new approach determines the client offset to the server, by initially comparing the local time and server time and then uses this offset and the current time to determine server time.

Please double-triple check my logic....