### PR TITLE
Add Kernel specification to be able to run phpunit tests locally.

### DIFF
--- a/webapp/phpunit.xml.dist
+++ b/webapp/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+        <env name="KERNEL_CLASS" value="App\Kernel" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
Re-install the DB and then
```
echo "INSERT INTO user (userid, username, name, password, teamid) VALUES (3, 'dummy', 'dummy user for example team', '\$2y\$10\$0d0sPmeAYTJ/Ya7rvA.kk.zvHu758ScyuHAjps0A6n9nm3eFmxW2K', 2)" | mysql domjudge
echo "INSERT INTO userrole (userid, roleid) VALUES (3, 2);" | mysql domjudge
echo "INSERT INTO userrole (userid, roleid) VALUES (3, 3);" | mysql domjudge
```

Finally run the tests with
`lib/vendor/phpunit/phpunit/phpunit -c webapp/phpunit.xml.dist`