### PR TITLE
Do not install software-properties-common during bootstrap for Ubuntu Focal

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -159,7 +159,7 @@ fi
 if [ "$DISTRO" = 'Ubuntu' ]; then
 
 # Packages to include during bootstrap process (comma separated):
-INCLUDEDEBS="software-properties-common"
+INCLUDEDEBS=""
 
 # Packages to install after upgrade (space separated):
 INSTALLDEBS="default-jre-headless pypy python3 locales"


### PR DESCRIPTION
I wonder if we need the package at all? At least it now builds for me on Focal.