### PR TITLE
Support missing id in organization JSON import

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -708,12 +708,12 @@ class ImportExportService
     protected function importOrganizationsJson(array $data, string &$message = null): int
     {
         $organizationData = [];
-        foreach ($data as $idx => $group) {
+        foreach ($data as $idx => $organization) {
             $organizationData[] = [
-                'externalid' => @$group['id'],
-                'shortname' => @$group['name'],
-                'name' => @$group['formal_name'],
-                'country' => @$group['country'],
+                'externalid' => @$organization['id'],
+                'shortname' => @$organization['name'],
+                'name' => @$organization['formal_name'],
+                'country' => @$organization['country'],
             ];
         }
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -733,7 +733,10 @@ class ImportExportService
     {
         foreach ($organizationData as $organizationItem) {
             $externalId      = $organizationItem['externalid'];
-            $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->findOneBy(['externalid' => $externalId]);
+            $teamAffiliation = null;
+            if ($externalId !== null) {
+                $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->findOneBy(['externalid' => $externalId]);
+            }
             if (!$teamAffiliation) {
                 $teamAffiliation = new TeamAffiliation();
                 $teamAffiliation->setExternalid($externalId);


### PR DESCRIPTION
Merge affiliations based on the shortname instead of the id when the id key is missing (otherwise they are all merged together).

It is common for affiliations to have a NULL externalid, for example those created through the self-registration form.