### PR TITLE
Use relative URL to registration form on the login page instead of absolute

### DIFF
--- a/webapp/templates/security/login.html.twig
+++ b/webapp/templates/security/login.html.twig
@@ -111,7 +111,7 @@
                 {% if allow_registration %}
                     <div class="mt-3">
                         Don't have an account?<br/>
-                        <a href="{{ url('register', {}, true) }}">Register now</a>.
+                        <a href="{{ path('register') }}">Register now</a>.
                     </div>
                 {% endif %}
             </form>


### PR DESCRIPTION
Some reverse proxies rewrite the "Host" header, which breaks absolute URLs. Switch to a relative URL like all the other links.

To verify, check the `href` attribute in the HTML source. For example on https://www.domjudge.org/demoweb/login it is
```
<a href="//www.domjudge.org/demoweb/register">Register now</a>.
```
(the other links don't include the domain)