### PR TITLE
Add support for showing select boxes in the config screen.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -138,25 +138,24 @@
                 general: General issue
                 tech: Technical issue
             public: true
-            description: List of additional clarification categories
+            description: List of additional clarification categories.
         -   name: clar_answers
             type: array_val
             default_value:
                 - No comment
                 - Read the problem statement carefully
             public: false
-            description: List of predefined clarification answers
+            description: List of predefined clarification answers.
         -   name: clar_queues
             type: array_keyval
             default_value: []
             public: true
-            description: List of clarification queues
+            description: List of clarification queues.
         -   name: clar_default_problem_queue
             type: string
             default_value: ""
             public: true
-            description: Queue to assign to problem clarifications
-
+            description: Queue to assign to problem clarifications.
 -   category: Display
     items:
         -   name: show_pending
@@ -188,7 +187,11 @@
             type: int
             default_value: 2
             public: true
-            description: "Show compile output in team webinterface? Choices: 0 = never, 1 = only on compilation error(s), 2 = always."
+            description: Show compile output in team webinterface?
+            options:
+                0: never
+                1: only on compilation error(s)
+                2: always
         -   name: show_sample_output
             type: bool
             default_value: false
@@ -218,7 +221,7 @@
             type: bool
             default_value: true
             public: true
-            description: Show time and memory limit on the team problems page
+            description: Show time and memory limit on the team problems page.
         -   name: team_column_width
             type: int
             default_value: 0
@@ -235,44 +238,51 @@
             type: int
             default_value: 0
             public: false
-            description: "Source of data. Choices: 0 = all local, 1 = configuration data external, 2 = configuration and live data external"
+            description: "Source of data: used to indicate whether internal or external IDs are exposed in the API. 'configuration data external' is typically used when loading configuration data from the ICPC CMS, and 'configuration and live data external when running DOMjudge as \"shadow system\""
+            options:
+                0: all local
+                1: configuration data external
+                2: configuration and live data external
         -   name: external_ccs_submission_url
             type: string
             default_value: ""
             public: false
-            description: URL of a submission detail page on the external CCS. Placeholder [id] will be replaced by submission ID and [contest] by the contest ID. Leave empty to not display links to external CCS
+            description: URL of a submission detail page on the external CCS. Placeholder [id] will be replaced by submission ID and [contest] by the contest ID. Leave empty to not display links to external CCS.
 -   category: Authentication
     items:
         -   name: auth_methods
             type: array_val
             default_value: []
             public: false
-            description: List of allowed additional authentication methods. Supported values are 'ipaddress', and 'xheaders'
+            description: List of allowed additional authentication methods.
+            options:
+                - ipaddress
+                - xheaders
         -   name: allow_openid_auth
             type: bool
             default_value: false
             public: true
-            description: Allow users to log in using OpenID
+            description: Allow users to log in using OpenID.
         -   name: openid_autocreate_team
             type: bool
             default_value: true
             public: true
-            description: Create a team for each user that logs in with OpenID
+            description: Create a team for each user that logs in with OpenID.
         -   name: openid_provider
             type: string
             default_value: https://accounts.google.com
             public: true
-            description: OpenID Provider URL
+            description: OpenID Provider URL.
         -   name: openid_clientid
             type: string
             default_value: ""
             public: false
-            description: OpenID Connect client id
+            description: OpenID Connect client id.
         -   name: openid_clientsecret
             type: string
             default_value: ""
             public: false
-            description: OpenID Connect client secret
+            description: OpenID Connect client secret.
         -   name: ip_autologin
             type: bool
             default_value: false

