### PR TITLE
Don't remove DB account "domjudge@%" during uninstall

### DIFF
--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -209,10 +209,7 @@ remove_db_users()
 {
 	(
 	echo "DROP DATABASE IF EXISTS \`$DBNAME\`;"
-# Also drop "@%" users, since those may have been created by pre-4.0 versions
-# of DOMjudge.
-	echo "DROP USER IF EXISTS
-		'$domjudge_DBUSER'@'%', '$domjudge_DBUSER'@'localhost';"
+	echo "DROP USER IF EXISTS '$domjudge_DBUSER'@'localhost';"
 	echo "FLUSH PRIVILEGES;"
 	) | mysql -f
 	verbose "DOMjudge database and user(s) removed."


### PR DESCRIPTION
Since commit 6d84573c4 (No longer grant access to from the world to the MySQL account, 2014-03-02), the only purpose of the removal is to clean up after pre-4.0 versions of DOMjudge, and they are long gone.

The removal can cause issues, see #826.

Fixes #826.