### PR TITLE
Fix order of judging.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -914,6 +914,11 @@ function judge(array $row)
     $last_sent = now();
     $outstanding_data = 0;
     $update_every_X_seconds = dbconfig_get_rest('update_judging_seconds');
+
+    // There is no guarantee in which order the API returns the data, so let's
+    // order it here by rank.
+    ksort($row['testcases']);
+
     foreach ($row['testcases'] as $tc) {
         // Check whether we have received an exit signal(but not a graceful exit signal)
         if (function_exists('pcntl_signal_dispatch')) {


### PR DESCRIPTION
The next-judging API endpoint contains the testcase data key-ed by rank.
The order is unspecified and if you re-order things in the DB it's
likely not the intended order.