### PR TITLE
Fix link to documentation from the admin index page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ maintainer-install: build domserver-create-dirs judgehost-create-dirs webapp/.en
 	ln -sf $(CURDIR)/judge/runpipe  $(judgehost_bindir)
 	ln -sf $(CURDIR)/sql/dj_setup_database $(domserver_bindir)
 	$(MAKE) -C misc-tools maintainer-install
+	$(MAKE) -C doc/manual maintainer-install
 # Create tmpdir and make tmpdir, submitdir writable for webserver,
 # because judgehost-create-dirs sets wrong permissions:
 	mkdir -p $(domserver_tmpdir)

--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -1,2 +1,4 @@
 /build
 /version.py
+/substitutions
+/html

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -21,13 +21,16 @@ endif
 install-docs: docs
 	$(call install_tree,$(DESTDIR)$(domjudge_docdir)/manual,build/html)
 
+maintainer-install: docs
+	ln -sf build/html
+
 clean-l:
 	rm -rf build
 
 distclean-l:
-	-rm -f $(SUBST_CONFIGS)
+	-rm -f $(SUBST_CONFIGS) html
 
 html:
 	sphinx-build -M $@ . build
 
-.PHONY: docs distdocs install-docs html
+.PHONY: docs distdocs install-docs maintainer-install html

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -95,7 +95,7 @@
       </div>
       <div class="card-body">
         <ul>
-        <li><a href="{{ asset('doc/manual/build/html/index.html') }}">DOMjudge manual</a></li>
+        <li><a href="{{ asset('doc/manual/html/index.html') }}">DOMjudge manual</a></li>
         <li><a href="{{ asset('doc/team/team-manual.pdf') }}">Team manual <i class="fas fa-file-pdf"></i></a></li>
         <li><a href="{{ path('app.swagger_ui') }}">API documentation</a><br />
             See also the <a href="https://clics.ecs.baylor.edu/index.php/Contest_API">ICPC Contest API</a>.</li>


### PR DESCRIPTION
The previous link only worked on the maintainer-install of DOMjudge.
Make it so we link to the right location at the regular install,
which also drops the ugly `build/` from the url path. And add a
symlink on the maintainer-install so the docs work there also.

Closes #698