### PR TITLE
Set team manual substitutions from Python

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -3,7 +3,7 @@ TOPDIR=../..
 endif
 include $(TOPDIR)/Makefile.global
 
-SUBST_CONFIGS = version.py substitutions
+SUBST_CONFIGS = version.py substitutions.py
 
 $(SUBST_CONFIGS): %: %.in $(TOPDIR)/paths.mk
 	$(substconfigvars)

--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -25,10 +25,16 @@ copyright = '2004-' + time.strftime('%Y') + ' by the DOMjudge developers and con
 author = 'DOMjudge Team'
 
 import os
+
 if os.path.isfile("version.py"):
     exec(open("version.py").read())
 else:
     exec(open("version.dist.py").read())
+
+if os.path.isfile("substitutions.py"):
+    exec(open("substitutions.py").read())
+else:
+    exec(open("substitutions.dist.py").read())
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/manual/substitutions.dist.py
+++ b/doc/manual/substitutions.dist.py
@@ -1,0 +1,15 @@
+# This is used instead of substitutions.py when generating the manual from
+# `make dist' when paths.mk is not yet available.
+
+# Keep this in sync with substitutions.py.in.
+
+rst_prolog = """
+.. |DOMjudge| replace:: DOMjudge
+
+.. |baseurlteam| replace:: https://example.com/domjudge/team
+
+.. |SOURCESIZE| replace:: 256
+.. |COMPILETIME| replace:: 30
+.. |PROCLIMIT| replace:: 15
+
+"""

--- a/doc/manual/substitutions.in
+++ b/doc/manual/substitutions.in
@@ -5,8 +5,6 @@
 
 .. |baseurlteam| replace:: @BASEURL@team
 
-.. |submit_enabled| replace:: @SUBMITCLIENT_ENABLED@
-
 .. |SOURCESIZE| replace:: 256
 .. |COMPILETIME| replace:: 30
 .. |PROCLIMIT| replace:: 15

--- a/doc/manual/substitutions.py.in
+++ b/doc/manual/substitutions.py.in
@@ -1,6 +1,6 @@
-..
-  @configure_input@
+# @configure_input@
 
+rst_prolog = """
 .. |DOMjudge| replace:: @PACKAGE_NAME@
 
 .. |baseurlteam| replace:: @BASEURL@team
@@ -8,3 +8,5 @@
 .. |SOURCESIZE| replace:: 256
 .. |COMPILETIME| replace:: 30
 .. |PROCLIMIT| replace:: 15
+
+"""

--- a/doc/manual/team.rst
+++ b/doc/manual/team.rst
@@ -1,8 +1,6 @@
 DOMjudge team manual
 ====================
 
-.. include:: substitutions
-
 .. footer::
 
    |DOMjudge| team manual version |version| - page ###Page### / ###Total###


### PR DESCRIPTION
This allows example values to be specified during `make dist`, much like version.py / version.dist.py.

Fixes #801.

Also remove unused definition for `submit_enabled`.