### PR TITLE
Document how to use REMOTE_USER for authentication

### DIFF
--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -35,11 +35,15 @@ Authentication and registration
 -------------------------------
 Out of the box users are able to authenticate using username and password.
 
-Two other authentication methods are available:
+Two other native authentication methods are available:
 
 - IP Address - authenticates users based on the IP address they are accessing
   the system from;
 - X-Headers - authenticates users based on some HTTP header values.
+
+Besides this, DOMjudge can be configured with any provider that can set
+the environment variable ``REMOTE_USER`` to an existing username,
+for example LDAP, SAML, CAS or OpenID connect modules for Apache.
 
 There's an option to let teams register themselves in the system.
 
@@ -74,6 +78,32 @@ Squid configuration for this might look like::
   acl autologin url_regex ^http://localhost/domjudge/login
   request_header_add X-DOMjudge-Login "$USERNAME" autologin
   request_header_add X-DOMjudge-Pass "$BASE64_PASSWORD" autologin
+
+Using REMOTE-USER
+`````````````````
+DOMjudge supports generic authentiation by various existing providers that
+can authenticate a user and set the ``REMOTE_USER`` environment variable
+to the authenticated username.
+
+Examples of this are several Apache modules: mod LDAP, Shibboleth or
+Mod Mellon for SAML 2.0, mod Auth CAS, mod OpenID Connect, or mod Kerb for
+Kerberos.
+
+This does not currently allow for auto-provisioning or self-registration,
+the users must already exist in DOMjudge and their DOMjudge username must
+match what is in the ``REMOTE_USER`` variable.
+
+Set up the respective module to authenticate incoming users for the URL
+path of your installation. Then, in ``webapp/config/packages/security.yml``
+change the ``main`` section to look like this::
+
+  main:
+    pattern: ^/
+    remote_user:
+      provider: domjudge_db_provider
+
+You may need to remove the entire ``var/cache/prod/`` directory for the changes
+to take effect.
 
 Self-registration
 `````````````````

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -258,31 +258,6 @@
             options:
                 - ipaddress
                 - xheaders
-        -   name: allow_openid_auth
-            type: bool
-            default_value: false
-            public: true
-            description: Allow users to log in using OpenID.
-        -   name: openid_autocreate_team
-            type: bool
-            default_value: true
-            public: true
-            description: Create a team for each user that logs in with OpenID.
-        -   name: openid_provider
-            type: string
-            default_value: https://accounts.google.com
-            public: true
-            description: OpenID Provider URL.
-        -   name: openid_clientid
-            type: string
-            default_value: ""
-            public: false
-            description: OpenID Connect client id.
-        -   name: openid_clientsecret
-            type: string
-            default_value: ""
-            public: false
-            description: OpenID Connect client secret.
         -   name: ip_autologin
             type: bool
             default_value: false

--- a/webapp/tests/Service/ConfigurationServiceTest.php
+++ b/webapp/tests/Service/ConfigurationServiceTest.php
@@ -192,10 +192,10 @@ class ConfigurationServiceTest extends KernelTestCase
 
         $this->assertSame($expectedValue, $this->config->get($itemName));
         // Also make sure it doesn't change other items by testing a different one
-        $openIdAuthItem = $this->findItem('Authentication', 'openid_provider');
+        $defaultCompareItem = $this->findItem('Judging', 'default_compare');
         $this->assertSame(
-            $openIdAuthItem['default_value'],
-            $this->config->get('openid_provider')
+            $defaultCompareItem['default_value'],
+            $this->config->get('default_compare')
         );
     }
 
@@ -229,9 +229,9 @@ class ConfigurationServiceTest extends KernelTestCase
         $all = $this->config->all();
         $this->assertSame($expectedValue, $all[$itemName]);
         // Also make sure it doesn't change other items by testing a different one
-        $openIdAuthItem = $this->findItem('Authentication', 'openid_provider');
+        $defaultCompareItem = $this->findItem('Judging', 'default_compare');
         $this->assertSame(
-            $openIdAuthItem['default_value'], $all['openid_provider']
+            $defaultCompareItem['default_value'], $all['default_compare']
         );
     }
 


### PR DESCRIPTION
This is a very generic solution for authenticating existing users.
Many (Apache) modules can handle a full authentication flow and
deliver an authenticated user, thereby instantly supporting a range
of methods for DOMjudge.

It does not (yet) support auto creation of users. That might need
more custom work per method, e.g. where to find the full name
or email address? But it's definitely better than what we have now.
Surely we can improve on it further.

Since this does provide a way to authenticate with OpenID Connect,
I think it's time to finally clean up the openid_ configuation
values which have not been working for many releases now.