### PR TITLE
Fix submit help to work when base url is incorrect/non responsive.

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -37,7 +37,7 @@ already listed under
 :ref:`judgehost <judgehost_requirements>` and
 :ref:`submit client <submit_client_requirements>` requirements)::
 
-  sudo apt install autoconf automake \
+  sudo apt install autoconf automake bats \
     python3-sphinx python3-sphinx-rtd-theme \
     texlive-latex-recommended texlive-latex-extra \
     texlive-fonts-recommended texlive-lang-european

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -29,6 +29,10 @@ ADMINPASS=$(cat etc/initial_admin_password.secret)
 sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.2/fpm/pool.d/domjudge-fpm.conf"
 sudo /usr/sbin/php-fpm7.2
 
+# test submit client
+cd ${DIR}/submit
+make check-full
+
 # configure judgehost
 cd /opt/domjudge/judgehost/
 sudo cp /opt/domjudge/judgehost/etc/sudoers-domjudge /etc/sudoers.d/

--- a/submit/Makefile
+++ b/submit/Makefile
@@ -45,4 +45,10 @@ $(SUBMITCLIENT:%=%$(OBJEXT)): %$(OBJEXT): %.cc $(SUBMITHEADERS) $(LIBHEADERS)
 clean-l:
 	-rm -f $(TARGETS) $(TARGETS:%=%$(OBJEXT))
 
-.PHONY: submitclient
+check:
+	bats submit_standalone.bats
+
+check-full:
+	bats submit_standalone.bats submit_online.bats
+
+.PHONY: submitclient check check-full

--- a/submit/submit.cc
+++ b/submit/submit.cc
@@ -298,6 +298,8 @@ int main(int argc, char **argv)
 
 	logmsg(LOG_INFO,"set verbosity to %d", verbose);
 
+	if ( show_version ) version(PROGRAM,VERSION);
+
 	/* Make sure that baseurl terminates with a '/' for later concatenation. */
 	if ( !baseurl.empty() && baseurl[baseurl.length()-1]!='/' ) baseurl += '/';
 
@@ -331,7 +333,6 @@ int main(int argc, char **argv)
 	}
 
 	if ( show_help ) usage();
-	if ( show_version ) version(PROGRAM,VERSION);
 
 	if ( mycontest.id.empty() ) usage2(0,"no (valid) contest specified");
 
@@ -716,7 +717,9 @@ Json::Value doAPIrequest(const char *funcname)
 	logmsg(LOG_INFO,"connecting to %s",url);
 
 	if ( (res=curl_easy_perform(handle))!=CURLE_OK ) {
-		error(0,"'%s': %s",url,curlerrormsg);
+		warnuser("'%s': %s",url,curlerrormsg);
+		free(url);
+		return Json::Value::null;
 	}
 
 	free(url);
