### PR TITLE
Fix Symfony 4.4 / PHP 7.4 deprecations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2501,16 +2501,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "3.1.1",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "7f8dc86e9168d0112b3cc38ba8cca41b17f409a0"
+                "reference": "e82527ceddedf8dd988a4ce900f4b14fedf4d6f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/7f8dc86e9168d0112b3cc38ba8cca41b17f409a0",
-                "reference": "7f8dc86e9168d0112b3cc38ba8cca41b17f409a0",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/e82527ceddedf8dd988a4ce900f4b14fedf4d6f2",
+                "reference": "e82527ceddedf8dd988a4ce900f4b14fedf4d6f2",
                 "shasum": ""
             },
             "require": {
@@ -2531,15 +2531,16 @@
                 "doctrine/phpcr-odm": "^1.3|^2.0",
                 "ext-pdo_sqlite": "*",
                 "jackalope/jackalope-doctrine-dbal": "^1.1.5",
-                "phpunit/phpunit": "^7.5",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "phpunit/phpunit": "^7.5||^8.0||^9.0",
                 "psr/container": "^1.0",
-                "symfony/dependency-injection": "^3.0|^4.0",
-                "symfony/expression-language": "^3.0|^4.0",
-                "symfony/filesystem": "^3.0|^4.0",
-                "symfony/form": "^3.0|^4.0",
-                "symfony/translation": "^3.0|^4.0",
-                "symfony/validator": "^3.1.9|^4.0",
-                "symfony/yaml": "^3.3|^4.0",
+                "symfony/dependency-injection": "^3.0|^4.0|^5.0",
+                "symfony/expression-language": "^3.0|^4.0|^5.0",
+                "symfony/filesystem": "^3.0|^4.0|^5.0",
+                "symfony/form": "^3.0|^4.0|^5.0",
+                "symfony/translation": "^3.0|^4.0|^5.0",
+                "symfony/validator": "^3.1.9|^4.0|^5.0",
+                "symfony/yaml": "^3.3|^4.0|^5.0",
                 "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
@@ -2550,7 +2551,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.6-dev"
                 }
             },
             "autoload": {
@@ -2564,12 +2565,12 @@
             ],
             "authors": [
                 {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                },
-                {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
                 }
             ],
             "description": "Library for (de-)serializing data of any complexity; supports XML, JSON, and YAML.",
@@ -2581,7 +2582,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2019-06-28T09:09:40+00:00"
+            "time": "2020-03-21T20:26:09+00:00"
         },
         {
             "name": "jms/serializer-bundle",

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -29,7 +29,7 @@ function read_credentials()
         error("Cannot read REST API credentials file " . $credfile);
     }
     foreach ($credentials as $credential) {
-        if ($credential{0} == '#') {
+        if ($credential[0] == '#') {
             continue;
         }
         list($endpointID, $resturl, $restuser, $restpass) = preg_split("/\s+/", trim($credential));

--- a/lib/lib.database.php
+++ b/lib/lib.database.php
@@ -149,7 +149,7 @@ class db
                 throw new BadMethodCallException("Not enough arguments");
             }
             $val = array_shift($argv);
-            switch ($part{0}) {
+            switch ($part[0]) {
                 case 'A':
                     if (!is_array($val) || !$val) {
                         $backtrace = debug_backtrace();
@@ -165,7 +165,7 @@ class db
                             . "'$key $query')! $callsite"
                         );
                     }
-                    $GLOBALS['MODE'] = $part{1};
+                    $GLOBALS['MODE'] = $part[1];
                     $query .= implode(', ', array_map(array($this, 'val2sql'), $val));
                     unset($GLOBALS['MODE']);
                     $query .= substr($part, 2);
@@ -177,7 +177,7 @@ class db
                     }
                     $separator = ', ';
                     $skip = 1;
-                    if (strlen($part) > 1 && $part{1} == 'S') {
+                    if (strlen($part) > 1 && $part[1] == 'S') {
                         $separator = ' AND ';
                         $skip = 2;
                     }
@@ -191,7 +191,7 @@ class db
                 case 'f':
                 case 'l':
                 case '.':
-                    $query .= $this->val2sql($val, $part{0});
+                    $query .= $this->val2sql($val, $part[0]);
                     $query .= substr($part, 1);
                     break;
                 case '_': // eat one argument
@@ -199,7 +199,7 @@ class db
                     break;
                 default:
                     throw new InvalidArgumentException(
-                        "Unknown %-code: " . $part{0}
+                        "Unknown %-code: " . $part[0]
                     );
             }
         }

