### PR TITLE
Register: only validate affiliation name uniqueness if "Add new affiliation" is selected

### DIFF
--- a/webapp/src/Form/Type/UserRegistrationType.php
+++ b/webapp/src/Form/Type/UserRegistrationType.php
@@ -91,7 +91,6 @@ class UserRegistrationType extends AbstractType
                     new Callback(function ($teamName, ExecutionContext $context) {
                         if ($this->em->getRepository(Team::class)->findOneBy(['name' => $teamName])) {
                             $context->buildViolation('This team name is already in use.')
-                                ->atPath('teamName')
                                 ->addViolation();
                         }
                     }),
@@ -145,15 +144,6 @@ class UserRegistrationType extends AbstractType
                     'required' => false,
                     'attr' => [
                         'placeholder' => 'Affiliation name',
-                    ],
-                    'constraints' => [
-                        new Callback(function ($affiliationName, ExecutionContext $context) {
-                            if ($this->em->getRepository(TeamAffiliation::class)->findOneBy(['name' => $affiliationName])) {
-                                $context->buildViolation('This affiliation name is already in use.')
-                                    ->atPath('team_name')
-                                    ->addViolation();
-                            }
-                        }),
                     ],
                     'mapped' => false,
                 ]);
@@ -219,8 +209,14 @@ class UserRegistrationType extends AbstractType
                 $form = $context->getRoot();
                 switch ($form->get('affiliation')->getData()) {
                     case 'new':
-                        if (empty($form->get('affiliationName')->getData())) {
+                        $affiliationName = $form->get('affiliationName')->getData();
+                        if (empty($affiliationName)) {
                             $context->buildViolation('This value should not be blank.')
+                                ->atPath('affiliationName')
+                                ->addViolation();
+                        }
+                        if ($this->em->getRepository(TeamAffiliation::class)->findOneBy(['name' => $affiliationName])) {
+                            $context->buildViolation('This affiliation name is already in use.')
                                 ->atPath('affiliationName')
                                 ->addViolation();
                         }


### PR DESCRIPTION
Also fix property path of violation (team_name => affiliationName).

While we are here, remove redundant property path from teamName validation (that violation error is in the current context).

Fixes #793.