### PR TITLE
Allow output to be "OUTPUT 0", but not "OUTPUT "

### DIFF
--- a/sql/files/examples/boolfind_cmp/check_boolfind.c
+++ b/sql/files/examples/boolfind_cmp/check_boolfind.c
@@ -47,8 +47,8 @@ int main(int argc, char **argv)
 		while ( i>=0 && line[i]=='\n' ) line[i--] = 0;
 
 		outputvalid = 1;
-		if ( strncmp(line,"OUTPUT ",7)!=0 ||
-		     strlen(line)<7 || line[7]=='0' ) outputvalid = 0;
+		if ( strncmp(line,"OUTPUT ",7)!=0 || strlen(line)==7 ||
+		     (strlen(line)>=9 && line[7]=='0') ) outputvalid = 0;
 
 		for(i=7; i<strlen(line); i++) {
 			if ( !isdigit(line[i]) ) {


### PR DESCRIPTION
If you want to add more sample test cases to the interactive example problem, e.g.
```
1
3
1 0 0
```
Then, "OUTPUT 0" is the correct answer but this was not accepted yet.