### PR TITLE
Bump PHP version to 7.2.5.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version 7.3.0 - DEV
    the sense the other ones are.
  - Add team display name support.
  - Add support for importing teams, organizations and groups using JSON.
+ - Minimum PHP version is now 7.2.5.
 
 Version 7.2.0 - 4 January 2020
 ------------------------------

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.1.3",
+		"php": "^7.2.5",
 		"ext-ctype": "*",
 		"ext-curl": "*",
 		"ext-gd": "*",
@@ -108,6 +108,9 @@
 			"*": "dist"
 		},
 		"sort-packages": true,
+		"platform": {
+			"php": "7.2.5"
+		},
 		"vendor-dir": "lib/vendor",
 		"component-dir": "lib/vendor/components"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "caea8145ea1cab098bd2533fcabaf466",
+    "content-hash": "35832a6056ada63898a6af7b1ce96f9d",
     "packages": [
         {
             "name": "angel-vladov/select2-bootstrap-theme",
@@ -8985,7 +8985,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3",
+        "php": "^7.2.5",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-gd": "*",
@@ -8997,5 +8997,8 @@
         "ext-pcntl": "*",
         "ext-zip": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2.5"
+    }
 }

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -23,7 +23,7 @@ System requirements
 
 Software requirements
 `````````````````````
-* A web server with support for PHP >= 7.1.3 and the ``mysqli``, ``curl``, ``gd``,
+* A web server with support for PHP >= 7.2.5 and the ``mysqli``, ``curl``, ``gd``,
   ``mbstring``, ``intl``, ``zip``, ``xml`` and ``json`` extensions for PHP.
 * MySQL or MariaDB >= 5.3.3 database. This can be on the same machine, but for
   advanced setups can also run on a dedicated machine.

--- a/doc/manual/overview.rst
+++ b/doc/manual/overview.rst
@@ -45,7 +45,7 @@ chapters for detailed software requirements.
 
 * At least one machine to act as the *DOMjudge server* (or *domserver* for
   brevity). The machine needs to be running Linux (or possibly a Unix
-  variant) and a webserver with PHP 7.1.3 or newer. A MySQL or MariaDB
+  variant) and a webserver with PHP 7.2.5 or newer. A MySQL or MariaDB
   database with version 5.3.3 or newer is also needed.
 
 * A number of machines to act as *judgehosts* (at least one). They need to run

--- a/symfony.lock
+++ b/symfony.lock
@@ -228,6 +228,9 @@
     "phar-io/version": {
         "version": "2.0.1"
     },
+    "php": {
+        "version": "7.2.5"
+    },
     "phpdocumentor/reflection-common": {
         "version": "1.0.1"
     },

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -132,7 +132,7 @@ class CheckConfigService
     public function checkPhpVersion()
     {
         $my = PHP_VERSION;
-        $req = '7.1.3';
+        $req = '7.2.5';
         $result = version_compare($my, $req, '>=');
         return ['caption' => 'PHP version',
                 'result' => ($result ? 'O' : 'E'),


### PR DESCRIPTION
See https://github.com/symfony/flex/issues/609 for why we put the `config.platform.php` thing in `composer.json`.

Also note that we actually should also bump the PHP version for DOMjudge 7.1 and 7.2, since https://packagist.org/packages/jms/serializer-bundle requires it since 3.x. The `config.platform.php` thing in `composer.lock` also makes sure that doesn't happen in the future.