### PR TITLE
Install fontconfig for rst2pdf

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -38,10 +38,10 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python-sphinx python-sphinx-rtd-theme rst2pdf python3-yaml
+    python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme rst2pdf python3-yaml`` instead.
+``python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml`` instead.
 
 When this software is present, bootstrapping can be done by running
 ``make dist``, which creates the ``configure`` script,

--- a/doc/manual/install-workstation.rst
+++ b/doc/manual/install-workstation.rst
@@ -66,11 +66,11 @@ When DOMjudge is configured and site-specific configuration set,
 the team manual can be generated with the command ``make docs``.
 The following should do it on a Debian-like system::
 
-  sudo apt install python-sphinx python-sphinx-rtd-theme rst2pdf python3-yaml
+  sudo apt install python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
   cd <INSTALL_PATH>/doc/
   make docs
 
 On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme rst2pdf python3-yaml`` instead.
+``python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml`` instead.
 
 The resulting manual will then be found in the ``team/`` subdirectory.


### PR DESCRIPTION
The rst2pdf package uses the fc-match command from the fontconfig package, but doesn't list it as a dependency for some reason.

See DOMjudge/domjudge-packaging#56.