### PR TITLE
Remove unused local variables.

### DIFF
--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -109,7 +109,6 @@ class AnalysisController extends AbstractController
         }
 
         // Next select information about the teams
-        $teams = [];
         if ($contest->isOpenToAllTeams()) {
             $teams = $this->applyFilter($em->createQueryBuilder()
                                             ->select('t', 'ts', 'j', 'lang', 'a')

--- a/webapp/src/Controller/Jury/BalloonController.php
+++ b/webapp/src/Controller/Jury/BalloonController.php
@@ -70,7 +70,6 @@ class BalloonController extends AbstractController
      */
     public function indexAction(Request $request, Packages $assetPackage, KernelInterface $kernel)
     {
-        $timeFormat = (string)$this->config->get('time_format');
         $showPostFreeze = (bool)$this->config->get('show_balloons_postfreeze');
 
         $em = $this->em;
@@ -195,7 +194,7 @@ class BalloonController extends AbstractController
             $balloons_table[] = [
                 'data' => $balloondata,
                 'actions' => $balloonactions,
-                'cssclass' => $balloon->getDone() ? 'disabled' : null,
+                'cssclass' => $cssclass,
             ];
         }
 

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -492,7 +492,6 @@ class CheckConfigService
     public function checkLanguagesValidate()
     {
         $languages = $this->em->getRepository(Language::class)->findAll();
-        $script_filesize_limit = $this->config->get('script_filesize_limit');
 
         $languageerrors = $scripterrors = [];
         $result = 'O';

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -410,7 +410,7 @@ class DOMJudgeService
         }
 
         if ($this->checkrole('admin')) {
-            $internal_error = $this->em->createQueryBuilder()
+            $internal_errors = $this->em->createQueryBuilder()
                 ->select('ie.errorid', 'ie.description')
                 ->from(InternalError::class, 'ie')
                 ->andWhere('ie.status = :status')

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -321,9 +321,7 @@ class ScoreboardService
         }
 
         // Determine whether we will use external judgements instead of judgings
-        $localSource           = DOMJudgeService::DATA_SOURCE_LOCAL;
-        $shadow                = DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
-        $useExternalJudgements = $this->config->get('data_source') == $shadow;
+        $useExternalJudgements = $this->config->get('data_source') == DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL;
 
         // Note the clause 's.submittime < c.endtime': this is used to
         // filter out TOO-LATE submissions from pending, but it also means


### PR DESCRIPTION
This also uncovered a bug in the getUpdates function for internal
errors which were always empty.