### PR TITLE
Preserve line breaks in team members on public team detail page

### DIFF
--- a/webapp/templates/partials/team.html.twig
+++ b/webapp/templates/partials/team.html.twig
@@ -18,7 +18,7 @@
                 {% if team.members is not empty %}
                     <tr>
                         <th>Members</th>
-                        <td>{{ team.members }}</td>
+                        <td>{{ team.members | nl2br }}</td>
                     </tr>
                 {% endif %}
                 {% if showAffiliations and team.affiliation is not empty %}


### PR DESCRIPTION
This is what the jury version of the page does.