### PR TITLE
Add option to allow teams to download their own submission. Fixes #714.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -222,6 +222,11 @@
             default_value: true
             public: true
             description: Show time and memory limit on the team problems page.
+        -   name: allow_team_submission_download
+            type: bool
+            default_value: false
+            public: true
+            description: Allow teams to download their own submission code
         -   name: team_column_width
             type: int
             default_value: 0

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -274,38 +274,7 @@ class SubmissionController extends AbstractRestController
 
         $submission = reset($submissions);
 
-        /** @var SubmissionFile[] $files */
-        $files = $submission->getFiles();
-        $zip   = new \ZipArchive;
-        if (!($tmpfname = tempnam($this->dj->getDomjudgeTmpDir(), "submission_file-"))) {
-            return new Response("Could not create temporary file.", Response::HTTP_INTERNAL_SERVER_ERROR);
-        }
-
-        $res = $zip->open($tmpfname, \ZipArchive::OVERWRITE);
-        if ($res !== true) {
-            return new Response("Could not create temporary zip file.", Response::HTTP_INTERNAL_SERVER_ERROR);
-        }
-        foreach ($files as $file) {
-            $zip->addFromString($file->getFilename(), $file->getSourcecode());
-        }
-        $zip->close();
-
-        $filename = 's' . $submission->getSubmitid() . '.zip';
-
-        $response = new StreamedResponse();
-        $response->setCallback(function () use ($tmpfname) {
-            $fp = fopen($tmpfname, 'rb');
-            fpassthru($fp);
-            unlink($tmpfname);
-        });
-        $response->headers->set('Content-Type', 'application/zip');
-        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
-        $response->headers->set('Content-Length', filesize($tmpfname));
-        $response->headers->set('Content-Transfer-Encoding', 'binary');
-        $response->headers->set('Connection', 'Keep-Alive');
-        $response->headers->set('Accept-Ranges', 'bytes');
-
-        return $response;
+        return $this->submissionService->getSubmissionZipResponse($submission);
     }
 
     /**

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -43,6 +43,16 @@
             </div>
         {% endif %}
 
+        {% if allowDownload %}
+            <div class="d-flex flex-row">
+                <div class="p-2">
+                    <a class="btn btn-primary" href="{{ path('team_submission_download', {'submitId': judging.submitid}) }}">
+                        <i class="fa fa-download"></i> Download submission
+                    </a>
+                </div>
+            </div>
+        {% endif %}
+
         {% if showCompile == 2 or (showCompile == 1 and judging.result == 'compiler-error') %}
             <hr/>
             <h4 class="text-center">Compilation output</h4>


### PR DESCRIPTION
If the option is enabled, this looks like this:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/550145/80859426-42e14f80-8c61-11ea-87a5-48d8d896a71c.png">

Note that the popup is only shown currently for submissions that have a valid judging and are submitted before contest end and thus the button also only appears then. If we want to change this I think it's better to do that in a separate PR, but I also think the current way is fine.