### PR TITLE
Add public / team stats. Fixes #429.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -240,6 +240,11 @@
             default_value: 0
             public: false
             description: Maximum width of team column on scoreboard. Leave 0 for no maximum.
+        -   name: show_public_stats
+            type: bool
+            default_value: true
+            public: true
+            description: Show submission and problem statistics on the team and public pages.
 -   category: Misc
     description: Miscellaneous configuration options.
     items:

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -674,3 +674,7 @@ function pinScoreheader()
 		}
 	}
 }
+
+$(function () {
+    $('[data-toggle="tooltip"]').tooltip();
+});

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -436,3 +436,136 @@ h3.teamoverview {
     padding: 40px 15px;
     text-align: center;
 }
+
+.problem-stats {
+    padding-top: 10px;
+}
+
+.problem-stats .problem-stats-item {
+    display: inline-block;
+    margin-right: 3px;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    box-shadow: inset 0 0 0 1px rgba(27, 31, 35, .04);
+}
+
+.problem-stats-item.correct-0 {
+    background-color: #eeeeee;
+}
+
+.problem-stats-item.correct-1 {
+    background-color: #dcffe4;
+}
+
+.problem-stats-item.correct-2 {
+    background-color: #bef5cb;
+}
+
+.problem-stats-item.correct-3 {
+    background-color: #85e89d;
+}
+
+.problem-stats-item.correct-4 {
+    background-color: #34d058;
+}
+
+.problem-stats-item.correct-5 {
+    background-color: #28a745;
+}
+
+.problem-stats-item.correct-6 {
+    background-color: #22863a;
+}
+
+.problem-stats-item.correct-7 {
+    background-color: #176f2c;
+}
+
+.problem-stats-item.correct-8 {
+    background-color: #165c26;
+}
+
+.problem-stats-item.correct-9 {
+    background-color: #144620;
+}
+
+.problem-stats-item.incorrect-0 {
+    background-color: #eeeeee;
+}
+
+.problem-stats-item.incorrect-1 {
+    background-color: #ffdce0;
+}
+
+.problem-stats-item.incorrect-2 {
+    background-color: #fdaeb7;
+}
+
+.problem-stats-item.incorrect-3 {
+    background-color: #f97583;
+}
+
+.problem-stats-item.incorrect-4 {
+    background-color: #ea4a5a;
+}
+
+.problem-stats-item.incorrect-5 {
+    background-color: #d73a49;
+}
+
+.problem-stats-item.incorrect-6 {
+    background-color: #cb2431;
+}
+
+.problem-stats-item.incorrect-7 {
+    background-color: #b31d28;
+}
+
+.problem-stats-item.incorrect-8 {
+    background-color: #9e1c23;
+}
+
+.problem-stats-item.incorrect-9 {
+    background-color: #86181d;
+}
+
+.problem-stats-item.frozen-0 {
+    background-color: #eeeeee;
+}
+
+.problem-stats-item.frozen-1 {
+    background-color: #dbedff;
+}
+
+.problem-stats-item.frozen-2 {
+    background-color: #c8e1ff;
+}
+
+.problem-stats-item.frozen-3 {
+    background-color: #79b8ff;
+}
+
+.problem-stats-item.frozen-4 {
+    background-color: #2188ff;
+}
+
+.problem-stats-item.frozen-5 {
+    background-color: #0366d6;
+}
+
+.problem-stats-item.frozen-6 {
+    background-color: #005cc5;
+}
+
+.problem-stats-item.frozen-7 {
+    background-color: #044289;
+}
+
+.problem-stats-item.frozen-8 {
+    background-color: #032f62;
+}
+
+.problem-stats-item.frozen-9 {
+    background-color: #05264c;
+}

--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -2,18 +2,17 @@
 
 namespace App\Controller\Jury;
 
-use App\Entity\Contest;
-use App\Entity\ContestProblem;
 use App\Entity\Judging;
 use App\Entity\Problem;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Service\DOMJudgeService;
+use App\Service\StatisticsService;
 use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\QueryBuilder;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -27,47 +26,22 @@ class AnalysisController extends AbstractController
      */
     private $dj;
 
-    const FILTERS = [
-        'visiblecat' => 'Teams from visible categories',
-        'hiddencat' => 'Teams from hidden categories',
-        'all' => 'All teams',
-    ];
+    /**
+     * @var StatisticsService
+     */
+    private $stats;
 