--- a/lib/use_db.php
+++ b/lib/use_db.php
@@ -25,7 +25,7 @@ function setup_database_connection()
     }
 
     foreach ($credentials as $credential) {
-        if ($credential{0} == '#') {
+        if ($credential[0] == '#') {
             continue;
         }
         list($priv, $host, $db, $user, $pass) =

--- a/webapp/config/load_db_secrets.php
+++ b/webapp/config/load_db_secrets.php
@@ -14,7 +14,7 @@ function get_db_url()
     }
 
     foreach ($db_credentials as $line) {
-        if ($line{0} == '#') {
+        if ($line[0] == '#') {
             continue;
         }
         list($dummy, $host, $db, $user, $pass) = explode(':', trim($line));

--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -57,7 +58,7 @@ class AwardsController extends AbstractRestController
      * @param Request $request
      * @return array
      * @Rest\Get("")
-     * @IsGranted({"ROLE_JURY", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns the current teams qualifying for each award",

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -26,7 +27,7 @@ class ClarificationController extends AbstractRestController
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      * @Rest\Get("")
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns all the clarifications for this contest",
@@ -57,7 +58,7 @@ class ClarificationController extends AbstractRestController
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\NonUniqueResultException
      * @Rest\Get("/{id}")
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns the given clarification for this contest",

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -17,6 +17,7 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 use Metadata\MetadataFactoryInterface;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -304,7 +305,7 @@ class ContestController extends AbstractRestController
      * Get the event feed for the given contest
      * @Rest\Get("/{cid}/event-feed")
      * @SWG\Get(produces={"application/x-ndjson"})
-     * @IsGranted({"ROLE_JURY", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_API_READER')")
      * @param Request                  $request
      * @param string                   $cid
      * @param MetadataFactoryInterface $metadataFactory

--- a/webapp/src/Controller/API/ExecutableController.php
+++ b/webapp/src/Controller/API/ExecutableController.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -37,7 +38,7 @@ class ExecutableController extends AbstractFOSRestController
      * @param string $id
      * @return array|string|null
      * @throws \Doctrine\ORM\NonUniqueResultException
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST')")
      * @Rest\Get("/{id}")
      * @SWG\Parameter(ref="#/parameters/id")
      * @SWG\Response(

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -47,7 +48,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
      * Get all the judgements for this contest
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
-     * @IsGranted({"ROLE_JURY", "ROLE_TEAM", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_TEAM') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @Rest\Get("")
      * @SWG\Response(
      *     response="200",
@@ -89,7 +90,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
      * @param string $id
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\NonUniqueResultException
-     * @IsGranted({"ROLE_JURY", "ROLE_TEAM", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_TEAM') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @Rest\Get("/{id}")
      * @SWG\Response(
      *     response="200",

--- a/webapp/src/Controller/API/RunController.php
+++ b/webapp/src/Controller/API/RunController.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -48,7 +49,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
      * Get all the runs for this contest
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @Rest\Get("")
      * @SWG\Response(
      *     response="200",
@@ -102,7 +103,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
      * @param string $id
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\NonUniqueResultException
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @Rest\Get("/{id}")
      * @SWG\Response(
      *     response="200",

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -55,7 +56,7 @@ class SubmissionController extends AbstractRestController
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      * @Rest\Get("")
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns all the submissions for this contest",
@@ -91,7 +92,7 @@ class SubmissionController extends AbstractRestController
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\NonUniqueResultException
      * @Rest\Get("/{id}")
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns the given submission for this contest",
@@ -312,7 +313,7 @@ class SubmissionController extends AbstractRestController
     /**
      * Get the source code of all the files for the given submission
      * @Rest\Get("/{id}/source-code")
-     * @IsGranted({"ROLE_JUDGEHOST", "ROLE_JURY"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST')")
      * @param Request $request
      * @param string  $id
      * @return array

--- a/webapp/src/Controller/API/TestcaseController.php
+++ b/webapp/src/Controller/API/TestcaseController.php
@@ -11,6 +11,7 @@ use FOS\RestBundle\Controller\AbstractFOSRestController;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -42,7 +43,7 @@ class TestcaseController extends AbstractFOSRestController
      * @param string $id
      * @return array|string|null
      * @throws \Doctrine\ORM\NonUniqueResultException
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST')")
      * @Rest\Get("/next-to-judge/{id}")
      * @SWG\Parameter(ref="#/parameters/id")
      * @SWG\Response(
@@ -111,7 +112,7 @@ class TestcaseController extends AbstractFOSRestController
      * @param string $type
      * @return string
      * @throws \Doctrine\ORM\NonUniqueResultException
-     * @IsGranted({"ROLE_JURY", "ROLE_JUDGEHOST"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST')")
      * @Rest\Get("/{id}/file/{type}")
      * @SWG\Parameter(ref="#/parameters/id")
      * @SWG\Parameter(

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -14,6 +14,7 @@ use Exception;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as SWG;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -222,7 +223,7 @@ class UserController extends AbstractRestController
      * @param Request $request
      * @return Response
      * @Rest\Get("")
-     * @IsGranted({"ROLE_ADMIN", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns all the users for this contest",
@@ -252,7 +253,7 @@ class UserController extends AbstractRestController
      * @return Response
      * @throws NonUniqueResultException
      * @Rest\Get("/{id}")
-     * @IsGranted({"ROLE_ADMIN", "ROLE_API_READER"})
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_READER')")
      * @SWG\Response(
      *     response="200",
      *     description="Returns the given user",

--- a/webapp/src/Controller/Jury/BalloonController.php
+++ b/webapp/src/Controller/Jury/BalloonController.php
@@ -11,7 +11,7 @@ use App\Service\EventLogService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route("/jury/balloons")
- * @IsGranted({"ROLE_JURY", "ROLE_BALLOON"})
+ * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
  */
 class BalloonController extends AbstractController
 {

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -15,6 +15,7 @@ use App\Service\ScoreboardService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -55,7 +56,7 @@ class JuryMiscController extends BaseController
 
     /**
      * @Route("", name="jury_index")
-     * @IsGranted({"ROLE_JURY", "ROLE_BALLOON"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
      */
     public function indexAction(Request $request)
     {
@@ -65,7 +66,7 @@ class JuryMiscController extends BaseController
 
     /**
      * @Route("/updates", methods={"GET"}, name="jury_ajax_updates")
-     * @IsGranted({"ROLE_JURY", "ROLE_BALLOON"})
+     * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
      */
     public function updatesAction(Request $request)
     {

--- a/webapp/src/Controller/Jury/PrintController.php
+++ b/webapp/src/Controller/Jury/PrintController.php
@@ -9,7 +9,7 @@ use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Utils\Printing;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class PrintController
  *
  * @Route("/jury/print")
- * @IsGranted({"ROLE_JURY", "ROLE_BALLOON"})
+ * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
  *
  * @package App\Controller\Jury
  */

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -722,7 +722,7 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         $split = explode("\n", $this->getBody());
         $newBody = '';
         foreach ($split as $line) {
-            if (strlen($line) > 0 && $line{0} != '>') {
+            if (strlen($line) > 0 && $line[0] != '>') {
                 $newBody .= $line . ' ';
             }
         }

--- a/webapp/tests/JuryPrintTest.php
+++ b/webapp/tests/JuryPrintTest.php
@@ -9,17 +9,24 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class JuryPrintTest extends WebTestCase
 {
+    private $client;
+
+    protected function setUp()
+    {
+        self::ensureKernelShutdown();
+        $this->client = self::createClient();
+    }
+
     private function loginHelper($username, $password, $redirectPage, $responseCode)
     {
-        $client = self::createClient();
-        $crawler = $client->request('GET', '/login');
+        $crawler = $this->client->request('GET', '/login');
 
         # load login page
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $message = var_export($response, true);
         $this->assertEquals(200, $response->getStatusCode(), $message);
 
-        $csrf_token = $client->getContainer()->get('security.csrf.token_manager')->getToken('authenticate');
+        $csrf_token = $this->client->getContainer()->get('security.csrf.token_manager')->getToken('authenticate');
 
         # submit form
         $button = $crawler->selectButton('Sign in');
@@ -28,46 +35,45 @@ class JuryPrintTest extends WebTestCase
             '_password' => $password,
             '_csrf_token' => $csrf_token,
         ));
-        $client->followRedirects();
-        $crawler = $client->submit($form);
-        $response = $client->getResponse();
-        $client->followRedirects(false);
+        $this->client->followRedirects();
+        $crawler = $this->client->submit($form);
+        $response = $this->client->getResponse();
+        $this->client->followRedirects(false);
 
         # check redirected to $redirectPage
         $message = var_export($response, true);
         $this->assertEquals($responseCode, $response->getStatusCode(), $message);
-        $this->assertEquals($redirectPage, $client->getRequest()->getUri(), $message);
+        $this->assertEquals($redirectPage, $this->client->getRequest()->getUri(), $message);
 
-        return $client;
+        return $this->client;
     }
 
     // This just injects a user object into the session so symfony will think we're logged in
     // It gets around the problem for now of trying to navigate to two legacy pages in a single
     // test(login index + anything else)
-    private function logIn($client)
+    private function logIn()
     {
-        $session = $client->getContainer()->get('session');
+        $session = $this->client->getContainer()->get('session');
 
         $firewallName = 'main';
         $firewallContext = 'main';
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
         $user = $em->getRepository(User::class)->findOneBy(['username' => 'dummy']);
         $token = new UsernamePasswordToken($user, null, $firewallName, array('ROLE_JURY'));
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
 
         $cookie = new Cookie($session->getName(), $session->getId());
-        $client->getCookieJar()->set($cookie);
+        $this->client->getCookieJar()->set($cookie);
     }
 
     public function testPrintingDisabledJuryIndexPage()
     {
-        $client = self::createClient();
-        $this->logIn($client);
-        $crawler = $client->request('GET', '/jury');
+        $this->logIn();
+        $crawler = $this->client->request('GET', '/jury');
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $message = var_export($response, true);
         $this->assertEquals(200, $response->getStatusCode(), $message);
         $this->assertEquals(0, $crawler->filter('a:contains("Print")')->count());
@@ -75,11 +81,10 @@ class JuryPrintTest extends WebTestCase
 
     public function testPrintingDisabledAccessDenied()
     {
-        $client = self::createClient();
-        $this->logIn($client);
-        $crawler = $client->request('GET', '/jury/print');
+        $this->logIn();
+        $crawler = $this->client->request('GET', '/jury/print');
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $message = var_export($response, true);
         $this->assertEquals(403, $response->getStatusCode(), $message);
 


### PR DESCRIPTION
This fixes another set of deprecation notices in our codebase triggered by either the upgrade of SF 4.4 or PHP 7.4.

One remains that I find hard to find a solution for, any idea @nickygerritsen ?
```
Loading the file "../src/Controller/API/" from the global resource directory "/opt/domjudge/domserver/webapp/src" is deprecated since Symfony 4.4 and will be removed in 5.0.
```
https://github.com/DOMjudge/domjudge/blob/fd5b3ef6ddb090b45b80e4fc69737e20b3107688/webapp/config/routes.yaml#L4

The other remaining notices that I managed to trigger are from libraries that have not yet fixed them in a released version or on a branch we can easily upgrade to.
