### PR TITLE
Refactor/scoreboard pod

### DIFF
--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -161,8 +161,8 @@ class AwardsController extends AbstractRestController
         $overall_winners = $medal_winners = [];
         // can we assume this is ordered just walk the first 12+B entries?
         foreach ($scoreboard->getScores() as $teamScore) {
-            $rank = $teamScore->getRank();
-            $teamid = (string)$teamScore->getTeam()->getApiId($this->eventLogService);
+            $rank = $teamScore->rank;
+            $teamid = (string)$teamScore->team->getApiId($this->eventLogService);
             if ($rank === 1) {
                 $overall_winners[] = $teamid;
             }

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -152,17 +152,17 @@ class ScoreboardController extends AbstractRestController
 
         foreach ($scoreboard->getScores() as $teamScore) {
             $row = [
-                'rank' => $teamScore->getRank(),
-                'team_id' => (string)$teamScore->getTeam()->getApiId($this->eventLogService),
+                'rank' => $teamScore->rank,
+                'team_id' => (string)$teamScore->team->getApiId($this->eventLogService),
                 'score' => [
-                    'num_solved' => $teamScore->getNumberOfPoints(),
-                    'total_time' => $teamScore->getTotalTime(),
+                    'num_solved' => $teamScore->numPoints,
+                    'total_time' => $teamScore->totalTime,
                 ],
                 'problems' => [],
             ];
 
             /** @var ScoreboardMatrixItem $matrixItem */
-            foreach ($scoreboard->getMatrix()[$teamScore->getTeam()->getTeamid()] as $problemId => $matrixItem) {
+            foreach ($scoreboard->getMatrix()[$teamScore->team->getTeamid()] as $problemId => $matrixItem) {
                 $contestProblem = $scoreboard->getProblems()[$problemId];
                 $problem        = [
                     'label' => $contestProblem->getShortname(),
@@ -170,11 +170,11 @@ class ScoreboardController extends AbstractRestController
                     'num_judged' => $matrixItem->numSubmissions,
                     'num_pending' => $matrixItem->numSubmissionsPending,
                     'solved' => $matrixItem->isCorrect,
-                    'first_to_solve' => $matrixItem->isCorrect && $scoreboard->solvedFirst($teamScore->getTeam(), $contestProblem),
+                    'first_to_solve' => $matrixItem->isCorrect && $scoreboard->solvedFirst($teamScore->team, $contestProblem),
                 ];
 
                 if ($matrixItem->isCorrect) {
-                    $problem['time'] = Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds);
+                    $problem['time'] = Utils::scoretime($matrixItem->time, $scoreIsInSeconds);
                 }
 
                 $row['problems'][] = $problem;

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -167,13 +167,13 @@ class ScoreboardController extends AbstractRestController
                 $problem        = [
                     'label' => $contestProblem->getShortname(),
                     'problem_id' => (string)$contestProblem->getApiId($this->eventLogService),
-                    'num_judged' => $matrixItem->getNumberOfSubmissions(),
-                    'num_pending' => $matrixItem->getNumberOfPendingSubmissions(),
-                    'solved' => $matrixItem->isCorrect(),
-                    'first_to_solve' => $matrixItem->isCorrect() && $scoreboard->solvedFirst($teamScore->getTeam(), $contestProblem),
+                    'num_judged' => $matrixItem->numSubmissions,
+                    'num_pending' => $matrixItem->numSubmissionsPending,
+                    'solved' => $matrixItem->isCorrect,
+                    'first_to_solve' => $matrixItem->isCorrect && $scoreboard->solvedFirst($teamScore->getTeam(), $contestProblem),
                 ];
 
-                if ($matrixItem->isCorrect()) {
+                if ($matrixItem->isCorrect) {
                     $problem['time'] = Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds);
                 }
 

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -101,13 +101,13 @@ class ScoreboardController extends AbstractRestController
     {
         $filter = new Filter();
         if ($request->query->has('category')) {
-            $filter->setCategories([$request->query->get('category')]);
+            $filter->categories = [ $request->query->get('category') ];
         }
         if ($request->query->has('country')) {
-            $filter->setCountries([$request->query->get('country')]);
+            $filter->countries = [ $request->query->get('country') ];
         }
         if ($request->query->has('affiliation')) {
-            $filter->setAffiliations([$request->query->get('affiliation')]);
+            $filter->affiliations = [ $request->query->get('affiliation') ];
         }
         $allTeams = $request->query->getBoolean('allteams', false);
         $public   = !$this->dj->checkrole('api_reader');

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -414,7 +414,7 @@ class ImportExportController extends BaseController
 
                 /** @var ScoreboardMatrixItem $matrixItem */
                 $matrixItem = $matrix[$team->getTeamid()][$problem->getProbid()];
-                if ($matrixItem->isCorrect() && $scoreboard->solvedFirst($team, $problem)) {
+                if ($matrixItem->isCorrect && $scoreboard->solvedFirst($team, $problem)) {
                     $firstToSolve[$problem->getProbid()] = [
                         'problem' => $problem->getShortname(),
                         'problem_name' => $problem->getProblem()->getName(),

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -341,7 +341,7 @@ class ImportExportController extends BaseController
 
         $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
         $filter           = new Filter();
-        $filter->setCategories($categoryIds);
+        $filter->categories = $categoryIds;
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);
         $teams      = $scoreboard->getTeams();
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -364,8 +364,8 @@ class ImportExportService
             /** @var ScoreboardMatrixItem $matrixItem */
             foreach ($scoreboard->getMatrix()[$teamScore->getTeam()->getTeamid()] as $matrixItem) {
                 $time    = Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds);
-                $drow[]  = $matrixItem->getNumberOfSubmissions();
-                $drow[]  = $matrixItem->isCorrect() ? $time : -1;
+                $drow[]  = $matrixItem->numSubmissions;
+                $drow[]  = $matrixItem->isCorrect ? $time : -1;
                 $maxtime = max($maxtime, $time);
             }
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -421,8 +421,8 @@ class ImportExportService
         }
 
         $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
-        $filter           = new Filter();
-        $filter->setCategories($categoryIds);
+        $filter = new Filter();
+        $filter->categories = $categoryIds;
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);
 
         /** @var Team[] $teams */

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -362,8 +362,8 @@ class ImportExportService
             $maxtime = -1;
             $drow    = [];
             /** @var ScoreboardMatrixItem $matrixItem */
-            foreach ($scoreboard->getMatrix()[$teamScore->getTeam()->getTeamid()] as $matrixItem) {
-                $time    = Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds);
+            foreach ($scoreboard->getMatrix()[$teamScore->team->getTeamid()] as $matrixItem) {
+                $time    = Utils::scoretime($matrixItem->time, $scoreIsInSeconds);
                 $drow[]  = $matrixItem->numSubmissions;
                 $drow[]  = $matrixItem->isCorrect ? $time : -1;
                 $maxtime = max($maxtime, $time);
@@ -371,11 +371,11 @@ class ImportExportService
 
             $data[] = array_merge(
                 [
-                    $teamScore->getTeam()->getAffiliation() ? $teamScore->getTeam()->getAffiliation()->getName() : '',
-                    $teamScore->getTeam()->getIcpcid(),
-                    $teamScore->getRank(),
-                    $teamScore->getNumberOfPoints(),
-                    $teamScore->getTotalTime(),
+                    $teamScore->team->getAffiliation() ? $teamScore->getTeam()->getAffiliation()->getName() : '',
+                    $teamScore->team->getIcpcid(),
+                    $teamScore->rank,
+                    $teamScore->numPoints,
+                    $teamScore->totalTime,
                     $maxtime,
                 ],
                 $drow
@@ -440,7 +440,7 @@ class ImportExportService
         $median = 0;
         foreach ($scoreboard->getScores() as $teamScore) {
             $count++;
-            $median = $teamScore->getNumberOfPoints();
+            $median = $teamScore->numPoints;
             if ($count > $numberOfTeams / 2) {
                 break;
             }
@@ -456,25 +456,25 @@ class ImportExportService
             }
             $maxTime = -1;
             /** @var ScoreboardMatrixItem $matrixItem */
-            foreach ($scoreboard->getMatrix()[$teamScore->getTeam()->getTeamid()] as $matrixItem) {
-                $time    = Utils::scoretime($matrixItem->getTime(), $scoreIsInSeconds);
+            foreach ($scoreboard->getMatrix()[$teamScore->team->getTeamid()] as $matrixItem) {
+                $time    = Utils::scoretime($matrixItem->time, $scoreIsInSeconds);
                 $maxTime = max($maxTime, $time);
             }
 
-            $rank           = $teamScore->getRank();
-            $numberOfPoints = $teamScore->getNumberOfPoints();
+            $rank      = $teamScore->rank;
+            $numPoints = $teamScore->numPoints;
             if ($rank <= 4) {
                 $awardString = 'Gold Medal';
             } elseif ($rank <= 8) {
                 $awardString = 'Silver Medal';
             } elseif ($rank <= 12 + $contest->getB()) {
                 $awardString = 'Bronze Medal';
-            } elseif ($numberOfPoints >= $median) {
+            } elseif ($numPoints >= $median) {
                 // teams with equally solved number of problems get the same rank
-                if (!isset($ranks[$numberOfPoints])) {
-                    $ranks[$numberOfPoints] = $rank;
+                if (!isset($ranks[$numPoints])) {
+                    $ranks[$numPoints] = $rank;
                 }
-                $rank        = $ranks[$numberOfPoints];
+                $rank        = $ranks[$numPoints];
                 $awardString = 'Ranked';
             } else {
                 $awardString = 'Honorable';
@@ -485,15 +485,15 @@ class ImportExportService
             $categoryId  = $teamScore->getTeam()->getCategoryid();
             if (!isset($groupWinners[$categoryId])) {
                 $groupWinners[$categoryId] = true;
-                $groupWinner               = $teamScore->getTeam()->getCategory()->getName();
+                $groupWinner               = $teamScore->team->getCategory()->getName();
             }
 
             $data[] = [
-                $teamScore->getTeam()->getIcpcid() ?? $teamScore->getTeam()->getIcpcid(),
+                $teamScore->team->getIcpcid() ?? $teamScore->team->getIcpcid(),
                 $rank,
                 $awardString,
-                $teamScore->getNumberOfPoints(),
-                $teamScore->getTotalTime(),
+                $teamScore->numbPoints,
+                $teamScore->totalTime,
                 $maxTime,
                 $groupWinner
             ];

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -259,10 +259,11 @@ class ScoreboardService
                     ->getResult();
 
                 foreach ($tiedScores as $tiedScore) {
-                    $teamScores[$tiedScore->getTeam()->getTeamid()]->addSolveTime(Utils::scoretime(
-                        $tiedScore->getSolveTime($restricted),
-                        (bool)$this->config->get('score_in_seconds')
-                    ));
+                    $teamScores[$tiedScore->getTeam()->getTeamid()]->solveTimes[] =
+                        Utils::scoretime(
+                            $tiedScore->getSolveTime($restricted),
+                            (bool)$this->config->get('score_in_seconds')
+                        );
                 }
 
                 // Now check for each team if it is ranked higher than $teamid.

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -854,10 +854,10 @@ class ScoreboardService
      */
     public function getFilterValues(Contest $contest, bool $jury): array
     {
-        $filters          = [
+        $filters = [
             'affiliations' => [],
-            'countries' => [],
-            'categories' => [],
+            'countries'    => [],
+            'categories'   => [],
         ];
         $showFlags        = $this->config->get('show_flags');
         $showAffiliations = $this->config->get('show_affiliations');
@@ -1006,28 +1006,28 @@ class ScoreboardService
         }
 
         if ($filter) {
-            if ($filter->getAffiliations()) {
+            if ($filter->affiliations) {
                 $queryBuilder
                     ->andWhere('t.affilid IN (:affiliations)')
-                    ->setParameter(':affiliations', $filter->getAffiliations());
+                    ->setParameter(':affiliations', $filter->affiliations);
             }
 
-            if ($filter->getCategories()) {
+            if ($filter->categories) {
                 $queryBuilder
                     ->andWhere('t.categoryid IN (:categories)')
-                    ->setParameter(':categories', $filter->getCategories());
+                    ->setParameter(':categories', $filter->categories);
             }
 
-            if ($filter->getCountries()) {
+            if ($filter->countries) {
                 $queryBuilder
                     ->andWhere('ta.country IN (:countries)')
-                    ->setParameter(':countries', $filter->getCountries());
+                    ->setParameter(':countries', $filter->countries);
             }
 
-            if ($filter->getTeams()) {
+            if ($filter->teams) {
                 $queryBuilder
                     ->andWhere('t.teamid IN (:teams)')
-                    ->setParameter(':teams', $filter->getTeams());
+                    ->setParameter(':teams', $filter->teams);
             }
         }
 

--- a/webapp/src/Utils/Scoreboard/Filter.php
+++ b/webapp/src/Utils/Scoreboard/Filter.php
@@ -7,22 +7,22 @@ class Filter
     /**
      * @var int[]
      */
-    protected $affiliations = [];
+    public $affiliations = [];
 
     /**
      * @var string[]
      */
-    protected $countries = [];
+    public $countries = [];
 
     /**
      * @var int[]
      */
-    protected $categories = [];
+    public $categories = [];
 
     /**
      * @var int[]
      */
-    protected $teams = [];
+    public $teams = [];
 
     /**
      * Filter constructor.
@@ -44,92 +44,16 @@ class Filter
     }
 
     /**
-     * @return int[]
-     */
-    public function getAffiliations(): array
-    {
-        return $this->affiliations;
-    }
-
-    /**
-     * @param int[] $affiliations
-     */
-    public function setAffiliations(array $affiliations)
-    {
-        $this->affiliations = $affiliations;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getCountries(): array
-    {
-        return $this->countries;
-    }
-
-    /**
-     * @param string[] $countries
-     */
-    public function setCountries(array $countries)
-    {
-        $this->countries = $countries;
-    }
-
-    /**
-     * @return int[]
-     */
-    public function getCategories(): array
-    {
-        return $this->categories;
-    }
-
-    /**
-     * @param int[] $categories
-     */
-    public function setCategories(array $categories)
-    {
-        $this->categories = $categories;
-    }
-
-    /**
-     * @return int[]
-     */
-    public function getTeams(): array
-    {
-        return $this->teams;
-    }
-
-    /**
-     * @param int[] $teams
-     */
-    public function setTeams(array $teams)
-    {
-        $this->teams = $teams;
-    }
-
-    /**
      * Get a string to display on what has been filtered
      * @return string
      */
     public function getFilteredOn(): string
     {
         $filteredOn = [];
-        if ($this->affiliations) {
-            $filteredOn[] = 'affiliations';
-        }
-        if ($this->countries) {
-            $filteredOn[] = 'countries';
-        }
-        if ($this->categories) {
-            $filteredOn[] = 'categories';
-        }
-        if ($this->teams) {
-            $filteredOn[] = 'teams';
-        }
-
-        if (empty($filteredOn)) {
-            return '';
-        }
+        if ($this->affiliations) $filteredOn[] = 'affiliations';
+        if ($this->countries)    $filteredOn[] = 'countries';
+        if ($this->categories)   $filteredOn[] = 'categories';
+        if ($this->teams)        $filteredOn[] = 'teams';
 
         return implode(', ', $filteredOn);
     }

--- a/webapp/src/Utils/Scoreboard/ProblemSummary.php
+++ b/webapp/src/Utils/Scoreboard/ProblemSummary.php
@@ -7,82 +7,47 @@ class ProblemSummary
     /**
      * @var int[]
      */
-    protected $numberOfSubmissions = [];
+    public $numSubmissions = [];
 
     /**
      * @var int[]
      */
-    protected $numberOfPendingSubmissions = [];
+    public $numSubmissionsPending = [];
 
     /**
      * @var int[]
      */
-    protected $numberOfCorrectSubmissions = [];
+    public $numSubmissionsCorrect = [];
 
     /**
      * @var float[]
      */
-    protected $bestTimes = [];
+    public $bestTimes = [];
 
     /**
      * @param int $sortorder
-     * @return int
-     */
-    public function getNumberOfSubmissions(int $sortorder): int
-    {
-        return $this->numberOfSubmissions[$sortorder] ?? 0;
-    }
-
-    /**
-     * @param int $sortorder
-     * @return int
-     */
-    public function getNumberOfPendingSubmissions(int $sortorder): int
-    {
-        return $this->numberOfPendingSubmissions[$sortorder] ?? 0;
-    }
-
-    /**
-     * @param int $sortorder
-     * @return int
-     */
-    public function getNumberOfCorrectSubmissions(int $sortorder): int
-    {
-        return $this->numberOfCorrectSubmissions[$sortorder] ?? 0;
-    }
-
-    /**
-     * @param int $sortorder
-     * @param int $numberOfSubmissions
-     * @param int $numberOfPendingSubmissions
-     * @param int $numberOfCorrectSubmissions
+     * @param int $numSubmissions
+     * @param int $numSubmissionsPending
+     * @param int $numSubmissionsCorrect
      */
     public function addSubmissionCounts(
         int $sortorder,
-        int $numberOfSubmissions,
-        int $numberOfPendingSubmissions,
-        int $numberOfCorrectSubmissions
+        int $numSubmissions,
+        int $numSubmissionsPending,
+        int $numSubmissionsCorrect
     ) {
-        if (!isset($this->numberOfSubmissions[$sortorder])) {
-            $this->numberOfSubmissions[$sortorder] = 0;
+        if (!isset($this->numSubmissions[$sortorder])) {
+            $this->numSubmissions[$sortorder] = 0;
         }
-        if (!isset($this->numberOfPendingSubmissions[$sortorder])) {
-            $this->numberOfPendingSubmissions[$sortorder] = 0;
+        if (!isset($this->numSubmissionsPending[$sortorder])) {
+            $this->numSubmissionsPending[$sortorder] = 0;
         }
-        if (!isset($this->numberOfCorrectSubmissions[$sortorder])) {
-            $this->numberOfCorrectSubmissions[$sortorder] = 0;
+        if (!isset($this->numSubmissionsCorrect[$sortorder])) {
+            $this->numSubmissionsCorrect[$sortorder] = 0;
         }
-        $this->numberOfSubmissions[$sortorder]        += $numberOfSubmissions;
-        $this->numberOfPendingSubmissions[$sortorder] += $numberOfPendingSubmissions;
-        $this->numberOfCorrectSubmissions[$sortorder] += $numberOfCorrectSubmissions;
-    }
-
-    /**
-     * @return float[]
-     */
-    public function getBestTimes(): array
-    {
-        return $this->bestTimes;
+        $this->numSubmissions[$sortorder]        += $numSubmissions;
+        $this->numSubmissionsPending[$sortorder] += $numSubmissionsPending;
+        $this->numSubmissionsCorrect[$sortorder] += $numSubmissionsCorrect;
     }
 
     /**

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -307,12 +307,12 @@ class Scoreboard
 
                 $problemSummary->addSubmissionCounts(
                     $sortOrder,
-                    $problemMatrixItem->getNumberOfSubmissions(),
-                    $problemMatrixItem->getNumberOfPendingSubmissions(),
-                    $problemMatrixItem->isCorrect() ? 1 : 0
+                    $problemMatrixItem->numSubmissions ?? 0,
+                    $problemMatrixItem->numSubmissionsPending ?? 0,
+                    $problemMatrixItem->isCorrect ? 1 : 0
                 );
-                if ($problemMatrixItem->isFirst()) {
-                    $problemSummary->updateBestTime($sortOrder, $problemMatrixItem->getTime());
+                if ($problemMatrixItem->isFirst) {
+                    $problemSummary->updateBestTime($sortOrder, $problemMatrixItem->time);
                 }
             }
         }
@@ -514,6 +514,6 @@ class Scoreboard
      */
     public function solvedFirst(Team $team, ContestProblem $problem): bool
     {
-        return $this->matrix[$team->getTeamid()][$problem->getProbid()]->isFirst();
+        return $this->matrix[$team->getTeamid()][$problem->getProbid()]->isFirst;
     }
 }

--- a/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -7,103 +7,55 @@ class ScoreboardMatrixItem
     /**
      * @var bool
      */
-    protected $isCorrect;
+    public $isCorrect;
 
     /**
      * @var bool
      */
-    protected $isFirst;
+    public $isFirst;
 
     /**
      * @var int
      */
-    protected $numberOfSubmissions;
+    public $numSubmissions;
 
     /**
      * @var int
      */
-    protected $numberOfPendingSubmissions;
+    public $numSubmissionsPending;
 
     /**
      * @var float|string
      */
-    protected $time;
+    public $time;
 
     /**
      * @var int
      */
-    protected $penaltyTime;
+    public $penaltyTime;
 
     /**
      * ScoreboardMatrixItem constructor.
      * @param bool $isCorrect
      * @param bool $isFirst
-     * @param int $numberOfSubmissions
-     * @param int $numberOfPendingSubmissions
+     * @param int $numSubmissions
+     * @param int $numSubmissionsPending
      * @param float|string $time
      * @param int $penaltyTime
      */
     public function __construct(
         bool $isCorrect,
         bool $isFirst,
-        int $numberOfSubmissions,
-        int $numberOfPendingSubmissions,
+        int $numSubmissions,
+        int $numSubmissionsPending,
         $time,
         int $penaltyTime
     ) {
-        $this->isCorrect                  = $isCorrect;
-        $this->isFirst                    = $isFirst;
-        $this->numberOfSubmissions        = $numberOfSubmissions;
-        $this->numberOfPendingSubmissions = $numberOfPendingSubmissions;
-        $this->time                       = $time;
-        $this->penaltyTime                = $penaltyTime;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isCorrect(): bool
-    {
-        return $this->isCorrect;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isFirst(): bool
-    {
-        return $this->isFirst;
-    }
-
-    /**
-     * @return int
-     */
-    public function getNumberOfSubmissions(): int
-    {
-        return $this->numberOfSubmissions;
-    }
-
-    /**
-     * @return int
-     */
-    public function getNumberOfPendingSubmissions(): int
-    {
-        return $this->numberOfPendingSubmissions;
-    }
-
-    /**
-     * @return string|float
-     */
-    public function getTime()
-    {
-        return $this->time;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPenaltyTime(): int
-    {
-        return $this->penaltyTime;
+        $this->isCorrect             = $isCorrect;
+        $this->isFirst               = $isFirst;
+        $this->numSubmissions        = $numSubmissions;
+        $this->numSubmissionsPending = $numSubmissionsPending;
+        $this->time                  = $time;
+        $this->penaltyTime           = $penaltyTime;
     }
 }

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -80,10 +80,10 @@ class SingleTeamScoreboard extends Scoreboard
     {
         $teamScore = $this->scores[$this->team->getTeamid()];
         if ($this->rankCache !== null) {
-            $teamScore->addNumberOfPoints($this->rankCache->getPointsRestricted());
-            $teamScore->addTotalTime($this->rankCache->getTotaltimeRestricted());
+            $teamScore->numPoints += $this->rankCache->getPointsRestricted();
+            $teamScore->totalTime += $this->rankCache->getTotaltimeRestricted();
         }
-        $teamScore->setRank($this->teamRank);
+        $teamScore->rank = $this->teamRank;
 
         // Loop all info the scoreboard cache and put it in our own datastructure
         $this->matrix = [];

--- a/webapp/src/Utils/Scoreboard/Summary.php
+++ b/webapp/src/Utils/Scoreboard/Summary.php
@@ -110,12 +110,4 @@ class Summary
     {
         return $this->problems[$problemId] ?? null;
     }
-
-    /**
-     * @param ProblemSummary[] $problems
-     */
-    public function setProblems(array $problems)
-    {
-        $this->problems = $problems;
-    }
 }

--- a/webapp/src/Utils/Scoreboard/TeamScore.php
+++ b/webapp/src/Utils/Scoreboard/TeamScore.php
@@ -9,27 +9,27 @@ class TeamScore
     /**
      * @var Team
      */
-    protected $team;
+    public $team;
 
     /**
      * @var int
      */
-    protected $numberOfPoints = 0;
+    public $numPoints = 0;
 
     /**
      * @var float[]
      */
-    protected $solveTimes = [];
+    public $solveTimes = [];
 
     /**
      * @var int
      */
-    protected $rank = 0;
+    public $rank = 0;
 
     /**
      * @var int
      */
-    protected $totalTime;
+    public $totalTime;
 
     /**
      * TeamScore constructor.
@@ -39,77 +39,5 @@ class TeamScore
     {
         $this->team      = $team;
         $this->totalTime = $team->getPenalty();
-    }
-
-    /**
-     * @return Team
-     */
-    public function getTeam(): Team
-    {
-        return $this->team;
-    }
-
-    /**
-     * @return int
-     */
-    public function getNumberOfPoints(): int
-    {
-        return $this->numberOfPoints;
-    }
-
-    /**
-     * @param int $numberOfPoints
-     */
-    public function addNumberOfPoints(int $numberOfPoints)
-    {
-        $this->numberOfPoints += $numberOfPoints;
-    }
-
-    /**
-     * @return float[]
-     */
-    public function getSolveTimes(): array
-    {
-        return $this->solveTimes;
-    }
-
-    /**
-     * @param float $solveTime
-     */
-    public function addSolveTime(float $solveTime)
-    {
-        $this->solveTimes[] = $solveTime;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRank(): int
-    {
-        return $this->rank;
-    }
-
-    /**
-     * @param int $rank
-     */
-    public function setRank(int $rank)
-    {
-        $this->rank = $rank;
-    }
-
-    /**
-     * @return int
-     */
-    public function getTotalTime(): int
-    {
-        return $this->totalTime;
-    }
-
-    /**
-     * @param int $totalTime
-     */
-    public function addTotalTime(int $totalTime)
-    {
-        $this->totalTime += $totalTime;
     }
 }

--- a/webapp/templates/partials/scoreboard_summary.html.twig
+++ b/webapp/templates/partials/scoreboard_summary.html.twig
@@ -24,19 +24,19 @@
                     <a {% if link %}href="{{ link }}"{% endif %}>
                         <i class="fas fa-thumbs-up fa-fw"></i>
                         <span style="font-size:90%;" title="number of accepted submissions">
-                                {{ summary.numberOfCorrectSubmissions(sortOrder) }}
+                                {{ summary.numSubmissionsCorrect[sortOrder] }}
                             </span>
                         <br/>
 
                         <i class="fas fa-thumbs-down fa-fw"></i>
                         <span style="font-size:90%;" title="number of rejected submissions">
-                                {{ summary.numberOfSubmissions(sortOrder) - summary.numberOfCorrectSubmissions(sortOrder) }}
+                                {{ summary.numSubmissions[sortOrder] - summary.numSubmissionsCorrect[sortOrder] }}
                             </span>
                         <br/>
 
                         <i class="fas fa-question-circle fa-fw"></i>
                         <span style="font-size:90%;" title="number of pending submissions">
-                                {{ summary.numberOfPendingSubmissions(sortOrder) }}
+                                {{ summary.numSubmissionsPending[sortOrder] }}
                             </span>
                         <br/>
 

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -233,15 +233,15 @@
                         {% if scoreboard.solvedFirst(score.team, problem) %}
                             {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %}
-                    {% elseif showPending and matrixItem.numberOfPendingSubmissions > 0 %}
+                    {% elseif showPending and matrixItem.numSubmissionsPending > 0 %}
                         {% set scoreCssClass = 'score_pending' %}
-                    {% elseif matrixItem.numberOfSubmissions > 0 %}
+                    {% elseif matrixItem.numSubmissions > 0 %}
                         {% set scoreCssClass = 'score_incorrect' %}
                     {% endif %}
 
-                    {% set numberOfSubmissions = matrixItem.numberOfSubmissions %}
-                    {% if showPending and matrixItem.numberOfPendingSubmissions > 0 %}
-                        {% set numberOfSubmissions = numberOfSubmissions ~ ' + ' ~ matrixItem.numberOfPendingSubmissions %}
+                    {% set numSubmissions = matrixItem.numSubmissions %}
+                    {% if showPending and matrixItem.numSubmissionsPending > 0 %}
+                        {% set numSubmissions = numSubmissions ~ ' + ' ~ matrixItem.numSubmissionsPending %}
                     {% endif %}
 
                     {# If correct, print time scored. The format will vary depending on the scoreboard resolution setting #}
@@ -250,8 +250,8 @@
                         {% set time = matrixItem.time %}
                         {% if scoreInSeconds %}
                             {% set time = time | scoreTime | printTimeRelative %}
-                            {% if matrixItem.numberOfSubmissions > 1 %}
-                                {% set time = time ~ ' + ' ~ (calculatePenaltyTime(true, matrixItem.numberOfSubmissions) | printTimeRelative) %}
+                            {% if matrixItem.numSubmissions > 1 %}
+                                {% set time = time ~ ' + ' ~ (calculatePenaltyTime(true, matrixItem.numSubmissions) | printTimeRelative) %}
                             {% endif %}
                         {% else %}
                             {% set time = time | scoreTime %}
@@ -265,15 +265,15 @@
                     {% endif %}
 
                     <td class="score_cell">
-                        {% if numberOfSubmissions != '0' %}
+                        {% if numSubmissions != '0' %}
                             <a {% if link %}href="{{ link }}"{% endif %}>
                                 <div class="{{ scoreCssClass }}">
                                     {{ time | raw }}
                                     <span>
-                                        {% if numberOfSubmissions is same as(1) %}
+                                        {% if numSubmissions is same as(1) %}
                                             1 try
                                         {% else %}
-                                            {{ numberOfSubmissions }} tries
+                                            {{ numSubmissions }} tries
                                         {% endif %}
                                     </span>
                                 </div>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -219,7 +219,7 @@
             {% if scoreInSeconds %}
                 {% set totalTime = totalTime | printTimeRelative %}
             {% endif %}
-            {% set totalPoints = score.numberOfPoints %}
+            {% set totalPoints = score.numPoints %}
             <td class="scorenc">{{ totalPoints }}</td>
             <td class="scorett">{{ totalTime }}</td>
 

--- a/webapp/tests/ScoreboardIntegrationTest.php
+++ b/webapp/tests/ScoreboardIntegrationTest.php
@@ -418,7 +418,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
                 $this->assertInstanceOf(ScoreboardMatrixItem::class, $item);
 
                 $expected = (@$fts_probid2teamid[$probid] === $teamid);
-                $this->assertEquals($expected, $item->isFirst(),
+                $this->assertEquals($expected, $item->isFirst,
                                     "Check FTS matches for team $teamname, problem $probname");
             }
         }

--- a/webapp/tests/ScoreboardIntegrationTest.php
+++ b/webapp/tests/ScoreboardIntegrationTest.php
@@ -391,9 +391,9 @@ class ScoreboardIntegrationTest extends KernelTestCase
             $score = $scores[$team->getTeamid()];
             $this->assertInstanceOf(TeamScore::class, $score);
 
-            $this->assertEquals($row['rank'],   $score->getRank(), "Rank for '$name'");
-            $this->assertEquals($row['solved'], $score->getNumberOfPoints(), "# solved for '$name'");
-            $this->assertEquals($row['time'],   $score->getTotalTime(), "Total time for '$name'");
+            $this->assertEquals($row['rank'],   $score->rank, "Rank for '$name'");
+            $this->assertEquals($row['solved'], $score->numPoints, "# solved for '$name'");
+            $this->assertEquals($row['time'],   $score->totalTime, "Total time for '$name'");
         }
     }
 

--- a/webapp/tests/Utils/Scoreboard/ScoreboardTest.php
+++ b/webapp/tests/Utils/Scoreboard/ScoreboardTest.php
@@ -29,11 +29,11 @@ class UtilsScoreboardTest extends TestCase
         $teamB = new Team();
         $scoreA = new TeamScore($teamA);
         foreach([6, 367, 2, 100] as $time) {
-            $scoreA->addSolvetime($time);
+            $scoreA->solveTimes[] = $time;
         }
         $scoreB = new TeamScore($teamB);
         foreach([100, 6, 2, 367] as $time) {
-            $scoreB->addSolvetime($time);
+            $scoreB->solveTimes[] = $time;
         }
 
         $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
@@ -48,7 +48,7 @@ class UtilsScoreboardTest extends TestCase
         $teamB = new Team();
         $scoreA = new TeamScore($teamA);
         foreach([6, 367, 2, 100] as $time) {
-            $scoreA->addSolvetime($time);
+            $scoreA->solveTimes[] = $time;
         }
         $scoreB = new TeamScore($teamB);
 
@@ -64,11 +64,11 @@ class UtilsScoreboardTest extends TestCase
         $teamB = new Team();
         $scoreA = new TeamScore($teamA);
         foreach([6, 367, 2, 100] as $time) {
-            $scoreA->addSolvetime($time);
+            $scoreA->solveTimes[] = $time;
         }
         $scoreB = new TeamScore($teamB);
         foreach([23, 150, 367] as $time) {
-            $scoreB->addSolvetime($time);
+            $scoreB->solveTimes[] = $time;
         }
 
         $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
@@ -83,11 +83,11 @@ class UtilsScoreboardTest extends TestCase
         $teamB = new Team();
         $scoreA = new TeamScore($teamA);
         foreach([6, 367, 2, 100] as $time) {
-            $scoreA->addSolvetime($time);
+            $scoreA->solveTimes[] = $time;
         }
         $scoreB = new TeamScore($teamB);
         foreach([23, 150, 2] as $time) {
-            $scoreB->addSolvetime($time);
+            $scoreB->solveTimes[] = $time;
         }
 
         $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);


### PR DESCRIPTION
Refactor scoreboard code to use "plain old data" structures instead of classes with private members to remove unnecessary get/set methods.
I would argue that the main reason for using classes is to clarify the data structure here.