### PR TITLE
Allow to "delete" testcases even with associated judgings.

### DIFF
--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -52,7 +52,7 @@ class Testcase
      * @var int
      * @ORM\Column(type="integer", name="probid", length=4,
      *     options={"comment"="Corresponding problem ID", "unsigned"=true},
-     *     nullable=false)
+     *     nullable=true)
      */
     private $probid;
 
@@ -103,6 +103,16 @@ class Testcase
      * @Serializer\Exclude()
      */
     private $sample = false;
+
+    /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="deleted",
+     *     options={"comment"="Deleted testcases are kept for referential integrity.",
+     *              "default"="0"},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $deleted = false;
 
     /**
      * @ORM\OneToMany(targetEntity="JudgingRun", mappedBy="testcase")
@@ -343,6 +353,20 @@ class Testcase
     }
 
     /**
+     * Set deleted
+     *
+     * @param boolean $deleted
+     *
+     * @return Testcase
+     */
+    public function setDeleted(bool $deleted)
+    {
+        $this->deleted = $deleted;
+
+        return $this;
+    }
+
+    /**
      * Get sample
      *
      * @return boolean
@@ -350,6 +374,16 @@ class Testcase
     public function getSample()
     {
         return $this->sample;
+    }
+
+    /**
+     * Get deleted
+     *
+     * @return boolean
+     */
+    public function getDeleted()
+    {
+        return $this->deleted;
     }
 
     /**

--- a/webapp/src/Migrations/Version20200425120051.php
+++ b/webapp/src/Migrations/Version20200425120051.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200425120051 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Adds deleted boolean field to testcase.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE testcase ADD deleted TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Deleted testcases are kept for referential integrity.\', CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Corresponding problem ID\', CHANGE orig_input_filename orig_input_filename VARCHAR(255) DEFAULT NULL COMMENT \'Original basename of the input file.\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE testcase DROP deleted, CHANGE probid probid INT UNSIGNED NOT NULL COMMENT \'Corresponding problem ID\', CHANGE orig_input_filename orig_input_filename VARCHAR(255) DEFAULT \'NULL\' COLLATE utf8mb4_unicode_ci COMMENT \'Original basename of the input file.\'');
+    }
+}

--- a/webapp/src/Migrations/Version20200425120051.php
+++ b/webapp/src/Migrations/Version20200425120051.php
@@ -22,7 +22,8 @@ final class Version20200425120051 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE testcase ADD deleted TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Deleted testcases are kept for referential integrity.\', CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Corresponding problem ID\', CHANGE orig_input_filename orig_input_filename VARCHAR(255) DEFAULT NULL COMMENT \'Original basename of the input file.\'');
+        $this->addSql('ALTER TABLE testcase ADD deleted TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Deleted testcases are kept for referential integrity.\'');
+        $this->addSql('ALTER TABLE testcase CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Corresponding problem ID\'');
     }
 
     public function down(Schema $schema) : void
@@ -30,6 +31,6 @@ final class Version20200425120051 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE testcase DROP deleted, CHANGE probid probid INT UNSIGNED NOT NULL COMMENT \'Corresponding problem ID\', CHANGE orig_input_filename orig_input_filename VARCHAR(255) DEFAULT \'NULL\' COLLATE utf8mb4_unicode_ci COMMENT \'Original basename of the input file.\'');
+        $this->addSql('ALTER TABLE testcase DROP deleted, CHANGE probid probid INT UNSIGNED NOT NULL COMMENT \'Corresponding problem ID\'');
     }
 }

--- a/webapp/templates/jury/problem_testcases.html.twig
+++ b/webapp/templates/jury/problem_testcases.html.twig
@@ -28,6 +28,9 @@
         <table class="table table-sm table-striped table-hover testcases">
             <thead>
             <tr>
+                {% if is_granted('ROLE_ADMIN') %}
+                    <th/>
+                {% endif %}
                 <th class="testrank">#</th>
                 <th class="testsample">sample</th>
                 <th>download</th>
@@ -42,6 +45,15 @@
             <tbody>
             {% for rank, testcase in testcases %}
                 <tr>
+                    {% if is_granted('ROLE_ADMIN') %}
+                        <td rowspan="2">
+                            <a href="{{  path('jury_testcase_delete', {'testcaseId': testcase.testcaseid}) }}"
+                               title="delete testcase {{ testcase.testcaseid }}"
+                               onclick="confirm('Proceed with the deletion of testcase {{ testcase.testcaseid }}?');">
+                                <i class="fas fa-trash-alt"></i>
+                            </a>
+                        </td>
+                    {% endif %}
                     <td rowspan="2" class="testrank">
                         <a href="{{ path('jury_problem_testcase_move', {'probId': problem.probid, 'rank': testcase.rank, 'direction': 'up'}) }}"
                            title="Move testcase up"><i class="fas fa-arrow-up"></i></a><br>


### PR DESCRIPTION
This only marks testcases as deleted but doesn't actually delete them.
Since the association with the problem is removed they will not be taken
into account with future (re)judgings of the problem.

All testcases that are ranked after the deleted one are moved up one
rank.

In a follow up change we can actually delete testcases which don't have
any associated judgings.

With commit d873b7c we added a warning to submissions which were judged
either in a different testcase order or with a now deleted testcase.

We may want to offer to rejudge all of those cases together with a
single click but I didn't want to bundle to much in this commit.

Fixes #189.