### PR TITLE
Fix PHPUnit.

### DIFF
--- a/gitlab/unit-tests.sh
+++ b/gitlab/unit-tests.sh
@@ -8,6 +8,9 @@ set -euxo pipefail
 # Copy the .env.test file, as this is normally not done during installation and we need it
 cp webapp/.env.test /opt/domjudge/domserver/webapp/
 
+# We also need the composer.json for PHPunit to detect the correct directory
+cp composer.json /opt/domjudge/domserver/
+
 cd /opt/domjudge/domserver
 
 # Remove the generated .env.local.php file as this contains production data
@@ -16,6 +19,9 @@ rm webapp/.env.local.php
 cp webapp/.env.local webapp/.env
 
 export APP_ENV="test"
+
+# Symlink lib/vendor to vendor since the Symfony PHPUnit bridge expects vendor packages to be there
+ln -s lib/vendor vendor
 
 # run phpunit tests
 webapp/bin/phpunit -c webapp/phpunit.xml.dist --log-junit ${CI_PROJECT_DIR}/unit-tests.xml --coverage-text --colors=never


### PR DESCRIPTION
The Symfony PHPUnit bridge expects the vendor directory to be in the root of the project,
see https://github.com/symfony/phpunit-bridge/blob/master/bin/simple-phpunit.php#L70-L76.

However, we don't do that so the bridge will install the latest version of itself (which is now 5.0) instead of using the existing version.
This breaks stuff if Symfony releases a new major version (like they just did).

A PR to make sure my fix works before messing with master.