### PR TITLE
Add simple option to switch between multiple doc versions.

### DIFF
--- a/doc/manual/_static/js/versionswitcher.js
+++ b/doc/manual/_static/js/versionswitcher.js
@@ -1,0 +1,37 @@
+function versionChange(selectList) {
+    url = window.location.href;
+    for (var i = 0; i < 2; i++) {
+        var to = url.lastIndexOf('/');
+        to = to == -1 ? url.length : to;
+        url = url.substring(0, to);
+    }
+    // TODO: Redirect to same page on the other version instead of the
+    // overview.
+    window.location.href = url + '/' + selectList.value + '/index.html'
+}
+
+window.onload = function() {
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+             var availableVersions = JSON.parse(this.responseText);
+             var version = document.getElementsByClassName(['version'])[0];
+             currentVersion = version.innerHTML.trim();
+             version.innerHTML = '';
+             var selectList = document.createElement("select");
+             selectList.id = "versionSelect";
+             version.appendChild(selectList);
+             
+             for (var i = 0; i < availableVersions.length; i++) {
+                 var option = document.createElement("option");
+                 option.value = availableVersions[i];
+                 option.text = availableVersions[i];
+                 selectList.appendChild(option);
+             }
+             selectList.onchange = function(){versionChange(selectList);};
+             selectList.value = currentVersion;
+        }
+    };
+    xmlhttp.open("GET", '../versions.json', true);
+    xmlhttp.send();
+}

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -115,6 +115,7 @@ html_static_path = ['_static']
 #
 # html_sidebars = {}
 
+html_js_files = ['js/versionswitcher.js']
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
This assumes that the docs for the multiple versions are arranged in a
structure like:
  <SERVER_URL>/docs/manual/<VERSION>/index.html
e.g.
  https://www.domjudge.org/docs/manual/7.2/
  https://www.domjudge.org/docs/manual/7.3/
  https://www.domjudge.org/docs/manual/master/
and that
  <SERVER_URL>/docs/manual/versions.json
contains a version list in JSON format, e.g.
  ["7.2", "7.3", "master"]
.

If the versions.json file is not readable, then the version div remains
unchanged and is not transformed to a select dropdown.