### PR TITLE
Bugfix: Don't hardcode the username in systemd service

### DIFF
--- a/judge/domjudge-judgehost.service.in
+++ b/judge/domjudge-judgehost.service.in
@@ -8,7 +8,7 @@ After=network.target
 Type=simple
 
 ExecStart=@judgehost_bindir@/judgedaemon -n 0
-User=domjudge
+User=@DOMJUDGE_USER@
 
 Restart=always
 RestartSec=3


### PR DESCRIPTION
@eldering was confused by what this PR did, so I thought I'd clarify here.

We allow the end user to choose the posix username that the judgedaemon will run as during `./configure`. However, we were failing to take this into account when generating the systemd service file that users could copy into place and use on their system. This code change addresses that issue so that the end user's configuration choice is honored.

This was primarily an issue with maintainer mode, which defaults to the judgedaemon running as the user who ran maintainer-conf, but the systemd service file always assumed that user was named `domjudge`.