### PR TITLE
Remove obsolete 'rm' command in dj_setup_database

### DIFF
--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -311,7 +311,6 @@ upgrade)
 	read_dbpasswords
 	symfony_console doctrine:migrations:migrate -n
 	verbose "DOMjudge database upgrade completed."
-	rm -f $TMPOUT
 	;;
 
 *)


### PR DESCRIPTION
$TMPOUT was removed in commit 144aba77f (Use Doctrine migrations and fixtures for setting up the database., 2019-08-04).