### PR TITLE
Automatically get ID of entities for audit log when null is given as ID.

### DIFF
--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -11,6 +11,7 @@ use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Doctrine\Common\Inflector\Inflector;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\MappingException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -100,6 +101,22 @@ abstract class BaseController extends AbstractController
                                       $contest->getCid());
             }
         }
+
+        // If we have no ID but we do have a Doctrine entity, automatically
+        // get the primary key if possible
+        if ($id === null) {
+            try {
+                $metadata = $entityManager->getClassMetadata($class);
+                if (count($metadata->getIdentifierColumnNames()) === 1) {
+                    $primaryKey = $metadata->getIdentifierColumnNames()[0];
+                    $accessor   = PropertyAccess::createPropertyAccessor();
+                    $id         = $accessor->getValue($entity, $primaryKey);
+                }
+            } catch (MappingException $e) {
+                // Entity is not actually a Doctrine entity, ignore
+            }
+        }
+
         $DOMJudgeService->auditlog($auditLogType, $id, $isNewEntity ? 'added' : 'updated');
     }
 

--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -107,8 +107,10 @@ class AuditLogController extends AbstractController
             $data['what']['value'] = $datatype . " " . $dataid . " " .
                             $logline->getAction() . " " .
                             $logline->getExtraInfo();
-            if( !is_null($dataid) ) {
+            if (!is_null($dataid)) {
                 $dataurl = $this->generateDatatypeUrl($datatype, $dataid);
+            } else {
+                $dataurl = null;
             }
             if (isset($dataurl)) {
                 $data['what']['link'] = $dataurl;


### PR DESCRIPTION
This happens for newly created entities using the BaseController.
Also make sure we reset the $dataurl variable when we should not display a link.