### PR TITLE
VarargsLogMessageProcessor does not use vsprintf if no args are provided

### DIFF
--- a/webapp/src/Logger/VarargsLogMessageProcessor.php
+++ b/webapp/src/Logger/VarargsLogMessageProcessor.php
@@ -17,7 +17,7 @@ class VarargsLogMessageProcessor implements ProcessorInterface
      */
     public function __invoke(array $record): array
     {
-        if (strpos($record['message'], '%') === false) {
+        if (strpos($record['message'], '%') === false || empty($record['context'])) {
             return $record;
         }
 


### PR DESCRIPTION
avoids errors when the message contains % characters (e.g., some sql statements)