### PR TITLE
Rename team.externalid to team.icpcid. Fixes #655

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ Version 7.3.0 - DEV
 -------------------
  - Move specification of database configuration out of database and into
    a YAML file.
+ - Rename team.externalid to team.icpcid, since it is not an external ID in
+   the sense the other ones are.
 
 Version 7.2.0 - 4 January 2020
 ------------------------------

--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -986,7 +986,7 @@ class ImportEventFeedCommand extends Command
                 $this->em->flush();
                 $this->eventLogService->log('teams', $team->getTeamid(),
                                             EventLogService::ACTION_DELETE,
-                                            $this->contestId, null, $team->getExternalid());
+                                            $this->contestId, null, $team->getTeamid());
                 return;
             } else {
                 $this->logger->error('Cannot delete nonexistent team %s', [ $teamId ]);
@@ -1003,7 +1003,7 @@ class ImportEventFeedCommand extends Command
             $team = new Team();
             $team
                 ->setTeamid($teamId)
-                ->setExternalid($icpcId);
+                ->setIcpcid($icpcId);
             $action = EventLogService::ACTION_CREATE;
         }
 
@@ -1063,7 +1063,7 @@ class ImportEventFeedCommand extends Command
         $this->em->flush();
         $this->eventLogService->log('teams', $team->getTeamid(), $action, $this->contestId);
 
