### PR TITLE
Move specification of configuration variables to YAML file and outside of database

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -37,7 +37,7 @@ install-domserver:
 	$(INSTALL_PROG) -t $(DESTDIR)$(domserver_etcdir) \
 		gendbpasswords genrestapicredentials genadminpassword
 	$(INSTALL_DATA) -t $(DESTDIR)$(domserver_etcdir) \
-		domserver-config.php common-config.php verdicts.php
+		domserver-config.php common-config.php verdicts.php db-config.yaml
 # Password files are installed from root Makefile.
 
 install-judgehost:

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -1,0 +1,285 @@
+# Configuration settings that can be overriden using the `configuration` database table
+-   category: Scoring
+    items:
+        -   name: verification_required
+            type: bool
+            default_value: false
+            public: false
+            description: Is verification of judgings by jury required before publication?
+        -   name: compile_penalty
+            type: bool
+            default_value: false
+            public: true
+            description: Should submissions with compiler-error incur penalty time (and show on the scoreboard)?
+        -   name: penalty_time
+            type: int
+            default_value: 20
+            public: true
+            description: Penalty time in minutes per wrong submission (if finally solved).
+        -   name: results_prio
+            type: array_keyval
+            default_value:
+                memory-limit: 99
+                output-limit: 99
+                run-error: 99
+                timelimit: 99
+                wrong-answer: 99
+                no-output: 99
+                correct: 1
+            public: false
+            description: Priorities of results for determining final result with multiple testcases. Higher priority is used first as final result. With equal priority, the first occurring result determines the final result.
+        -   name: results_remap
+            type: array_keyval
+            default_value: []
+            public: false
+            description: Remap testcase result, e.g. to disable a specific result type such as 'no-output'.
+        -   name: score_in_seconds
+            type: bool
+            default_value: false
+            public: true
+            description: Should the scoreboard resolution be measured in seconds instead of minutes?
+-   category: Judging
+    items:
+        -   name: memory_limit
+            type: int
+            default_value: 2097152
+            public: false
+            description: Maximum memory usage (in kB) by submissions. This includes the shell which starts the compiled solution and also any interpreter like the Java VM, which takes away approx. 300MB! Can be overridden per problem.
+        -   name: output_limit
+            type: int
+            default_value: 8192
+            public: false
+            description: Maximum output (in kB) submissions may generate. Any excessive output is truncated, so this should be greater than the maximum testdata output.
+        -   name: process_limit
+            type: int
+            default_value: 64
+            public: false
+            description: Maximum number of processes that the submission is allowed to start (including shell and possibly interpreters).
+        -   name: sourcesize_limit
+            type: int
+            default_value: 256
+            public: true
+            description: Maximum source code size (in kB) of a submission. This setting should be kept in sync with that in "etc/submit-config.h.in".
+        -   name: sourcefiles_limit
+            type: int
+            default_value: 100
+            public: true
+            description: Maximum number of source files in one submission. Set to one to disable multiple file submissions.
+        -   name: script_timelimit
+            type: int
+            default_value: 30
+            public: false
+            description: Maximum seconds available for compile/compare scripts. This is a safeguard against malicious code and buggy scripts, so a reasonable but large amount should do.
+        -   name: script_memory_limit
+            type: int
+            default_value: 2097152
+            public: false
+            description: Maximum memory usage (in kB) by compile/compare scripts. This is a safeguard against malicious code and buggy script, so a reasonable but large amount should do.
+        -   name: script_filesize_limit
+            type: int
+            default_value: 540672
+            public: false
+            description: Maximum filesize (in kB) compile/compare scripts may write. Submission will fail with compiler-error when trying to write more, so this should be greater than any *intermediate or final* result written by compilers.
+        -   name: timelimit_overshoot
+            type: string
+            default_value: 1s|10%
+            public: false
+            description: Time that submissions are kept running beyond timelimit before being killed. Specify as "Xs" for X seconds, "Y%" as percentage, or a combination of both separated by one of "+|&" for the sum, maximum, or minimum of both.
+        -   name: output_storage_limit
+            type: int
+            default_value: 50000
+            public: false
+            description: Maximum size of error/system output stored in the database (in bytes); use "-1" to disable any limits.
+        -   name: output_display_limit
+            type: int
+            default_value: 2000
+            public: false
+            description: Maximum size of run/diff/error/system output shown in the jury interface (in bytes); use "-1" to disable any limits.
+        -   name: lazy_eval_results
+            type: bool
+            default_value: true
+            public: false
+            description: Lazy evaluation of results? If enabled, stops judging as soon as a highest priority result is found, otherwise always all testcases will be judged.
+        -   name: judgehost_warning
+            type: int
+            default_value: 30
+            public: false
+            description: Time in seconds after a judgehost last checked in before showing its status as "warning".
+        -   name: judgehost_critical
+            type: int
+            default_value: 120
+            public: false
+            description: Time in seconds after a judgehost last checked in before showing its status as "critical".
+        -   name: diskspace_error
+            type: int
+            default_value: 1048576
+            public: false
+            description: Minimum free disk space (in kB) on judgehosts.
+        -   name: update_judging_seconds
+            type: int
+            default_value: 5
+            public: false
+            description: Post updates to a judging every X seconds. Set to 0 to update after each judging_run.
+        -   name: default_compare
+            type: string
+            default_value: compare
+            public: false
+            description: The script used to compare outputs if no special compare script specified.
+        -   name: default_run
+            type: string
+            default_value: run
+            public: false
+            description: The script used to run submissions if no special run script specified.
+-   category: Clarification
+    items:
+        -   name: clar_categories
+            type: array_keyval
+            default_value:
+                general: General issue
+                tech: Technical issue
+            public: true
+            description: List of additional clarification categories
+        -   name: clar_answers
+            type: array_val
+            default_value:
+                - No comment
+                - Read the problem statement carefully
+            public: false
+            description: List of predefined clarification answers
+        -   name: clar_queues
+            type: array_keyval
+            default_value: []
+            public: true
+            description: List of clarification queues
+        -   name: clar_default_problem_queue
+            type: string
+            default_value: ""
+            public: true
+            description: Queue to assign to problem clarifications
+
+-   category: Display
+    items:
+        -   name: show_pending
+            type: bool
+            default_value: true
+            public: true
+            description: Show pending submissions on the scoreboard?
+        -   name: show_flags
+            type: bool
+            default_value: true
+            public: true
+            description: Show country flags in the interfaces?
+        -   name: show_affiliations
+            type: bool
+            default_value: true
+            public: true
+            description: Show affiliation names in the interfaces?
+        -   name: show_affiliation_logos
+            type: bool
+            default_value: false
+            public: true
+            description: Show affiliation logos on the scoreboard?
+        -   name: show_teams_submissions
+            type: bool
+            default_value: true
+            public: true
+            description: Show problem columns with submission information on the public and team scoreboards?
+        -   name: show_compile
+            type: int
+            default_value: 2
+            public: true
+            description: "Show compile output in team webinterface? Choices: 0 = never, 1 = only on compilation error(s), 2 = always."
+        -   name: show_sample_output
+            type: bool
+            default_value: false
+            public: true
+            description: Should teams be able to view a diff of their and the reference output to sample testcases?
+        -   name: show_balloons_postfreeze
+            type: bool
+            default_value: false
+            public: true
+            description: Give out balloon notifications after the scoreboard has been frozen?
+        -   name: show_relative_time
+            type: bool
+            default_value: false
+            public: true
+            description: Print times of contest events relative to contest start (instead of absolute).
+        -   name: time_format
+            type: string
+            default_value: "%H:%M"
+            public: false
+            description: The format used to print times. For formatting options see the PHP 'strftime' function.
+        -   name: thumbnail_size
+            type: int
+            default_value: 200
+            public: false
+            description: Maximum width/height of a thumbnail for uploaded testcase images.
+        -   name: show_limits_on_team_page
+            type: bool
+            default_value: true
+            public: true
+            description: Show time and memory limit on the team problems page
+        -   name: team_column_width
+            type: int
+            default_value: 0
+            public: false
+            description: Maximum width of team column on scoreboard. Leave 0 for no maximum.
+-   category: Misc
+    items:
+        -   name: print_command
+            type: string
+            default_value: ""
+            public: true
+            description: If not empty, enable teams and jury to send source code to this command. See admin manual for allowed arguments.
+        -   name: registration_category_name
+            type: string
+            default_value: ""
+            public: true
+            description: Team category for users that register themselves with the system. Self-registration is disabled if this field is left empty.
+        -   name: data_source
+            type: int
+            default_value: 0
+            public: false
+            description: "Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external"
+        -   name: external_ccs_submission_url
+            type: string
+            default_value: ""
+            public: false
+            description: URL of a submission detail page on the external CCS. Placeholder [id] will be replaced by submission ID and [contest] by the contest ID. Leave empty to not display links to external CCS
+-   category: Authentication
+    items:
+        -   name: auth_methods
+            type: array_val
+            default_value: []
+            public: false
+            description: List of allowed additional authentication methods. Supported values are 'ipaddress', and 'xheaders'
+        -   name: allow_openid_auth
+            type: bool
+            default_value: false
+            public: true
+            description: Allow users to log in using OpenID
+        -   name: openid_autocreate_team
+            type: bool
+            default_value: true
+            public: true
+            description: Create a team for each user that logs in with OpenID
+        -   name: openid_provider
+            type: string
+            default_value: https://accounts.google.com
+            public: true
+            description: OpenID Provider URL
+        -   name: openid_clientid
+            type: string
+            default_value: ""
+            public: false
+            description: OpenID Connect client id
+        -   name: openid_clientsecret
+            type: string
+            default_value: ""
+            public: false
+            description: OpenID Connect client secret
+        -   name: ip_autologin
+            type: bool
+            default_value: false
+            public: false
+            description: Enable to skip the login page when using IP authentication.

--- a/lib/lib.dbconfig.php
+++ b/lib/lib.dbconfig.php
@@ -43,33 +43,13 @@ function dbconfig_init()
             error("JSON config '$key' decode: unknown error");
         }
 
-        switch ($type = $row['type']) {
-        case 'bool':
-        case 'int':
-            if (!is_int($val)) {
-                error("invalid type '$type' for config variable '$key'");
-            }
-            break;
-        case 'string':
-            if (!is_string($val)) {
-                error("invalid type '$type' for config variable '$key'");
-            }
-            break;
-        case 'array_val':
-        case 'array_keyval':
-            if (!is_array($val)) {
-                error("invalid type '$type' for config variable '$key'");
-            }
-            break;
-        default:
-            error("unknown type '$type' for config variable '$key'");
-        }
+        // TODO: here used to be a check for type. We have removed this after
+        // moving database configuration to a YAML file. This whole function
+        // should be removed at some point anyway and we only use it in legacy
+        // calls. Also we dont store the type and public values anymore, but
+        // we don't need them in the legacy code.
 
-        $LIBDBCONFIG[$key] = array('value' => $val,
-                                   'type' => $row['type'],
-                                   'public' => $row['public'],
-                                   'category' => $row['category'],
-                                   'desc' => $row['description']);
+        $LIBDBCONFIG[$key] = array('value' => $val);
     }
 }
 
@@ -79,11 +59,8 @@ function dbconfig_init()
  * values can be used.
  *
  * When $name is null, then all variables will be returned.
- *
- * Set $onlyifpublic to true to only return a value when this is
- * a variable marked 'public'.
  */