-    private static function set_or_increment(array &$array, $index)
-    {
-        if (!array_key_exists($index, $array)) {
-            $array[$index] = 0;
-        }
-        $array[$index]++;
-    }
-
-    public function __construct(DOMJudgeService $dj)
+    public function __construct(DOMJudgeService $dj, StatisticsService $stats)
     {
         $this->dj = $dj;
-    }
-
-    /**
-     * Apply the filter to the given query builder
-     * @param QueryBuilder $queryBuilder
-     * @param string       $filter
-     * @return QueryBuilder
-     */
-    protected function applyFilter(QueryBuilder $queryBuilder, string $filter)
-    {
-        switch ($filter) {
-            case 'visiblecat':
-                $queryBuilder->andWhere('tc.visible = true');
-                break;
-            case 'hiddencat':
-                $queryBuilder->andWhere('tc.visible = false');
-                break;
-        }
-
-        return $queryBuilder;
+        $this->stats = $stats;
     }
 
     /**
      * @Route("", name="analysis_index")
+     * @param Request $request
+     *
+     * @return Response
      */
     public function indexAction(Request $request)
     {
@@ -75,185 +49,24 @@ class AnalysisController extends AbstractController
         $contest = $this->dj->getCurrentContest();
 
         if ($contest == null) {
-          return $this->render('jury/error.html.twig', [
-              'error' => 'No contest selected',
-          ]);
+            return $this->render('jury/error.html.twig', [
+                'error' => 'No contest selected',
+            ]);
         }
 
-        $filterKeys = array_keys(self::FILTERS);
+        $filterKeys = array_keys(StatisticsService::FILTERS);
         $view = $request->query->get('view') ?: reset($filterKeys);
 
-        // First collect information about problems in this contest
-        $problems = $em->createQueryBuilder()
-          ->select('cp', 'p')
-          ->from(ContestProblem::class, 'cp')
-          ->join('cp.problem', 'p')
-          ->andWhere('cp.contest = :contest')
-          ->setParameter('contest', $contest)
-          ->getQuery()->getResult();
-
-        // Need to query directly the count, otherwise symfony memory explodes
-        // I think because it tries to load the testdata if you do this the naive way.
-        $results = $em->createQueryBuilder()
-          ->select('p.probid, count(tc.testcaseid) as num_testcases')
-          ->from(Contest::class, 'c')
-          ->join('c.problems', 'cp')
-          ->join('cp.problem', 'p')
-          ->leftJoin('p.testcases', 'tc')
-          ->andWhere('c = :contest')
-          ->groupBy('p.probid')
-          ->setParameter('contest', $contest)
-          ->getQuery()->getResult();
-        $num_testcases = [];
-        foreach($results as $r) {
-          $num_testcases[$r['probid']] = $r['num_testcases'];
-        }
-
-        // Next select information about the teams
-        if ($contest->isOpenToAllTeams()) {
-            $teams = $this->applyFilter($em->createQueryBuilder()
-                                            ->select('t', 'ts', 'j', 'lang', 'a')
-                                            ->from(Team::class, 't')
-                                            ->join('t.category', 'tc')
-                                            ->join('t.affiliation', 'a')
-                                            ->join('t.submissions', 'ts')
-                                            ->join('ts.judgings', 'j')
-                                            ->join('ts.language', 'lang')
-                                            ->orderBy('t.teamid'), $view)
-                ->getQuery()->getResult();
-        } else {
-            $teams = $this->applyFilter($em->createQueryBuilder()
-                                            ->select('t', 'c', 'ts', 'j', 'lang', 'a')
-                                            ->from(Team::class, 't')
-                                            ->leftJoin('t.contests', 'c')
-                                            ->join('t.affiliation', 'a')
-                                            ->join('t.category', 'tc')
-                                            ->leftJoin('tc.contests', 'cc')
-                                            ->join('t.submissions', 'ts')
-                                            ->join('ts.judgings', 'j')
-                                            ->join('ts.language', 'lang')
-                                            ->andWhere('c = :contest OR cc = :contest'), $view)
-                ->orderBy('t.teamid')
-                ->setParameter('contest', $contest)
-                ->getQuery()->getResult();
-        }
-
-        // Figure out how many submissions each team has
-        $results = $this->applyFilter($em->createQueryBuilder()
-                                          ->select('s.teamid as teamid, count(s.teamid) as num_submissions')
-                                          ->from(Submission::class, 's')
-                                          ->join('s.team', 't')
-                                          ->join('t.category', 'tc')
-                                          ->andWhere('s.contest = :contest'), $view)
-            ->groupBy('s.teamid')
-            ->setParameter('contest', $contest)
-            ->getQuery()->getResult();
-        $num_submissions = [];
-        foreach($results as $r) {
-          $num_submissions[$r['teamid']] = $r['num_submissions'];
-        }
-
-
-        // Come up with misc stats
-        // find last correct judgement for a team, figure out how many minutes are left in the contest(or til now if now is earlier)
-        $now = (new \DateTime())->getTimeStamp();
-        $misc = [
-          'total_submissions' => 0,
-          'total_accepted' => 0,
-          'num_teams' => count($teams),
-          'problem_num_testcases' => $num_testcases,
-          'team_num_submissions' => $num_submissions,
-
-          'team_attempted_n_problems' => [],
-          'teams_solved_n_problems' => [],
-
-          'problem_attempts' => [],
-          'problem_solutions' => [],
-
-          'problem_stats' => [
-            'teams_attempted' => [],
-            'teams_solved' => [],
-          ],
-
-          'language_stats' => [
-            'total_submissions' => [],
-            'total_solutions' => [],
-            'teams_attempted' => [],
-            'teams_solved' => [],
-          ],
-        ];
-
-        $total_misery_minutes = 0;
-        $submissions = [];
-        foreach($teams as $team) {
-          $lastSubmission = null;
-          $team_stats = [
-            'total_submitted' => 0,
-            'total_accepted' => 0,
-            'problems_submitted' => [],
-            'problems_accepted' => [],
-          ];
-          foreach ($team->getSubmissions() as $s) {
-            if ($s->getContest() != $contest) continue;
-            if ($s->getSubmitTime() > $contest->getEndTime()) continue;
-            if ($s->getSubmitTime() < $contest->getStartTime()) continue;
-
-            $submissions[] = $s;
-            $misc['total_submissions']++;
-            $team_stats['total_submitted']++;
-            AnalysisController::set_or_increment($misc['problem_attempts'], $s->getProbId());
-            AnalysisController::set_or_increment($team_stats['problems_submitted'], $s->getProbId());
-            $misc['problem_stats']['teams_attempted'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
-
-
-            AnalysisController::set_or_increment($misc['language_stats']['total_submissions'], $s->getLangid());
-            $misc['language_stats']['teams_attempted'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
-
-            if ($s->getResult() != 'correct') continue;
-            $misc['total_accepted']++;
-            $team_stats['total_accepted']++;
-            AnalysisController::set_or_increment($team_stats['problems_accepted'], $s->getProbId());
-            AnalysisController::set_or_increment($misc['problem_solutions'], $s->getProbId());
-            $misc['problem_stats']['teams_solved'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
-
-            $misc['language_stats']['teams_solved'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
-            AnalysisController::set_or_increment($misc['language_stats']['total_solutions'], $s->getLangid());
-
-            if ($lastSubmission == null || $s->getSubmitTime() > $lastSubmission->getSubmitTime()) {
-              $lastSubmission = $s;
-            }
-          }
-          $misc['team_stats'][$team->getTeamId()] = $team_stats;
-          AnalysisController::set_or_increment($misc['team_attempted_n_problems'], count($team_stats['problems_submitted']));
-          AnalysisController::set_or_increment($misc['teams_solved_n_problems'], $team_stats['total_accepted']);
-
-          // Calculate how long it has been since their last submission
-          if ($lastSubmission != null) {
-            $misery_seconds = min(
-              $contest->getEndTime() - $lastSubmission->getSubmitTime(),
-              $now - $lastSubmission->getSubmitTime()
-            );
-          } else {
-            $misery_seconds = $contest->getEndTime() - $contest->getStartTime();
-          }
-          $misery_minutes = ($misery_seconds / 60) * 3;
-
-          $misc['team_stats'][$team->getTeamId()]['misery_index'] = $misery_minutes;
-          $total_misery_minutes += $misery_minutes;
-        }
-        $misc['misery_index'] = count($teams) > 0 ? $total_misery_minutes/count($teams) : 0;
-        usort($submissions, function($a, $b){
-          if ($a->getSubmitTime() == $b->getSubmitTime()) {
-            return 0;
-          }
-          return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1: 1;
-        });
+        $problems = $this->stats->getContestProblems($contest);
+        $teams = $this->stats->getTeams($contest, $view);
+        $misc = $this->stats->getMiscContestStatistics($contest, $teams, $view);
 
         $maxDelayedJudgings = 10;
         $delayedTimeDiff = 5;
         $delayedJudgings = $em->createQueryBuilder()
             ->from(Submission::class, 's')
-            ->innerJoin(Judging::class, 'j', Expr\Join::WITH, 's.submitid = j.submitid')
+            ->innerJoin(Judging::class, 'j', Expr\Join::WITH,
+                's.submitid = j.submitid')
             ->select('s.submitid, MIN(j.judgingid) AS judgingid, s.submittime, MIN(j.starttime) - s.submittime AS timediff, COUNT(j.judgingid) AS num_judgings')
             ->andWhere('s.contest = :contest')
             ->setParameter('contest', $contest)
@@ -267,202 +80,55 @@ class AnalysisController extends AbstractController
             'contest' => $contest,
             'problems' => $problems,
             'teams' => $teams,
-            'submissions' => $submissions,
+            'submissions' => $misc['submissions'],
             'delayed_judgings' => [
                 'data' => array_slice($delayedJudgings, 0, $maxDelayedJudgings),
                 'overflow' => count($delayedJudgings) - $maxDelayedJudgings,
                 'delay' => $delayedTimeDiff,
             ],
             'misc' => $misc,
-            'filters' => self::FILTERS,
+            'filters' => StatisticsService::FILTERS,
             'view' => $view,
         ]);
     }
+
     /**
      * @Route("/team/{teamid}", name="analysis_team")
+     * @param Team $team
+     *
+     * @return Response
      */
-    public function teamAction(Request $request, Team $team)
+    public function teamAction(Team $team)
     {
-        $em = $this->getDoctrine()->getManager();
         $contest = $this->dj->getCurrentContest();
 
         if ($contest == null) {
-          return $this->render('jury/error.html.twig', [
-              'error' => 'No contest selected',
-          ]);
+            return $this->render('jury/error.html.twig', [
+                'error' => 'No contest selected',
+            ]);
         }
 
-        // Get a whole bunch of judgings(and related objects)
-        // Where:
-        //   - The judging is valid(NOT - for team pages it might be neat to see rejudgings/etc)
-        //   - The judging submission is part of the selected contest
-        //   - The judging submission matches the problem we're analyzing
-        //   - The submission was made by a team in a visible category
-        $judgings = $em->createQueryBuilder()
-          ->select('j, jr','s','team', 'partial p.{timelimit,name,probid}')
-          ->from(Judging::class, 'j')
-          ->join('j.submission', 's')
-          ->join('s.problem', 'p')
-          ->join('j.runs', 'jr')
-          ->join('s.team', 'team')
-          ->join('team.category', 'tc')
-          // ->andWhere('j.valid = true')
-          ->andWhere('s.contest = :contest')
-          ->andWhere('s.team = :team')
-          // ->andWhere('tc.visible = true')
-          ->setParameter('team', $team)
-          ->setParameter('contest', $contest)
-          ->getQuery()->getResult();
-        ;
-
-        // Create a summary of the results(how many correct, timelimit, wrong-answer, etc)
-        $results = array();
-        foreach($judgings as $j) {
-          if (!$j->getValid()) continue;
-          if ($j->getResult()) {
-            AnalysisController::set_or_increment($results, $j->getResult() ?? 'pending');
-          }
-        }
-        // Sort the judgings by runtime
-        usort($judgings, function($a, $b) {
-          if ($a->getMaxRuntime() == $b->getMaxRuntime()) {
-            return 0;
-          }
-          return $a->getMaxRuntime() < $b->getMaxRuntime() ? -1 : 1;
-        });
-
-        // Go through the judgings we found, and get the submissions
-        $submissions = [];
-        $problems = [];
-        foreach($judgings as $j) {
-          if (!$j->getValid()) continue;
-
-          $s = $j->getSubmission();
-          $submissions[] = $s;
-          if (!in_array($s->getProblem(), $problems)) {
-            $problems[] = $s->getProblem();
-          }
-
-        }
-        usort($submissions, function($a, $b){
-          if ($a->getSubmitTime() == $b->getSubmitTime()) {
-            return 0;
-          }
-          return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1: 1;
-        });
-        usort($problems, function($a, $b){
-          if ($a->getName() == $b->getName()) {
-            return 0;
-          }
-          return ($a->getName() < $b->getName()) ? -1: 1;
-        });
-        usort($judgings, function($a, $b){
-          if ($a->getJudgingid() == $b->getJudgingid()) {
-            return 0;
-          }
-          return ($a->getJudgingid() < $b->getJudgingid()) ? -1: 1;
-        });
-
-
-        $misc = array();
-        $misc['correct_percentage'] = array_key_exists('correct', $results) ? ($results['correct'] / count($judgings) )* 100.0 : 0;
-
-        return $this->render('jury/analysis/team.html.twig', [
-            'contest' => $contest,
-            'team' => $team,
-            'submissions' => $submissions,
-            'problems' => $problems,
-            'judgings' => $judgings,
-            'results' => $results,
-            'misc' => $misc,
-        ]);
+        return $this->render('jury/analysis/team.html.twig',
+            $this->stats->getTeamStats($contest, $team)
+        );
     }
+
     /**
      * @Route("/problem/{probid}", name="analysis_problem")
+     * @param Request $request
+     * @param Problem $problem
+     *
+     * @return Response
      */
     public function problemAction(Request $request, Problem $problem)
     {
-        $em = $this->getDoctrine()->getManager();
         $contest = $this->dj->getCurrentContest();
 
-        $filterKeys = array_keys(self::FILTERS);
+        $filterKeys = array_keys(StatisticsService::FILTERS);
         $view = $request->query->get('view') ?: reset($filterKeys);
 
-        // Get a whole bunch of judgings(and related objects)
-        // Where:
-        //   - The judging is valid
-        //   - The judging submission is part of the selected contest
-        //   - The judging submission matches the problem we're analyzing
-        //   - The submission was made by a team in a visible category
-        $judgings = $this->applyFilter($em->createQueryBuilder()
-                                           ->select('j, jr', 's', 'team', 'sj')
-                                           ->from(Judging::class, 'j')
-                                           ->join('j.submission', 's')
-                                           ->join('s.problem', 'p')
-                                           ->join('s.judgings', 'sj')
-                                           ->join('j.runs', 'jr')
-                                           ->join('s.team', 'team')
-                                           ->join('team.category', 'tc')
-                                           ->andWhere('j.valid = true')
-                                           ->andWhere('j.result IS NOT NULL')
-                                           ->andWhere('s.contest = :contest')
-                                           ->andWhere('s.problem = :problem'), $view)
-            ->setParameter('problem', $problem)
-            ->setParameter('contest', $contest)
-            ->getQuery()->getResult();
-
-        // Create a summary of the results(how many correct, timelimit, wrong-answer, etc)
-        $results = array();
-        foreach($judgings as $j) {
-            AnalysisController::set_or_increment($results, $j->getResult() ?? 'pending');
-        }
-
-        // Sort the judgings by runtime
-        usort($judgings, function($a, $b) {
-          if ($a->getMaxRuntime() == $b->getMaxRuntime()) {
-            return 0;
-          }
-          return $a->getMaxRuntime() < $b->getMaxRuntime() ? -1 : 1;
-        });
-
-        // Go through the judgings we found, and get the submissions
-        $submissions = [];
-        foreach($judgings as $j) {
-          $submissions[] = $j->getSubmission();
-        }
-        usort($submissions, function($a, $b){
-          if ($a->getSubmitTime() == $b->getSubmitTime()) {
-            return 0;
-          }
-          return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1: 1;
-        });
-
-
-        $misc = array();
-        $teams_correct = [];
-        $teams_attempted = [];
-        foreach($judgings as $judging) {
-          $s = $judging->getSubmission();
-          $teams_attempted[$s->getTeamID()] = $s->getTeamID();
-          if ($judging->getResult() == 'correct') {
-            $teams_correct[$s->getTeamID()] = $s->getTeamID();
-          }
-        }
-        $misc['num_teams_attempted'] = count($teams_attempted);
-        $misc['num_teams_correct'] = count($teams_correct);
-        $misc['correct_percentage'] = array_key_exists('correct', $results) ? ($results['correct'] / count($judgings) )* 100.0 : 0;
-        $misc['teams_correct_percentage'] = count($teams_attempted) > 0 ? (count($teams_correct) / count($teams_attempted) )* 100.0 : 0;
-
-        return $this->render('jury/analysis/problem.html.twig', [
-            'contest' => $contest,
-            'problem' => $problem,
-            'timelimit' => $problem->getTimelimit(),
-            'submissions' => $submissions,
-            'judgings' => $judgings,
-            'results' => $results,
-            'misc' => $misc,
-            'filters' => self::FILTERS,
-            'view' => $view,
-        ]);
+        return $this->render('jury/analysis/problem.html.twig',
+            $this->stats->getProblemStats($contest, $problem, $view)
+        );
     }
 }

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -3,12 +3,16 @@
 namespace App\Controller;
 
 use App\Entity\ContestProblem;
+use App\Entity\Judging;
 use App\Entity\Language;
+use App\Entity\Submission;
 use App\Entity\Team;
 use App\Entity\Testcase;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
+use App\Service\StatisticsService;
+use App\Utils\FreezeData;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -44,6 +48,11 @@ class PublicController extends BaseController
     protected $scoreboardService;
 
     /**
+     * @var StatisticsService
+     */
+    protected $stats;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
@@ -52,11 +61,13 @@ class PublicController extends BaseController
         DOMJudgeService $dj,
         ConfigurationService $config,
         ScoreboardService $scoreboardService,
+        StatisticsService $stats,
         EntityManagerInterface $em
     ) {
         $this->dj                = $dj;
         $this->config            = $config;
         $this->scoreboardService = $scoreboardService;
+        $this->stats             = $stats;
         $this->em                = $em;
     }
 
