### PR TITLE
make baseurl end with "/"

### DIFF
--- a/doc/manual/substitutions.py.in
+++ b/doc/manual/substitutions.py.in
@@ -3,10 +3,10 @@
 rst_prolog = """
 .. |DOMjudge| replace:: @PACKAGE_NAME@
 
-.. |baseurlteam| replace:: @BASEURL@team
+.. |baseurlteam| replace:: @BASEURL@%steam
 
 .. |SOURCESIZE| replace:: 256
 .. |COMPILETIME| replace:: 30
 .. |PROCLIMIT| replace:: 15
 
-"""
+""" % ('/' if '@BASEURL@'[-1]!='/' else '')


### PR DESCRIPTION
When installing our new server I forgot to end the url with "/", and ended with broken team docs.

As this would typicly be found only during the contest it might be fine to force it into the format of the example url. Its echoed later in the install but at that point someone does not know that the format has to be respected.

I'm not a pro at autoconf but I think this should fix the problem in the configure file. If there is a better way with autoconf itself I'm fine with changing, I just couldn't find it in the docs howto.