-function dbconfig_get(string $name, $default = null, bool $cacheok = true, bool $onlyifpublic = false)
+function dbconfig_get(string $name, $default = null, bool $cacheok = true)
 {
     global $LIBDBCONFIG;
 
@@ -94,14 +71,12 @@ function dbconfig_get(string $name, $default = null, bool $cacheok = true, bool 
     if (is_null($name)) {
         $ret = array();
         foreach ($LIBDBCONFIG as $name => $config) {
-            if ( !$onlyifpublic || $config['public'] ) {
-                $ret[$name] = $config['value'];
-            }
+            $ret[$name] = $config['value'];
         }
         return $ret;
     }
 
-    if (isset($LIBDBCONFIG[$name]) && (!$onlyifpublic || $LIBDBCONFIG[$name]['public'])) {
+    if (isset($LIBDBCONFIG[$name])) {
         return $LIBDBCONFIG[$name]['value'];
     }
 

--- a/webapp/config/services.yaml
+++ b/webapp/config/services.yaml
@@ -15,7 +15,9 @@ services:
             $debug: '%kernel.debug%'
             $domjudgeVersion: '%domjudge.version%'
             $projectDir: '%kernel.project_dir%'
+            $cacheDir: '%kernel.cache_dir%'
             $sqlDir: '%domjudge.sqldir%'
+            $etcDir: '%domjudge.etcdir%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -53,3 +55,9 @@ services:
             - '%kernel.debug%'
 
     Metadata\MetadataFactoryInterface: '@jms_serializer.metadata_factory'
+
+    # We need the configuration serivce to be public to be able to run two of the migrations
+    App\Service\ConfigurationService:
+        public: true
+        arguments:
+            $configCache: '@config_cache_factory'

--- a/webapp/src/Command/CheckDatabaseConfigurationDefaultValuesCommand.php
+++ b/webapp/src/Command/CheckDatabaseConfigurationDefaultValuesCommand.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\ConfigurationService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class CheckDatabaseConfigurationDefaultValuesCommand
+ *
+ * @package App\Command
+ */
+class CheckDatabaseConfigurationDefaultValuesCommand extends Command
+{
+    /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
+     * CheckDatabaseConfigurationDefaultValuesCommand constructor.
+     *
+     * @param ConfigurationService $config
+     * @param string|null          $name
+     */
+    public function __construct(
+        ConfigurationService $config,
+        string $name = null
+    ) {
+        parent::__construct($name);
+        $this->config = $config;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('domjudge:db-config:check')
+            ->setDescription(
+                'Check if the default values of the database configuration are valid'
+            );
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $style    = new SymfonyStyle($input, $output);
+        $messages = [];
+        foreach ($this->config->getConfigSpecification() as $specification) {
+            $message = sprintf(
+                'Configuration %s (in category %s) is of type %s but has wrong type for default_value (%s)',
+                $specification['name'], $specification['category'],
+                $specification['type'],
+                json_encode($specification['default_value'])
+            );
+            switch ($specification['type']) {
+                case 'bool':
+                    if (!is_bool($specification['default_value'])) {
+                        $messages[] = $message;
+                    }
+                    break;
+                case 'int':
+                    if (!is_int($specification['default_value'])) {
+                        $messages[] = $message;
+                    }
+                    break;
+                case 'string':
+                    if (!is_string($specification['default_value'])) {
+                        $messages[] = $message;
+                    }
+                    break;
+                case 'array_val':
+                    if (!(empty($specification['default_value']) || (
+                            is_array($specification['default_value']) &&
+                            is_int(key($specification['default_value']))))) {
+                        $messages[] = $message;
+                    }
+                    break;
+                case 'array_keyval':
+                    if (!(empty($specification['default_value']) || (
+                            is_array($specification['default_value']) &&
+                            is_string(key($specification['default_value']))))) {
+                        $messages[] = $message;
+                    }
+                    break;
+            }
+        }
+        if (empty($messages)) {
+            $style->success('All default values have the correct type');
+        } else {
+            $style->error('Some default values have the wrong type:');
+            $style->listing($messages);
+        }
+    }
+}

--- a/webapp/src/Command/ScoreboardMergeCommand.php
+++ b/webapp/src/Command/ScoreboardMergeCommand.php
@@ -9,6 +9,7 @@ use App\Entity\ScoreCache;
 use App\Entity\Team;
 use App\Entity\TeamAffiliation;
 use App\Entity\TeamCategory;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
 use App\Utils\FreezeData;
@@ -48,6 +49,11 @@ class ScoreboardMergeCommand extends Command
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var Environment
      */
     protected $twig;
@@ -74,16 +80,19 @@ class ScoreboardMergeCommand extends Command
 
     /**
      * ScoreboardMergeCommand constructor.
-     * @param DOMJudgeService     $dj
-     * @param Environment         $twig
-     * @param HttpClientInterface $client
-     * @param ScoreboardService   $scoreboardService
-     * @param RouterInterface     $router
-     * @param string              $projectDir
-     * @param string|null         $name
+     *
+     * @param DOMJudgeService      $dj
+     * @param ConfigurationService $config
+     * @param Environment          $twig
+     * @param HttpClientInterface  $client
+     * @param ScoreboardService    $scoreboardService
+     * @param RouterInterface      $router
+     * @param string               $projectDir
+     * @param string|null          $name
      */
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         Environment $twig,
         HttpClientInterface $client,
         ScoreboardService $scoreboardService,
@@ -93,6 +102,7 @@ class ScoreboardMergeCommand extends Command
     ) {
         parent::__construct($name);
         $this->dj = $dj;
+        $this->config = $config;
         $this->twig = $twig;
         $this->client = $client;
         $this->scoreboardService = $scoreboardService;
@@ -336,7 +346,7 @@ class ScoreboardMergeCommand extends Command
             $scoreCache,
             $freezeData,
             false,
-            (int)$this->dj->dbconfig_get('penalty_time', 20),
+            (int)$this->config->get('penalty_time'),
             false
         );
 

--- a/webapp/src/Config/Loader/YamlConfigLoader.php
+++ b/webapp/src/Config/Loader/YamlConfigLoader.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\Config\Loader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class YamlConfigLoader
+ *
+ * Class that loads a YAML file
+ *
+ * @see     https://symfony.com/doc/current/components/config/resources.html#resource-loaders
+ *
+ * @package App\Config\Loader
+ */
+class YamlConfigLoader extends FileLoader
+{
+    /**
+     * @inheritDoc
+     */
+    public function load($resource, $type = null)
+    {
+        return Yaml::parse(file_get_contents($resource));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) &&
+            pathinfo($resource, PATHINFO_EXTENSION) === 'yaml';
+    }
+}

--- a/webapp/src/Controller/API/AbstractRestController.php
+++ b/webapp/src/Controller/API/AbstractRestController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\API;
 
 use App\Entity\Contest;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -32,20 +33,33 @@ abstract class AbstractRestController extends AbstractFOSRestController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
 
     /**
      * AbstractRestController constructor.
+     *
      * @param EntityManagerInterface $entityManager
-     * @param DOMJudgeService $dj
+     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
+     * @param EventLogService        $eventLogService
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj, EventLogService $eventLogService)
-    {
-        $this->em   = $entityManager;
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EventLogService $eventLogService
+    ) {
+        $this->em              = $entityManager;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
+        $this->config          = $config;
     }
 
     /**
@@ -130,6 +144,7 @@ abstract class AbstractRestController extends AbstractFOSRestController
 
         // Set the DOMjudge service on the context, so we can use it for permissions
         $view->getContext()->setAttribute('domjudge_service', $this->dj);
+        $view->getContext()->setAttribute('config_service', $this->config);
 
         $groups = ['Default'];
         if (!$request->query->has('strict') || !$request->query->getBoolean('strict')) {

--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\API;
 
 use App\Entity\Contest;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ScoreboardService;
@@ -33,18 +34,21 @@ class AwardsController extends AbstractRestController
 
     /**
      * ScoreboardController constructor.
+     *
      * @param EntityManagerInterface $entityManager
      * @param DOMJudgeService        $DOMJudgeService
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      * @param ScoreboardService      $scoreboardService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $DOMJudgeService,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         ScoreboardService $scoreboardService
     ) {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
         $this->scoreboardService = $scoreboardService;
     }
 

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -5,6 +5,7 @@ namespace App\Controller\API;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Event;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ImportExportService;
@@ -44,10 +45,20 @@ class ContestController extends AbstractRestController
     protected $importExportService;
 
     /**
+     * @param EntityManagerInterface $entityManager
+     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
+     * @param EventLogService        $eventLogService
      * @param ImportExportService    $importExportService
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj, EventLogService $eventLogService, ImportExportService $importExportService) {
-        parent::__construct($entityManager, $dj, $eventLogService);
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EventLogService $eventLogService,
+        ImportExportService $importExportService
+    ) {
+        parent::__construct($entityManager, $dj, $config, $eventLogService);
         $this->importExportService = $importExportService;
     }
 
@@ -239,7 +250,7 @@ class ContestController extends AbstractRestController
     public function getContestYamlAction(Request $request, string $cid)
     {
         $contest      = $this->getContestWithId($request, $cid);
-        $penalty_time = $this->dj->dbconfig_get('penalty_time', 20);
+        $penalty_time = $this->config->get('penalty_time');
         $response     = new StreamedResponse();
         $response->setCallback(function () use ($contest, $penalty_time) {
             echo "name:                     " . $contest->getName() . "\n";

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -5,6 +5,7 @@ namespace App\Controller\API;
 use App\Entity\Contest;
 use App\Entity\User;
 use App\Service\CheckConfigService;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -39,6 +40,11 @@ class GeneralInfoController extends AbstractFOSRestController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
@@ -55,8 +61,10 @@ class GeneralInfoController extends AbstractFOSRestController
 
     /**
      * GeneralInfoController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      * @param CheckConfigService     $checkConfigService
      * @param RouterInterface        $router
@@ -64,6 +72,7 @@ class GeneralInfoController extends AbstractFOSRestController
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         CheckConfigService $checkConfigService,
         RouterInterface $router
@@ -73,6 +82,7 @@ class GeneralInfoController extends AbstractFOSRestController
         $this->eventLogService    = $eventLogService;
         $this->checkConfigService = $checkConfigService;
         $this->router             = $router;
+        $this->config             = $config;
     }
 
     /**
@@ -237,7 +247,7 @@ class GeneralInfoController extends AbstractFOSRestController
         $onlypublic = !($this->dj->checkrole('jury') || $this->dj->checkrole('judgehost'));
         $name       = $request->query->get('name');
 
-        $result = $this->dj->dbconfig_get($name, null, $onlypublic);
+        $result = $this->config->get($name, $onlypublic);
 
         if ($name !== null) {
             return [$name => $result];

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -4,6 +4,7 @@ namespace App\Controller\API;
 
 use App\Entity\Judging;
 use App\Helpers\JudgingWrapper;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,9 +34,10 @@ class JudgementController extends AbstractRestController implements QueryObjectT
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $DOMJudgeService,
+        ConfigurationService $config,
         EventLogService $eventLogService
     ) {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
 
         $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $this->verdicts = include $verdictsConfig;
@@ -153,7 +155,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
             $queryBuilder
                 ->andWhere('s.submittime < c.endtime')
                 ->andWhere('j.valid = 1');
-            if ($this->dj->dbconfig_get('verification_required', false)) {
+            if ($this->config->get('verification_required')) {
                 $queryBuilder->andWhere('j.verified = 1');
             }
         }

--- a/webapp/src/Controller/API/JudgementTypeController.php
+++ b/webapp/src/Controller/API/JudgementTypeController.php
@@ -104,7 +104,7 @@ class JudgementTypeController extends AbstractRestController
                 $solved  = true;
             }
             if ($name == 'compiler-error') {
-                $penalty = $this->dj->dbconfig_get('compile_penalty', false);
+                $penalty = $this->config->get('compile_penalty');
             }
             if ($filteredOn !== null && !in_array($label, $filteredOn)) {
                 continue;

--- a/webapp/src/Controller/API/ProblemController.php
+++ b/webapp/src/Controller/API/ProblemController.php
@@ -7,6 +7,7 @@ use App\Entity\ContestProblem;
 use App\Entity\Problem;
 use App\Helpers\ContestProblemWrapper;
 use App\Helpers\OrdinalArray;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ImportProblemService;
@@ -39,10 +40,11 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $DOMJudgeService,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         ImportProblemService $importProblemService
     ) {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
         $this->importProblemService = $importProblemService;
     }
 

--- a/webapp/src/Controller/API/RunController.php
+++ b/webapp/src/Controller/API/RunController.php
@@ -4,6 +4,7 @@ namespace App\Controller\API;
 
 use App\Entity\JudgingRun;
 use App\Helpers\JudgingRunWrapper;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -30,9 +31,14 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
      */
     protected $verdicts;
 
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $DOMJudgeService, EventLogService $eventLogService)
-    {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DOMJudgeService $DOMJudgeService,
+        ConfigurationService $config,
+        EventLogService $eventLogService
+    ) {
+        parent::__construct($entityManager, $DOMJudgeService, $config,
+            $eventLogService);
 
         $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $this->verdicts = include $verdictsConfig;
@@ -157,7 +163,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
             $queryBuilder
                 ->andWhere('s.submittime < c.endtime')
                 ->andWhere('j.rejudgingid IS NULL OR j.valid = 1');
-            if ($this->dj->dbconfig_get('verification_required', false)) {
+            if ($this->config->get('verification_required')) {
                 $queryBuilder->andWhere('j.verified = 1');
             }
         }

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -4,6 +4,7 @@ namespace App\Controller\API;
 
 use App\Entity\Contest;
 use App\Entity\Event;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ScoreboardService;
@@ -35,18 +36,21 @@ class ScoreboardController extends AbstractRestController
 
     /**
      * ScoreboardController constructor.
+     *
      * @param EntityManagerInterface $entityManager
      * @param DOMJudgeService        $DOMJudgeService
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      * @param ScoreboardService      $scoreboardService
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $DOMJudgeService,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         ScoreboardService $scoreboardService
     ) {
-        parent::__construct($entityManager, $DOMJudgeService, $eventLogService);
+        parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
         $this->scoreboardService = $scoreboardService;
     }
 
@@ -144,7 +148,7 @@ class ScoreboardController extends AbstractRestController
         // Return early if there's nothing to display yet.
         if (!$scoreboard) return $results;
 
-        $scoreIsInSeconds = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
 
         foreach ($scoreboard->getScores() as $teamScore) {
             $row = [

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -7,6 +7,7 @@ use App\Entity\Language;
 use App\Entity\Problem;
 use App\Entity\Submission;
 use App\Entity\SubmissionFile;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\SubmissionService;
@@ -41,10 +42,11 @@ class SubmissionController extends AbstractRestController
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         SubmissionService $submissionService
     ) {
-        parent::__construct($entityManager, $dj, $eventLogService);
+        parent::__construct($entityManager, $dj, $config, $eventLogService);
         $this->submissionService = $submissionService;
     }
 

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\API;
 
 use App\Entity\User;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ImportExportService;
@@ -35,10 +36,20 @@ class UserController extends AbstractRestController
     protected $importExportService;
 
     /**
+     * @param EntityManagerInterface $entityManager
+     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
+     * @param EventLogService        $eventLogService
      * @param ImportExportService    $importExportService
      */
-    public function __construct(EntityManagerInterface $entityManager, DOMJudgeService $dj, EventLogService $eventLogService, ImportExportService $importExportService) {
-        parent::__construct($entityManager, $dj, $eventLogService);
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EventLogService $eventLogService,
+        ImportExportService $importExportService
+    ) {
+        parent::__construct($entityManager, $dj, $config, $eventLogService);
         $this->importExportService = $importExportService;
     }
 

--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Jury;
 use App\Entity\AuditLog;
 use App\Entity\Testcase;
 use App\Entity\User;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -34,23 +35,32 @@ class AuditLogController extends AbstractController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
 
     /**
      * AuditLogController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
     }
 
@@ -59,7 +69,7 @@ class AuditLogController extends AbstractController
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
+        $timeFormat = (string)$this->config->get('time_format');
 
         $showAll = $request->query->get('showAll', false);
         $page = $request->query->get('page', 1);

--- a/webapp/src/Controller/Jury/BalloonController.php
+++ b/webapp/src/Controller/Jury/BalloonController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Jury;
 use App\Entity\Balloon;
 use App\Entity\ScoreCache;
 use App\Entity\TeamAffiliation;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -35,23 +36,32 @@ class BalloonController extends AbstractController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
 
     /**
      * BalloonController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
     }
 
@@ -60,8 +70,8 @@ class BalloonController extends AbstractController
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
-        $showPostFreeze = (bool)$this->dj->dbconfig_get('show_balloons_postfreeze', false);
+        $timeFormat = (string)$this->config->get('time_format');
+        $showPostFreeze = (bool)$this->config->get('show_balloons_postfreeze');
 
         $em = $this->em;
 

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -12,6 +12,7 @@ use App\Entity\Team;
 use App\Form\Type\ContestType;
 use App\Form\Type\FinalizeContestType;
 use App\Form\Type\RemovedIntervalType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -43,6 +44,11 @@ class ContestController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -54,19 +60,23 @@ class ContestController extends BaseController
 
     /**
      * TeamCategoryController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
         $this->kernel          = $kernel;
     }
@@ -209,7 +219,7 @@ class ContestController extends BaseController
 
         $currentContests = $this->dj->getCurrentContests();
 
-        $timeFormat = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
+        $timeFormat = (string)$this->config->get('time_format');
 
         $etcDir = $this->dj->getDomjudgeEtcDir();
         require_once $etcDir . '/domserver-config.php';

--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Executable;
 use App\Form\Type\ExecutableType;
 use App\Form\Type\ExecutableUploadType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -42,6 +43,11 @@ class ExecutableController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -53,19 +59,23 @@ class ExecutableController extends BaseController
 
     /**
      * ExecutableController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->kernel          = $kernel;
         $this->eventLogService = $eventLogService;
     }
@@ -219,8 +229,8 @@ class ExecutableController extends BaseController
 
         return $this->render('jury/executable.html.twig', [
             'executable' => $executable,
-            'default_compare' => (string)$this->dj->dbconfig_get('default_compare'),
-            'default_run' => (string)$this->dj->dbconfig_get('default_run'),
+            'default_compare' => (string)$this->config->get('default_compare'),
+            'default_run' => (string)$this->config->get('default_run'),
         ]);
     }
 

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -12,6 +12,7 @@ use App\Form\Type\ContestExportType;
 use App\Form\Type\ContestImportType;
 use App\Form\Type\TsvImportType;
 use App\Service\BaylorCmsService;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ImportExportService;
@@ -62,6 +63,11 @@ class ImportExportController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
@@ -71,11 +77,13 @@ class ImportExportController extends BaseController
 
     /**
      * ImportExportController constructor.
+     *
      * @param BaylorCmsService       $baylorCmsService
      * @param ImportExportService    $importExportService
      * @param EntityManagerInterface $em
      * @param ScoreboardService      $scoreboardService
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EventLogService        $eventLogService
      * @param string                 $domjudgeVersion
      */
@@ -85,6 +93,7 @@ class ImportExportController extends BaseController
         EntityManagerInterface $em,
         ScoreboardService $scoreboardService,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         string $domjudgeVersion
     ) {
@@ -93,6 +102,7 @@ class ImportExportController extends BaseController
         $this->em                  = $em;
         $this->scoreboardService   = $scoreboardService;
         $this->dj                  = $dj;
+        $this->config              = $config;
         $this->eventLogService     = $eventLogService;
         $this->domjudgeVersion     = $domjudgeVersion;
     }