--- a/webapp/templates/jury/config.html.twig
+++ b/webapp/templates/jury/config.html.twig
@@ -6,6 +6,7 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.toggle_extrahead() }}
+    {{ macros.select2_extrahead() }}
     <style>
         .btn.toggle-on {
             right: initial;
@@ -35,59 +36,131 @@
                                             {% if option.value == 1 %} checked="checked"{% endif %}>
                                         <br/>
                                     {% elseif option.type == 'int' %}
-                                        <input class="form-control form-control-sm"
-                                               style="margin-left:5px;width:7em;text-align:right;display:inline-block;"
-                                               type="number"
-                                               name="config_{{ option.name }}" id="config_{{ option.name }}"
-                                               value="{{ option.value }}">
+                                        {% if option.options is not null %}
+                                            <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                   style="margin-left:5px;width:15em;text-align:right;display:inline-block;"
+                                                   name="config_{{ option.name }}" id="config_{{ option.name }}">
+                                                {% for value, label in option.options %}
+                                                    <option {% if option.value == value %}selected{% endif %} value="{{ value }}">{{ label }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% else %}
+                                            <input class="form-control form-control-sm"
+                                                   style="margin-left:5px;width:7em;text-align:right;display:inline-block;"
+                                                   type="number"
+                                                   name="config_{{ option.name }}" id="config_{{ option.name }}"
+                                                   value="{{ option.value }}">
+                                        {% endif %}
                                         <br/>
                                     {% elseif option.type == 'string' %}
-                                        <input class="form-control form-control-sm" style="width:30em;" type="text"
-                                               name="config_{{ option.name }}" id="config_{{ option.name }}"
-                                               value="{{ option.value }}">
+                                        {% if option.options is not null %}
+                                            <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                    style="width:30em;display: block;"
+                                                    name="config_{{ option.name }}" id="config_{{ option.name }}">
+                                                {% for value, label in option.options %}
+                                                    <option {% if option.value == value %}selected{% endif %} value="{{ value }}">{{ label }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% else %}
+                                            <input class="form-control form-control-sm" style="width:30em;" type="text"
+                                                   name="config_{{ option.name }}" id="config_{{ option.name }}"
+                                                   value="{{ option.value }}">
+                                        {% endif %}
                                     {% elseif option.type == 'array_keyval' %}
                                         <br/>
                                         {% set counter = 0 %}
                                         {% for key,val in option.value %}
-                                            <input class="form-control form-control-sm"
-                                                   style="width:10em;text-align:right;display:inline-block;" type="text"
-                                                   value="{{ key }}"
-                                                   name="config_{{ option.name }}[{{ counter }}][key]"
-                                                   id="config_{{ option.name }}_{{ counter }}__key_">
-                                            <input class="form-control form-control-sm"
-                                                   style="width:30em;display:inline-block;" type="text"
-                                                   value="{{ val }}"
-                                                   name="config_{{ option.name }}[{{ counter }}][val]"
-                                                   id="config_{{ option.name }}_{{ counter }}__val">
+                                            {% if option.key_options is not null %}
+                                                <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                        style="width:10em;text-align:right;display:inline-block;"
+                                                        name="config_{{ option.name }}[{{ counter }}][key]">
+                                                    {% for value, label in option.key_options %}
+                                                        <option {% if key == value %}selected{% endif %} value="{{ value }}">{{ label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            {% else %}
+                                                <input class="form-control form-control-sm"
+                                                       style="width:10em;text-align:right;display:inline-block;" type="text"
+                                                       value="{{ key }}"
+                                                       name="config_{{ option.name }}[{{ counter }}][key]"
+                                                       id="config_{{ option.name }}_{{ counter }}__key_">
+                                            {% endif %}
+                                            {% if option.value_options is not null %}
+                                                <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                        style="width:30em;display:inline-block;"
+                                                        name="config_{{ option.name }}[{{ counter }}][val]">
+                                                    {% for value, label in option.value_options %}
+                                                        <option {% if val == value %}selected{% endif %} value="{{ value }}">{{ label }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            {% else %}
+                                                <input class="form-control form-control-sm"
+                                                       style="width:30em;display:inline-block;" type="text"
+                                                       value="{{ val }}"
+                                                       name="config_{{ option.name }}[{{ counter }}][val]"
+                                                       id="config_{{ option.name }}_{{ counter }}__val">
+                                                {% endif %}
                                             <br/>
                                             {% set counter = counter + 1 %}
                                         {% endfor %}
-                                        <input class="form-control form-control-sm"
-                                               style="width:10em;text-align:right;display:inline-block;" type="text"
-                                               name="config_{{ option.name }}[{{ counter }}][key]"
-                                               id="config_{{ option.name }}_{{ counter }}__key_">
-                                        <input class="form-control form-control-sm"
-                                               style="width:30em;display:inline-block;" type="text"
-                                               name="config_{{ option.name }}[{{ counter }}][val]"
-                                               id="config_{{ option.name }}_{{ counter }}__val">
+                                        {% if option.key_options is not null %}
+                                            <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                    style="width:10em;text-align:right;display:inline-block;"
+                                                    name="config_{{ option.name }}[{{ counter }}][key]">
+                                                {% for value, label in option.key_options %}
+                                                    <option value="{{ value }}">{{ label }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% else %}
+                                            <input class="form-control form-control-sm"
+                                                   style="width:10em;text-align:right;display:inline-block;" type="text"
+                                                   name="config_{{ option.name }}[{{ counter }}][key]"
+                                                   id="config_{{ option.name }}_{{ counter }}__key_">
+                                        {% endif %}
+                                        {% if option.value_options is not null %}
+                                            <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                    style="width:30em;display:inline-block;"
+                                                    name="config_{{ option.name }}[{{ counter }}][val]">
+                                                {% for value, label in option.value_options %}
+                                                    <option value="{{ value }}">{{ label }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% else %}
+                                            <input class="form-control form-control-sm"
+                                                   style="width:30em;display:inline-block;" type="text"
+                                                   name="config_{{ option.name }}[{{ counter }}][val]"
+                                                   id="config_{{ option.name }}_{{ counter }}__val">
+                                            {% endif %}
                                         <br/>
                                     {% elseif option.type == 'array_val' %}
                                         <br/>
-                                        {% set counter = 0 %}
-                                        {% for val in option.value %}
+                                        {% if option.options is not null %}
+                                            <select class="form-control form-control-sm custom-select custom-select-sm"
+                                                    style="width:30em;display:inline-block;"
+                                                    multiple
+                                                    name="config_{{ option.name }}[]"
+                                                    id="config_{{ option.name }}">
+                                                {% for value in option.options %}
+                                                    <option {% if value in option.value %}selected{% endif %} value="{{ value }}">{{ value }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% else %}
+                                            {% set counter = 0 %}
+                                            {% for val in option.value %}
+                                                <input class="form-control form-control-sm"
+                                                       style="width:30em;display:inline-block;" type="text"
+                                                       value="{{ val }}"
+                                                       name="config_{{ option.name }}[{{ counter }}]"
+                                                       id="config_{{ option.name }}_{{ counter }}_">
+                                                <br/>
+                                                {% set counter = counter + 1 %}
+                                            {% endfor %}
                                             <input class="form-control form-control-sm"
                                                    style="width:30em;display:inline-block;" type="text"
-                                                   value="{{ val }}"
                                                    name="config_{{ option.name }}[{{ counter }}]"
                                                    id="config_{{ option.name }}_{{ counter }}_">
                                             <br/>
-                                            {% set counter = counter + 1 %}
-                                        {% endfor %}
-                                        <input class="form-control form-control-sm"
-                                               style="width:30em;display:inline-block;" type="text"
-                                               name="config_{{ option.name }}[{{ counter }}]"
-                                               id="config_{{ option.name }}_{{ counter }}_">
-                                        <br/>
+                                        {% endif %}
                                     {% endif %}
                                     <small class="text-muted">{{ option.description }}</small>
                                 </div>


### PR DESCRIPTION
Since we now have a YAML for config options, it was easier to populate 'magic' config option choices from that YAML or the database.

A pictures is better than a 1000 words, so imagine if we have 4:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/550145/72662274-8fbc5580-39e5-11ea-8515-63581cfba8cf.png">
<img width="658" alt="image" src="https://user-images.githubusercontent.com/550145/72662277-98ad2700-39e5-11ea-8adf-5695fe7eb7cc.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/550145/72662280-a1056200-39e5-11ea-9ee5-7c128f3d650f.png">
<img width="590" alt="image" src="https://user-images.githubusercontent.com/550145/72662285-a9f63380-39e5-11ea-9811-e16fa8776577.png">
