### PR TITLE
Relax same/different judgehost restriction.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1127,7 +1127,7 @@ class JudgehostController extends AbstractFOSRestController
         }
     }
 
-    private function getSubmissionsToJudge(Judgehost $judgehost, boolean $restrictJudgingOnSameJudgehost)
+    private function getSubmissionsToJudge(Judgehost $judgehost, $restrictJudgingOnSameJudgehost)
     {
         // Get all active contests
         $contests   = $this->dj->getCurrentContests();

--- a/webapp/src/Form/Type/JudgehostRestrictionType.php
+++ b/webapp/src/Form/Type/JudgehostRestrictionType.php
@@ -69,8 +69,8 @@ class JudgehostRestrictionType extends AbstractType
         ]);
         $builder->add('rejudge_own', ChoiceType::class, [
             'expanded' => true,
-            'choices' => ['Yes' => true, 'No' => false],
-            'label' => 'Allow rejudge on same judgehost',
+            'choices' => ['Yes' => true, 'Prefer a different judgehost (if possible)' => false],
+            'label' => 'Allow rejudging on any judgehost',
         ]);
         $builder->add('save', SubmitType::class);
     }


### PR DESCRIPTION
If the restriction is set, we first look for submissions to judge
with this restriction and if empty, we will look again without.