### PR TITLE
Update password generate export to reflect accounts.tsv. Fixes #694.

### DIFF
--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -324,6 +324,7 @@ class UserController extends BaseController
         if ($form->isSubmitted() && $form->isValid()) {
             $groups = $form->get('group')->getData();
 
+            /** @var User[] $users */
             $users = $this->em->getRepository(User::class)->findAll();
 
             $changes = [];
@@ -356,7 +357,6 @@ class UserController extends BaseController
                     $this->dj->auditlog('user', $user->getUserid(), 'set password');
                     $changes[] = [
                             'type' => $role,
-                            'id' => $user->getUserid(),
                             'fullname' => $user->getName(),
                             'username' => $user->getUsername(),
                             'password' => $newpass,
@@ -364,12 +364,12 @@ class UserController extends BaseController
                 }
             }
             $this->em->flush();
-            $response = $this->render('jury/tsv/userdata.tsv.twig', [
+            $response = $this->render('jury/tsv/accounts.tsv.twig', [
                 'data' => $changes,
             ]);
             $disposition = $response->headers->makeDisposition(
                 ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                'userdata.tsv');
+                'accounts.tsv');
             $response->headers->set('Content-Disposition', $disposition);
             $response->headers->set('Content-Type', 'text/plain');
             return $response;

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -126,6 +126,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('descriptionExpand', [$this, 'descriptionExpand'], ['is_safe' => ['html']]),
             new TwigFilter('wrapUnquoted', [$this, 'wrapUnquoted']),
             new TwigFilter('hexColorToRGBA', [$this, 'hexColorToRGBA']),
+            new TwigFilter('tsvField', [$this, 'toTsvField']),
         ];
     }
 
@@ -964,5 +965,21 @@ EOF;
         }
 
         return $text;
+    }
+
+    /**
+     * Convert the given string to a field that is safe to use in a TSV file
+     *
+     * @param string $field
+     *
+     * @return string
+     */
+    public function toTsvField(string $field)
+    {
+        return str_replace(
+            ["\\",   "\t",  "\n",  "\r"],
+            ["\\\\", "\\t", "\\n", "\\r"],
+            $field
+        );
     }
 }

--- a/webapp/templates/jury/tsv/accounts.tsv.twig
+++ b/webapp/templates/jury/tsv/accounts.tsv.twig
@@ -1,0 +1,4 @@
+accounts	1
+{% for row in data %}
+{{ row.type|tsvField }}	{{ row.fullname|tsvField }}	{{ row.username|tsvField }}	{{ row.password|tsvField }}
+{% endfor %}

--- a/webapp/templates/jury/tsv/userdata.tsv.twig
+++ b/webapp/templates/jury/tsv/userdata.tsv.twig
@@ -1,4 +1,0 @@
-userdata	1
-{% for row in data %}
-{{ row.type|replace({'\t':' '}) }}	{{ row.id|replace({'\t':' '}) }}	{{ row.fullname|replace({'\t':' '}) }}	{{ row.username|replace({'\t':' '}) }}	{{ row.password|replace({'\t':' '}) }}
-{% endfor %}


### PR DESCRIPTION
https://clics.ecs.baylor.edu/index.php/Contest_Control_System_Requirements#accounts.tsv specifies `For accounts of type team username is on the form "team-nnn" where "nnn" is the zero padded team number as given in teams.tsv.` but I think it would be strange to do that in this export since then you loose the original username.