### PR TITLE
Process escape sequences in TSV import

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -615,7 +615,7 @@ class ImportExportService
         $l         = 1;
         foreach ($content as $line) {
             $l++;
-            $line = explode("\t", trim($line));
+            $line = Utils::parseTsvLine(trim($line));
             if (!is_numeric($line[0])) {
                 $message = sprintf('Invalid id format on line %d', $l);
                 return -1;
@@ -771,7 +771,7 @@ class ImportExportService
         $l        = 1;
         foreach ($content as $line) {
             $l++;
-            $line = explode("\t", trim($line));
+            $line = Utils::parseTsvLine(trim($line));
 
             // teams.tsv contains data pertaining both to affiliations and teams.
             // hence return data for both tables.
@@ -995,7 +995,7 @@ class ImportExportService
 
         foreach ($content as $line) {
             $l++;
-            $line = explode("\t", trim($line));
+            $line = Utils::parseTsvLine(trim($line));
 
             $team  = $juryTeam = null;
             $roles = [];

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -1084,4 +1084,16 @@ class Utils
             $field
         );
     }
+
+    /**
+     * Split a line from a Tab Separated Values file into fields
+     *
+     * @param string $line
+     *
+     * @return array
+     */
+    public static function parseTsvLine(string $line) : array
+    {
+        return array_map('stripcslashes', explode("\t", rtrim($line, "\r\n")));
+    }
 }

--- a/webapp/tests/Utils/UtilsTest.php
+++ b/webapp/tests/Utils/UtilsTest.php
@@ -847,4 +847,24 @@ part.";
         $this->assertEquals('team nåme…',   Utils::toTsvField("team nåme…"));
         $this->assertEquals('team🎈name',   Utils::toTsvField("team🎈name"));
     }
+
+    /**
+     * Test Tab Separated Value parsing
+     */
+    public function testParseTsvLine()
+    {
+        $bs  = "\\";
+        $tab = "\t";
+        $this->assertEquals(["team name", "rank"],    Utils::parseTsvLine("team name".$tab."rank"));
+        $this->assertEquals(["team\tname\t", "rank"], Utils::parseTsvLine("team".$bs."t"."name".$bs."t".$tab."rank"));
+        $this->assertEquals(["team\nname\r", "rank"], Utils::parseTsvLine("team".$bs."n"."name".$bs."r".$tab."rank"));
+        $this->assertEquals(["team\\name\\", "rank"], Utils::parseTsvLine("team".$bs.$bs."name".$bs.$bs.$tab."rank"));
+        $this->assertEquals([$bs],                    Utils::parseTsvLine($bs.$bs));
+        $this->assertEquals([$bs."t"],                Utils::parseTsvLine($bs.$bs."t"));
+        $this->assertEquals(["Team,,, name"],         Utils::parseTsvLine("Team,,, name\n"));
+        $this->assertEquals(["Team", "", "", " nm "], Utils::parseTsvLine("Team".$tab.$tab.$tab." nm \r\n"));
+        $this->assertEquals(["tea\\mname", "rank"],   Utils::parseTsvLine("tea".$bs.$bs."mname".$tab."rank"));
+        $this->assertEquals(["team nåme…", "rank"],   Utils::parseTsvLine("team nåme…".$tab."rank"));
+        $this->assertEquals(["team🎈name", "rank"],   Utils::parseTsvLine("team🎈name".$tab."rank"));
+    }
 }


### PR DESCRIPTION
From the commit message:

> Together with commit e42f594d3 [[PR]](https://github.com/DOMjudge/domjudge/pull/807) (Escape newlines and other reserved characters in TSV export, 2020-05-18), this allows arbitrary data to be exported and imported losslessly via TSV.
> 
> This implementation uses `stripcslashes`, which also supports other escape sequences that are not used in the export format. Those escape sequences can't appear in the exported data, so there's no harm.
> 
> (It's tempting to use `str_replace` instead of `stripcslashes`, and mirror `toTsvField()`, but it's tricky because `str_replace` performs each substitution in order on the entire string. For example `\\t` should be decoded as `\t`, but the naive approaches either process it twice and give `<TAB>`, or disregard precedence and give `\<TAB>`. Here is a correct approach:
> 
>     return str_replace(
>         ["\\\\", "\\t", "\\n", "\\r", "\\\\e"],
>         ["\\\\e", "\t", "\n", "\r", "\\"],
>         explode("\t", rtrim($line, "\r\n"))
>     );
> 
> However, `stripcslashes` is simpler.)

The previous code used `trim()` on each line, which removes the newline from the end but also removes other leading/trailing whitespace. I wasn't sure if it was intentional so I left it as it is, and also explicitly removed trailing newlines in the `parseTsvLine` function.