### PR TITLE
Add index to event table for cid,endpointtype,endpointid. Fixes #662.

### DIFF
--- a/webapp/src/Entity/Event.php
+++ b/webapp/src/Entity/Event.php
@@ -12,7 +12,8 @@ use Doctrine\ORM\Mapping as ORM;
  *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of all events during a contest"},
  *     indexes={
  *         @ORM\Index(name="eventtime", columns={"cid","eventtime"}),
- *         @ORM\Index(name="cid", columns={"cid"})
+ *         @ORM\Index(name="cid", columns={"cid"}),
+ *         @ORM\Index(name="endpoint", columns={"cid","endpointtype","endpointid"})
  *     })
  * @ORM\Entity
  */

--- a/webapp/src/Migrations/Version20191119183145.php
+++ b/webapp/src/Migrations/Version20191119183145.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20191119183145 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'add (cid, endpointtype, endpointid) index to event table';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE INDEX endpoint ON event (cid, endpointtype, endpointid)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX endpoint ON event');
+    }
+}


### PR DESCRIPTION
Note that it is an extra index instead of renaming the previous `cid` one, since that is a foreign key and Symfony wants to have a specific index for foreign keys.