### PR TITLE
Emit events for all contests an entity belongs to. Fixes #441.

### DIFF
--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -408,7 +408,7 @@ class ExecutableController extends BaseController
             throw new NotFoundHttpException(sprintf('Executable with ID %s not found', $execId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $executable,
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel, $executable,
                                    $executable->getDescription(), $this->generateUrl('jury_executables'));
     }
 

--- a/webapp/src/Controller/Jury/JudgehostController.php
+++ b/webapp/src/Controller/Jury/JudgehostController.php
@@ -8,6 +8,7 @@ use App\Entity\Judging;
 use App\Form\Type\JudgehostsType;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
@@ -42,6 +43,11 @@ class JudgehostController extends BaseController
     protected $config;
 
     /**
+     * @var EventLogService
+     */
+    protected $eventLog;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -52,18 +58,21 @@ class JudgehostController extends BaseController
      * @param EntityManagerInterface $em
      * @param DOMJudgeService        $dj
      * @param ConfigurationService   $config
+     * @param EventLogService        $eventLog
      * @param KernelInterface        $kernel
      */
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
         ConfigurationService $config,
+        EventLogService $eventLog,
         KernelInterface $kernel
     ) {
-        $this->em     = $em;
-        $this->dj     = $dj;
-        $this->config = $config;
-        $this->kernel = $kernel;
+        $this->em       = $em;
+        $this->dj       = $dj;
+        $this->config   = $config;
+        $this->eventLog = $eventLog;
+        $this->kernel   = $kernel;
     }
 
     /**
@@ -325,7 +334,8 @@ class JudgehostController extends BaseController
             ->getQuery()
             ->getOneOrNullResult();
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $judgehost, $judgehost->getHostname(), $this->generateUrl('jury_judgehosts'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLog, $this->kernel,
+                                   $judgehost, $judgehost->getHostname(), $this->generateUrl('jury_judgehosts'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/JudgehostRestrictionController.php
+++ b/webapp/src/Controller/Jury/JudgehostRestrictionController.php
@@ -9,6 +9,7 @@ use App\Entity\Language;
 use App\Entity\Problem;
 use App\Form\Type\JudgehostRestrictionType;
 use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
 use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,24 +35,33 @@ class JudgehostRestrictionController extends BaseController
     protected $dj;
 
     /**
+     * @var EventLogService
+     */
+    protected $eventLog;
+
+    /**
      * @var KernelInterface
      */
     protected $kernel;
 
     /**
      * JudgehostRestrictionController constructor.
+     *
      * @param EntityManagerInterface $entityManager
      * @param DOMJudgeService        $dj
+     * @param EventLogService        $eventLog
      * @param KernelInterface        $kernel
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         DOMJudgeService $dj,
+        EventLogService $eventLog,
         KernelInterface $kernel
     ) {
-        $this->em = $entityManager;
-        $this->dj = $dj;
-        $this->kernel = $kernel;
+        $this->em       = $entityManager;
+        $this->dj       = $dj;
+        $this->eventLog = $eventLog;
+        $this->kernel   = $kernel;
     }
 
     /**
@@ -227,7 +237,9 @@ class JudgehostRestrictionController extends BaseController
         /** @var JudgehostRestriction $judgehostRestriction */
         $judgehostRestriction = $this->em->getRepository(JudgehostRestriction::class)->find($restrictionId);
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $judgehostRestriction, $judgehostRestriction->getName(), $this->generateUrl('jury_judgehost_restrictions'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLog, $this->kernel,
+                                   $judgehostRestriction, $judgehostRestriction->getName(),
+                                   $this->generateUrl('jury_judgehost_restrictions'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -337,7 +337,7 @@ class LanguageController extends BaseController
         }
 
         return $this->deleteEntity(
-            $request, $this->em, $this->dj, $this->kernel,
+            $request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
             $language, $language->getName(), $this->generateUrl('jury_languages')
         );
     }

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -1045,8 +1045,8 @@ class ProblemController extends BaseController
             throw new NotFoundHttpException(sprintf('Problem with ID %s not found', $probId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $problem,
-                                   $problem->getName(), $this->generateUrl('jury_problems'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
+                                   $problem, $problem->getName(), $this->generateUrl('jury_problems'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/Controller/Jury/TeamAffiliationController.php
@@ -281,8 +281,8 @@ class TeamAffiliationController extends BaseController
             throw new NotFoundHttpException(sprintf('Team affiliation with ID %s not found', $affilId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $teamAffiliation,
-                                   $teamAffiliation->getName(), $this->generateUrl('jury_team_affiliations'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
+                                   $teamAffiliation, $teamAffiliation->getName(), $this->generateUrl('jury_team_affiliations'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -249,8 +249,8 @@ class TeamCategoryController extends BaseController
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $teamCategory,
-                                   $teamCategory->getName(), $this->generateUrl('jury_team_categories'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
+                                   $teamCategory, $teamCategory->getName(), $this->generateUrl('jury_team_categories'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -412,8 +412,8 @@ class TeamController extends BaseController
             throw new NotFoundHttpException(sprintf('Team with ID %s not found', $teamId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $team, $team->getEffectiveName(),
-                                   $this->generateUrl('jury_teams'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
+                                   $team, $team->getEffectiveName(), $this->generateUrl('jury_teams'));
     }
 
     /**

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -272,8 +272,8 @@ class UserController extends BaseController
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $userId));
         }
 
-        return $this->deleteEntity($request, $this->em, $this->dj, $this->kernel, $user, $user->getName(),
-                                   $this->generateUrl('jury_users'));
+        return $this->deleteEntity($request, $this->em, $this->dj, $this->eventLogService, $this->kernel,
+                                   $user, $user->getName(), $this->generateUrl('jury_users'));
     }
 
     /**

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -642,7 +642,7 @@ class Problem extends BaseApiEntity
     /**
      * Get contestProblems
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return \Doctrine\Common\Collections\Collection|ContestProblem[]
      */
     public function getContestProblems()
     {

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -854,4 +854,18 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
             }
         }
     }
+
+    /**
+     * Check if this team belongs to the given contest
+     *
+     * @param Contest $contest
+     *
+     * @return bool
+     */
+    public function inContest(Contest $contest): bool
+    {
+        return $contest->isOpenToAllTeams() ||
+            $this->getContests()->contains($contest) ||
+            ($this->getCategory() !== null && $this->getCategory()->inContest($contest));
+    }
 }

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -320,4 +320,16 @@ class TeamCategory extends BaseApiEntity
 
         return $this;
     }
+
+    /**
+     * Check if this team category belongs to the given contest
+     *
+     * @param Contest $contest
+     *
+     * @return bool
+     */
+    public function inContest(Contest $contest): bool
+    {
+        return $contest->isOpenToAllTeams() || $this->getContests()->contains($contest);
+    }
 }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -3,6 +3,7 @@ namespace App\Utils;
 
 use App\Entity\SubmissionFile;
 use DateTime;
+use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Generic utility class.
@@ -1025,5 +1026,19 @@ class Utils
             case 'G': case 'g': return (int)$size_str * 1073741824;
             default: return $size_str;
         }
+    }
+
+    /**
+     * Return the table name for the given entity
+     * @param $entity
+     *
+     * @return string
+     */
+    public static function tableForEntity($entity)
+    {
+        $class        = get_class($entity);
+        $parts        = explode('\\', $class);
+        $entityType   = $parts[count($parts) - 1];
+        return Inflector::tableize($entityType);
     }
 }


### PR DESCRIPTION
Wow this was more than I expected. We did not emit a lot of create/update events:
* We only emitted them for the current contest.
* We did not emit any when creating entities, because the ID was not known yet.

Also we didn't emit *any* delete events.

Now we:
* Emit delete events for direct deletion of entities.
* Emit create / update events for all contests an entity belongs to, or all active contests if the entity is 'global'.
* Emit delete events when editing a contest and deleting teams, team categories and/or problems.

We still don't emit the following:
* Cascading delete events. We can try to fix this later, the code has a `TODO` to mark where to do it. We could maybe use the existing `BaseController::getDependentEntities()` method, or we could move it into `EventLogService::log` with a thing similar to `initStaticEvents`, but then for deletions.
* Create / update events when editing a contest and adding or modifying teams, team categories and/or problems. We could, but it's not trivial to check for changes. Furthermore this will happen when a client connects or we have an event that needs it anyway.