### PR TITLE
Generate configuration reference from db-values.yaml.

### DIFF
--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -3,3 +3,4 @@
 /substitutions
 /html
 /team
+/conf_ref.rst

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -27,7 +27,7 @@ maintainer-install: docs
 	ln -sf build/team
 
 clean-l:
-	rm -rf build/doctrees
+	rm -rf build/doctrees conf_ref.rst
 
 maintainer-clean-l:
 	rm -rf build
@@ -35,7 +35,10 @@ maintainer-clean-l:
 distclean-l:
 	-rm -f $(SUBST_CONFIGS) html team
 
-html:
+conf_ref.rst: gen_conf_ref.py
+	./gen_conf_ref.py
+
+html: conf_ref.rst
 	sphinx-build -M $@ . build $(subst 1,-Q,$(QUIET))
 
 team:

--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -31,6 +31,8 @@ follows:
   The IDs for affiliations and teams need to be the *external ID*
   if the ``data_source`` setting of DOMjudge is set to external.
 
+.. _authentication:
+
 Authentication and registration
 -------------------------------
 Out of the box users are able to authenticate using username and password.
@@ -236,6 +238,7 @@ must probably also be created, so the exact data written to
 correctness of the contestants' program can be deduced from the
 contents by the compare program.
 
+.. _printing:
 
 Printing
 --------

--- a/doc/manual/configuration-reference.rst
+++ b/doc/manual/configuration-reference.rst
@@ -1,0 +1,18 @@
+Appendix: Configuration reference
+=================================
+
+DOMjudge has several configuration settings available. They can be accessed in
+the admin interface under *Configuration settings*. This appendix contains a
+list of all the available options with a description of what they mean.
+
+The system has the following types of configuration options:
+
+* ``bool``: a boolean, either ``true`` or ``false``.
+* ``int``: a numeric value.
+* ``string``: a string value.
+* ``array_val``: an array of values.
+* ``array_keyval``: an array of values with specific keys (also known as a dictionary).
+
+**Public** means whether the option is exposed in the API to non-jury members.
+
+.. include:: conf_ref.rst

--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -38,10 +38,10 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python-sphinx python-sphinx-rtd-theme rst2pdf
+    python-sphinx python-sphinx-rtd-theme rst2pdf python-yaml
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme rst2pdf`` instead.
+``python3-sphinx python3-sphinx-rtd-theme python3-yaml rst2pdf`` instead.
 
 When this software is present, bootstrapping can be done by running
 ``make dist``, which creates the ``configure`` script,

--- a/doc/manual/gen_conf_ref.py
+++ b/doc/manual/gen_conf_ref.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import json
+import sys
+import textwrap
+import yaml
+
+
+def _get_category_description(category):
+    return '''
+{category}
+{underline}
+{description}
+
+'''.format(
+    category=category['category'],
+    underline='-' * len(category['category']),
+    description=category['description'])
+
+
+def _wrap(wrap, text):
+    return wrap + text + wrap
+
+
+def _get_default_value(item):
+    if item['type'] in ['bool', 'int']:
+        return _wrap('``', str(item['default_value']))
+    elif item['type'] == 'string':
+        return _wrap('``', _wrap('\'', item['default_value']))
+    else:
+        return '''
+
+  .. code-block:: json
+
+{json}
+'''.format(
+        json=textwrap.indent(
+            json.dumps(item['default_value'], indent=2),
+            prefix=' ' * 8))
+
+def _get_description(item):
+    description = item['description'] + ' '
+    if 'docdescription' in item:
+        description += item['docdescription']
+    return description
+
+def _get_options(item):
+    if not 'options' in item:
+        return ''
+    options = item['options']
+    options_header = '* **Possible options:**\n\n'
+    if type(options) is dict:
+        return options_header + '\n'.join(['    * ``{option}``: *{desc}*'.format(
+            option=option,
+            desc=options[option]
+        ) for option in options])
+    else:
+        return options_header + '\n'.join(['    * ``{}``'.format(option) for option in options])
+
+def _get_item_description(item):
+    return '''
+``{name}``
+{underline}
+
+{description}
+
+* **Type:** ``{typ}``
+* **Public:** {public}
+* **Default value:** {default_value}
+{maybe_options}
+
+'''.format(
+    name=item['name'],
+    underline='^' * (len(item['name']) + 4),
+    typ=item['type'],
+    public='yes' if item['public'] else 'no',
+    default_value=_get_default_value(item),
+    description=_get_description(item),
+    maybe_options=_get_options(item))
+
+
+if __name__ == "__main__":
+    try:
+        with open('../../etc/db-config.yaml') as db_config_file:
+            db_config = yaml.load(db_config_file)
+    except IOError as e:
+        print('Failed to read config values: %s' % e.strerror)
+        sys.exit(-1)
+
+    try:
+        with open('conf_ref.rst', 'w') as rst_file:
+            for category in db_config:
+                rst_file.write(_get_category_description(category))
+                for item in category['items']:
+                    rst_file.write(_get_item_description(item))
+    except IOError as e:
+        print('Failed to write rst file: %s' % e.strerror)
+        sys.exit(-1)

