### PR TITLE
Always install python3-yaml, never python-yaml

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -38,10 +38,10 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python-sphinx python-sphinx-rtd-theme rst2pdf python-yaml
+    python-sphinx python-sphinx-rtd-theme rst2pdf python3-yaml
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme python3-yaml rst2pdf`` instead.
+``python3-sphinx python3-sphinx-rtd-theme rst2pdf python3-yaml`` instead.
 
 When this software is present, bootstrapping can be done by running
 ``make dist``, which creates the ``configure`` script,

--- a/doc/manual/install-workstation.rst
+++ b/doc/manual/install-workstation.rst
@@ -66,11 +66,11 @@ When DOMjudge is configured and site-specific configuration set,
 the team manual can be generated with the command ``make docs``.
 The following should do it on a Debian-like system::
 
-  sudo apt install python-sphinx python-sphinx-rtd-theme python-yaml rst2pdf
+  sudo apt install python-sphinx python-sphinx-rtd-theme rst2pdf python3-yaml
   cd <INSTALL_PATH>/doc/
   make docs
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme python3-yaml rst2pdf`` instead.
+``python3-sphinx python3-sphinx-rtd-theme rst2pdf python3-yaml`` instead.
 
 The resulting manual will then be found in the ``team/`` subdirectory.


### PR DESCRIPTION
It is required by gen_conf_ref.py, which uses `python3` in the shebang line and so will always run on Python 3, never Python 2.

This is in contrast with the python-sphinx package, which may need to be Python 2 to match the rst2pdf package.

I also moved python3-yaml to the end to emphasise that python-sphinx and rst2pdf are related, is that OK? Should I do the same in the domjudge-packaging repository, in [docker-gitlabci/Dockerfile:10](https://github.com/DOMjudge/domjudge-packaging/blob/8fc6462b6e0f78d4de2112bcf28e33f87a853168/docker-gitlabci/Dockerfile#L10)?
