### PR TITLE
Remove standard webserver support for TLS1.0

### DIFF
--- a/etc/apache.conf.in
+++ b/etc/apache.conf.in
@@ -45,6 +45,7 @@
 #ServerName _default_
 #DocumentRoot @domserver_webappdir@/public
 #
+# See https://ssl-config.mozilla.org/ to generate good TLS settings for your server
 #SSLEngine on
 #SSLCertificateFile    /path/to/your/SSL-certificate.crt
 #SSLCertificateKeyFile /path/to/your/SSL-key.key

--- a/etc/nginx-conf.in
+++ b/etc/nginx-conf.in
@@ -41,12 +41,11 @@ server {
 # 	listen   443;
 # 	listen   [::]:443;
 
+    # See https://ssl-config.mozilla.org/ to generate good TLS settings for your server
 # 	ssl on;
 # 	ssl_certificate /path/to/your/SSL-certificate-with-chain.crt;
 # 	ssl_certificate_key /path/to/your/SSL-key.key;
 # 	ssl_session_timeout 5m;
-# 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-#	ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA;
 # 	ssl_prefer_server_ciphers on;
 
 	# Strict-Transport-Security is not set by default since it will break


### PR DESCRIPTION
I think the major reason to have 1.0 was for old win7 clients, those are now really without support so lets try to drop the support.