### PR TITLE
Add option to verify shadow differences. Fixes #706.

### DIFF
--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -171,6 +171,8 @@ class AuditLogController extends AbstractController
                 return $this->generateUrl('jury_judgehost_restriction', ['restrictionId' => $id]);
             case 'judging':
                 return $this->generateUrl('jury_submission_by_judging', ['jid' => $id]);
+            case 'external_judgement':
+                return $this->generateUrl('jury_submission_by_external_judgement', ['externalJudgement' => $id]);
             case 'language':
                 return $this->generateUrl('jury_language', ['langId' => $id]);
             case 'problem':

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -174,6 +174,15 @@ class ShadowDifferencesController extends BaseController
             }
         }
 
+        $verificationViewTypes = [0 => 'all', 1 => 'unverified', 2 => 'verified'];
+        $verificationView      = 0;
+        if ($request->query->has('verificationview')) {
+            $index = array_search($request->query->get('verificationview'), $verificationViewTypes);
+            if ($index !== false) {
+                $verificationView = $index;
+            }
+        }
+
         $restrictions = [];
         if ($viewTypes[$view] == 'unjudged local') {
             $restrictions['judged'] = 0;
@@ -183,6 +192,12 @@ class ShadowDifferencesController extends BaseController
         }
         if ($viewTypes[$view] == 'diff') {
             $restrictions['external_diff'] = 1;
+        }
+        if ($verificationViewTypes[$verificationView] == 'unverified') {
+            $restrictions['externally_verified'] = 0;
+        }
+        if ($verificationViewTypes[$verificationView] == 'verified') {
+            $restrictions['externally_verified'] = 1;
         }
         if ($request->query->get('external', 'all') !== 'all') {
             $restrictions['external_result'] = $request->query->get('external');
@@ -204,6 +219,8 @@ class ShadowDifferencesController extends BaseController
             'verdictTable' => $verdictTable,
             'viewTypes' => $viewTypes,
             'view' => $view,
+            'verificationViewTypes' => $verificationViewTypes,
+            'verificationView' => $verificationView,
             'submissions' => $submissions,
             'submissionCounts' => $submissionCounts,
             'external' => $request->query->get('external', 'all'),

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
 
 /**
  * Judgement in external system
@@ -14,6 +15,7 @@ use Doctrine\ORM\Mapping as ORM;
  *     indexes={
  *         @ORM\Index(name="submitid", columns={"submitid"}),
  *         @ORM\Index(name="cid", columns={"cid"}),
+ *         @ORM\Index(name="verified", columns={"verified"}),
  *     },
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="externalid", columns={"cid", "externalid"}, options={"lengths": {null, "190"}}),
@@ -51,6 +53,36 @@ class ExternalJudgement
      *     nullable=true)
      */
     private $result = null;
+
+    /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="verified",
+     *     options={"comment"="Result / difference verified?",
+     *              "default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $verified = false;
+
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="jury_member", length=255,
+     *     options={"comment"="Name of user who verified the result / diference",
+     *              "default"=NULL},
+     *     nullable=true)
+     * @Serializer\Exclude()
+     */
+    private $jury_member;
+
+    /**
+     * @var string
+     * @ORM\Column(type="string", name="verify_comment", length=255,
+     *     options={"comment"="Optional additional information provided by the verifier",
+     *              "default"=NULL},
+     *     nullable=true)
+     * @Serializer\Exclude()
+     */
+    private $verify_comment;
 
     /**
      * @var double
@@ -184,6 +216,78 @@ class ExternalJudgement
     public function getResult()
     {
         return $this->result;
+    }
+
+    /**
+     * Set verified status of the result / difference
+     *
+     * @param boolean $verified
+     *
+     * @return ExternalJudgement
+     */
+    public function setVerified($verified)
+    {
+        $this->verified = $verified;
+
+        return $this;
+    }
+
+    /**
+     * Get verified status of the result / difference
+     *
+     * @return boolean
+     */
+    public function getVerified()
+    {
+        return $this->verified;
+    }
+
+    /**
+     * Set jury member who verified this judgement
+     *
+     * @param string $juryMember
+     *
+     * @return ExternalJudgement
+     */
+    public function setJuryMember($juryMember)
+    {
+        $this->jury_member = $juryMember;
+
+        return $this;
+    }
+
+    /**
+     * Get jury member who verified this judgement
+     *
+     * @return string
+     */
+    public function getJuryMember()
+    {
+        return $this->jury_member;
+    }
+
+    /**
+     * Set verify comment
+     *
+     * @param string $verifyComment
+     *
+     * @return ExternalJudgement
+     */
+    public function setVerifyComment($verifyComment)
+    {
+        $this->verify_comment = $verifyComment;
+
+        return $this;
+    }
+
+    /**
+     * Get verifyComment
+     *
+     * @return string
+     */
+    public function getVerifyComment()
+    {
+        return $this->verify_comment;
     }
 
     /**

--- a/webapp/src/Migrations/Version20200516101037.php
+++ b/webapp/src/Migrations/Version20200516101037.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200516101037 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add verification fields to external judgements';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            "Migration can only be executed safely on 'mysql'.");
+
+        $this->addSql("ALTER TABLE external_judgement
+            ADD verified TINYINT(1) DEFAULT '0' NOT NULL COMMENT 'Result / difference verified?' AFTER result,
+            ADD jury_member VARCHAR(255) DEFAULT NULL COMMENT 'Name of user who verified the result / diference' AFTER verified,
+            ADD verify_comment VARCHAR(255) DEFAULT NULL COMMENT 'Optional additional information provided by the verifier' AFTER jury_member");
+        $this->addSql('CREATE INDEX verified ON external_judgement (verified)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql',
+            "Migration can only be executed safely on 'mysql'.");
+
+        $this->addSql('DROP INDEX verified ON external_judgement');
+        $this->addSql('ALTER TABLE external_judgement DROP verified, DROP jury_member, DROP verify_comment');
+    }
+}

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -182,6 +182,14 @@ class SubmissionService
             }
         }
 
+        if (isset($restrictions['externally_verified'])) {
+            if ($restrictions['externally_verified']) {
+                $queryBuilder->andWhere('ej.verified = true');
+            } else {
+                $queryBuilder->andWhere('ej.verified = false');
+            }
+        }
+
         if (isset($restrictions['external_diff'])) {
             if ($restrictions['external_diff']) {
                 $queryBuilder->andWhere('j.result != ej.result');

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -43,7 +43,13 @@
             {% if showExternalResult and not showExternalTestcases %}
                 <th scope="col">external result</th>
             {% endif %}
-            <th scope="col">verified</th>
+            <th scope="col">
+                {% if showExternalResult and showExternalTestcases %}
+                    shadow diff verified
+                {% else %}
+                    verified
+                {% endif %}
+            </th>
             {% if not showExternalResult or not showExternalTestcases %}
                 <th scope="col">by</th>
             {% endif %}
@@ -145,27 +151,54 @@
                     </td>
                 {% endif %}
                 {%- set claim = false %}
-                {%- if submission.judgings.first is empty or submission.judgings.first.result is empty -%}
-                    {%- set verified = '' %}
-                    {%- set juryMember = '' %}
-                {%- else %}
-                    {%- set juryMember = submission.judgings.first.juryMember %}
-                    {%- if submission.judgings.first.verified %}
-                        {%- set verified = 'yes' %}
+                {% if showExternalResult and showExternalTestcases %}
+                    {%- if submission.externalJudgements.first is empty or submission.externalJudgements.first.result is empty or submission.judgings.first is empty or submission.judgings.first.result is empty or submission.judgings.first.result == submission.externalJudgements.first.result -%}
+                        {%- set verified = '-' %}
+                        {%- set juryMember = '-' %}
                     {%- else %}
-                        {%- set verified = 'no' %}
-                        {%- if submission.judgings.first.juryMember is empty %}
-                            {%- set claim = true %}
+                        {%- set juryMember = submission.externalJudgements.first.juryMember %}
+                        {%- if submission.externalJudgements.first.verified %}
+                            {%- set verified = 'yes' %}
+                            {%- if submission.externalJudgements.first.verifyComment %}
+                                {%- set verified = verified ~ ': ' ~ submission.externalJudgements.first.verifyComment %}
+                            {% endif %}
                         {%- else %}
-                            {%- set verified = 'claimed' %}
+                            {%- set verified = 'no' %}
+                            {%- if submission.externalJudgements.first.juryMember is empty %}
+                                {%- set claim = true %}
+                            {%- else %}
+                                {%- set verified = 'claimed' %}
+                            {%- endif %}
                         {%- endif %}
                     {%- endif %}
-                {%- endif %}
-                {%- if claim %}
-                    {%- set claimArg = {claim: 1} %}
-                {%- else %}
-                    {%- set claimArg = {unclaim: 1} %}
-                {%- endif %}
+                    {%- if claim %}
+                        {%- set claimArg = {claimdiff: 1} %}
+                    {%- else %}
+                        {%- set claimArg = {unclaimdiff: 1} %}
+                    {%- endif %}
+                {% else %}
+                    {%- if submission.judgings.first is empty or submission.judgings.first.result is empty -%}
+                        {%- set verified = '' %}
+                        {%- set juryMember = '' %}
+                    {%- else %}
+                        {%- set juryMember = submission.judgings.first.juryMember %}
+                        {%- if submission.judgings.first.verified %}
+                            {%- set verified = 'yes' %}
+                        {%- else %}
+                            {%- set verified = 'no' %}
+                            {%- if submission.judgings.first.juryMember is empty %}
+                                {%- set claim = true %}
+                            {%- else %}
+                                {%- set verified = 'claimed' %}
+                            {%- endif %}
+                        {%- endif %}
+                    {%- endif %}
+                    {%- if claim %}
+                        {%- set claimArg = {claim: 1} %}
+                    {%- else %}
+                        {%- set claimArg = {unclaim: 1} %}
+                    {%- endif %}
+                {% endif %}
                 <td class="{{ tdExtraClass }}"><a href="{{ link }}">{{ verified }}</a></td>
                 {% if not showExternalResult or not showExternalTestcases %}
                     <td class="{{ tdExtraClass }}">
@@ -234,14 +267,10 @@
                     </a>
                 </td>
                 <td>
-                    {%- if rejudging is defined %}
-                        {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid, rejudgingid: rejudging.rejudgingid})) %}
-                    {%- else %}
-                        {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid})) %}
-                    {%- endif %}
+                    {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.submitid})) %}
                     {%- if claim -%}
                         <a class="btn btn-outline-secondary btn-sm" href="{{ claimLink }}">claim</a>
-                    {%- elseif (not submission.judgings.first or not submission.judgings.first.verified) and juryMember == app.user.username -%}
+                    {%- elseif (not submission.externalJudgements.first or not submission.externalJudgements.first.verified) and juryMember == app.user.username -%}
                         <a class="btn btn-info btn-sm" href="{{ claimLink }}">unclaim</a>
                     {%- else -%}
                         <a href="{{ link }}">{{ juryMember }}</a>

--- a/webapp/templates/jury/partials/verify_form.html.twig
+++ b/webapp/templates/jury/partials/verify_form.html.twig
@@ -1,0 +1,30 @@
+<form action="{{ form_action }}" method="post">
+    <input type="hidden" name="verified" value="{% if judging.verified %}0{% else %}1{% endif %}"/>
+
+    {# Display verification data: verified, by whom, and comment #}
+    <p>
+        {{ label }}: <strong>{% if judging.verified %}yes{% else %}no{% endif %}</strong>
+        {%- if judging.verified and judging.juryMember is not empty -%}
+            , by {{ judging.juryMember }}
+            {%- if judging.verifyComment is not empty %}
+                with comment "{{ judging.verifyComment }}"
+            {%- endif -%}
+        {%- endif -%}
+        {% if show_form %}
+            <input type="submit" value="{% if judging.verified %}un{% endif %}mark verified"
+                   class="btn btn-outline-secondary btn-sm"/>
+
+            {% if not judging.verified %}
+                with comment
+                <input type="text" name="comment" size="25" class="form-control" id="comment"
+                       style="display: inline; width: auto;"/>
+            {% endif %}
+
+            {% if show_icat and icat_url is not null and submission.contestProblem %}
+                <button class="btn btn-outline-secondary btn-sm" id="post-to-icat">
+                    post to iCAT
+                </button>
+            {% endif %}
+        {% endif %}
+    </p>
+</form>

--- a/webapp/templates/jury/shadow_differences.html.twig
+++ b/webapp/templates/jury/shadow_differences.html.twig
@@ -32,9 +32,19 @@
                 </label>
             {%- endfor %}
         </div>
+        <div class="btn-group btn-group-toggle btn-group-sm mb-3" data-toggle="buttons">
+            {%- for idx, type in verificationViewTypes %}
+
+                <label class="btn btn-secondary {% if idx == verificationView %}active{% endif %}">
+                    <input type="radio" name="verificationviewtype" autocomplete="off" value="{{ type }}"
+                           {% if idx == verificationView %}checked{% endif %}> {{ type }}
+                </label>
+            {%- endfor %}
+        </div>
 
         <form action="{{ path('jury_shadow_differences') }}" method="get">
             <input type="hidden" name="view" value="{{ viewTypes[view] }}"/>
+            <input type="hidden" name="verificationview" value="{{ verificationViewTypes[verificationView] }}"/>
             <div class="form-row">
                 <div class="form-group col-md-4">
                     <label for="oldverdict">External verdict</label>
@@ -68,7 +78,7 @@
                 </div>
                 <div class="form-group col-md-2">
                     <label>&nbsp;</label>
-                    <a href="{{ path('jury_shadow_differences', {view: viewTypes[view]}) }}"
+                    <a href="{{ path('jury_shadow_differences', {view: viewTypes[view], verificationview: verificationViewTypes[verificationView]}) }}"
                        class="btn btn-secondary form-control">Clear</a>
                 </div>
             </div>
@@ -86,7 +96,10 @@
         <script>
             $(function () {
                 $('input[name=viewtype]').on('change', function () {
-                    window.location = '{{ path('jury_shadow_differences', {view: 'REPLACE_ME', external: external, local: local}) }}'.replace('REPLACE_ME', $(this).val());
+                    window.location = '{{ path('jury_shadow_differences', {view: 'REPLACE_ME', verificationview: verificationViewTypes[verificationView], external: external, local: local}) | escape('js') }}'.replace('REPLACE_ME', $(this).val());
+                });
+                $('input[name=verificationviewtype]').on('change', function () {
+                    window.location = '{{ path('jury_shadow_differences', {view: viewTypes[view], verificationview: 'REPLACE_ME', external: external, local: local}) | escape('js') }}'.replace('REPLACE_ME', $(this).val());
                 });
 
                 $('.select2').select2();

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -180,6 +180,13 @@
                 by DOMjudge.
             </p>
         </div>
+
+        {% include 'jury/partials/verify_form.html.twig' with {
+            label: 'Shadow difference verified',
+            judging: externalJudgement,
+            form_action: path('jury_shadow_difference_verify', {extjudgementid: externalJudgement.extjudgementid}),
+            show_form: true,
+            show_icat: false} %}
     {% endif %}
 
     {% if not sameTestcaseIds and selectedJudging is not null and selectedJudging.result is not empty %}
@@ -415,36 +422,12 @@
 
         {# Show verify info, but only when a result is known #}
         {% if selectedJudging is not null and selectedJudging.result is not empty %}
-            <form action="{{ path('jury_judging_verify', {judgingId: selectedJudging.judgingid}) }}" method="post">
-                <input type="hidden" name="verified" value="{% if selectedJudging.verified %}0{% else %}1{% endif %}"/>
-
-                {# Display verification data: verified, by whom, and comment #}
-                <p>
-                    Verified: <strong>{% if selectedJudging.verified %}yes{% else %}no{% endif %}</strong>
-                    {%- if selectedJudging.verified and selectedJudging.juryMember is not empty -%}
-                        , by {{ selectedJudging.juryMember }}
-                        {%- if selectedJudging.verifyComment is not empty %}
-                            with comment "{{ selectedJudging.verifyComment }}"
-                        {%- endif -%}
-                    {%- endif -%}
-                    {% if not (verificationRequired and selectedJudging.verified and selectedJudging.valid) %}
-                        <input type="submit" value="{% if selectedJudging.verified %}un{% endif %}mark verified"
-                               class="btn btn-outline-secondary btn-sm"/>
-
-                        {% if not selectedJudging.verified %}
-                            with comment
-                            <input type="text" name="comment" size="25" class="form-control" id="comment"
-                                   style="display: inline; width: auto;"/>
-                        {% endif %}
-
-                        {% if icat_url is not null and submission.contestProblem %}
-                            <button class="btn btn-outline-secondary btn-sm" id="post-to-icat">
-                                post to iCAT
-                            </button>
-                        {% endif %}
-                    {% endif %}
-                </p>
-            </form>
+            {% include 'jury/partials/verify_form.html.twig' with {
+                label: 'Verified',
+                judging: selectedJudging,
+                form_action: path('jury_judging_verify', {judgingId: selectedJudging.judgingid}),
+                show_form: not (verificationRequired and selectedJudging.verified and selectedJudging.valid),
+                show_icat: true} %}
             {% if submission.contestProblem %}
                 <script>
                     $(function () {


### PR DESCRIPTION
I decided to mimic the judging verification logic on the external judgement. This makes it so we can move some logic into shared functions that do the same.

By default we still show all submissions (well the diff actually) but you can switch it to show only verified or unverified ones,

I made it that you can only verify a difference if there is actually a difference.

Note that because the info is stored on the external judgement, if a new one comes in (even with the same result), the verification is gone. Do we want that? We could copy it if the result didn't change for example. Similarly, if we have a new (valid) (internal) judging with a different result, should we remove the verification on the current valid external judgement if it has any? I'm not sure what the best behavior is.

Some screens:

![Screenshot 2020-05-16 at 13 16 23](https://user-images.githubusercontent.com/550145/82118442-cd54a380-9777-11ea-9d39-cad51ffde80b.png)
![Screenshot 2020-05-16 at 13 16 37](https://user-images.githubusercontent.com/550145/82118445-d5144800-9777-11ea-901d-b9b1bc602e2a.png)
<img width="1784" alt="Screenshot 2020-05-16 at 13 17 34" src="https://user-images.githubusercontent.com/550145/82118462-e8271800-9777-11ea-8a1b-093cac649619.png">
<img width="1792" alt="Screenshot 2020-05-16 at 13 17 59" src="https://user-images.githubusercontent.com/550145/82118466-f07f5300-9777-11ea-8893-11d129375d6a.png">
