### PR TITLE
Fix output directory of gen_all_secrets when running from a different directory

### DIFF
--- a/etc/gen_all_secrets
+++ b/etc/gen_all_secrets
@@ -13,7 +13,7 @@ create_pw_file()
 	[ -n "$QUIET" ] || echo -n "Running '$SCRIPT'... "
 	touch "$FILE"
 	chmod go= "$FILE"
-	$(dirname $0)/$SCRIPT > "$FILE"
+	"./$SCRIPT" > "$FILE"
 	[ -n "$QUIET" ] || echo "file '$FILE' created."
 }
 
@@ -38,6 +38,7 @@ while getopts ':q' OPT ; do
 done
 shift $((OPTIND-1))
 
+cd "$(dirname "$0")"
 create_pw_file gendbpasswords dbpasswords.secret
 create_pw_file genrestapicredentials restapi.secret
 create_pw_file gensymfonysecret symfony_app.secret


### PR DESCRIPTION
This is a more complete fix than cb1afca77cd4970bdeff0210e80fc041a0f31102.