### PR TITLE
Escape newlines and other reserved characters in TSV export

### DIFF
--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -280,7 +280,9 @@ class ImportExportController extends BaseController
             echo sprintf("%s\t%s\n", $type, $version);
             // output the rows, filtering out any tab characters in the data
             foreach ($data as $row) {
-                echo implode("\t", str_replace("\t", " ", $row)) . "\n";
+                echo implode("\t", array_map(function ($field) {
+                    return Utils::toTsvField((string)$field);
+                }, $row)) . "\n";
             }
         });
         $filename = sprintf('%s.tsv', $type);

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -976,10 +976,6 @@ EOF;
      */
     public function toTsvField(string $field)
     {
-        return str_replace(
-            ["\\",   "\t",  "\n",  "\r"],
-            ["\\\\", "\\t", "\\n", "\\r"],
-            $field
-        );
+        return Utils::toTsvField($field);
     }
 }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -1062,4 +1062,20 @@ class Utils
         $response->headers->set('Accept-Ranges', 'bytes');
         return $response;
     }
+
+    /**
+     * Convert the given string to a field that is safe to use in a TSV file
+     *
+     * @param string $field
+     *
+     * @return string
+     */
+    public static function toTsvField(string $field)
+    {
+        return str_replace(
+            ["\\",   "\t",  "\n",  "\r"],
+            ["\\\\", "\\t", "\\n", "\\r"],
+            $field
+        );
+    }
 }


### PR DESCRIPTION
Some of the fields can contain newlines, which corrupts the exported TSV files. For example the team name can be made to contain newlines with a bit of effort during self-registration, which breaks teams.tsv.

This PR also uses backslash escapes for tabs, which were previously replaced with spaces.

The [CLICS CCS spec](https://clics.ecs.baylor.edu/index.php?title=Contest_Control_System_Requirements#groups.tsv) doesn't mention handling of special characters; backslash escape sequences seem reasonable.