### PR TITLE
Do not show FTS on team row scoreboard on team page during freeze.

### DIFF
--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -101,7 +101,7 @@ class MiscController extends BaseController
         ];
         if ($contest) {
             $scoreboard = $this->scoreboardService
-                ->getTeamScoreboard($contest, $teamId, true);
+                ->getTeamScoreboard($contest, $teamId, false);
             $data = array_merge(
                 $data,
                 $this->scoreboardService->getScoreboardTwigData(

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -38,7 +38,7 @@ class SingleTeamScoreboard extends Scoreboard
     /**
      * @var bool
      */
-    protected $jury;
+    protected $showRestrictedFts;
 
     /**
      * SingleTeamScoreboard constructor.
@@ -49,7 +49,7 @@ class SingleTeamScoreboard extends Scoreboard
      * @param RankCache|null   $rankCache
      * @param ScoreCache[]     $scoreCache
      * @param FreezeData       $freezeData
-     * @param bool             $jury
+     * @param bool             $showFtsInFreeze
      * @param int              $penaltyTime
      * @param bool             $scoreIsInSeconds
      */
@@ -61,16 +61,16 @@ class SingleTeamScoreboard extends Scoreboard
         $rankCache,
         array $scoreCache,
         FreezeData $freezeData,
-        bool $jury,
+        bool $showFtsInFreeze,
         int $penaltyTime,
         bool $scoreIsInSeconds
     ) {
-        $this->team      = $team;
-        $this->teamRank  = $teamRank;
-        $this->rankCache = $rankCache;
-        $this->jury      = $jury;
-        parent::__construct($contest, [$team->getTeamid() => $team], [], $problems, $scoreCache, $freezeData, $jury,
-                            $penaltyTime, $scoreIsInSeconds);
+        $this->team              = $team;
+        $this->teamRank          = $teamRank;
+        $this->rankCache         = $rankCache;
+        $this->showRestrictedFts = $showFtsInFreeze || $freezeData->showFinal();
+        parent::__construct($contest, [$team->getTeamid() => $team], [], $problems, $scoreCache, $freezeData, true,
+            $penaltyTime, $scoreIsInSeconds);
     }
 
     /**
@@ -100,7 +100,7 @@ class SingleTeamScoreboard extends Scoreboard
 
             $this->matrix[$scoreRow->getTeam()->getTeamid()][$scoreRow->getProblem()->getProbid()] = new ScoreboardMatrixItem(
                 $scoreRow->getIsCorrect($this->restricted),
-                $scoreRow->getIsFirstToSolve(),
+                $scoreRow->getIsCorrect($this->showRestrictedFts) && $scoreRow->getIsFirstToSolve(),
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),


### PR DESCRIPTION
We always had `$jury = true` for the team row, so I removed that and replaced it with a flag that indicates whether we should show FTS in the freeze, since we only want that on the jury pages.

I tested the following:

* Submissions before freeze on both jury and team page show FTS
* Submissions during freeze on team page don't show FTS, but on jury it does
* After unfreeze it also shows FTS on team page

I think that is what we want, but please doublecheck...