### PR TITLE
Fix typo (change getIcpcid back to getTeamid in ImportExportService)

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -489,7 +489,7 @@ class ImportExportService
             }
 
             $data[] = [
-                $teamScore->team->getIcpcid() ?? $teamScore->team->getIcpcid(),
+                $teamScore->team->getIcpcid() ?? $teamScore->team->getTeamid(),
                 $rank,
                 $awardString,
                 $teamScore->numbPoints,


### PR DESCRIPTION
From commit 0356a0469 (Rename team.externalid to team.icpcid, 2020-01-18).