### PR TITLE
Compile phase inside chroot

### DIFF
--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -22,24 +22,20 @@ System requirements
 Software requirements
 `````````````````````
 
+* Sudo
+* Debootstrap
 * PHP command line interface with the ``curl``, ``json``, ``xml``,
   ``zip`` extensions.
-* Compilers for the languages you want to support.
 
 For Debian (with some example compilers)::
 
   sudo apt install make sudo debootstrap libcgroup-dev lsof \
-        php-cli php-curl php-json php-xml php-zip procps \
-        gcc g++ default-jre-headless default-jdk-headless \
-        ghc fp-compiler
+        php-cli php-curl php-json php-xml php-zip procps
 
-For RedHat::
+For Red Hat::
 
   sudo yum install make sudo libcgroup-devel lsof \
-        php-cli php-mbstring php-xml php-process procps-ng \
-        gcc gcc-c++ glibc-static libstdc++-static \
-        java-11-openjdk-headless java-11-openjdk-devel \
-        ghc-compiler fpc
+        php-cli php-mbstring php-xml php-process procps-ng
 
 Building and installing
 -----------------------
@@ -76,23 +72,23 @@ paths, be sure to update the sudoers rules accordingly.
 Creating a chroot environment
 -----------------------------
 
-The judgedaemon executes submissions inside a chroot environment for
-security reasons. By default it mounts parts of a prebuilt chroot tree
-read-only during this judging process (using the script
-``lib/judge/chroot-startstop.sh``). This is needed to support
-extra languages that require access to interpreters or support
-libraries at runtime, for example Java, C#, and any interpreted
-languages like Python, Perl, Shell script, etc.
+The judgedaemon compiles and executes submissions inside a chroot
+environment for security reasons. By default it mounts parts of a
+prebuilt chroot tree read-only during this judging process (using
+the script ``lib/judge/chroot-startstop.sh``). The chroot needs
+to contain the compilers, interpreters and support libraries that
+are needed at compile- and at runtime for the supported languages.
 
 This chroot tree can be built using the script
 ``bin/dj_make_chroot``. On Debian and Ubuntu the same
 distribution and version as the host system are used, on other Linux
 distributions the latest stable Debian release will be used to build
-the chroot. Any extra packages to support languages can be passed with
-the option ``-i`` or be added to the ``INSTALLDEBS``
-variable in the script. The script ``bin/dj_run_chroot`` runs an
-interactive shell or a command inside the chroot. This can be used for
-example to install new or upgrade existing packages inside the chroot.
+the chroot. Any extra packages to support languages (compilers and
+runtime environments) can be passed with the option ``-i`` or be
+added to the ``INSTALLDEBS`` variable in the script. The script
+``bin/dj_run_chroot`` runs an interactive shell or a command inside
+the chroot. This can be used for example to install new or upgrade
+existing packages inside the chroot.
 Run these scripts with option ``-h`` for more information.
 
 Finally, if necessary edit the script ``lib/judge/chroot-startstop.sh``

--- a/etc/sudoers-domjudge.in
+++ b/etc/sudoers-domjudge.in
@@ -7,7 +7,6 @@
 # in or add its content to the end of /etc/sudoers)
 
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: @judgehost_bindir@/runguard *
-@DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/cp -pR /dev/null ../dev/null
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/chown -R @DOMJUDGE_USER@\: @judgehost_judgedir@/*
 
 # The chroot path below must match the path in chroot-startstop.sh.
@@ -17,7 +16,6 @@
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/mount -o remount\,ro\,bind @judgehost_judgedir@/*
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/umount @judgehost_judgedir@/*
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/umount -f -vvv @judgehost_judgedir@/*
-@DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/cp -pR /dev/random dev
-@DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/cp -pR /dev/urandom dev
+@DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/cp -pR /dev/random /dev/urandom /dev/null dev
 @DOMJUDGE_USER@ ALL=(root) NOPASSWD: /bin/chmod o-w dev/random dev/urandom
 

--- a/judge/chroot-startstop.sh.in
+++ b/judge/chroot-startstop.sh.in
@@ -91,8 +91,7 @@ case "$1" in
 
 		# copy dev/random and /dev/urandom as a random source
 		mkdir -p dev
-		sudo -n cp -pR /dev/random  dev < /dev/null
-		sudo -n cp -pR /dev/urandom dev < /dev/null
+		sudo -n cp -pR /dev/random /dev/urandom /dev/null dev < /dev/null
 		sudo -n chmod o-w dev/random dev/urandom < /dev/null
 		;;
 
@@ -100,8 +99,7 @@ case "$1" in
 
 		dj_umount "$PWD/proc"
 
-		rm -f dev/urandom
-		rm -f dev/random
+		rm -f dev/urandom dev/random dev/null
 		rmdir dev || true
 
 		for i in $SUBDIRMOUNTS ; do

--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -42,7 +42,7 @@ cleanexit ()
 {
 	trap - EXIT
 
-	chmod go= "$WORKDIR/compile"
+	chmod go= "$WORKDIR/compile" "$WORKDIR/compile-script"
 	logmsg $LOG_DEBUG "exiting, code = '$1'"
 	exit $1
 }
@@ -121,6 +121,10 @@ chmod a+rwx "$WORKDIR/compile"
 # Create files which are expected to exist: compiler output and runtime
 touch compile.out compile.meta
 
+# Copy compile script into chroot
+mkdir -m 0777 -p "$WORKDIR/compile-script"
+cp -a $(dirname $COMPILE_SCRIPT)/* $PWD/compile-script
+
 cd "$WORKDIR/compile"
 
 for src in "$@" ; do
@@ -139,8 +143,6 @@ if [ -n "$DEBUG" ]; then
 	ENVIRONMENT_VARS="$ENVIRONMENT_VARS -V DEBUG=$DEBUG"
 fi
 
-cp -a $(dirname $COMPILE_SCRIPT)/* $PWD
-
 # First compile to 'source' then rename to 'program' to avoid problems with
 # the compiler writing to different filenames and deleting intermediate files.
 exitcode=0
@@ -148,7 +150,7 @@ $GAINROOT "$RUNGUARD" ${DEBUG:+-v} $CPUSET_OPT -u "$RUNUSER" -g "$RUNGROUP" \
 	-r "$PWD/.." -d "/compile" \
 	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT -c -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
 	-M "$WORKDIR/compile.meta" $ENVIRONMENT_VARS -- \
-	"./$(basename $COMPILE_SCRIPT)" program "$MEMLIMIT" "$@" >"$WORKDIR/compile.tmp" 2>&1 || \
+	"/compile-script/$(basename $COMPILE_SCRIPT)" program "$MEMLIMIT" "$@" >"$WORKDIR/compile.tmp" 2>&1 || \
 	exitcode=$?
 
 # Make sure that all files are owned by the current user/group, so

--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -139,13 +139,16 @@ if [ -n "$DEBUG" ]; then
 	ENVIRONMENT_VARS="$ENVIRONMENT_VARS -V DEBUG=$DEBUG"
 fi
 
+cp -a $(dirname $COMPILE_SCRIPT)/* $PWD
+
 # First compile to 'source' then rename to 'program' to avoid problems with
 # the compiler writing to different filenames and deleting intermediate files.
 exitcode=0
 $GAINROOT "$RUNGUARD" ${DEBUG:+-v} $CPUSET_OPT -u "$RUNUSER" -g "$RUNGROUP" \
+	-r "$PWD/.." -d "/compile" \
 	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT -c -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
 	-M "$WORKDIR/compile.meta" $ENVIRONMENT_VARS -- \
-	"$COMPILE_SCRIPT" program "$MEMLIMIT" "$@" >"$WORKDIR/compile.tmp" 2>&1 || \
+	"./$(basename $COMPILE_SCRIPT)" program "$MEMLIMIT" "$@" >"$WORKDIR/compile.tmp" 2>&1 || \
 	exitcode=$?
 
 # Make sure that all files are owned by the current user/group, so

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -856,6 +856,13 @@ function judge(array $row)
         return;
     }
 
+    // create chroot environment
+    logmsg(LOG_INFO, "executing chroot script: '".CHROOT_SCRIPT." start'");
+    system(LIBJUDGEDIR.'/'.CHROOT_SCRIPT.' start', $retval);
+    if ($retval!=0) {
+        error("chroot script exited with exitcode $retval");
+    }
+
     // Compile the program.
     system(LIBJUDGEDIR . "/compile.sh $cpuset_opt '$execrunpath' '$workdir' " .
            implode(' ', $files), $retval);
@@ -917,13 +924,6 @@ function judge(array $row)
         chmod($workdir, 0700);
         logmsg(LOG_NOTICE, "Judging s$row[submitid]/j$row[judgingid]: compile error");
         return;
-    }
-
-    // create chroot environment
-    logmsg(LOG_INFO, "executing chroot script: '".CHROOT_SCRIPT." start'");
-    system(LIBJUDGEDIR.'/'.CHROOT_SCRIPT.' start', $retval);
-    if ($retval!=0) {
-        error("chroot script exited with exitcode $retval");
     }
 
     $overshoot = djconfig_get_value('timelimit_overshoot');

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -735,6 +735,26 @@ function send_unsent_judging_runs($unsent_judging_runs, $judgingid)
     );
 }
 
+function cleanup_judging(string $workdir) : void
+{
+    // revoke readablity for domjudge-run user to this workdir
+    chmod($workdir, 0700);
+
+    // destroy chroot environment
+    logmsg(LOG_INFO, "executing chroot script: '".CHROOT_SCRIPT." stop'");
+    system(LIBJUDGEDIR.'/'.CHROOT_SCRIPT.' stop', $retval);
+    if ($retval!=0) {
+        error("chroot script exited with exitcode $retval");
+    }
+
+    // Evict all contents of the workdir from the kernel fs cache
+    system(LIBJUDGEDIR . "/evict $workdir", $retval);
+    if ($retval!=0) {
+        warning("evict script exited with exitcode $retval");
+    }
+
+}
+
 function judge(array $row)
 {
     global $EXITCODES, $myhost, $options, $workdirpath, $exitsignalled, $gracefulexitsignalled;
@@ -891,8 +911,8 @@ function judge(array $row)
             disable('judgehost', 'hostname', $myhost, $description, $row['judgingid'], (string)$row['cid'], $compile_output);
         }
         logmsg(LOG_ERR, $description);
-        // revoke readablity for domjudge-run user to this workdir
-        chmod($workdir, 0700);
+
+        cleanup_judging($workdir);
         return;
     }
 
@@ -902,8 +922,8 @@ function judge(array $row)
         logmsg(LOG_ERR, "Unknown exitcode from compile.sh for s$row[submitid]: $retval");
         $description = "compile script '" . $row['compile_script'] . "' returned exit code " . $retval;
         disable('language', 'langid', $row['langid'], $description, $row['judgingid'], (string)$row['cid'], $compile_output);
-        // revoke readablity for domjudge-run user to this workdir
-        chmod($workdir, 0700);
+
+        cleanup_judging($workdir);
         return;
     }
     $compile_success = ($EXITCODES[$retval]==='correct');
@@ -920,8 +940,7 @@ function judge(array $row)
 
     // compile error: our job here is done
     if (! $compile_success) {
-        // revoke readablity for domjudge-run user to this workdir
-        chmod($workdir, 0700);
+        cleanup_judging($workdir);
         logmsg(LOG_NOTICE, "Judging s$row[submitid]/j$row[judgingid]: compile error");
         return;
     }
@@ -1099,26 +1118,12 @@ function judge(array $row)
         }
     }
 
-    // revoke readablity for domjudge-run user to this workdir
-    chmod($workdir, 0700);
-
-    // destroy chroot environment
-    logmsg(LOG_INFO, "executing chroot script: '".CHROOT_SCRIPT." stop'");
-    system(LIBJUDGEDIR.'/'.CHROOT_SCRIPT.' stop', $retval);
-    if ($retval!=0) {
-        error("chroot script exited with exitcode $retval");
-    }
-
-    // Evict all contents of the workdir from the kernel fs cache
-    system(LIBJUDGEDIR . "/evict $workdir", $retval);
-    if ($retval!=0) {
-        warning("evict script exited with exitcode $retval");
-    }
-
     // Sanity check: need to have had at least one testcase
     if ($totalcases == 0) {
         logmsg(LOG_WARNING, "No testcases judged for s$row[submitid]/j$row[judgingid]!");
     }
+
+    cleanup_judging($workdir);
 
     // done!
     logmsg(LOG_NOTICE, "Judging s$row[submitid]/j$row[judgingid] finished");

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -26,9 +26,7 @@ cleanup ()
 {
 	# Remove some copied files to save disk space
 	if [ "$WORKDIR" ]; then
-		# This assumes that if bin is bind-mounted from the chroot,
-		# then it is read-only so the removal of bin/sh will fail.
-		rm -f "$WORKDIR/../dev/null" "$WORKDIR/../bin/sh" "$WORKDIR/../dj-bin/runpipe" 2> /dev/null || true
+		rm -f "$WORKDIR/../dj-bin/runpipe" 2> /dev/null || true
 
 		# Replace testdata by symlinks to reduce disk usage
 		if [ -f "$WORKDIR/testdata.in" ]; then
@@ -187,12 +185,6 @@ if [ "$CREATE_WRITABLE_TEMP_DIR" ]; then
 	# shellcheck disable=SC2174
 	mkdir -m 777 -p "$WORKDIR/write_tmp"
 fi
-
-# We copy /dev/null: mknod (and the major/minor device numbers) are
-# not portable, while a fifo link has the problem that a cat program
-# must be run and killed.
-logmsg $LOG_DEBUG "creating /dev/null character-special device"
-$GAINROOT cp -pR /dev/null ../dev/null
 
 # Run the solution program (within a restricted environment):
 logmsg $LOG_INFO "running program"

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -133,7 +133,7 @@ if [ "$DISTRO" = 'Debian' ]; then
 INCLUDEDEBS="ca-certificates"
 
 # Packages to install after upgrade (space separated):
-INSTALLDEBS="default-jre-headless pypy python3 locales"
+INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy python3 locales"
 # For C# support add: mono-runtime libmono-system2.0-cil
 # However running mono within chroot still gives errors...
 
@@ -141,7 +141,7 @@ INSTALLDEBS="default-jre-headless pypy python3 locales"
 REMOVEDEBS=""
 
 # Which debootstrap package to install on non-Debian systems:
-DEBOOTDEB="debootstrap_1.0.89_all.deb"
+DEBOOTDEB="debootstrap_1.0.114_all.deb"
 
 # The Debian mirror/proxy below can be passed as environment
 # variables; if none are given the following defaults are used.
@@ -162,7 +162,7 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
 INCLUDEDEBS="software-properties-common"
 
 # Packages to install after upgrade (space separated):
-INSTALLDEBS="default-jre-headless pypy python3 locales"
+INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy python3 locales"
 # For C# support add: mono-mcs mono-devel
 # However running mono within chroot still gives errors...
 
@@ -171,8 +171,8 @@ REMOVEDEBS=""
 
 # Which debootstrap package to install on non-Ubuntu systems:
 # This is only used when the default distro changed from Debian to
-# Ubuntu. The version below corresponds to Ubuntu 16.04 Xenial.
-DEBOOTDEB="debootstrap_1.0.78+nmu1ubuntu1.1_all.deb"
+# Ubuntu. The version below corresponds to Ubuntu 20.04 Focal.
+DEBOOTDEB="debootstrap_1.0.118ubuntu1_all.deb"
 
 # The Debian mirror/proxy below can be passed as environment
 # variables; if none are given the following defaults are used.

--- a/sql/files/defaultdata/java_javac_detect/run
+++ b/sql/files/defaultdata/java_javac_detect/run
@@ -43,7 +43,7 @@ else
 	MAINCLASS="$ENTRY_POINT"
 fi
 
-TMPFILE=$(mktemp --tmpdir domjudge_javac_output.XXXXXX) || exit 1
+TMPFILE=$(mktemp domjudge_javac_output.XXXXXX) || exit 1
 
 # Byte-compile:
 javac -encoding UTF-8 -sourcepath . -d . "$@" 2> "$TMPFILE"
@@ -56,9 +56,9 @@ rm -f $TMPFILE
 
 if [ -z "$MAINCLASS" ]; then
 	# Look for class that has the 'main' function:
-	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' \
+	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' ! -name DetectMain.class \
 	            | sed -e 's/\.class$//' -e 's/^\.\///' -e 's/\//./g')"
-	MAINCLASS=$(java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $CLASSNAMES)
+	MAINCLASS=$(java -cp "$(pwd)" DetectMain "$(pwd)" $CLASSNAMES)
 	EXITCODE=$?
 
 	# Report the entry point, so it can be saved, e.g. for later replay:
@@ -67,7 +67,7 @@ if [ -z "$MAINCLASS" ]; then
 	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 else
 	# Check if entry point is valid
-	java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $MAINCLASS > /dev/null
+	java -cp "$(pwd)" DetectMain "$(pwd)" $MAINCLASS > /dev/null
 	EXITCODE=$?
 	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 fi

--- a/sql/files/defaultdata/java_javac_detect/run
+++ b/sql/files/defaultdata/java_javac_detect/run
@@ -56,9 +56,9 @@ rm -f $TMPFILE
 
 if [ -z "$MAINCLASS" ]; then
 	# Look for class that has the 'main' function:
-	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' ! -name DetectMain.class \
+	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' \
 	            | sed -e 's/\.class$//' -e 's/^\.\///' -e 's/\//./g')"
-	MAINCLASS=$(java -cp "$(pwd)" DetectMain "$(pwd)" $CLASSNAMES)
+	MAINCLASS=$(java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $CLASSNAMES)
 	EXITCODE=$?
 
 	# Report the entry point, so it can be saved, e.g. for later replay:
@@ -67,7 +67,7 @@ if [ -z "$MAINCLASS" ]; then
 	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 else
 	# Check if entry point is valid
-	java -cp "$(pwd)" DetectMain "$(pwd)" $MAINCLASS > /dev/null
+	java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $MAINCLASS > /dev/null
 	EXITCODE=$?
 	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 fi


### PR DESCRIPTION
This is an approach to put the compile phase inside the chroot. It works for me with C/C++ and Java (detect).

By and large this now works. I think actually it does not make things much more complex and I've managed to clean some things up a little even.

Some further improvements are thinkable, it could be e.g. optimised a little more to clean up the compile scripts from the chroot and symlink them back, as we do in testcase run.