--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -25,3 +25,4 @@ Appendices
    team
    problem-format
    shadow
+   configuration-reference

--- a/doc/manual/install-workstation.rst
+++ b/doc/manual/install-workstation.rst
@@ -66,11 +66,11 @@ When DOMjudge is configured and site-specific configuration set,
 the team manual can be generated with the command ``make docs``.
 The following should do it on a Debian-like system::
 
-  sudo apt install python-sphinx python-sphinx-rtd-theme rst2pdf
+  sudo apt install python-sphinx python-sphinx-rtd-theme python-yaml rst2pdf
   cd <INSTALL_PATH>/doc/
   make docs
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme rst2pdf`` instead.
+``python3-sphinx python3-sphinx-rtd-theme python3-yaml rst2pdf`` instead.
 
 The resulting manual will then be found in the ``team/`` subdirectory.

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -1,5 +1,6 @@
 # Configuration settings that can be overriden using the `configuration` database table
 -   category: Scoring
+    description: Options related to how scoring is handled.
     items:
         -   name: verification_required
             type: bool
@@ -39,6 +40,7 @@
             public: true
             description: Should the scoreboard resolution be measured in seconds instead of minutes?
 -   category: Judging
+    description: Options related to how judging is performed.
     items:
         -   name: memory_limit
             type: int
@@ -131,6 +133,7 @@
             public: false
             description: The script used to run submissions if no special run script specified.
 -   category: Clarification
+    description: Options related to clarifications.
     items:
         -   name: clar_categories
             type: array_keyval
@@ -157,6 +160,7 @@
             public: true
             description: Queue to assign to problem clarifications.
 -   category: Display
+    description: Options related to the DOMjudge user interface.
     items:
         -   name: show_pending
             type: bool
@@ -226,40 +230,50 @@
             type: bool
             default_value: false
             public: true
-            description: Allow teams to download their own submission code
+            description: Allow teams to download their own submission code.
+            docdescription: |
+                Note that enabling this option means that if someone gets access to the account of a team, they can download
+                the source code of all submissions from that team. When this option is disabled, getting access to the account
+                of a team only allows someone to submit as that team, which can then easily be ignored by the jury later.
         -   name: team_column_width
             type: int
             default_value: 0
             public: false
             description: Maximum width of team column on scoreboard. Leave 0 for no maximum.
 -   category: Misc
+    description: Miscellaneous configuration options.
     items:
         -   name: print_command
             type: string
             default_value: ""
             public: true
-            description: If not empty, enable teams and jury to send source code to this command. See admin manual for allowed arguments.
+            description: If set, enable teams and jury to send source code to this command. See admin manual for allowed arguments.
+            docdescription: See :ref:`printing` for more information.
         -   name: data_source
             type: int
             default_value: 0
             public: false
-            description: "Source of data: used to indicate whether internal or external IDs are exposed in the API. 'configuration data external' is typically used when loading configuration data from the ICPC CMS, and 'configuration and live data external when running DOMjudge as \"shadow system\""
+            description: "Source of data: used to indicate whether internal or external IDs are exposed in the API. 'configuration data external' is typically used when loading configuration data from the ICPC CMS, and 'configuration and live data external' when running DOMjudge as \"shadow system\"."
             options:
                 0: all local
                 1: configuration data external
                 2: configuration and live data external
+            docdescription: See :doc:`the chapter on running DOMjudge as a shadow system<shadow>` for more information.
         -   name: external_ccs_submission_url
             type: string
             default_value: ""
             public: false
             description: URL of a submission detail page on the external CCS. Placeholder [id] will be replaced by submission ID and [contest] by the contest ID. Leave empty to not display links to external CCS.
+            docdescription: See :doc:`the chapter on running DOMjudge as a shadow system<shadow>` for more information.
 -   category: Authentication
+    description: Options related to authentication.
     items:
         -   name: auth_methods
             type: array_val
             default_value: []
             public: false
             description: List of allowed additional authentication methods.
+            docdescription: See :ref:`authentication` for more information.
             options:
                 - ipaddress
                 - xheaders

--- a/gitlab/syntax.sh
+++ b/gitlab/syntax.sh
@@ -9,4 +9,5 @@ make clean
 
 cd doc/manual/
 make version.py
-sphinx-build -W -b html . build
+./gen_conf_ref.py
+sphinx-build -b html . build


### PR DESCRIPTION
Example generated from current master can be found at https://djdoc.thuis.nickygerritsen.nl/configuration-reference.html .

My Python skills are -3 so probably it can be improved. If one of you feels like improving the code, you should be able to commit to this branch.

Note that we need `python3-yaml` (or `python-yaml`) as stated in the docs for the Python script to read the YAML file. I will add it to the appropriate Docker containers if you guys agree with this approach.

Feedback more than welcome!