@@ -728,17 +731,20 @@ Json::Value doAPIrequest(const char *funcname)
 			printf("%s\n", decode_HTML_entities(line).c_str());
 		}
 		if ( http_code == 401 ) {
-			error(0, "Authentication failed. Please check your DOMjudge credentials.");
+			warnuser("Authentication failed. Please check your DOMjudge credentials.");
+			return Json::Value::null;
 		} else {
-			error(0, "API request %s failed (code %li)", funcname, http_code);
+			warnuser("API request %s failed (code %li)", funcname, http_code);
+			return Json::Value::null;
 		}
 	}
 
 	logmsg(LOG_DEBUG,"API call '%s' returned:\n%s\n",funcname,curloutput.str().c_str());
 
 	if ( !reader.parse(curloutput, result) ) {
-		error(0,"parsing REST API output: %s",
+		warnuser("parsing REST API output: %s",
 		        reader.getFormattedErrorMessages().c_str());
+		return Json::Value::null;
 	}
 
 	return result;

--- a/submit/submit.cc
+++ b/submit/submit.cc
@@ -451,7 +451,7 @@ lang_found:
 		printf("  problem:     %s\n",myproblem.label.c_str());
 		printf("  language:    %s\n",mylanguage.name.c_str());
 		if ( entry_point!=NULL ) {
-			printf("  entry_point: %s\n",entry_point);
+			printf("  entry point: %s\n",entry_point);
 		}
 		printf("  url:         %s\n",baseurl.c_str());
 

--- a/submit/submit_online.bats
+++ b/submit/submit_online.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# These tests assume presence of a running DOMjudge instance at the
+# compiled in baseurl that has the DOMjudge example data loaded.
+
+setup() {
+  export SUBMITCONTEST="demo"
+} 
+
+@test "contest via parameter overrides environment" {
+  run ./submit -c bestaatniet
+  echo $output | grep "error: no (valid) contest specified"
+  run ./submit --contest=bestaatookniet
+  echo $output | grep "error: no (valid) contest specified"
+  [ "$status" -eq 1 ]
+}
+
+@test "hello problem id and name are in help output" {
+  run ./submit --help
+  echo $output | grep "hello *- *Hello World"
+  [ "$status" -eq 0 ]
+}
+
+@test "languages and extensions are in help output" {
+  run ./submit --help
+  echo $output | grep "C: *c"
+  echo $output | grep "C++: *cpp, cc, cxx, c++"
+  echo $output | grep "Java: *java"
+}
+
+@test "stale file emits warning" {
+  cp -a ../tests/test-hello.c $BATS_TMPDIR
+  run ./submit -p hello $BATS_TMPDIR/test-hello.c <<< "n"
+  echo $output | grep "test-hello.c' has not been modified for [0-9]* minutes!"
+}
+
+@test "recent file omits warning" {
+  touch $BATS_TMPDIR/test-hello.c
+  run ./submit -p hello $BATS_TMPDIR/test-hello.c <<< "n"
+  echo $output | grep -v "test-hello.c' has not been modified for [0-9]* minutes!"
+}
+
+@test "binary file emits warning" {
+  cp ./submit $BATS_TMPDIR/binary.c
+  run ./submit -p hello $BATS_TMPDIR/binary.c <<< "n"
+  echo $output | grep "binary.c' is detected as binary/data!"
+}
+
+@test "empty file emits warning" {
+  touch $BATS_TMPDIR/empty.c
+  run ./submit -p hello $BATS_TMPDIR/empty.c <<< "n"
+  echo $output | grep "empty.c' is empty"
+}
+
+@test "detect problem name and language" {
+  cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
+  run ./submit $BATS_TMPDIR/hello.java <<< "n"
+  [ "${lines[1]}" = "Submission information:" ]
+  [ "${lines[4]}" = "  problem:     hello" ]
+  [ "${lines[5]}" = "  language:    Java" ]
+}
+
+@test "options override detection of problem name and language" {
+  cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
+  run ./submit -p boolfind -l cpp $BATS_TMPDIR/hello.java <<< "n"
+  [ "${lines[1]}" = "Submission information:" ]
+  [ "${lines[4]}" = "  problem:     boolfind" ]
+  [ "${lines[5]}" = "  language:    C++" ]
+}
+
+@test "detect entry point Java" {
+  run ./submit -p hello ../tests/test-hello.java <<< "n"
+  [ "${lines[7]}" = "  entry point: test-hello" ]
+}
+
+@test "detect entry point Python" {
+  skip "Python not enabled in the default installation"
+  run ./submit -p hello ../tests/test-hello.py <<< "n"
+  [ "${lines[7]}" = "  entry point: test_hello.py" ]
+}
+
+@test "detect entry point Kotlin" {
+  skip "Kotlin not enabled in the default installation"
+  run ./submit -p hello ../tests/test-hello.kt <<< "n"
+  [ "${lines[7]}" = "  entry point: Test_helloKt" ]
+}
+
+@test "accept multiple files" {
+  cp ../tests/test-hello.java ../tests/test-classname.java ../tests/test-package.java $BATS_TMPDIR/
+  run ./submit -p hello $BATS_TMPDIR/test-*.java <<< "n"
+  [ "${lines[2]}" = "  filenames:   $BATS_TMPDIR/test-classname.java $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java" ]
+}
+
+@test "deduplicate multiple files" {
+  cp ../tests/test-hello.java ../tests/test-package.java $BATS_TMPDIR/
+  run ./submit -p hello $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java <<< "n"
+  [ "${lines[2]}" = "  filenames:   $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java" ]
+}
+
+@test "submit solution" {
+  run ./submit -y -p hello ../tests/test-hello.c
+  echo $output | grep "Submission received, id = s[0-9]*"
+}

--- a/submit/submit_standalone.bats
+++ b/submit/submit_standalone.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# These tests can be run without a working DOMjudge api endpoint
+
+@test "version output" {
+  run ./submit --version
+  [ "$status" -eq 0 ]
+  echo "${lines[0]}" | grep "^submit -- part of DOMjudge"
+  [ "${lines[1]}" = "Written by the DOMjudge developers" ]
+}
+
+setup() {
+  export SUBMITBASEURL="https://domjudge.example.org/somejudge"
+} 
+
+@test "baseurl set in environment" {
+  run ./submit
+  echo $output | grep "WARNING: 'https://domjudge.example.org/somejudge/api/v4/contests': Could not resolve host"
+  [ "$status" -eq 1 ]
+}
+
+@test "baseurl via parameter overrides environment" {
+  run ./submit --url https://domjudge.example.edu
+  echo $output | grep "WARNING: 'https://domjudge.example.edu/api/v4/contests': Could not resolve host"
+  run ./submit -u https://domjudge3.example.edu
+  echo $output | grep "WARNING: 'https://domjudge3.example.edu/api/v4/contests': Could not resolve host"
+  [ "$status" -eq 1 ]
+}
+
+@test "baseurl can end in slash" {
+  run ./submit --url https://domjudge.example.edu/domjudge/
+  echo $output | grep "WARNING: 'https://domjudge.example.edu/domjudge/api/v4/contests': Could not resolve host"
+  [ "$status" -eq 1 ]
+}
+
+@test "display basic usage information" {
+  run ./submit --help
+  [ "${lines[3]}" = "Usage: ./submit [OPTION]... FILENAME..." ]
+  [ "${lines[4]}" = "Submit a solution for a problem." ]
+  [ "$status" -eq 0 ]
+}
+
+@test "usage information displays API url" {
+  run ./submit --help
+  echo $output | grep "The (pre)configured URL is 'https://domjudge.example.org/somejudge/'."
+}
+
+@test "nonexistent option refers to help" {
+  run ./submit --doesnotexist
+  [ "${lines[1]}" = "Type './submit --help' to get help." ]
+  [ "$status" -eq 1 ]
+}
+
+@test "verbosity option defaults to 6" {
+  run ./submit -v
+  echo $output | grep "set verbosity to 6"
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,18 +29,7 @@ $(SUBST_FILES): %: %.in $(TOPDIR)/paths.mk
 check-syntax:
 	$(TOPDIR)/tests/syntax
 
-check-client: $(SUBMITCMD)
-	$(SUBMITCMD) --something 2>&1 | grep -a "unknown option or missing argument"
-	$(SUBMITCMD) --help | grep "the only active contest 'demo'"
-	$(SUBMITCMD) -c demo --help | grep "Java:\s*java"
-	$(SUBMITCMD) -c dEMo --help | grep "hello\s*-\s*Hello World"
-	$(SUBMITCMD) -c DEMO -l c -y -p hello ../tests/test-hello.c
-	$(SUBMITCMD) -c DEMO -l Cpp -y -p hello ../tests/test-hello.c++
-	ln -sf ../tests/test-hello.c++ hello.c++
-	$(SUBMITCMD) -c DEMO -y hello.c++
-	rm -f hello.c++
-
-check: check-client test-normal test-fltcmp test-boolfind
+check: test-normal test-fltcmp test-boolfind
 
 PROBLEM=hello
 test-fltcmp: PROBLEM=fltcmp


### PR DESCRIPTION
There's a catch 22 in that the help text incorporates elements from
the API but when the API would be completely unavailable, submit
would fail fast thereby also not proviing the user with help to
e.g. specify another URL.

This makes the api information requests only warn when they cannot
get the information, so processing can continue.
(The submit POST will still fail hard when it cannot reach the API.)

Also move handling of --version to above the API requests since they
are not needed at all to produce this output.

Closes: #707