### PR TITLE
Escape testcase description in runtime graphs.

### DIFF
--- a/webapp/templates/jury/partials/submission_graph.html.twig
+++ b/webapp/templates/jury/partials/submission_graph.html.twig
@@ -113,7 +113,7 @@
                         "label": "{{ run.rank }}",
                         "value": {% if run.firstJudgingRun %}{{ run.firstJudgingRun.runtime|default(0) }}{% else %}0{% endif %},
                         "color": "{% if run.firstJudgingRun %}{{ colors[run.firstJudgingRun.runresult]|default('grey') }}{% else %}grey{% endif %}",
-                        "description": "{{ run.description(true)|default(run.rank) }}",
+                        "description": "{{ run.description(true)|default(run.rank)|escape("js") }}",
                     },
                     {% endfor %}
                 ]


### PR DESCRIPTION
Newlines may appear in testcase descriptions and need to be escaped
properly for JS.