@@ -182,7 +193,7 @@ class PublicController extends BaseController
     public function problemsAction()
     {
         return $this->render('public/problems.html.twig',
-            $this->dj->getTwigDataForProblemsAction(-1));
+            $this->dj->getTwigDataForProblemsAction(-1, $this->stats));
     }
 
 

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -8,6 +8,7 @@ use App\Entity\Language;
 use App\Entity\Testcase;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
+use App\Service\StatisticsService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
@@ -39,6 +40,11 @@ class ProblemController extends BaseController
     protected $config;
 
     /**
+     * @var StatisticsService
+     */
+    protected $stats;
+
+    /**
      * @var EntityManagerInterface
      */
     protected $em;
@@ -48,15 +54,18 @@ class ProblemController extends BaseController
      *
      * @param DOMJudgeService        $dj
      * @param ConfigurationService   $config
+     * @param StatisticsService      $stats
      * @param EntityManagerInterface $em
      */
     public function __construct(
         DOMJudgeService $dj,
         ConfigurationService $config,
+        StatisticsService $stats,
         EntityManagerInterface $em
     ) {
         $this->dj     = $dj;
         $this->config = $config;
+        $this->stats  = $stats;
         $this->em     = $em;
     }
 
@@ -69,7 +78,7 @@ class ProblemController extends BaseController
     public function problemsAction()
     {
         return $this->render('team/problems.html.twig',
-            $this->dj->getTwigDataForProblemsAction($this->dj->getUser()->getTeamid()));
+            $this->dj->getTwigDataForProblemsAction($this->dj->getUser()->getTeamid(), $this->stats));
     }
 
 

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -1,0 +1,652 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Problem;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Utils\Utils;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Class StatisticsService
+ *
+ * Service to display statistics data
+ *
+ * @package App\Service
+ */
+class StatisticsService
+{
+    const NUM_GROUPED_BINS = 20;
+
+    const FILTERS = [
+        'visiblecat' => 'Teams from visible categories',
+        'hiddencat' => 'Teams from hidden categories',
+        'all' => 'All teams',
+    ];
+
+    /**
+     * @var DOMJudgeService
+     */
+    private $dj;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    /**
+     * StatisticsService constructor.
+     *
+     * @param DOMJudgeService        $dj
+     * @param EntityManagerInterface $em
+     */
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
+    {
+        $this->dj = $dj;
+        $this->em = $em;
+    }
+
+    /**
+     * Get the problems for the given contest
+     *
+     * @param Contest $contest
+     *
+     * @return ContestProblem[]
+     */
+    public function getContestProblems(Contest $contest)
+    {
+        return $this->em->createQueryBuilder()
+            ->select('cp', 'p')
+            ->from(ContestProblem::class, 'cp')
+            ->join('cp.problem', 'p')
+            ->andWhere('cp.contest = :contest')
+            ->setParameter('contest', $contest)
+            ->getQuery()->getResult();
+    }
+
+    /**
+     * Get the teams for the given contest and view filter
+     *
+     * @param Contest $contest
+     * @param string  $filter
+     *
+     * @return Team[]
+     */
+    public function getTeams(Contest $contest, string $filter)
+    {
+        if ($contest->isOpenToAllTeams()) {
+            return $this->applyFilter($this->em->createQueryBuilder()
+                ->select('t', 'ts', 'j', 'lang', 'a')
+                ->from(Team::class, 't')
+                ->join('t.category', 'tc')
+                ->join('t.affiliation', 'a')
+                ->join('t.submissions', 'ts')
+                ->join('ts.judgings', 'j')
+                 ->andWhere('j.valid = true')
+                ->join('ts.language', 'lang')
+                ->orderBy('t.teamid'), $filter)
+                ->getQuery()->getResult();
+        } else {
+            return $this->applyFilter($this->em->createQueryBuilder()
+                ->select('t', 'c', 'ts', 'j', 'lang', 'a')
+                ->from(Team::class, 't')
+                ->leftJoin('t.contests', 'c')
+                ->join('t.affiliation', 'a')
+                ->join('t.category', 'tc')
+                ->leftJoin('tc.contests', 'cc')
+                ->join('t.submissions', 'ts')
+                ->join('ts.judgings', 'j')
+                ->andWhere('j.valid = true')
+                ->join('ts.language', 'lang')
+                ->andWhere('c = :contest OR cc = :contest'), $filter)
+                ->orderBy('t.teamid')
+                ->setParameter('contest', $contest)
+                ->getQuery()->getResult();
+        }
+    }
+
+    /**
+     * Get miscellaneous contest statistics
+     *
+     * @param Contest $contest
+     * @param Team[]  $teams
+     * @param string  $filter
+     * @param bool    $noFrozen             Do not show frozen data
+     * @param bool    $verificationRequired Only show verified submissions
+     *
+     * @return array
+     */
+    public function getMiscContestStatistics(
+        Contest $contest,
+        array $teams,
+        string $filter,
+        bool $noFrozen = false,
+        bool $verificationRequired = false
+    ) {
+        $numTestcases = $this->getNumTestcases($contest);
+        $numSubmissions = $this->getTeamNumSubmissions($contest, $filter);
+
+        // Come up with misc stats
+        // find last correct judgement for a team, figure out how many minutes are left in the contest(or til now if now is earlier)
+        $now = (new DateTime())->getTimeStamp();
+        $misc = [
+            'total_submissions' => 0,
+            'total_accepted' => 0,
+            'num_teams' => count($teams),
+            'problem_num_testcases' => $numTestcases,
+            'team_num_submissions' => $numSubmissions,
+
+            'team_attempted_n_problems' => [],
+            'teams_solved_n_problems' => [],
+
+            'problem_attempts' => [],
+            'problem_solutions' => [],
+
+            'problem_stats' => [
+                'teams_attempted' => [],
+                'teams_solved' => [],
+            ],
+
+            'language_stats' => [
+                'total_submissions' => [],
+                'total_solutions' => [],
+                'teams_attempted' => [],
+                'teams_solved' => [],
+            ],
+        ];
+
+        $totalMiseryMinutes = 0;
+        $submissions = [];
+        foreach ($teams as $team) {
+            $lastSubmission = null;
+            $teamStats = [
+                'total_submitted' => 0,
+                'total_accepted' => 0,
+                'problems_submitted' => [],
+                'problems_accepted' => [],
+            ];
+            /** @var Submission $s */
+            foreach ($team->getSubmissions() as $s) {
+                if ($s->getContest() != $contest) {
+                    continue;
+                }
+                if ($s->getSubmitTime() > $contest->getEndTime()) {
+                    continue;
+                }
+                if ($s->getSubmitTime() < $contest->getStartTime()) {
+                    continue;
+                }
+
+                if ($noFrozen && $s->getSubmittime() > $contest->getFreezetime()) {
+                    continue;
+                }
+
+                if ($verificationRequired && !$s->getJudgings()->first()->getVerified()) {
+                    continue;
+                }
+
+                $submissions[] = $s;
+                $misc['total_submissions']++;
+                $teamStats['total_submitted']++;
+                static::setOrIncrement($misc['problem_attempts'],
+                    $s->getProbId());
+                static::setOrIncrement($teamStats['problems_submitted'],
+                    $s->getProbId());
+                $misc['problem_stats']['teams_attempted'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
+
+
+                static::setOrIncrement($misc['language_stats']['total_submissions'],
+                    $s->getLangid());
+                $misc['language_stats']['teams_attempted'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
+
+                if ($s->getResult() != 'correct') {
+                    continue;
+                }
+                $misc['total_accepted']++;
+                $teamStats['total_accepted']++;
+                static::setOrIncrement($teamStats['problems_accepted'],
+                    $s->getProbId());
+                static::setOrIncrement($misc['problem_solutions'],
+                    $s->getProbId());
+                $misc['problem_stats']['teams_solved'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
+
+                $misc['language_stats']['teams_solved'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
+                static::setOrIncrement($misc['language_stats']['total_solutions'],
+                    $s->getLangid());
+
+                if ($lastSubmission == null || $s->getSubmitTime() > $lastSubmission->getSubmitTime()) {
+                    $lastSubmission = $s;
+                }
+            }
+            $misc['team_stats'][$team->getTeamId()] = $teamStats;
+            static::setOrIncrement($misc['team_attempted_n_problems'],
+                count($teamStats['problems_submitted']));
+            static::setOrIncrement($misc['teams_solved_n_problems'],
+                $teamStats['total_accepted']);
+
+            // Calculate how long it has been since their last submission
+            if ($lastSubmission != null) {
+                $miserySeconds = min(
+                    $contest->getEndTime() - $lastSubmission->getSubmitTime(),
+                    $now - $lastSubmission->getSubmitTime()
+                );
+            } else {
+                $miserySeconds = $contest->getEndTime() - $contest->getStartTime();
+            }
+            $miseryMinutes = ($miserySeconds / 60) * 3;
+
+            $misc['team_stats'][$team->getTeamId()]['misery_index'] = $miseryMinutes;
+            $totalMiseryMinutes += $miseryMinutes;
+        }
+        $misc['misery_index'] = count($teams) > 0 ? $totalMiseryMinutes / count($teams) : 0;
+        usort($submissions, function ($a, $b) {
+            if ($a->getSubmitTime() == $b->getSubmitTime()) {
+                return 0;
+            }
+            return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1 : 1;
+        });
+
+        $misc['submissions'] = $submissions;
+
+        return $misc;
+    }
+
+    /**
+     * Get the team statistics for the given team
+     *
+     * @param Contest $contest
+     * @param Team    $team
+     *
+     * @return array
+     */
+    public function getTeamStats(Contest $contest, Team $team)
+    {
+        // Get a whole bunch of judgings(and related objects)
+        // Where:
+        //   - The judging is valid(NOT - for team pages it might be neat to see rejudgings/etc)
+        //   - The judging submission is part of the selected contest
+        //   - The judging submission matches the problem we're analyzing
+        //   - The submission was made by a team in a visible category
+        $judgings = $this->em->createQueryBuilder()
+            ->select('j, jr', 's', 'team', 'partial p.{timelimit,name,probid}')
+            ->from(Judging::class, 'j')
+            ->join('j.submission', 's')
+            ->join('s.problem', 'p')
+            ->join('j.runs', 'jr')
+            ->join('s.team', 'team')
+            ->join('team.category', 'tc')
+            // ->andWhere('j.valid = true')
+            ->andWhere('s.contest = :contest')
+            ->andWhere('s.team = :team')
+            // ->andWhere('tc.visible = true')
+            ->setParameter('team', $team)
+            ->setParameter('contest', $contest)
+            ->getQuery()->getResult();;
+
+        // Create a summary of the results(how many correct, timelimit, wrong-answer, etc)
+        $results = [];
+        foreach ($judgings as $j) {
+            if (!$j->getValid()) {
+                continue;
+            }
+            if ($j->getResult()) {
+                static::setOrIncrement($results, $j->getResult() ?? 'pending');
+            }
+        }
+        // Sort the judgings by runtime
+        usort($judgings, function ($a, $b) {
+            if ($a->getMaxRuntime() == $b->getMaxRuntime()) {
+                return 0;
+            }
+            return $a->getMaxRuntime() < $b->getMaxRuntime() ? -1 : 1;
+        });
+
+        // Go through the judgings we found, and get the submissions
+        $submissions = [];
+        $problems = [];
+        foreach ($judgings as $j) {
+            if (!$j->getValid()) {
+                continue;
+            }
+
+            $s = $j->getSubmission();
+            $submissions[] = $s;
+            if (!in_array($s->getProblem(), $problems)) {
+                $problems[] = $s->getProblem();
+            }
+
+        }
+        usort($submissions, function ($a, $b) {
+            if ($a->getSubmitTime() == $b->getSubmitTime()) {
+                return 0;
+            }
+            return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1 : 1;
+        });
+        usort($problems, function ($a, $b) {
+            if ($a->getName() == $b->getName()) {
+                return 0;
+            }
+            return ($a->getName() < $b->getName()) ? -1 : 1;
+        });
+        usort($judgings, function ($a, $b) {
+            if ($a->getJudgingid() == $b->getJudgingid()) {
+                return 0;
+            }
+            return ($a->getJudgingid() < $b->getJudgingid()) ? -1 : 1;
+        });
+
+
+        $misc = [];
+        $misc['correct_percentage'] = array_key_exists('correct',
+            $results) ? ($results['correct'] / count($judgings)) * 100.0 : 0;
+
+        return [
+            'contest' => $contest,
+            'team' => $team,
+            'submissions' => $submissions,
+            'problems' => $problems,
+            'judgings' => $judgings,
+            'results' => $results,
+            'misc' => $misc,
+        ];
+    }
+
+    public function getProblemStats(
+        Contest $contest,
+        Problem $problem,
+        string $view
+    ) {
+        // Get a whole bunch of judgings(and related objects)
+        // Where:
+        //   - The judging is valid
+        //   - The judging submission is part of the selected contest
+        //   - The judging submission matches the problem we're analyzing
+        //   - The submission was made by a team in a visible category
+        $judgings = $this->applyFilter($this->em->createQueryBuilder()
+            ->select('j, jr', 's', 'team', 'sj')
+            ->from(Judging::class, 'j')
+            ->join('j.submission', 's')
+            ->join('s.problem', 'p')
+            ->join('s.judgings', 'sj')
+            ->join('j.runs', 'jr')
+            ->join('s.team', 'team')
+            ->join('team.category', 'tc')
+            ->andWhere('j.valid = true')
+            ->andWhere('j.result IS NOT NULL')
+            ->andWhere('s.contest = :contest')
+            ->andWhere('s.problem = :problem'), $view)
+            ->setParameter('problem', $problem)
+            ->setParameter('contest', $contest)
+            ->getQuery()->getResult();
+
+        // Create a summary of the results(how many correct, timelimit, wrong-answer, etc)
+        $results = [];
+        foreach ($judgings as $j) {
+            static::setOrIncrement($results, $j->getResult() ?? 'pending');
+        }
+
+        // Sort the judgings by runtime
+        usort($judgings, function ($a, $b) {
+            if ($a->getMaxRuntime() == $b->getMaxRuntime()) {
+                return 0;
+            }
+            return $a->getMaxRuntime() < $b->getMaxRuntime() ? -1 : 1;
+        });
+
+        // Go through the judgings we found, and get the submissions
+        $submissions = [];
+        foreach ($judgings as $j) {
+            $submissions[] = $j->getSubmission();
+        }
+        usort($submissions, function ($a, $b) {
+            if ($a->getSubmitTime() == $b->getSubmitTime()) {
+                return 0;
+            }
+            return ($a->getSubmitTime() < $b->getSubmitTime()) ? -1 : 1;
+        });
+
+
+        $misc = [];
+        $teamsCorrect = [];
+        $teamsAttempted = [];
+        foreach ($judgings as $judging) {
+            $s = $judging->getSubmission();
+            $teamsAttempted[$s->getTeamID()] = $s->getTeamID();
+            if ($judging->getResult() == 'correct') {
+                $teamsCorrect[$s->getTeamID()] = $s->getTeamID();
+            }
+        }
+        $misc['num_teams_attempted'] = count($teamsAttempted);
+        $misc['num_teams_correct'] = count($teamsCorrect);
+        $misc['correct_percentage'] = array_key_exists('correct',
+            $results) ? ($results['correct'] / count($judgings)) * 100.0 : 0;
+        $misc['teams_correct_percentage'] = count($teamsAttempted) > 0 ? (count($teamsCorrect) / count($teamsAttempted)) * 100.0 : 0;
+
+        return [
+            'contest' => $contest,
+            'problem' => $problem,
+            'timelimit' => $problem->getTimelimit(),
+            'submissions' => $submissions,
+            'judgings' => $judgings,
+            'results' => $results,
+            'misc' => $misc,
+            'filters' => StatisticsService::FILTERS,
+            'view' => $view,
+        ];
+    }
+
+    /**
+     * @param Contest   $contest
+     * @param Problem[] $problems
+     * @param bool      $showFrozen
+     * @param bool      $verificationRequired
+     *
+     * @return array
+     */
+    public function getGroupedProblemsStats(
+        Contest $contest,
+        array $problems,
+        bool $showFrozen,
+        bool $verificationRequired
+    ) {
+        $stats = [
+            'problems' => [],
+            'numBuckets' => static::NUM_GROUPED_BINS,
+        ];
+        // Get a whole bunch of judgings(and related objects)
+        // Where:
+        //   - The judging is valid
+        //   - The judging submission is part of the selected contest
+        //   - The judging submission matches the problem we're analyzing
+        //   - The submission was made by a team in a visible category
+        $judgingsQueryBuilder = $this->em->createQueryBuilder()
+            ->select('COUNT(j) AS count, s.probid')
+            ->from(Judging::class, 'j')
+            ->join('j.submission', 's')
+            ->join('s.problem', 'p')
+            ->join('s.team', 'team')
+            ->join('team.category', 'tc')
+            ->andWhere('j.valid = true')
+            ->andWhere('j.result IS NOT NULL')
+            ->andWhere('s.contest = :contest')
+            ->andWhere('s.problem IN (:problems)')
+            ->andWhere('tc.visible = true')
+            ->setParameter('problems', $problems)
+            ->setParameter('contest', $contest)
+            ->groupBy('s.problem');
+
+        if ($verificationRequired) {
+            $judgingsQueryBuilder->andWhere('j.verified = true');
+        }
+
+        // Determine the bins to use
+        $duration = $contest->getEndtime() - $contest->getStarttime(false);
+        $binDuration = round($duration / static::NUM_GROUPED_BINS, 0);
+
+        for ($bin = 0; $bin < static::NUM_GROUPED_BINS; $bin++) {
+            $start = new DateTime(Utils::absTime($contest->getStarttime(false) + $bin * $binDuration));
+            $end = (clone $start)->add(new \DateInterval(sprintf('PT%dS',
+                $binDuration)));
+            foreach ([true, false] as $correct) {
+                $queryBuilder = clone $judgingsQueryBuilder;
+                $queryBuilder->andWhere('s.submittime >= :starttime');
+                if ($bin === static::NUM_GROUPED_BINS - 1) {
+                    // Special case: we need submissions from the last second
+                    $queryBuilder->andWhere('s.submittime <= :endtime');
+                } else {
+                    $queryBuilder->andWhere('s.submittime < :endtime');
+                }
+                if ($showFrozen || $end->getTimestamp() <= $contest->getFreezetime()) {
+                    // When we don't want to show frozen correct/incorrect submissions,
+                    // get the same data for both correct and incorrect.
+                    // This logic assumes the freeze matches with the start of a bucket.
+                    // If this is not the case, the whole bucket that contains the freeze
+                    // will be showed as frozen.
+                    if ($correct) {
+                        $queryBuilder->andWhere('j.result = :correct');
+                    } else {
+                        $queryBuilder->andWhere('j.result != :correct');
+                    }
+                    $queryBuilder->setParameter('correct', 'correct');
+                }
+                $queryBuilder
+                    ->setParameter('starttime', $start->getTimestamp())
+                    ->setParameter('endtime', $end->getTimestamp());
+
+                $statsIndex = $correct ? 'correct' : 'incorrect';
+
+                $result = $queryBuilder->getQuery()->getArrayResult();
+                foreach ($result as $resultItem) {
+                    $stats['problems'][$resultItem['probid']][$statsIndex][$bin] = [
+                        'start' => $start,
+                        'end' => $end,
+                        'count' => $resultItem['count'],
+                    ];
+                }
+
+                foreach ($problems as $problem) {
+                    if (!isset($stats['problems'][$problem->getProbid()][$statsIndex][$bin])) {
+                        $stats['problems'][$problem->getProbid()][$statsIndex][$bin] = [
+                            'start' => $start,
+                            'end' => $end,
+                            'count' => 0,
+                        ];
+                    }
+                }
+            }
+        }
+
+        $maxBucketSizeCorrect = 0;
+        $maxBucketSizeIncorrect = 0;
+        foreach ($stats['problems'] as $problemStats) {
+            foreach ([true, false] as $correct) {
+                $statsIndex = $correct ? 'correct' : 'incorrect';
+                foreach ($problemStats[$statsIndex] as $statItem) {
+                    if ($correct) {
+                        $maxBucketSizeCorrect = max($maxBucketSizeCorrect, $statItem['count']);
+                    } else {
+                        $maxBucketSizeIncorrect = max($maxBucketSizeIncorrect, $statItem['count']);
+                    }
+                }
+            }
+        }
+
+        $stats['maxBucketSizeCorrect'] = $maxBucketSizeCorrect;
+        $stats['maxBucketSizeIncorrect'] = $maxBucketSizeIncorrect;
+
+        return $stats;
+    }
+
+    /**
+     * Apply the filter to the given query builder
+     *
+     * @param QueryBuilder $queryBuilder
+     * @param string       $filter
+     *
+     * @return QueryBuilder
+     */
+    protected function applyFilter(QueryBuilder $queryBuilder, string $filter)
+    {
+        switch ($filter) {
+            case 'visiblecat':
+                $queryBuilder->andWhere('tc.visible = true');
+                break;
+            case 'hiddencat':
+                $queryBuilder->andWhere('tc.visible = false');
+                break;
+        }
+
+        return $queryBuilder;
+    }
+
+    protected static function setOrIncrement(array &$array, $index)
+    {
+        if (!array_key_exists($index, $array)) {
+            $array[$index] = 0;
+        }
+        $array[$index]++;
+    }
+
+    /**
+     * Get the number of testcases per problem
+     *
+     * @param Contest $contest
+     *
+     * @return int[]
+     */
+    protected function getNumTestcases(Contest $contest)
+    {
+        // Need to query directly the count, otherwise symfony memory explodes
+        // I think because it tries to load the testdata if you do this the naive way.
+        $results = $this->em->createQueryBuilder()
+            ->select('p.probid, count(tc.testcaseid) as num_testcases')
+            ->from(Contest::class, 'c')
+            ->join('c.problems', 'cp')
+            ->join('cp.problem', 'p')
+            ->leftJoin('p.testcases', 'tc')
+            ->andWhere('c = :contest')
+            ->groupBy('p.probid')
+            ->setParameter('contest', $contest)
+            ->getQuery()->getResult();
+        $numTestcases = [];
+        foreach ($results as $r) {
+            $numTestcases[$r['probid']] = $r['num_testcases'];
+        }
+
+        return $numTestcases;
+    }
+
+    /**
+     * Get the number of submissions per team
+     *
+     * @param Contest $contest
+     * @param string  $filter
+     *
+     * @return array
+     */
+    protected function getTeamNumSubmissions(Contest $contest, string $filter)
+    {
+        // Figure out how many submissions each team has
+        $results = $this->applyFilter($this->em->createQueryBuilder()
+            ->select('s.teamid as teamid, count(s.teamid) as num_submissions')
+            ->from(Submission::class, 's')
+            ->join('s.team', 't')
+            ->join('t.category', 'tc')
+            ->andWhere('s.contest = :contest'), $filter)
+            ->groupBy('s.teamid')
+            ->setParameter('contest', $contest)
+            ->getQuery()->getResult();
+        $numSubmissions = [];
+        foreach ($results as $r) {
+            $numSubmissions[$r['teamid']] = $r['num_submissions'];
+        }
+
+        return $numSubmissions;
+    }
+}

--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -51,6 +51,48 @@
                                             </div>
                                         {% endif %}
 
+                                        {% if stats is defined %}
+                                            <div class="mt-3">
+                                                {% for correct in [true, false] %}
+                                                    <div class="problem-stats d-flex justify-content-center">
+                                                        {% for bucket in 0..stats.numBuckets - 1 %}
+                                                            {% if correct %}
+                                                                {% set index = 'correct' %}
+                                                                {% set maxBucketSize = stats.maxBucketSizeCorrect %}
+                                                            {% else %}
+                                                                {% set index = 'incorrect' %}
+                                                                {% set maxBucketSize = stats.maxBucketSizeIncorrect %}
+                                                            {% endif %}
+                                                            {% set stat = stats.problems[problem.problem.probid][index][bucket] %}
+                                                            {% set count = stat.count %}
+                                                            {% set bucket = (count / maxBucketSize * 9) | round(0, 'ceil') %}
+                                                            {% if count == 1 %}
+                                                                {% set submissionText = 'submission' %}
+                                                            {% else %}
+                                                                {% set submissionText = 'submissions' %}
+                                                            {% endif %}
+                                                            {% if not current_contest.freezeData.showFinal and stat.start.timestamp >= current_contest.freezetime %}
+                                                                {% set maxBucketSize = max(stats.maxBucketSizeCorrect, stats.maxBucketSizeIncorrect) %}
+                                                                {% set bucket = (count / maxBucketSize * 9) | round(0, 'ceil') %}
+                                                                {% set itemClass = 'frozen' ~ '-' ~ bucket %}
+                                                                {% set label = count ~ ' ' ~ submissionText ~ ' in freeze' %}
+                                                            {% else %}
+                                                                {% set itemClass = index ~ '-' ~ bucket %}
+                                                                {% set label = count ~ ' ' ~ index ~ ' ' ~ submissionText %}
+                                                            {% endif %}
+                                                            <div
+                                                                class="problem-stats-item {{ itemClass }}"
+                                                                data-toggle="tooltip"
+                                                                data-placement="top"
+                                                                data-html="true"
+                                                                title="Between {{ stat.start.timestamp | printtime(null, current_contest) }} and {{ stat.end.timestamp | printtime(null, current_contest) }}:<br/>{{ label }}">
+                                                            </div>
+                                                        {% endfor %}
+                                                    </div>
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
+
                                         {% if numsamples > 0 %}
                                             <div>
                                                 <br/>
@@ -79,6 +121,7 @@
                                         {% endif %}
                                     </div>
                                 </div>
+                                <div class="w-100 d-none d-sm-block d-md-block d-lg-none"><!-- wrap every 2 on sm--></div>
                             {% endif %}
                         {% endfor %}
                     </div>


### PR DESCRIPTION
This moves the stats logic to a service, so we can reuse it on the team/public pages. 

On the team/public problem pages it shows this if enabled:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/550145/98442890-0a3a9b00-2108-11eb-93a0-e57861feba95.png">