-        $this->processPendingEvents('team', $team->getExternalid());
+        $this->processPendingEvents('team', $team->getTeamid());
     }
 
     /**
@@ -1281,13 +1281,13 @@ class ImportEventFeedCommand extends Command
         // If any of the other fields are different, this is an error
         if ($submission) {
             $matches = true;
-            if ($submission->getTeam()->getExternalid() !== $team->getExternalid()) {
+            if ($submission->getTeam()->getTeamid() !== $team->getTeamid()) {
                 $this->logger->error(
                     'Got new event for submission %s with different team ID (%s instead of %s)',
                     [
                         $submission->getExternalid(),
-                        $team->getExternalid(),
-                        $submission->getTeam()->getExternalid()
+                        $team->getTeamid(),
+                        $submission->getTeam()->getTeamid()
                     ]
                 );
                 $matches = false;

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -129,7 +129,7 @@ class TeamController extends BaseController
 
         $table_fields = [
             'teamid' => ['title' => 'ID', 'sort' => true,],
-            'externalid' => ['title' => 'external ID', 'sort' => true,],
+            'icpcid' => ['title' => 'ICPC ID', 'sort' => true,],
             'name' => ['title' => 'teamname', 'sort' => true, 'default_sort' => true],
             'category' => ['title' => 'category', 'sort' => true,],
             'affiliation' => ['title' => 'affiliation', 'sort' => true,],

--- a/webapp/src/DataFixtures/TeamFixture.php
+++ b/webapp/src/DataFixtures/TeamFixture.php
@@ -21,7 +21,7 @@ class TeamFixture extends AbstractExampleDataFixture implements DependentFixture
     {
         $team = new Team();
         $team
-            ->setExternalid('exteam')
+            ->setIcpcid('exteam')
             ->setName('Example teamname')
             ->setAffiliation($this->getReference(TeamAffiliationFixture::AFFILIATION_REFERENCE))
             ->setCategory($this->getReference(TeamCategoryFixture::PARTICIPANTS_REFERENCE));

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -21,14 +21,9 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  *         @ORM\Index(name="categoryid", columns={"categoryid"})
  *     },
  *     uniqueConstraints={
- *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {"190"}}),
+ *         @ORM\UniqueConstraint(name="icpcid", columns={"icpcid"}, options={"lengths": {"190"}}),
  *     })
- * @Serializer\VirtualProperty(
- *     "externalid_nonstrict",
- *     exp="object.getExternalId()",
- *     options={@Serializer\SerializedName("externalid"), @Serializer\Type("string"), @Serializer\Groups({"Nonstrict"})}
- * )
- * @UniqueEntity("externalid")
+ * @UniqueEntity("icpcid")
  */
 class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
 {
@@ -45,11 +40,11 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
 
     /**
      * @var string
-     * @ORM\Column(type="string", name="externalid", length=255, options={"comment"="Team ID in an external system",
+     * @ORM\Column(type="string", name="icpcid", length=255, options={"comment"="Team ID in the ICPC system",
      *                            "collation"="utf8mb4_bin","default"="NULL"}, nullable=true)
      * @Serializer\SerializedName("icpc_id")
      */
-    protected $externalid;
+    protected $icpcid;
 
     /**
      * @var string
@@ -211,27 +206,27 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     }
 
     /**
-     * Set externalid
+     * Set icpcid
      *
-     * @param string $externalid
+     * @param string $icpcid
      *
      * @return Team
      */
-    public function setExternalid($externalid)
+    public function setIcpcid($icpcid)
     {
-        $this->externalid = $externalid;
+        $this->icpcid = $icpcid;
 
         return $this;
     }
 
     /**
-     * Get externalid
+     * Get icpcid
      *
      * @return string
      */
-    public function getExternalid()
+    public function getIcpcid()
     {
-        return $this->externalid;
+        return $this->icpcid;
     }
 
     /**

--- a/webapp/src/Form/Type/TeamType.php
+++ b/webapp/src/Form/Type/TeamType.php
@@ -8,6 +8,7 @@ use App\Entity\TeamAffiliation;
 use App\Entity\TeamCategory;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -21,7 +22,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Regex;
 
-class TeamType extends AbstractExternalIdEntityType
+class TeamType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder
@@ -30,9 +31,10 @@ class TeamType extends AbstractExternalIdEntityType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('externalid', TextType::class, [
-            'label' => 'External ID',
+        $builder->add('icpcid', TextType::class, [
+            'label' => 'ICPC ID',
             'required' => false,
+            'help' => 'ID of the team in the ICPC CMS',
             'constraints' => [
                 new Regex(
                     [

--- a/webapp/src/Migrations/Version20200118092658.php
+++ b/webapp/src/Migrations/Version20200118092658.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200118092658 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'rename team.externalid to team.icpcid';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX externalid ON team');
+        $this->addSql('ALTER TABLE team CHANGE externalid icpcid VARCHAR(255) DEFAULT NULL COLLATE utf8mb4_bin COMMENT \'Team ID in the ICPC system\'');
+        $this->addSql('CREATE UNIQUE INDEX icpcid ON team (icpcid(190))');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX icpcid ON team');
+        $this->addSql('ALTER TABLE team CHANGE icpcid externalid VARCHAR(255) DEFAULT NULL COLLATE utf8mb4_bin COMMENT \'Team ID in an external system\'');
+        $this->addSql('CREATE UNIQUE INDEX externalid ON team (externalid(190))');
+    }
+}

--- a/webapp/src/Service/BaylorCmsService.php
+++ b/webapp/src/Service/BaylorCmsService.php
@@ -127,7 +127,8 @@ class BaylorCmsService
                  * FIXME: team members are behind a different API call and not important for now
                  */
 
-                $team = $this->em->getRepository(Team::class)->findOneBy(['externalid' => $teamData['teamId']]);
+                /** @var Team $team */
+                $team = $this->em->getRepository(Team::class)->findOneBy(['icpcid' => $teamData['teamId']]);
                 // Note: teams are not deleted but disabled depending on their status
                 $enabled = $teamData['status'] === 'ACCEPTED';
                 if ($team === null) {
@@ -138,7 +139,7 @@ class BaylorCmsService
                         ->setAffiliation($affiliation)
                         ->setEnabled($enabled)
                         ->setComments('Status: ' . $teamData['status'])
-                        ->setExternalid($teamData['teamId'])
+                        ->setIcpcid($teamData['teamId'])
                         ->setRoom($siteName);
                     $this->em->persist($team);
                     $this->em->flush();
@@ -160,7 +161,7 @@ class BaylorCmsService
                         ->setAffiliation($affiliation)
                         ->setEnabled($enabled)
                         ->setComments('Status: ' . $teamData['status'])
-                        ->setExternalid($teamData['teamId'])
+                        ->setIcpcid($teamData['teamId'])
                         ->setRoom($siteName);
 
                     $user = $this->em->getRepository(User::class)->findOneBy(['username' => $username]);

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -316,7 +316,7 @@ class ImportExportService
         foreach ($teams as $team) {
             $data[] = [
                 $team->getTeamid(),
-                $team->getExternalid(),
+                $team->getIcpcid(),
                 $team->getCategoryid(),
                 $team->getName(),
                 $team->getAffiliation() ? $team->getAffiliation()->getName() : '',
@@ -370,7 +370,7 @@ class ImportExportService
             $data[] = array_merge(
                 [
                     $teamScore->getTeam()->getAffiliation() ? $teamScore->getTeam()->getAffiliation()->getName() : '',
-                    $teamScore->getTeam()->getExternalid(),
+                    $teamScore->getTeam()->getIcpcid(),
                     $teamScore->getRank(),
                     $teamScore->getNumberOfPoints(),
                     $teamScore->getTotalTime(),
@@ -425,10 +425,10 @@ class ImportExportService
 
         /** @var Team[] $teams */
         $teams = $this->em->createQueryBuilder()
-            ->from(Team::class, 't', 't.externalid')
+            ->from(Team::class, 't', 't.icpcid')
             ->select('t')
-            ->where('t.externalid IS NOT NULL')
-            ->orderBy('t.externalid')
+            ->where('t.icpcid IS NOT NULL')
+            ->orderBy('t.icpcid')
             ->getQuery()
             ->getResult();
 
@@ -487,7 +487,7 @@ class ImportExportService
             }
 
             $data[] = [
-                $teamScore->getTeam()->getExternalid() ?? $teamScore->getTeam()->getTeamid(),
+                $teamScore->getTeam()->getIcpcid() ?? $teamScore->getTeam()->getIcpcid(),
                 $rank,
                 $awardString,
                 $teamScore->getNumberOfPoints(),
@@ -639,10 +639,10 @@ class ImportExportService
 
             // we may do more integrity/format checking of the data here.
 
-            // Set external ID's to null if they are not given
-            $teamExternalId = @$line[1];
-            if (empty($teamExternalId)) {
-                $teamExternalId = null;
+            // Set ICPC  ID's to null if they are not given
+            $teamIcpcId = @$line[1];
+            if (empty($teamIcpcId)) {
+                $teamIcpcId = null;
             }
             $affiliationExternalid = preg_replace('/^INST-(U-)?/', '', @$line[7]);
             if (empty($affiliationExternalid)) {
@@ -652,16 +652,16 @@ class ImportExportService
                 $affiliationExternalid = null;
             }
 
-            // Set team ID to external ID if it has the literal value 'null' and the external ID is numeric
+            // Set team ID to ICPC ID if it has the literal value 'null' and the ICPC ID is numeric
             $teamId = @$line[0];
-            if ($teamId === 'null' && is_numeric($teamExternalId)) {
-                $teamId = (int)$teamExternalId;
+            if ($teamId === 'null' && is_numeric($teamIcpcId)) {
+                $teamId = (int)$teamIcpcId;
             }
 
             $teamData[] = [
                 'team' => [
                     'teamid' => $teamId,
-                    'externalid' => $teamExternalId,
+                    'icpcid' => $teamIcpcId,
                     'categoryid' => @$line[2],
                     'name' => @$line[3],
                 ],

--- a/webapp/templates/jury/partials/team_form.html.twig
+++ b/webapp/templates/jury/partials/team_form.html.twig
@@ -1,9 +1,7 @@
 <div class="row">
     <div class="col-lg-4">
         {{ form_start(form) }}
-        {% if form.offsetExists('externalid') %}
-            {{ form_row(form.externalid) }}
-        {% endif %}
+        {{ form_row(form.icpcid) }}
         {{ form_row(form.name) }}
         {{ form_row(form.category) }}
         {{ form_row(form.members) }}

--- a/webapp/templates/jury/team.html.twig
+++ b/webapp/templates/jury/team.html.twig
@@ -20,10 +20,10 @@
                     <td>{{ team.teamid }}</td>
                 </tr>
                 <tr>
-                    <th>External ID</th>
+                    <th>ICPC ID</th>
                     <td>
-                        {% if team.externalid %}
-                            {{ team.externalid }}
+                        {% if team.icpcid %}
+                            {{ team.icpcid }}
                         {% else %}
                             -
                         {% endif %}


### PR DESCRIPTION
For other entries we use the external ID as the 'primary' ID as given by either the primary CCS or another system.
However, for teams we always use team.id for this and team.externalid was a (second) external ID, always representing the ID from the ICPC CMS.
This gave a lot of confusion (as can also be seen in the commit, since I have fixed a few places we used it incorrectly).
So I believe it is better to rename it to something else to not have any confusion.