### PR TITLE
WIP: scoreboard FTS tests and bugfix

### DIFF
--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -462,22 +462,18 @@ class ScoreboardService
                     tc.sortorder = :teamSortOrder AND
                     round(s.submittime,4) < :submitTime', $params);
             } else {
-                if ($verificationRequired) {
-                    $verificationRequiredExtra = 'OR j.verified = 0';
-                } else {
-                    $verificationRequiredExtra = '';
-                }
-                $firstToSolve = 0 == $this->em->getConnection()->fetchColumn(sprintf('
+                $verificationRequiredExtra = $verificationRequired ? 'OR j.verified = 0' : '';
+                $firstToSolve = 0 == $this->em->getConnection()->fetchColumn('
                 SELECT count(*) FROM submission s
                     LEFT JOIN judging j USING (submitid)
                     LEFT JOIN team t USING(teamid)
                     LEFT JOIN team_category tc USING (categoryid)
                 WHERE s.valid = 1 AND
-                    ((j.valid = 1 AND ( j.rejudgingid IS NULL AND (j.result IS NULL OR j.result = :correctResult %s))) OR
-                      s.judgehost IS NULL) AND
+                    ((j.valid = 1 AND (j.result IS NULL OR j.result = :correctResult '.
+                    $verificationRequiredExtra.')) OR s.judgehost IS NULL) AND
                     s.cid = :cid AND s.probid = :probid AND
                     tc.sortorder = :teamSortOrder AND
-                    round(s.submittime,4) < :submitTime', $verificationRequiredExtra), $params);
+                    round(s.submittime,4) < :submitTime', $params);
             }
         }
 

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -465,12 +465,12 @@ class ScoreboardService
                 $verificationRequiredExtra = $verificationRequired ? 'OR j.verified = 0' : '';
                 $firstToSolve = 0 == $this->em->getConnection()->fetchColumn('
                 SELECT count(*) FROM submission s
-                    LEFT JOIN judging j USING (submitid)
-                    LEFT JOIN team t USING(teamid)
+                    LEFT JOIN judging j ON (s.submitid=j.submitid AND j.valid=1)
+                    LEFT JOIN team t USING (teamid)
                     LEFT JOIN team_category tc USING (categoryid)
                 WHERE s.valid = 1 AND
-                    ((j.valid = 1 AND (j.result IS NULL OR j.result = :correctResult '.
-                    $verificationRequiredExtra.')) OR s.judgehost IS NULL) AND
+                    (j.judgingid IS NULL OR j.result IS NULL OR j.result = :correctResult '.
+                    $verificationRequiredExtra.') AND
                     s.cid = :cid AND s.probid = :probid AND
                     tc.sortorder = :teamSortOrder AND
                     round(s.submittime,4) < :submitTime', $params);

--- a/webapp/tests/Utils/Scoreboard/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Utils/Scoreboard/ScoreboardIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Utils\Scoreboard;
 
+use App\Entity\Configuration;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Judgehost;
@@ -69,6 +70,14 @@ class ScoreboardTest extends KernelTestCase
         $this->dj = self::$container->get(DOMJudgeService::class);
         $this->ss = self::$container->get(ScoreboardService::class);
         $this->em = self::$container->get('doctrine')->getManager();
+
+        // Reset scoring related config to default.
+        $config = $this->em->getRepository(Configuration::class);
+        $config->findOneBy(['name' => 'verification_required'])->setValue(false);
+        $config->findOneBy(['name' => 'penalty_time'])->setValue(20);
+        $config->findOneBy(['name' => 'compile_penalty'])->setValue(false);
+        $config->findOneBy(['name' => 'score_in_seconds'])->setValue(false);
+        $config->findOneBy(['name' => 'data_source'])->setValue(0);
 
         // Create a contest, problems and teams for which to test the
         // scoreboard. These get deleted again in tearDown().
@@ -297,6 +306,7 @@ class ScoreboardTest extends KernelTestCase
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+57.240, null);
 
         $team = $this->teams[1];
+        $this->createSubmission($lang, $this->problems[0], $team, 61*60+00.000, 'compiler-error');
         $this->createSubmission($lang, $this->problems[0], $team, 69*60+00.000, 'correct');
         $this->createSubmission($lang, $this->problems[0], $team, 72*60+07.824, 'wrong-answer');
         $this->createSubmission($lang, $this->problems[1], $team, 72*60+39.733, 'wrong-answer');

--- a/webapp/tests/Utils/Scoreboard/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Utils/Scoreboard/ScoreboardIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Entity\Judgehost;
 use App\Entity\Judging;
 use App\Entity\Language;
 use App\Entity\Problem;
+use App\Entity\Rejudging;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Entity\TeamCategory;
@@ -18,6 +19,7 @@ use App\Utils\Scoreboard\Scoreboard;
 use App\Utils\Scoreboard\SingleTeamScoreboard;
 use App\Utils\Scoreboard\ScoreboardMatrixItem;
 use App\Utils\Scoreboard\TeamScore;
+use App\Utils\Utils;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -52,6 +54,11 @@ class ScoreboardTest extends KernelTestCase
      * @var App\Entity\Judgehost
      */
     private $judgehost;
+
+    /**
+     * @var App\Entity\Rejudging
+     */
+    private $rejudging;
 
     /**
      * @var App\Entity\Problem[]
@@ -101,6 +108,12 @@ class ScoreboardTest extends KernelTestCase
             $this->em->persist($this->judgehost);
         }
 
+        $this->rejudging = new Rejudging();
+        $this->rejudging
+            ->setStarttime(Utils::now())
+            ->setReason(self::CONTEST_NAME);
+        $this->em->persist($this->rejudging);
+
         $category = $this->em->getRepository(TeamCategory::class)
             ->findOneBy(['sortorder' => 0]);
 
@@ -141,6 +154,7 @@ class ScoreboardTest extends KernelTestCase
         if ( !$this->hasFailed() ) {
             $this->em->remove($this->contest);
             $this->em->remove($this->judgehost);
+            $this->em->remove($this->rejudging);
             foreach ($this->teams    as $team)    $this->em->remove($team);
             foreach ($this->problems as $problem) $this->em->remove($problem);
         }
@@ -252,7 +266,7 @@ class ScoreboardTest extends KernelTestCase
 
         $team = $this->teams[0];
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+15.053, 'correct', true)
-            ->getJudgings()[0]->setRejudgingid(1);
+            ->getJudgings()[0]->setRejudgingid($this->rejudging->getRejudgingid());
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+57.240, null);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+59.841, 'wrong-answer');
         $this->createSubmission($lang, $this->problems[1], $team, 61*60+00.000, 'correct', true);
@@ -285,7 +299,7 @@ class ScoreboardTest extends KernelTestCase
 
         $team = $this->teams[0];
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+15.053, 'correct', true)
-            ->getJudgings()[0]->setRejudgingid(1);
+            ->getJudgings()[0]->setRejudgingid($this->rejudging->getRejudgingid());
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+57.240, null);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+59.841, 'wrong-answer');
         $this->createSubmission($lang, $this->problems[1], $team, 61*60+00.000, 'correct', true);


### PR DESCRIPTION
This adds some test for first to solve and tries to fix a bug. However, I think the bugfix creates a new bug:
Currently, if there is a submission with a valid judging that is part of a rejudging, then that submission is not counted towards previous submissions for FTS, leading to multiple teams having FTS for the same problem.
My last commit fixes that, but I think it opens up another bug, when an earlier incorrect submission has `s.judgehost = NULL`, e.g. when it is part of an ongoing rejudging. The issue is, I think, that `s.judgehost = NULL` does not imply that that submission is unjudged, just that it needs to be picked up for (re)judging, which is a subtly different thing