### PR TITLE
Fix for rejudging issue in #656

### DIFF
--- a/webapp/src/Service/RejudgingService.php
+++ b/webapp/src/Service/RejudgingService.php
@@ -165,7 +165,7 @@ class RejudgingService
 
             if ($action === self::ACTION_APPLY) {
                 $this->em->transactional(function () use ($submission, $rejudgingId) {
-                    // First invalidate old judging, maybe different from prevjudgingid!
+                    // First invalidate old judging, may be different from prevjudgingid!
                     $this->em->getConnection()->executeQuery(
                         'UPDATE judging SET valid=0 WHERE submitid = :submitid',
                         [':submitid' => $submission['submitid']]
@@ -183,7 +183,7 @@ class RejudgingService
                         [':submitid' => $submission['submitid']]
                     );
 
-                    // Last update cache
+                    // Update cache
                     $contest = $this->em->getRepository(Contest::class)->find($submission['cid']);
                     $team    = $this->em->getRepository(Team::class)->find($submission['teamid']);
                     $problem = $this->em->getRepository(Problem::class)->find($submission['probid']);
@@ -210,7 +210,7 @@ class RejudgingService
                                                     $submission['cid'], null, null, false);
                     }
 
-                    // Update ballons
+                    // Update balloons
                     $contest    = $this->em->getRepository(Contest::class)->find($submission['cid']);
                     $submission = $this->em->getRepository(Submission::class)->find($submission['submitid']);
                     $this->balloonService->updateBalloons($contest, $submission);

--- a/webapp/src/Service/RejudgingService.php
+++ b/webapp/src/Service/RejudgingService.php
@@ -122,19 +122,12 @@ class RejudgingService
         }
 
         // Get all submissions that we should consider
-        $queryBuilder = $this->em->createQueryBuilder()
+        $submissions = $this->em->createQueryBuilder()
             ->from(Submission::class, 's')
-            ->join('s.judgings', 'j')
-            ->select('s.submitid, s.cid, s.teamid, s.probid, j.judgingid, j.result')
-            ->andWhere('s.rejudging = :rejudging');
-        if ($action === self::ACTION_APPLY) {
-            $queryBuilder->andWhere('j.rejudging = :rejudging');
-        }
-        /** @var array $submissions */
-        $submissions = $queryBuilder
+            ->leftJoin('s.judgings', 'j', 'WITH', 'j.rejudging = :rejudging')
+            ->select('s.submitid, s.cid, s.teamid, s.probid, j.judgingid')
+            ->andWhere('s.rejudging = :rejudging')
             ->setParameter(':rejudging', $rejudging)
-            ->groupBy('s.submitid')
-            ->groupBy('j.judgingid')
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
This fixes the duplicate submissions listed when you cancel a rejudging, as I reported in #656.

Not sure if this also fixes the original issue reported by Per. But I think that might also have been a race condition between the judgehost and the rejudging being cancelled. If so, that would be hard to reproduce.