### PR TITLE
Fix test-memsize.cc

### DIFF
--- a/tests/test-memsize.cc
+++ b/tests/test-memsize.cc
@@ -5,6 +5,7 @@
  * @EXPECTED_RESULTS@: RUN-ERROR
  */
 
+#include <cstdlib>
 #include <vector>
 
 using namespace std;
@@ -18,7 +19,8 @@ int main() {
 			v.reserve(1ll * 1024 * 1024);
 			vs.push_back(std::move(v));
 		} catch(const std::bad_alloc&) {
-			// Handle the exception and clean-up manually to prevent slow termination of the program.
+			// Handle the exception and clean-up manually to prevent slow termination of the
+			// program.
 			vs.~vector<vector<char>>();
 			// Make sure to re-raise the exit with SIGABRT.
 			abort();

--- a/tests/test-memsize.cc
+++ b/tests/test-memsize.cc
@@ -1,41 +1,28 @@
 /*
  * This should fail with RUN-ERROR due to running out of memory, which
- * is restricted. The amount allocated may seem to be half of the
- * available, but that is because (GNU implementation) STL vectors by
- * default allocate double the amount of memory requested.
+ * is restricted.
  *
  * @EXPECTED_RESULTS@: RUN-ERROR
  */
 
-#include <iostream>
 #include <vector>
 
 using namespace std;
 
-vector<char> a;
-
-int main()
-{
-	int p, i;
-
-	/*
-	  Watch out: resizing of a vector allocates AT LEAST that much memory!
-	  Testing shows, that (glibc 2.2.5) twice the requested amount is
-	  allocated, so e.g. when you have 64 MB memory available, already when
-	  resizing to more than 32 MB, you run out of memory.
-	*/
-	for(p=4; 1; p*=2) {
-		for(i=p/2; i<p; i+=p/4) {
-			cout << "trying to allocate " << i << " MB... ";
-			a.resize(i*1024*1024,0);
-			if ( a.capacity()<i*1024*1024 ) {
-				cout << "resizing failed." << endl;
-				return 0;
-			}
-			for(int j=a.capacity()/2; j<a.capacity(); j += 512) a[j] = j%137;
-			cout << "allocated: " << a.capacity()/1024/1024 << " MB." << endl;
+int main() {
+	vector<vector<char>> vs;
+	while(true) {
+		vector<char> v;
+		// Allocate 2GB at a time.
+		try {
+			v.reserve(1ll * 1024 * 1024);
+			vs.push_back(std::move(v));
+		} catch(const std::bad_alloc&) {
+			// Handle the exception and clean-up manually to prevent slow termination of the program.
+			vs.~vector<vector<char>>();
+			// Make sure to re-raise the exit with SIGABRT.
+			abort();
 		}
 	}
-
 	return 0;
 }

--- a/tests/test-memsize.cc
+++ b/tests/test-memsize.cc
@@ -14,7 +14,7 @@ int main() {
 	vector<vector<char>> vs;
 	while(true) {
 		vector<char> v;
-		// Allocate 2GB at a time.
+		// Allocate 1MB at a time.
 		try {
 			v.reserve(1ll * 1024 * 1024);
 			vs.push_back(std::move(v));

--- a/tests/test-memsize.cc
+++ b/tests/test-memsize.cc
@@ -2,29 +2,24 @@
  * This should fail with RUN-ERROR due to running out of memory, which
  * is restricted.
  *
+ * Note: This may try to create a coredump on exit and time out. This
+ * can be prevented with `ulimit -c 0`.
+ *
  * @EXPECTED_RESULTS@: RUN-ERROR
  */
 
-#include <cstdlib>
+#include <iostream>
 #include <vector>
 
 using namespace std;
 
+const size_t inc_mb = 128;
+
 int main() {
 	vector<vector<char>> vs;
 	while(true) {
-		vector<char> v;
-		// Allocate 1MB at a time.
-		try {
-			v.reserve(1ll * 1024 * 1024);
-			vs.push_back(std::move(v));
-		} catch(const std::bad_alloc&) {
-			// Handle the exception and clean-up manually to prevent slow termination of the
-			// program.
-			vs.~vector<vector<char>>();
-			// Make sure to re-raise the exit with SIGABRT.
-			abort();
-		}
+		vs.emplace_back(inc_mb * 1024 * 1024);
+		std::cerr << "Allocated: " << inc_mb * vs.size() << " MB" << std::endl;
 	}
 	return 0;
 }


### PR DESCRIPTION
For some reason c++ (sometimes) takes a long time (~2 seconds) to handle program termination after after bad_alloc is thrown.
With this change, the error is now catched manually and we explicitly abort the program. This seems to be much faster (~0.3 seconds).

#839 