### PR TITLE
Allow multiple team categories for self-registration

### DIFF
--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -77,11 +77,13 @@ Squid configuration for this might look like::
 
 Self-registration
 `````````````````
-There is also a configuration option to allow teams to self-register with
-the system: ``registration_category_name``. When left empty, no self-registration
-is allowed; when filled with a category name, newly registered teams will
-be placed in this category. During registration, a team can specify their
-affiliation.
+Teams can be allowed to self-register with the system. Each team category can
+be set to allow registration or not. When none of the categories are set to
+allow, self-registration is disabled. When one category is set to allow,
+self-registration is enabled and newly registered teams will be placed in this
+category. When multiple categories are set to allow, teams can choose one of
+them during registration. Teams can also specify their affiliation during
+registration.
 
 Executables
 -----------

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -231,11 +231,6 @@
             default_value: ""
             public: true
             description: If not empty, enable teams and jury to send source code to this command. See admin manual for allowed arguments.
-        -   name: registration_category_name
-            type: string
-            default_value: ""
-            public: true
-            description: Team category for users that register themselves with the system. Self-registration is disabled if this field is left empty.
         -   name: data_source
             type: int
             default_value: 0

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -93,6 +93,7 @@ class TeamCategoryController extends BaseController
             'name' => ['title' => 'name', 'sort' => true],
             'num_teams' => ['title' => '# teams', 'sort' => true],
             'visible' => ['title' => 'visible', 'sort' => true],
+            'allow_self_registration' => ['title' => 'self-registration', 'sort' => true],
         ];
 
         // Insert external ID field when configured to use it
@@ -134,8 +135,9 @@ class TeamCategoryController extends BaseController
                 ];
             }
 
-            $categorydata['num_teams'] = ['value' => $teamCategoryData['num_teams']];
-            $categorydata['visible']   = ['value' => $teamCategory->getVisible() ? 'yes' : 'no'];
+            $categorydata['num_teams']               = ['value' => $teamCategoryData['num_teams']];
+            $categorydata['visible']                 = ['value' => $teamCategory->getVisible() ? 'yes' : 'no'];
+            $categorydata['allow_self_registration'] = ['value' => $teamCategory->getAllowSelfRegistration() ? 'yes' : 'no'];
 
             $team_categories_table[] = [
                 'data' => $categorydata,

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -78,6 +78,16 @@ class TeamCategory extends BaseApiEntity
     private $visible = true;
 
     /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="allow_self_registration",
+     *     options={"comment"="Are self-registered teams allowed to choose this category?",
+     *              "default"="0"},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $allow_self_registration = false;
+
+    /**
      * @ORM\OneToMany(targetEntity="Team", mappedBy="category")
      * @Serializer\Exclude()
      */
@@ -223,6 +233,30 @@ class TeamCategory extends BaseApiEntity
     public function getVisible()
     {
         return $this->visible;
+    }
+
+    /**
+     * Set allowSelfRegistration
+     *
+     * @param boolean $allowSelfRegistration
+     *
+     * @return TeamCategory
+     */
+    public function setAllowSelfRegistration($allowSelfRegistration)
+    {
+        $this->allow_self_registration = $allowSelfRegistration;
+
+        return $this;
+    }
+
+    /**
+     * Get allowSelfRegistration
+     *
+     * @return boolean
+     */
+    public function getAllowSelfRegistration()
+    {
+        return $this->allow_self_registration;
     }
 
     /**

--- a/webapp/src/Form/Type/TeamCategoryType.php
+++ b/webapp/src/Form/Type/TeamCategoryType.php
@@ -32,6 +32,14 @@ class TeamCategoryType extends AbstractType
                 'No' => false,
             ],
         ]);
+        $builder->add('allow_self_registration', ChoiceType::class, [
+            'label' => 'Allow self-registration',
+            'expanded' => true,
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+        ]);
         $builder->add('save', SubmitType::class);
     }
 

--- a/webapp/src/Form/Type/UserRegistrationType.php
+++ b/webapp/src/Form/Type/UserRegistrationType.php
@@ -4,11 +4,13 @@ namespace App\Form\Type;
 
 use App\Entity\Team;
 use App\Entity\TeamAffiliation;
+use App\Entity\TeamCategory;
 use App\Entity\User;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -96,6 +98,30 @@ class UserRegistrationType extends AbstractType
                 ],
                 'mapped' => false,
             ]);
+
+        $selfRegistrationCategoriesCount = $this->em->getRepository(TeamCategory::class)->count(['allow_self_registration' => 1]);
+        if ($selfRegistrationCategoriesCount > 1) {
+            $builder
+                ->add('teamCategory', EntityType::class, [
+                    'class' => TeamCategory::class,
+                    'label' => false,
+                    'mapped' => false,
+                    'choice_label' => 'name',
+                    'placeholder' => '-- Select category --',
+                    'query_builder' => function (EntityRepository $er) {
+                        return $er
+                            ->createQueryBuilder('c')
+                            ->where('c.allow_self_registration = 1')
+                            ->orderBy('c.sortorder');
+                    },
+                    'attr' => [
+                        'placeholder' => 'Category',
+                    ],
+                    'constraints' => [
+                        new NotBlank(),
+                    ],
+                ]);
+        }
 
         if ($this->config->get('show_affiliations')) {
             $countries = [];

--- a/webapp/src/Migrations/Version20200131064449.php
+++ b/webapp/src/Migrations/Version20200131064449.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Configuration;
+use App\Entity\TeamCategory;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+final class Version20200131064449 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription() : string
+    {
+        return 'replace configuration option registration_category_name with a boolean field for each category';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // Note: can't use ConfigurationService::get on 'registration_category_name' because the specification has been removed from db-config.yaml
+        $em = $this->container->get('doctrine')->getManager();
+        $registrationCategoryNameConfig = $em->getRepository(Configuration::class)->findOneBy(['name' => 'registration_category_name']);
+        if ($registrationCategoryNameConfig) {
+            $registrationCategoryName = $registrationCategoryNameConfig->getValue();
+        } else {
+            $registrationCategoryName = '';
+        }
+
+        $this->addSql('ALTER TABLE team_category ADD allow_self_registration TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Are self-registered teams allowed to choose this category?\'');
+
+        if ($registrationCategoryName !== '') {
+            $this->addSql(
+                'UPDATE team_category SET allow_self_registration = 1 WHERE name = :name',
+                ['name' => $registrationCategoryName]
+            );
+        }
+        $this->addSql("DELETE FROM configuration WHERE name = 'registration_category_name'");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $em = $this->container->get('doctrine')->getManager();
+        $selfRegistrationCategories = $em->getRepository(TeamCategory::class)->findBy(
+            ['allow_self_registration' => 1],
+            ['sortorder' => 'ASC']
+        );
+
+        $this->warnIf(
+            count($selfRegistrationCategories) > 1,
+            sprintf('Team categories for self-registered teams were %s. Only first will be kept.',
+                implode(', ', array_map(function($category) {
+                    return $category->getName();
+                }, $selfRegistrationCategories)))
+        );
+
+        $this->addSql(
+            "INSERT INTO configuration (name, value) VALUES ('registration_category_name', :value)",
+            ['value' => empty($selfRegistrationCategories) ? '""' : json_encode($selfRegistrationCategories[0]->getName())]
+        );
+
+        $this->addSql('ALTER TABLE team_category DROP allow_self_registration');
+    }
+}

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -37,6 +37,10 @@
                     <th>Visible</th>
                     <td>{{ teamCategory.visible | printYesNo }}</td>
                 </tr>
+                <tr>
+                    <th>Allow self-registration</th>
+                    <td>{{ teamCategory.allowSelfRegistration | printYesNo }}</td>
+                </tr>
             </table>
         </div>
     </div>


### PR DESCRIPTION
Replace the configuration option `registration_category_name` with a boolean property `TeamCategory::$allow_self_registration`. When it is set to true on multiple categories, they are offered as choices during registration.

---
_Original version_

Change the configuration option `registration_category_name` from a string to a list. When more than one category name is specified, users are offered a choice during registration.

An empty list disables self-registration (like an empty string did before).

---
_Cover letter_

Hi,

I'm involved with the New Zealand Programming Contest, which uses DOMjudge. We want self-registered teams to be able to choose their team category during registration instead of being assigned to a fixed category (we use categories such as "High School", "Tertiary", "Open" rather than "Participants", "Self-Registered").

I've written a patch that implements this, are you interested in merging it in?

Disclaimer: I am not familiar with PHP/Symfony. In particular, please check the way I've hidden the category field when only one category name is specified in the configuration (I used an HTML attribute to hide it, which I thought was simpler than conditionally building the Symfony form type).

Regards,  
Tom Levy