### PR TITLE
Disable gitlab cache.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,8 +63,9 @@ integration:
       - misc-tools/icpctools/dj-scoreboard.json
       - misc-tools/icpctools/cds-events.json
       - misc-tools/icpctools/cds-scoreboard.json
-  cache:
-    key: integration
-    paths:
-      - lib/vendor/
-      - chroot
+# TODO: Re-enable when gitlab is in better shape...
+#  cache:
+#    key: integration
+#    paths:
+#      - lib/vendor/
+#      - chroot


### PR DESCRIPTION
Uploading the cache seems to cause most timeouts that we see recently.