@@ -311,7 +321,7 @@ class ImportExportController extends BaseController
             throw new BadRequestHttpException('No current contest');
         }
 
-        $scoreIsInSeconds = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
         $filter           = new Filter();
         $filter->setCategories($categoryIds);
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);
@@ -446,13 +456,13 @@ class ImportExportController extends BaseController
             throw new BadRequestHttpException('No current contest');
         }
 
-        $queues              = (array)$this->dj->dbconfig_get('clar_queues');
+        $queues              = (array)$this->config->get('clar_queues');
         $clarificationQueues = [null => 'Unassigned issues'];
         foreach ($queues as $key => $val) {
             $clarificationQueues[$key] = $val;
         }
 
-        $categories = (array)$this->dj->dbconfig_get('clar_categories');
+        $categories = (array)$this->config->get('clar_categories');
 
         $clarificationCategories = [];
         foreach ($categories as $key => $val) {

--- a/webapp/src/Controller/Jury/JudgehostController.php
+++ b/webapp/src/Controller/Jury/JudgehostController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Judgehost;
 use App\Entity\Judging;
 use App\Form\Type\JudgehostsType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,23 +37,32 @@ class JudgehostController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
 
     /**
      * JudgehostController constructor.
+     *
      * @param EntityManagerInterface $em
-     * @param DOMJudgeService $dj
-     * @param KernelInterface $kernel
+     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
+     * @param KernelInterface        $kernel
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel
     ) {
-        $this->em = $em;
-        $this->dj = $dj;
+        $this->em     = $em;
+        $this->dj     = $dj;
+        $this->config = $config;
         $this->kernel = $kernel;
     }
 
@@ -106,8 +116,8 @@ class JudgehostController extends BaseController
         $workcontest = $map($workcontest);
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $time_warn = $this->dj->dbconfig_get('judgehost_warning', 30);
-        $time_crit = $this->dj->dbconfig_get('judgehost_critical', 120);
+        $time_warn = $this->config->get('judgehost_warning');
+        $time_crit = $this->config->get('judgehost_critical');
         $judgehosts_table = [];
         foreach ($judgehosts as $judgehost) {
             $judgehostdata    = [];
@@ -251,9 +261,9 @@ class JudgehostController extends BaseController
         }
 
         $reltime = floor(Utils::difftime(Utils::now(), (float)$judgehost->getPolltime()));
-        if ($reltime < $this->dj->dbconfig_get('judgehost_warning', 30)) {
+        if ($reltime < $this->config->get('judgehost_warning')) {
             $status = 'OK';
-        } elseif ($reltime < $this->dj->dbconfig_get('judgehost_critical', 120)) {
+        } elseif ($reltime < $this->config->get('judgehost_critical')) {
             $status = 'Warning';
         } else {
             $status = 'Critical';

--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Language;
 use App\Entity\Submission;
 use App\Form\Type\LanguageType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\SubmissionService;
@@ -35,6 +36,11 @@ class LanguageController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -46,19 +52,23 @@ class LanguageController extends BaseController
 
     /**
      * LanguageController constructor.
+     *
      * @param EntityManagerInterface $em
-     * @param DOMJudgeService $dj
-     * @param KernelInterface $kernel
-     * @param EventLogService $eventLogService
+     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
+     * @param KernelInterface        $kernel
+     * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->kernel          = $kernel;
         $this->eventLogService = $eventLogService;
     }
@@ -209,7 +219,7 @@ class LanguageController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+            'showExternalResult' => $this->config->get('data_source') ==
                 DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,

--- a/webapp/src/Controller/Jury/PrintController.php
+++ b/webapp/src/Controller/Jury/PrintController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Jury;
 use App\Controller\BaseController;
 use App\Entity\Language;
 use App\Form\Type\PrintType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Utils\Printing;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,14 +36,25 @@ class PrintController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * PrintController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      */
-    public function __construct(EntityManagerInterface $em, DOMJudgeService $dj)
-    {
-        $this->em = $em;
-        $this->dj = $dj;
+    public function __construct(
+        EntityManagerInterface $em,
+        DOMJudgeService $dj,
+        ConfigurationService $config
+    ) {
+        $this->em     = $em;
+        $this->dj     = $dj;
+        $this->config = $config;
     }
 
     /**
@@ -53,7 +65,7 @@ class PrintController extends BaseController
      */
     public function showAction(Request $request)
     {
-        if (!$this->dj->dbconfig_get('print_command', '')) {
+        if (!$this->config->get('print_command')) {
             throw new AccessDeniedHttpException("Printing disabled in config");
         }
 

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -10,6 +10,7 @@ use App\Entity\Rejudging;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Form\Type\RejudgingType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\RejudgingService;
 use App\Service\ScoreboardService;
@@ -47,6 +48,11 @@ class RejudgingController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var RouterInterface
      */
     protected $router;
@@ -59,11 +65,13 @@ class RejudgingController extends BaseController
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         RouterInterface $router,
         SessionInterface $session
     ) {
         $this->em      = $em;
         $this->dj      = $dj;
+        $this->config  = $config;
         $this->router  = $router;
         $this->session = $session;
     }
@@ -97,7 +105,7 @@ class RejudgingController extends BaseController
             'status' => ['title' => 'status', 'sort' => true],
         ];
 
-        $timeFormat       = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
+        $timeFormat       = (string)$this->config->get('time_format');
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $rejudgings_table = [];
         foreach ($rejudgings as $rejudging) {
@@ -349,7 +357,7 @@ class RejudgingController extends BaseController
             'submissionCounts' => $submissionCounts,
             'oldverdict' => $request->query->get('oldverdict', 'all'),
             'newverdict' => $request->query->get('newverdict', 'all'),
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+            'showExternalResult' => $this->config->get('data_source') ==
                 DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Jury;
 
+use App\Service\ConfigurationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use App\Controller\BaseController;
@@ -27,6 +28,11 @@ class ShadowDifferencesController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var SubmissionService
      */
     protected $submissions;
@@ -43,11 +49,13 @@ class ShadowDifferencesController extends BaseController
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         SubmissionService $submissions,
         SessionInterface $session,
         EntityManagerInterface $em
     ) {
         $this->dj          = $dj;
+        $this->config      = $config;
         $this->submissions = $submissions;
         $this->session     = $session;
         $this->em          = $em;
@@ -59,7 +67,7 @@ class ShadowDifferencesController extends BaseController
     public function indexAction(Request $request)
     {
         $shadowMode = DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
-        $dataSource = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
+        $dataSource = $this->config->get('data_source');
         if ($dataSource != $shadowMode) {
             $this->addFlash('danger', sprintf(
                 'Shadow differences only supported when data_source is %d',

--- a/webapp/src/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/Controller/Jury/TeamAffiliationController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Jury;
 use App\Controller\BaseController;
 use App\Entity\TeamAffiliation;
 use App\Form\Type\TeamAffiliationType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ScoreboardService;
@@ -34,6 +35,11 @@ class TeamAffiliationController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -45,19 +51,23 @@ class TeamAffiliationController extends BaseController
 
     /**
      * TeamCategoryController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->kernel          = $kernel;
         $this->eventLogService = $eventLogService;
     }
@@ -76,7 +86,7 @@ class TeamAffiliationController extends BaseController
             ->groupBy('a.affilid')
             ->getQuery()->getResult();
 
-        $showFlags = $this->dj->dbconfig_get('show_flags', true);
+        $showFlags = $this->config->get('show_flags');
 
         $table_fields = [
             'affilid' => ['title' => 'ID', 'sort' => true],
@@ -192,13 +202,13 @@ class TeamAffiliationController extends BaseController
 
         $data = [
             'teamAffiliation' => $teamAffiliation,
-            'showFlags' => $this->dj->dbconfig_get('show_flags', true),
+            'showFlags' => $this->config->get('show_flags'),
             'refresh' => [
                 'after' => 30,
                 'url' => $this->generateUrl('jury_team_affiliation', ['affilId' => $teamAffiliation->getAffilid()]),
                 'ajax' => true,
             ],
-            'maxWidth' => $this->dj->dbconfig_get('team_column_width', 0),
+            'maxWidth' => $this->config->get('team_column_width'),
         ];
 
         if ($currentContest = $this->dj->getCurrentContest()) {

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Submission;
 use App\Entity\TeamCategory;
 use App\Form\Type\TeamCategoryType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\SubmissionService;
@@ -35,6 +36,11 @@ class TeamCategoryController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -46,19 +52,23 @@ class TeamCategoryController extends BaseController
 
     /**
      * TeamCategoryController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
         $this->kernel          = $kernel;
     }
@@ -170,7 +180,7 @@ class TeamCategoryController extends BaseController
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'showExternalResult' => $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+            'showExternalResult' => $this->config->get('data_source') ==
                 DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'refresh' => [
                 'after' => 15,

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -8,6 +8,7 @@ use App\Entity\Role;
 use App\Entity\Team;
 use App\Entity\User;
 use App\Form\Type\TeamType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ScoreboardService;
@@ -41,6 +42,11 @@ class TeamController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -52,19 +58,23 @@ class TeamController extends BaseController
 
     /**
      * TeamController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
         $this->kernel          = $kernel;
     }
@@ -278,10 +288,10 @@ class TeamController extends BaseController
                 'ajax' => true,
             ],
             'team' => $team,
-            'showAffiliations' => (bool)$this->dj->dbconfig_get('show_affiliations', true),
-            'showFlags' => (bool)$this->dj->dbconfig_get('show_flags', true),
+            'showAffiliations' => (bool)$this->config->get('show_affiliations'),
+            'showFlags' => (bool)$this->config->get('show_flags'),
             'showContest' => count($this->dj->getCurrentContests()) > 1,
-            'maxWidth' => $this->dj->dbconfig_get("team_column_width", 0),
+            'maxWidth' => $this->config->get("team_column_width"),
         ];
 
         $currentContest = $this->dj->getCurrentContest();
@@ -338,7 +348,7 @@ class TeamController extends BaseController
         $data['restrictionText']    = $restrictionText;
         $data['submissions']        = $submissions;
         $data['submissionCounts']   = $submissionCounts;
-        $data['showExternalResult'] = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) ==
+        $data['showExternalResult'] = $this->config->get('data_source') ==
             DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -8,6 +8,7 @@ use App\Entity\Team;
 use App\Entity\User;
 use App\Form\Type\GeneratePasswordsType;
 use App\Form\Type\UserType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -39,6 +40,11 @@ class UserController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -55,8 +61,10 @@ class UserController extends BaseController
 
     /**
      * UserController constructor.
+     *
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param KernelInterface        $kernel
      * @param EventLogService        $eventLogService
      * @param TokenStorageInterface  $tokenStorage
@@ -64,12 +72,14 @@ class UserController extends BaseController
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         KernelInterface $kernel,
         EventLogService $eventLogService,
         TokenStorageInterface $tokenStorage
     ) {
         $this->em              = $em;
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->eventLogService = $eventLogService;
         $this->tokenStorage    = $tokenStorage;
         $this->kernel          = $kernel;
@@ -102,7 +112,7 @@ class UserController extends BaseController
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $users_table      = [];
-        $timeFormat  = (string)$this->dj->dbconfig_get('time_format', '%H:%M');
+        $timeFormat  = (string)$this->config->get('time_format');
         foreach ($users as $u) {
             $userdata    = [];
             $useractions = [];

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -6,6 +6,7 @@ use App\Entity\ContestProblem;
 use App\Entity\Language;
 use App\Entity\Team;
 use App\Entity\Testcase;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +34,11 @@ class PublicController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var ScoreboardService
      */
     protected $scoreboardService;
@@ -44,10 +50,12 @@ class PublicController extends BaseController
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         ScoreboardService $scoreboardService,
         EntityManagerInterface $em
     ) {
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->scoreboardService = $scoreboardService;
         $this->em                = $em;
     }
@@ -149,8 +157,8 @@ class PublicController extends BaseController
     public function teamAction(Request $request, int $teamId)
     {
         $team             = $this->em->getRepository(Team::class)->find($teamId);
-        $showFlags        = (bool)$this->dj->dbconfig_get('show_flags', true);
-        $showAffiliations = (bool)$this->dj->dbconfig_get('show_affiliations', true);
+        $showFlags        = (bool)$this->config->get('show_flags');
+        $showAffiliations = (bool)$this->config->get('show_affiliations');
         $data             = [
             'team' => $team,
             'showFlags' => $showFlags,
@@ -173,8 +181,8 @@ class PublicController extends BaseController
     public function problemsAction()
     {
         $contest            = $this->dj->getCurrentContest(-1);
-        $showLimits         = (bool)$this->dj->dbconfig_get('show_limits_on_team_page');
-        $defaultMemoryLimit = (int)$this->dj->dbconfig_get('memory_limit', 0);
+        $showLimits         = (bool)$this->config->get('show_limits_on_team_page');
+        $defaultMemoryLimit = (int)$this->config->get('memory_limit');
         $timeFactorDiffers  = false;
         if ($showLimits) {
             $timeFactorDiffers = $this->em->createQueryBuilder()

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Clarification;
 use App\Entity\Problem;
 use App\Form\Type\TeamClarificationType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -36,6 +37,11 @@ class ClarificationController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
@@ -52,11 +58,13 @@ class ClarificationController extends BaseController
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EntityManagerInterface $em,
         EventLogService $eventLogService,
         FormFactoryInterface $formFactory
     ) {
         $this->dj              = $dj;
+        $this->config          = $config;
         $this->em              = $em;
         $this->eventLogService = $eventLogService;
         $this->formFactory     = $formFactory;
@@ -72,7 +80,7 @@ class ClarificationController extends BaseController
      */
     public function viewAction(Request $request, int $clarId)
     {
-        $categories = $this->dj->dbconfig_get('clar_categories');
+        $categories = $this->config->get('clar_categories');
         $user       = $this->dj->getUser();
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
@@ -123,7 +131,7 @@ class ClarificationController extends BaseController
                 $category = $problemId;
             } else {
                 $problem = $this->em->getRepository(Problem::class)->find($problemId);
-                $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
+                $queue   = $this->config->get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
                 }
@@ -192,7 +200,7 @@ class ClarificationController extends BaseController
      */
     public function addAction(Request $request)
     {
-        $categories = $this->dj->dbconfig_get('clar_categories');
+        $categories = $this->config->get('clar_categories');
         $user       = $this->dj->getUser();
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
@@ -216,7 +224,7 @@ class ClarificationController extends BaseController
                 $category = $problemId;
             } else {
                 $problem = $this->em->getRepository(Problem::class)->find($problemId);
-                $queue   = $this->dj->dbconfig_get('clar_default_problem_queue');
+                $queue   = $this->config->get('clar_default_problem_queue');
                 if ($queue === "") {
                     $queue = null;
                 }

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\Clarification;
 use App\Entity\Language;
 use App\Form\Type\PrintType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
 use App\Service\SubmissionService;
@@ -41,6 +42,11 @@ class MiscController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
@@ -57,18 +63,22 @@ class MiscController extends BaseController
 
     /**
      * MiscController constructor.
+     *
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EntityManagerInterface $em
      * @param ScoreboardService      $scoreboardService
      * @param SubmissionService      $submissionService
      */
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EntityManagerInterface $em,
         ScoreboardService $scoreboardService,
         SubmissionService $submissionService
     ) {
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->em                = $em;
         $this->scoreboardService = $scoreboardService;
         $this->submissionService = $submissionService;
@@ -97,7 +107,7 @@ class MiscController extends BaseController
                 'url' => $this->generateUrl('team_index'),
                 'ajax' => true,
             ],
-            'maxWidth' => $this->dj->dbconfig_get('team_column_width', 0),
+            'maxWidth' => $this->config->get('team_column_width'),
         ];
         if ($contest) {
             $scoreboard = $this->scoreboardService
@@ -110,7 +120,7 @@ class MiscController extends BaseController
                 )
             );
             $data['limitToTeams'] = [$team];
-            $data['verificationRequired'] = $this->dj->dbconfig_get('verification_required', false);
+            $data['verificationRequired'] = $this->config->get('verification_required');
             // We need to clear the entity manager, because loading the team scoreboard seems to break getting submission
             // contestproblems for the contest we get the scoreboard for
             $this->em->clear();
@@ -155,7 +165,7 @@ class MiscController extends BaseController
 
             $data['clarifications']        = $clarifications;
             $data['clarificationRequests'] = $clarificationRequests;
-            $data['categories']            = $this->dj->dbconfig_get('clar_categories');
+            $data['categories']            = $this->config->get('clar_categories');
         }
 
         if ($request->isXmlHttpRequest()) {
@@ -192,7 +202,7 @@ class MiscController extends BaseController
      */
     public function printAction(Request $request)
     {
-        if (!$this->dj->dbconfig_get('print_command', '')) {
+        if (!$this->config->get('print_command')) {
             throw new AccessDeniedHttpException("Printing disabled in config");
         }
 

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\ContestProblem;
 use App\Entity\Language;
 use App\Entity\Testcase;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
@@ -33,19 +34,30 @@ class ProblemController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
 
     /**
      * ProblemController constructor.
+     *
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EntityManagerInterface $em
      */
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
-    {
-        $this->dj = $dj;
-        $this->em = $em;
+    public function __construct(
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EntityManagerInterface $em
+    ) {
+        $this->dj     = $dj;
+        $this->config = $config;
+        $this->em     = $em;
     }
 
     /**
@@ -58,8 +70,8 @@ class ProblemController extends BaseController
     {
         $user               = $this->dj->getUser();
         $contest            = $this->dj->getCurrentContest($user->getTeamid());
-        $showLimits         = (bool)$this->dj->dbconfig_get('show_limits_on_team_page');
-        $defaultMemoryLimit = (int)$this->dj->dbconfig_get('memory_limit', 0);
+        $showLimits         = (bool)$this->config->get('show_limits_on_team_page');
+        $defaultMemoryLimit = (int)$this->config->get('memory_limit');
         $timeFactorDiffers  = false;
         if ($showLimits) {
             $timeFactorDiffers = $this->em->createQueryBuilder()

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Team;
 
 use App\Controller\BaseController;
 use App\Entity\Team;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -30,6 +31,11 @@ class ScoreboardController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var ScoreboardService
      */
     protected $scoreboardService;
@@ -41,16 +47,20 @@ class ScoreboardController extends BaseController
 
     /**
      * ScoreboardController constructor.
+     *
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param ScoreboardService      $scoreboardService
      * @param EntityManagerInterface $em
      */
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         ScoreboardService $scoreboardService,
         EntityManagerInterface $em
     ) {
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->scoreboardService = $scoreboardService;
         $this->em                = $em;
     }
@@ -89,8 +99,8 @@ class ScoreboardController extends BaseController
     public function teamAction(Request $request, int $teamId)
     {
         $team             = $this->em->getRepository(Team::class)->find($teamId);
-        $showFlags        = (bool)$this->dj->dbconfig_get('show_flags', true);
-        $showAffiliations = (bool)$this->dj->dbconfig_get('show_affiliations', true);
+        $showFlags        = (bool)$this->config->get('show_flags');
+        $showAffiliations = (bool)$this->config->get('show_affiliations');
         $data             = [
             'team' => $team,
             'showFlags' => $showFlags,

--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -7,6 +7,7 @@ use App\Entity\Judging;
 use App\Entity\Problem;
 use App\Entity\Testcase;
 use App\Form\Type\SubmitProblemType;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\SubmissionService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -45,6 +46,11 @@ class SubmissionController extends BaseController
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var FormFactoryInterface
      */
     protected $formFactory;
@@ -53,11 +59,13 @@ class SubmissionController extends BaseController
         EntityManagerInterface $em,
         SubmissionService $submissionService,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         FormFactoryInterface $formFactory
     ) {
         $this->em                = $em;
         $this->submissionService = $submissionService;
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->formFactory       = $formFactory;
     }
 
@@ -132,9 +140,9 @@ class SubmissionController extends BaseController
      */
     public function viewAction(Request $request, int $submitId)
     {
-        $verificationRequired = (bool)$this->dj->dbconfig_get('verification_required', false);;
-        $showCompile      = $this->dj->dbconfig_get('show_compile', 2);
-        $showSampleOutput = $this->dj->dbconfig_get('show_sample_output', 0);
+        $verificationRequired = (bool)$this->config->get('verification_required');;
+        $showCompile      = $this->config->get('show_compile');
+        $showSampleOutput = $this->config->get('show_sample_output');
         $user             = $this->dj->getUser();
         $team             = $user->getTeam();
         $contest          = $this->dj->getCurrentContest($team->getTeamid());

--- a/webapp/src/Entity/Configuration.php
+++ b/webapp/src/Entity/Configuration.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(name="configuration",
  *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Global configuration variables"},
- *     indexes={@ORM\Index(name="public", columns={"public"})},
  *     uniqueConstraints={@ORM\UniqueConstraint(name="name", columns={"name"})})
  */
 class Configuration
@@ -36,40 +35,6 @@ class Configuration
      *     nullable=false)
      */
     private $value;
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="type", length=32,
-     *     options={"comment"="Type of the value (metatype for use in the webinterface)",
-     *              "default"="NULL"},
-     *     nullable=true)
-     */
-    private $type;
-
-    /**
-     * @var bool
-     * @ORM\Column(type="boolean", name="public",
-     *     options={"comment"="Is this variable publicly visible?","unsigned"=true,"default"="0"},
-     *     nullable=false)
-     */
-    private $public = false;
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="category", length=32,
-     *     options={"comment"="Option category of the configuration variable",
-     *              "default"="'Uncategorized'"},
-     *     nullable=false)
-     */
-    private $category = 'Uncategorized';
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="description", length=255,
-     *     options={"comment"="Description for in the webinterface","default"="NULL"},
-     *     nullable=true)
-     */
-    private $description;
 
     /**
      * Get configid
@@ -115,14 +80,10 @@ class Configuration
     public function setValue($value)
     {
         // Do not use 'True'/'False' but 1/0 since the former cannot be parsed by the old code.
-        if ($this->type == 'bool') {
-            if ($value === TRUE) {
-                $value = 1;
-            } elseif ($value === FALSE) {
-                $value = 0;
-            }
-        } elseif ($this->type == 'int') {
-            $value = (int) $value;
+        if ($value === TRUE) {
+            $value = 1;
+        } elseif ($value === FALSE) {
+            $value = 0;
         }
 
         $this->value = $value;
@@ -138,101 +99,5 @@ class Configuration
     public function getValue()
     {
         return $this->value;
-    }
-
-    /**
-     * Set type
-     *
-     * @param string $type
-     *
-     * @return Configuration
-     */
-    public function setType($type)
-    {
-        $this->type = $type;
-
-        return $this;
-    }
-
-    /**
-     * Get type
-     *
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * Set public
-     *
-     * @param bool $public
-     *
-     * @return Configuration
-     */
-    public function setPublic(bool $public)
-    {
-        $this->public = $public;
-
-        return $this;
-    }
-
-    /**
-     * Get public
-     *
-     * @return bool
-     */
-    public function getPublic()
-    {
-        return $this->public;
-    }
-
-    /**
-     * Set category
-     *
-     * @param string $category
-     *
-     * @return Configuration
-     */
-    public function setCategory($category)
-    {
-        $this->category = $category;
-
-        return $this;
-    }
-
-    /**
-     * Get category
-     *
-     * @return string
-     */
-    public function getCategory()
-    {
-        return $this->category;
-    }
-
-    /**
-     * Set description
-     *
-     * @param string $description
-     *
-     * @return Configuration
-     */
-    public function setDescription($description)
-    {
-        $this->description = $description;
-
-        return $this;
-    }
-
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
     }
 }

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -775,7 +775,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
      * @Serializer\VirtualProperty()
      * @Serializer\Type("string")
      * @Serializer\Groups({"Nonstrict"})
-     * @Serializer\Expose(if="context.getAttribute('domjudge_service').dbconfig_get('show_flags', true)")
+     * @Serializer\Expose(if="context.getAttribute('config_service').get('show_flags')")
      */
     public function getNationality()
     {

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -76,7 +76,7 @@ class TeamAffiliation extends BaseApiEntity
      *     options={"comment"="ISO 3166-1 alpha-3 country code","default"="NULL",
      *              "fixed"=true},
      *     nullable=true)
-     * @Serializer\Expose(if="context.getAttribute('domjudge_service').dbconfig_get('show_flags', true)")
+     * @Serializer\Expose(if="context.getAttribute('config_service').get('show_flags')")
      * @Country()
      */
     private $country;

--- a/webapp/src/Form/Type/SubmitProblemType.php
+++ b/webapp/src/Form/Type/SubmitProblemType.php
@@ -4,6 +4,7 @@ namespace App\Form\Type;
 
 use App\Entity\Language;
 use App\Entity\Problem;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -24,19 +25,28 @@ class SubmitProblemType extends AbstractType
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
 
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
-    {
+    public function __construct(
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EntityManagerInterface $em
+    ) {
         $this->dj = $dj;
         $this->em = $em;
+        $this->config = $config;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $allowMultipleFiles = $this->dj->dbconfig_get('sourcefiles_limit', 100) > 1;
+        $allowMultipleFiles = $this->config->get('sourcefiles_limit') > 1;
         $user               = $this->dj->getUser();
         $contest            = $this->dj->getCurrentContest($user->getTeamid());
 

--- a/webapp/src/Form/Type/TeamClarificationType.php
+++ b/webapp/src/Form/Type/TeamClarificationType.php
@@ -3,6 +3,7 @@
 namespace App\Form\Type;
 
 use App\Entity\ContestProblem;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -16,9 +17,17 @@ class TeamClarificationType extends AbstractType
      */
     protected $dj;
 
-    public function __construct(DOMJudgeService $dj)
-    {
-        $this->dj = $dj;
+    /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    public function __construct(
+        DOMJudgeService $dj,
+        ConfigurationService $config
+    ) {
+        $this->dj     = $dj;
+        $this->config = $config;
     }
 
     /**
@@ -36,7 +45,7 @@ class TeamClarificationType extends AbstractType
 
         $subjects = [];
         /** @var string[] $categories */
-        $categories = $this->dj->dbconfig_get('clar_categories');
+        $categories = $this->config->get('clar_categories');
         $user       = $this->dj->getUser();
         $contest    = $this->dj->getCurrentContest($user->getTeamid());
         foreach ($categories as $categoryId => $categoryName) {

--- a/webapp/src/Form/Type/UserRegistrationType.php
+++ b/webapp/src/Form/Type/UserRegistrationType.php
@@ -5,6 +5,7 @@ namespace App\Form\Type;
 use App\Entity\Team;
 use App\Entity\TeamAffiliation;
 use App\Entity\User;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,19 +33,30 @@ class UserRegistrationType extends AbstractType
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
 
     /**
      * UserRegistrationType constructor.
+     *
      * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      * @param EntityManagerInterface $em
      */
-    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
-    {
-        $this->dj = $dj;
-        $this->em = $em;
+    public function __construct(
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EntityManagerInterface $em
+    ) {
+        $this->dj     = $dj;
+        $this->config = $config;
+        $this->em     = $em;
     }
 
     /**
@@ -85,7 +97,7 @@ class UserRegistrationType extends AbstractType
                 'mapped' => false,
             ]);
 
-        if ($this->dj->dbconfig_get('show_affiliations', true)) {
+        if ($this->config->get('show_affiliations')) {
             $countries = [];
             foreach (Utils::ALPHA3_COUNTRIES as $alpha3 => $country) {
                 $countries["$country ($alpha3)"] = $alpha3;
@@ -174,7 +186,7 @@ class UserRegistrationType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $validateAffiliation = function ($data, ExecutionContext $context) {
-            if ($this->dj->dbconfig_get('show_affiliations', true)) {
+            if ($this->config->get('show_affiliations')) {
                 /** @var Form $form */
                 $form = $context->getRoot();
                 switch ($form->get('affiliation')->getData()) {

--- a/webapp/src/Migrations/Version20200111104226.php
+++ b/webapp/src/Migrations/Version20200111104226.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Service\ConfigurationService;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200111104226 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'remove unneeded columns from the configuration table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX public ON configuration');
+        $this->addSql('ALTER TABLE configuration DROP type, DROP public, DROP category, DROP description');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE configuration
+    ADD type VARCHAR(32) DEFAULT \'NULL\' COLLATE utf8mb4_unicode_ci COMMENT \'Type of the value (metatype for use in the webinterface)\',
+    ADD public TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Is this variable publicly visible?\',
+    ADD category VARCHAR(32) DEFAULT \'Uncategorized\' NOT NULL COLLATE utf8mb4_unicode_ci COMMENT \'Option category of the configuration variable\',
+    ADD description VARCHAR(255) DEFAULT \'NULL\' COLLATE utf8mb4_unicode_ci COMMENT \'Description for in the webinterface\'');
+        $this->addSql('CREATE INDEX public ON configuration (public)');
+
+        // We also need to add back the type, category,  public and description values
+        $configService = $this->container->get(ConfigurationService::class);
+        $specs         = $configService->getConfigSpecification();
+        foreach ($specs as $name => $spec) {
+            $this->addSql(
+                'UPDATE configuration SET type = :type, category = :category, public = :public, description = :description WHERE name = :name',
+                [
+                    'name' => $name,
+                    'type' => $spec['type'],
+                    'category' => $spec['category'],
+                    'public' => (int)$spec['public'],
+                    'description' => $spec['description'],
+                ]
+            );
+        }
+    }
+}

--- a/webapp/src/Migrations/Version20200111104415.php
+++ b/webapp/src/Migrations/Version20200111104415.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Service\ConfigurationService;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200111104415 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'remove configuration options with default values';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $configService = $this->container->get(ConfigurationService::class);
+        $specs         = $configService->getConfigSpecification();
+        $allConfig     = $configService->all();
+
+        foreach ($allConfig as $name => $value) {
+            if ($value == ($specs[$name]['default_value'] ?? null)) {
+                $this->addSql(
+                    'DELETE FROM configuration WHERE name = :name',
+                    ['name' => $name]
+                );
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $configService = $this->container->get(ConfigurationService::class);
+        $allConfig     = $configService->all();
+
+        foreach ($allConfig as $name => $value) {
+            $this->addSql(
+                'INSERT INTO configuration (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE configid=configid',
+                ['name' => $name, 'value' => json_encode($value, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES)]
+            );
+        }
+    }
+}

--- a/webapp/src/Security/DOMJudgeIPAuthenticator.php
+++ b/webapp/src/Security/DOMJudgeIPAuthenticator.php
@@ -3,6 +3,7 @@
 namespace App\Security;
 
 use App\Entity\User;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -28,16 +29,17 @@ class DOMJudgeIPAuthenticator extends AbstractGuardAuthenticator
     private $csrfTokenManager;
     private $security;
     private $em;
-    private $dj;
+    private $config;
     private $router;
     private $requestStack;
 
     /**
      * DOMJudgeIPAuthenticator constructor.
+     *
      * @param CsrfTokenManagerInterface $csrfTokenManager
      * @param Security                  $security
      * @param EntityManagerInterface    $em
-     * @param DOMJudgeService           $dj
+     * @param ConfigurationService      $config
      * @param RouterInterface           $router
      * @param RequestStack              $requestStack
      */
@@ -45,14 +47,14 @@ class DOMJudgeIPAuthenticator extends AbstractGuardAuthenticator
         CsrfTokenManagerInterface $csrfTokenManager,
         Security $security,
         EntityManagerInterface $em,
-        DOMJudgeService $dj,
+        ConfigurationService $config,
         RouterInterface $router,
         RequestStack $requestStack
     ) {
         $this->csrfTokenManager = $csrfTokenManager;
         $this->security         = $security;
         $this->em               = $em;
-        $this->dj               = $dj;
+        $this->config           = $config;
         $this->router           = $router;
         $this->requestStack     = $requestStack;
     }
@@ -63,7 +65,7 @@ class DOMJudgeIPAuthenticator extends AbstractGuardAuthenticator
     public function supports(Request $request)
     {
         // Make sure ipaddress auth is enabled.
-        $authmethods          = $this->dj->dbconfig_get('auth_methods', []);
+        $authmethods          = $this->config->get('auth_methods');
         $auth_allow_ipaddress = in_array('ipaddress', $authmethods);
         if (!$auth_allow_ipaddress) {
             return false;
@@ -81,7 +83,7 @@ class DOMJudgeIPAuthenticator extends AbstractGuardAuthenticator
             'security.firewall.map.context.api',
         ];
         $fwcontext             = $request->attributes->get('_firewall_context', '');
-        $ipAutologin           = $this->dj->dbconfig_get('ip_autologin', false);
+        $ipAutologin           = $this->config->get('ip_autologin');
         if (in_array($fwcontext, $stateless_fw_contexts) || $ipAutologin) {
             return true;
         }

--- a/webapp/src/Security/DOMJudgeXHeadersAuthenticator.php
+++ b/webapp/src/Security/DOMJudgeXHeadersAuthenticator.php
@@ -2,7 +2,7 @@
 
 namespace App\Security;
 
-use App\Service\DOMJudgeService;
+use App\Service\ConfigurationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,26 +23,27 @@ class DOMJudgeXHeadersAuthenticator extends AbstractGuardAuthenticator
 
     private $security;
     private $encoder;
-    private $dj;
+    private $config;
     private $router;
 
     /**
      * DOMJudgeXHeadersAuthenticator constructor.
+     *
      * @param Security                     $security
      * @param UserPasswordEncoderInterface $encoder
-     * @param DOMJudgeService              $dj
+     * @param ConfigurationService         $config
      * @param RouterInterface              $router
      */
     public function __construct(
         Security $security,
         UserPasswordEncoderInterface $encoder,
-        DOMJudgeService $dj,
+        ConfigurationService $config,
         RouterInterface $router
     ) {
-        $this->security  = $security;
-        $this->encoder   = $encoder;
-        $this->dj        = $dj;
-        $this->router    = $router;
+        $this->security = $security;
+        $this->encoder  = $encoder;
+        $this->config   = $config;
+        $this->router   = $router;
     }
 
     /**
@@ -52,7 +53,7 @@ class DOMJudgeXHeadersAuthenticator extends AbstractGuardAuthenticator
      */
     public function supports(Request $request)
     {
-        $authmethods = $this->dj->dbconfig_get('auth_methods', []);
+        $authmethods = $this->config->get('auth_methods');
         $auth_allow_xheaders = in_array('xheaders', $authmethods);
         if (!$auth_allow_xheaders) {
             return false;

--- a/webapp/src/Serializer/ContestVisitor.php
+++ b/webapp/src/Serializer/ContestVisitor.php
@@ -3,6 +3,7 @@
 namespace App\Serializer;
 
 use App\Entity\Contest;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
@@ -17,17 +18,18 @@ use JMS\Serializer\Metadata\StaticPropertyMetadata;
 class ContestVisitor implements EventSubscriberInterface
 {
     /**
-     * @var DOMJudgeService
+     * @var ConfigurationService
      */
-    private $dj;
+    protected $config;
 
     /**
      * ContestVisitor constructor.
-     * @param DOMJudgeService $dj
+     *
+     * @param ConfigurationService $config
      */
-    public function __construct(DOMJudgeService $dj)
+    public function __construct(ConfigurationService $config)
     {
-        $this->dj = $dj;
+        $this->config = $config;
     }
 
     /**
@@ -58,6 +60,6 @@ class ContestVisitor implements EventSubscriberInterface
             'penalty_time',
             null
         );
-        $visitor->visitProperty($property, (int)$this->dj->dbconfig_get('penalty_time'));
+        $visitor->visitProperty($property, (int)$this->config->get('penalty_time'));
     }
 }

--- a/webapp/src/Service/BalloonService.php
+++ b/webapp/src/Service/BalloonService.php
@@ -16,21 +16,22 @@ class BalloonService
     protected $em;
 
     /**
-     * @var DOMJudgeService
+     * @var ConfigurationService
      */
-    protected $dj;
+    protected $config;
 
     /**
      * BalloonService constructor.
+     *
      * @param EntityManagerInterface $em
-     * @param DOMJudgeService        $dj
+     * @param ConfigurationService   $config
      */
     public function __construct(
         EntityManagerInterface $em,
-        DOMJudgeService $dj
+        ConfigurationService $config
     ) {
-        $this->em = $em;
-        $this->dj = $dj;
+        $this->em     = $em;
+        $this->config = $config;
     }
 
     /**
@@ -62,7 +63,7 @@ class BalloonService
 
         // Also make sure it is verified if this is required
         if (!$judging->getVerified() &&
-            $this->dj->dbconfig_get('verification_required', false)) {
+            $this->config->get('verification_required')) {
             return;
         }
 

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -29,6 +29,11 @@ class CheckConfigService
     protected $em;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var DOMJudgeService
      */
     protected $dj;
@@ -56,6 +61,7 @@ class CheckConfigService
     public function __construct(
         bool $debug,
         EntityManagerInterface $em,
+        ConfigurationService $config,
         DOMJudgeService $dj,
         EventLogService $eventLogService,
         RouterInterface $router,
@@ -63,6 +69,7 @@ class CheckConfigService
     ) {
         $this->debug           = $debug;
         $this->em              = $em;
+        $this->config          = $config;
         $this->dj              = $dj;
         $this->eventLogService = $eventLogService;
         $this->router          = $router;
@@ -159,7 +166,7 @@ class CheckConfigService
 
     public function checkPhpSettings()
     {
-        $sourcefiles_limit = $this->config->get('sourcefiles_limit', 100);
+        $sourcefiles_limit = $this->config->get('sourcefiles_limit');
         $max_files = ini_get('max_file_uploads');
 
         /* PHP will silently discard any files above the max_file_uploads limit,

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -159,7 +159,7 @@ class CheckConfigService
 
     public function checkPhpSettings()
     {
-        $sourcefiles_limit = $this->dj->dbconfig_get('sourcefiles_limit', 100);
+        $sourcefiles_limit = $this->config->get('sourcefiles_limit', 100);
         $max_files = ini_get('max_file_uploads');
 
         /* PHP will silently discard any files above the max_file_uploads limit,
@@ -279,7 +279,7 @@ class CheckConfigService
 
         $scripts = ['compare', 'run'];
         foreach ($scripts as $type) {
-            $scriptid = $this->dj->dbconfig_get('default_' . $type);
+            $scriptid = $this->config->get('default_' . $type);
             if (!$this->em->getRepository(Executable::class)->find($scriptid)) {
                 $res = 'E';
                 $desc .= sprintf("The default %s script '%s' does not exist.\n", $type, $scriptid);
@@ -295,8 +295,8 @@ class CheckConfigService
 
     public function checkScriptFilesizevsMemoryLimit()
     {
-        if ($this->dj->dbconfig_get('script_filesize_limit') <
-            $this->dj->dbconfig_get('memory_limit')) {
+        if ($this->config->get('script_filesize_limit') <
+            $this->config->get('memory_limit')) {
              $result = 'W';
         } else {
              $result = 'O';
@@ -410,8 +410,8 @@ class CheckConfigService
     public function checkProblemsValidate()
     {
         $problems = $this->em->getRepository(Problem::class)->findAll();
-        $script_filesize_limit = $this->dj->dbconfig_get('script_filesize_limit');
-        $output_limit = $this->dj->dbconfig_get('output_limit');
+        $script_filesize_limit = $this->config->get('script_filesize_limit');
+        $output_limit = $this->config->get('output_limit');
 
         $problemerrors = $scripterrors = [];
         $result = 'O';
@@ -496,7 +496,7 @@ class CheckConfigService
     public function checkLanguagesValidate()
     {
         $languages = $this->em->getRepository(Language::class)->findAll();
-        $script_filesize_limit = $this->dj->dbconfig_get('script_filesize_limit');
+        $script_filesize_limit = $this->config->get('script_filesize_limit');
 
         $languageerrors = $scripterrors = [];
         $result = 'O';
@@ -591,8 +591,8 @@ class CheckConfigService
 
     public function checkAffiliations()
     {
-        $show_logos = $this->dj->dbconfig_get('show_affiliation_logos');
-        $show_flags = $this->dj->dbconfig_get('show_flags');
+        $show_logos = $this->config->get('show_affiliation_logos');
+        $show_flags = $this->config->get('show_flags');
 
         if (!$show_logos && !$show_flags) {
             return ['caption' => 'Team affiliations',

--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -1,0 +1,209 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Config\Loader\YamlConfigLoader;
+use App\Entity\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * Class ConfigurationService
+ *
+ * @package App\Service
+ */
+class ConfigurationService
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var ConfigCacheFactoryInterface
+     */
+    protected $configCache;
+
+    /**
+     * @var bool
+     */
+    protected $debug;
+
+    /**
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
+     * @var string
+     */
+    protected $etcDir;
+
+    /**
+     * @var array
+     */
+    protected $dbConfigCache = [];
+
+    /**
+     * ConfigurationService constructor.
+     *
+     * @param EntityManagerInterface      $em
+     * @param LoggerInterface             $logger
+     * @param ConfigCacheFactoryInterface $configCache
+     * @param bool                        $debug
+     * @param string                      $cacheDir
+     * @param string                      $etcDir
+     */
+    public function __construct(
+        EntityManagerInterface $em,
+        LoggerInterface $logger,
+        ConfigCacheFactoryInterface $configCache,
+        bool $debug,
+        string $cacheDir,
+        string $etcDir
+    ) {
+        $this->em          = $em;
+        $this->logger      = $logger;
+        $this->configCache = $configCache;
+        $this->debug       = $debug;
+        $this->cacheDir    = $cacheDir;
+        $this->etcDir      = $etcDir;
+    }
+
+    /**
+     * Get the value for the given configuration name
+     *
+     * @param string $name         The config name to get the value of
+     * @param bool   $onlyIfPublic Only return the value if the config is
+     *                             public
+     *
+     * @return mixed The configuration value
+     * @throws Exception If the config can't be found and not default is
+     *                   supplied
+     */
+    public function get(string $name, bool $onlyIfPublic = false)
+    {
+        $spec    = $this->getConfigSpecification()[$name] ?? null;
+        $dbValue = $this->getDbValues()[$name] ?? null;
+
+        if (isset($spec)) {
+            if ($onlyIfPublic && !$spec['public']) {
+                // If we require public values and the spec is not public,
+                // set the value from the DB to null to not have a value
+                $dbValue = null;
+            }
+        }
+
+        if (isset($dbValue)) {
+            return $dbValue;
+        } elseif (!array_key_exists('default_value', $spec)) {
+            throw new Exception("Configuration variable '$name' not found.");
+        } else {
+            return $spec['default_value'];
+        }
+    }
+
+    /**
+     * Get all the configuration values, indexed by name
+     *
+     * @param bool $onlyIfPublic
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function all(bool $onlyIfPublic = false): array
+    {
+        $specs  = $this->getConfigSpecification();
+        $result = [];
+        foreach ($specs as $name => $spec) {
+            if (!$onlyIfPublic || $spec['public']) {
+                $result[$name] = $spec['default_value'];
+            }
+        }
+
+        foreach ($this->getDbValues() as $name => $value) {
+            if (!isset($result[$name])) {
+                $this->logger->warning(
+                    'Configuration value %s not defined', [$name]
+                );
+                continue;
+            }
+            if (!$onlyIfPublic ||
+                (isset($specs[$name]) && $specs[$name]['public'])) {
+                $result[$name] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get all configuration specifications
+     *
+     * @throws Exception
+     */
+    public function getConfigSpecification(): array
+    {
+        // We use Symfony resource caching so we can load the config on every
+        // request without having a performance impact.
+        // See https://symfony.com/doc/4.3/components/config/caching.html for
+        // more information.
+        $cacheFile = $this->cacheDir . '/djDbConfig.php';
+        $this->configCache->cache($cacheFile,
+            function (ConfigCacheInterface $cache) {
+                $yamlDbConfigFile = $this->etcDir . '/db-config.yaml';
+                $fileLocator      = new FileLocator($this->etcDir);
+                $loader           = new YamlConfigLoader($fileLocator);
+                $yamlConfig       = $loader->load($yamlDbConfigFile);
+
+                // We first modify the data such that it contains the category as a field,
+                //since requesting data is faster in that case
+                $config = [];
+                foreach ($yamlConfig as $category) {
+                    foreach ($category['items'] as $item) {
+                        $config[$item['name']] = $item + ['category' => $category['category']];
+                    }
+                }
+
+                $code          = var_export($config, true);
+                $specification = <<<EOF
+<?php
+
+return {$code};
+EOF;
+
+                $cache->write($specification,
+                    [new FileResource($yamlDbConfigFile)]);
+            });
+
+        $specification = require $cacheFile;
+        return $specification;
+    }
+
+    /**
+     * Get the configuration values from the database
+     *
+     * @return array
+     */
+    protected function getDbValues(): array
+    {
+        if (empty($this->dbConfigCache)) {
+            $configs = $this->em->getRepository(Configuration::class)->findAll();
+            foreach ($configs as $config) {
+                $this->dbConfigCache[$config->getName()] = $config->getValue();
+            }
+        }
+
+        return $this->dbConfigCache;
+    }
+}

--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -93,7 +93,7 @@ class ConfigurationService
      */
     public function get(string $name, bool $onlyIfPublic = false)
     {
-        $spec = $this->getConfigSpecification()[$name];
+        $spec = $this->getConfigSpecification()[$name] ?? null;
 
         if (!isset($spec) || ($onlyIfPublic && !$spec['public'])) {
             throw new Exception("Configuration variable '$name' not found.");
@@ -148,6 +148,7 @@ class ConfigurationService
         $cacheFile = $this->cacheDir . '/djDbConfig.php';
         $this->configCache->cache($cacheFile,
             function (ConfigCacheInterface $cache) {
+                // @codeCoverageIgnoreStart
                 $yamlDbConfigFile = $this->etcDir . '/db-config.yaml';
                 $fileLocator      = new FileLocator($this->etcDir);
                 $loader           = new YamlConfigLoader($fileLocator);
@@ -171,6 +172,7 @@ EOF;
 
                 $cache->write($specification,
                     [new FileResource($yamlDbConfigFile)]);
+                // @codeCoverageIgnoreEnd
             });
 
         $specification = require $cacheFile;

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -136,6 +136,11 @@ class EventLogService implements ContainerAwareInterface
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
@@ -147,10 +152,12 @@ class EventLogService implements ContainerAwareInterface
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EntityManagerInterface $em,
         LoggerInterface $logger
     ) {
         $this->dj     = $dj;
+        $this->config = $config;
         $this->em     = $em;
         $this->logger = $logger;
 
@@ -912,8 +919,7 @@ class EventLogService implements ContainerAwareInterface
         if ($endpointData[self::KEY_ALWAYS_USE_EXTERNAL_ID] ?? false) {
             $lookupExternalid = true;
         } else {
-            $dataSource = $this->dj->dbconfig_get('data_source',
-                                                  DOMJudgeService::DATA_SOURCE_LOCAL);
+            $dataSource = $this->config->get('data_source');
 
             if ($dataSource !== DOMJudgeService::DATA_SOURCE_LOCAL) {
                 $endpointType = $endpointData[self::KEY_TYPE];

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -45,6 +45,11 @@ class ImportExportService
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
@@ -58,12 +63,14 @@ class ImportExportService
         EntityManagerInterface $em,
         ScoreboardService $scoreboardService,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         ValidatorInterface $validator
     ) {
         $this->em                = $em;
         $this->scoreboardService = $scoreboardService;
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->eventLogService   = $eventLogService;
         $this->validator         = $validator;
     }
@@ -90,9 +97,9 @@ class ImportExportService
                 true);
         }
         $data = array_merge($data, [
-            'penalty-time' => $this->dj->dbconfig_get('penalty_time'),
-            'default-clars' => $this->dj->dbconfig_get('clar_answers'),
-            'clar-categories' => array_values($this->dj->dbconfig_get('clar_categories')),
+            'penalty-time' => $this->config->get('penalty_time'),
+            'default-clars' => $this->config->get('clar_answers'),
+            'clar-categories' => array_values($this->config->get('clar_categories')),
             'languages' => [],
             'problems' => [],
         ]);
@@ -316,7 +323,7 @@ class ImportExportService
         if ($contest === null) {
             throw new BadRequestHttpException('No current contest');
         }
-        $scoreIsInSeconds = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
         $scoreboard       = $this->scoreboardService->getScoreboard($contest, true);
 
         $data = [];
@@ -382,7 +389,7 @@ class ImportExportService
             $categoryIds[] = $category->getCategoryid();
         }
 
-        $scoreIsInSeconds = (bool)$this->dj->dbconfig_get('score_in_seconds', false);
+        $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
         $filter           = new Filter();
         $filter->setCategories($categoryIds);
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -44,6 +44,11 @@ class ImportProblemService
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var SubmissionService
      */
     protected $submissionService;
@@ -62,6 +67,7 @@ class ImportProblemService
         EntityManagerInterface $em,
         LoggerInterface $logger,
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         SubmissionService $submissionService,
         ValidatorInterface $validator
@@ -69,6 +75,7 @@ class ImportProblemService
         $this->em                = $em;
         $this->logger            = $logger;
         $this->dj                = $dj;
+        $this->config            = $config;
         $this->eventLogService   = $eventLogService;
         $this->submissionService = $submissionService;
         $this->validator         = $validator;
@@ -422,7 +429,7 @@ class ImportProblemService
                                                   $imageFileName, $imageType);
                             $imageFile  = false;
                         } else {
-                            $thumbnailSize = $this->dj->dbconfig_get('thumbnail_size', 128);
+                            $thumbnailSize = $this->config->get('thumbnail_size');
                             $imageThumb    = Utils::getImageThumb(
                                 $imageFile, $thumbnailSize,
                                 $this->dj->getDomjudgeTmpDir(),
@@ -604,7 +611,7 @@ class ImportProblemService
                         $source = $zip->getFromIndex($indices[$k]);
                         if ($results === null) {
                             $results = SubmissionService::getExpectedResults($source,
-                                $this->dj->dbconfig_get('results_remap', []));
+                                $this->config->get('results_remap'));
                         }
                         if (!($tempFileName = tempnam($tmpDir, 'ref_solution-'))) {
                             throw new ServiceUnavailableHttpException(null,
@@ -643,7 +650,7 @@ class ImportProblemService
                     if (isset($submission_details[$path]['entry_point'])) {
                         $entry_point = $submission_details[$path]['entry_point'];
                     }
-                    if ($totalSize <= $this->dj->dbconfig_get('sourcesize_limit') * 1024) {
+                    if ($totalSize <= $this->config->get('sourcesize_limit') * 1024) {
                         $contest        = $this->em->getRepository(Contest::class)->find(
                             $contest->getCid());
                         $team           = $this->em->getRepository(Team::class)->find($jury_team_id);

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -9,6 +9,7 @@ use App\Entity\Language;
 use App\Entity\Submission;
 use App\Entity\SubmissionFile;
 use App\Entity\Testcase;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\SubmissionService;
@@ -27,6 +28,11 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      * @var DOMJudgeService
      */
     protected $dj;
+
+    /**
+     * @var ConfigurationService
+     */
+    protected $config;
 
     /**
      * @var EntityManagerInterface
@@ -60,6 +66,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EntityManagerInterface $em,
         SubmissionService $submissionService,
         EventLogService $eventLogService,
@@ -68,6 +75,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         string $projectDir
     ) {
         $this->dj                   = $dj;
+        $this->config               = $config;
         $this->em                   = $em;
         $this->submissionService    = $submissionService;
         $this->eventLogService      = $eventLogService;
@@ -136,10 +144,10 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             'current_contests' => $this->dj->getCurrentContests(),
             'current_public_contest' => $this->dj->getCurrentContest(-1),
             'current_public_contests' => $this->dj->getCurrentContests(-1),
-            'have_printing' => $this->dj->dbconfig_get('print_command', ''),
+            'have_printing' => $this->config->get('print_command'),
             'refresh_flag' => $refresh_flag,
             'icat_url' => defined('ICAT_URL') ? ICAT_URL : null,
-            'external_ccs_submission_url' => $this->dj->dbconfig_get('external_ccs_submission_url', ''),
+            'external_ccs_submission_url' => $this->config->get('external_ccs_submission_url'),
             'current_team_contest' => $team ? $this->dj->getCurrentContest($user->getTeamid()) : null,
             'current_team_contests' => $team ? $this->dj->getCurrentContests($user->getTeamid()) : null,
             'submission_languages' => $this->em->createQueryBuilder()
@@ -151,7 +159,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             'alpha3_countries' => Utils::ALPHA3_COUNTRIES,
             'show_shadow_differences' => $this->tokenStorage->getToken() &&
                                          $this->authorizationChecker->isGranted('ROLE_ADMIN') &&
-                                         $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL) === DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
+                                         $this->config->get('data_source') === DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
         ];
     }
 
@@ -179,7 +187,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         if ($datetime === null) {
             $datetime = Utils::now();
         }
-        if ($contest !== null && $this->dj->dbconfig_get('show_relative_time', false)) {
+        if ($contest !== null && $this->config->get('show_relative_time')) {
             $relativeTime = $contest->getContestTime((float)$datetime);
             $sign         = ($relativeTime < 0 ? -1 : 1);
             $relativeTime *= $sign;
@@ -202,7 +210,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             }
         } else {
             if ($format === null) {
-                $format = $this->dj->dbconfig_get('time_format', '%H:%M');
+                $format = $this->config->get('time_format');
             }
             return Utils::printtime($datetime, $format);
         }
@@ -497,9 +505,9 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     {
         require_once $this->dj->getDomjudgeEtcDir() . '/domserver-config.php';
 
-        $extCcsUrl = $this->dj->dbconfig_get('external_ccs_submission_url', '');
+        $extCcsUrl = $this->config->get('external_ccs_submission_url');
         if (!empty($extCcsUrl)) {
-            $dataSource = $this->dj->dbconfig_get('data_source', DOMJudgeService::DATA_SOURCE_LOCAL);
+            $dataSource = $this->config->get('data_source');
             if ($dataSource == 2) {
                 return str_replace(['[contest]', '[id]'], [$submission->getContest()->getExternalid(), $submission->getExternalid()], $extCcsUrl);
             } elseif ($dataSource == 1) {
@@ -885,7 +893,7 @@ JS;
      */
     public function scoreTime($time)
     {
-        return Utils::scoretime($time, (bool)$this->dj->dbconfig_get('score_in_seconds', false));
+        return Utils::scoretime($time, (bool)$this->config->get('score_in_seconds'));
     }
 
     /**
@@ -897,8 +905,8 @@ JS;
      */
     public function calculatePenaltyTime(bool $solved, int $num_submissions)
     {
-        return Utils::calcPenaltyTime($solved, $num_submissions, (int)$this->dj->dbconfig_get('penalty_time', 20),
-                                      (bool)$this->dj->dbconfig_get('score_in_seconds', false));
+        return Utils::calcPenaltyTime($solved, $num_submissions, (int)$this->config->get('penalty_time'),
+                                      (bool)$this->config->get('score_in_seconds'));
     }
 
     /**

--- a/webapp/tests/Service/ScoreboardServiceTest.php
+++ b/webapp/tests/Service/ScoreboardServiceTest.php
@@ -1,0 +1,349 @@
+<?php declare(strict_types=1);
+
+namespace Service;
+
+use App\Entity\Configuration;
+use App\Service\ConfigurationService;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Generator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ScoreboardServiceTest extends KernelTestCase
+{
+    /**
+     * @var EntityManagerInterface|MockObject
+     */
+    private $em;
+
+    /**
+     * @var ObjectRepository|MockObject
+     */
+    private $configRepository;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * @var ConfigurationService
+     */
+    private $config;
+
+    /**
+     * @var array
+     */
+    private $dbConfig;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        self::bootKernel();
+
+        $this->em               = $this->createMock(EntityManagerInterface::class);
+        $this->configRepository = $this->createMock(ObjectRepository::class);
+        $this->em->expects($this->any())
+            ->method('getRepository')
+            ->with(Configuration::class)
+            ->willReturn($this->configRepository);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->config = new ConfigurationService(
+            $this->em, $this->logger,
+            self::$container->get('config_cache_factory'),
+            self::$container->getParameter('kernel.debug'),
+            self::$container->getParameter('kernel.cache_dir'),
+            self::$container->getParameter('domjudge.etcdir')
+        );
+
+        $this->dbConfig = Yaml::parseFile(
+            self::$container->getParameter('domjudge.etcdir') . '/db-config.yaml'
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown()
+    {
+        $this->em     = null;
+        $this->logger = null;
+        $this->config = null;
+    }
+
+    /**
+     * @dataProvider provideConfigDefaults
+     *
+     * @param string $categoryName
+     * @param string $itemName
+     *
+     * @throws Exception
+     */
+    public function testConfigDefaults(string $categoryName, string $itemName)
+    {
+        $foundItem = $this->findItem($categoryName, $itemName);
+
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $defaultValue = $foundItem['default_value'];
+        $this->assertSame($defaultValue, $this->config->get($itemName));
+    }
+
+    /**
+     * @dataProvider provideConfigDefaults
+     *
+     * @param string $categoryName
+     * @param string $itemName
+     *
+     * @throws Exception
+     */
+    public function testConfigDefaultsAll(
+        string $categoryName,
+        string $itemName
+    ) {
+        $foundItem = $this->findItem($categoryName, $itemName);
+
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $defaultValue = $foundItem['default_value'];
+        $all          = $this->config->all();
+        $this->assertSame($defaultValue, $all[$itemName]);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideConfigDefaults()
+    {
+        yield ['Scoring', 'compile_penalty'];
+        yield ['Scoring', 'results_prio'];
+        yield ['Clarification', 'clar_categories'];
+        yield ['Display', 'show_compile'];
+        yield ['Display', 'time_format'];
+    }
+
+    /**
+     * @dataProvider provideInvalidItem
+     * @expectedException Exception
+     * @expectedExceptionMessageRegExp /^Configuration variable '.*' not found\.$/
+     *
+     * @param string $itemName
+     * @param bool   $publicOnly
+     */
+    public function testInvalidItem(string $itemName, bool $publicOnly)
+    {
+        $this->configRepository->expects($this->never())
+            ->method('findAll');
+
+        $this->config->get($itemName, $publicOnly);
+    }
+
+    public function provideInvalidItem()
+    {
+        yield ['does_not_exist', false]; // This item does not exist
+        yield ['does_not_exist', true];
+        yield ['results_prio', true]; // This item exists but is non-public
+    }
+
+    /**
+     * @dataProvider provideConfigFromDatabase
+     *
+     * @param string $itemName
+     * @param mixed  $dbValue
+     *
+     * @param null   $expectedValue
+     *
+     * @throws Exception
+     */
+    public function testConfigFromDatabase(
+        string $itemName,
+        $dbValue,
+        $expectedValue = null
+    ) {
+        $config = new Configuration();
+        $config
+            ->setName($itemName)
+            ->setValue($dbValue);
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$config]);
+
+        if ($expectedValue === null) {
+            $expectedValue = $dbValue;
+        }
+
+        $this->assertSame($expectedValue, $this->config->get($itemName));
+        // Also make sure it doesn't change other items by testing a different one
+        $openIdAuthItem = $this->findItem('Authentication', 'openid_provider');
+        $this->assertSame(
+            $openIdAuthItem['default_value'],
+            $this->config->get('openid_provider')
+        );
+    }
+
+    /**
+     * @dataProvider provideConfigFromDatabase
+     *
+     * @param string $itemName
+     * @param mixed  $dbValue
+     *
+     * @param null   $expectedValue
+     *
+     * @throws Exception
+     */
+    public function testConfigFromDatabaseAll(
+        string $itemName,
+        $dbValue,
+        $expectedValue = null
+    ) {
+        $config = new Configuration();
+        $config
+            ->setName($itemName)
+            ->setValue($dbValue);
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$config]);
+
+        if ($expectedValue === null) {
+            $expectedValue = $dbValue;
+        }
+
+        $all = $this->config->all();
+        $this->assertSame($expectedValue, $all[$itemName]);
+        // Also make sure it doesn't change other items by testing a different one
+        $openIdAuthItem = $this->findItem('Authentication', 'openid_provider');
+        $this->assertSame(
+            $openIdAuthItem['default_value'], $all['openid_provider']
+        );
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideConfigFromDatabase()
+    {
+        yield ['compile_penalty', true, 1];
+        yield ['results_prio', ['no-output' => 37, 'correct' => 1]];
+        yield ['clar_categories', ['Category 1', 'Category 2']];
+        yield ['show_compile', 1];
+        yield ['time_format', '%H:%M:%s'];
+    }
+
+    /**
+     * @dataProvider provideAllHidesNonPublic
+     *
+     * @param string $itemName
+     *
+     * @throws Exception
+     */
+    public function testAllHidesNonPublic(string $itemName)
+    {
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $all = $this->config->all(true);
+        $this->assertArrayNotHasKey($itemName, $all);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideAllHidesNonPublic()
+    {
+        yield ['verification_required'];
+        yield ['script_timelimit'];
+        yield ['default_run'];
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUnknownConfigsNonPublic()
+    {
+        $unknownItems = [
+            (new Configuration())
+                ->setName('unknown1')
+                ->setValue('foobar'),
+            (new Configuration())
+                ->setName('unknown2')
+                ->setValue('barfoo'),
+        ];
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn($unknownItems);
+        $this->logger->expects($this->exactly(2))
+            ->method('warning')
+            ->withConsecutive(
+                ['Configuration value %s not defined', ['unknown1']],
+                ['Configuration value %s not defined', ['unknown2']]
+            );
+
+        $all = $this->config->all();
+        $this->assertArrayNotHasKey('unknown1', $all);
+        $this->assertArrayNotHasKey('unknown2', $all);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUnknownConfigsPublic()
+    {
+        $unknownItems = [
+            (new Configuration())
+                ->setName('unknown1')
+                ->setValue('foobar'),
+            (new Configuration())
+                ->setName('unknown2')
+                ->setValue('barfoo'),
+        ];
+        $this->configRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn($unknownItems);
+        $this->logger->expects($this->never())
+            ->method('warning');
+
+        $all = $this->config->all(true);
+        $this->assertArrayNotHasKey('unknown1', $all);
+        $this->assertArrayNotHasKey('unknown2', $all);
+    }
+
+    /**
+     * Find a config item specification
+     *
+     * @param string $categoryName
+     * @param string $itemName
+     *
+     * @return array|null
+     */
+    protected function findItem(string $categoryName, string $itemName)
+    {
+        $foundItem = null;
+        foreach ($this->dbConfig as $category) {
+            if ($category['category'] === $categoryName) {
+                foreach ($category['items'] as $item) {
+                    if ($item['name'] === $itemName) {
+                        $foundItem = $item;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $this->assertNotNull(
+            $foundItem, 'Config item not found in db-config.yaml'
+        );
+
+        return $foundItem;
+    }
+}


### PR DESCRIPTION
So after checking the Symfony docs a bit, I found this thing that allows us to basically 'cache' a YAML file in the Symfony cache directory, which IMHO gives us the best of all worlds:

* The spec of the config is completely outside the database and in a readable YAML file.
* We can 'load the YAML' for every request without performance impact, since we actually load the cached PHP file. In dev-mode Symfony automatically re-caches the file when it changed and in prod mode it only does this if you clear the Symfony cache.

I put the configuration logic in a separate service, since IMHO that makes sense.

The migrations are a bit 'messy': I have build in support for rolling it back and I remove all configuration options from the database that have the default value. I do like the idea that we don't have config options in the DB with the default value and I don't really see how we could do that better without breaking upgrades. The rolling back stuff is then basically 'free'.

Also a lot of the changes is just `s/->dj->dbconfig_get/->config->get` so the PR seems bigger than it actually is I guess.

Input is very much welcome.