### PR TITLE
Run html/css validation on src files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,34 @@ check_w3c_css:
     - python3 -m json.tool < result
     - exit $RES
 
+check_w3c_html:
+  stage: test
+  before_script:
+    # Takes about 1 minute to pull
+    - echo -e "section_start:`date +%s`:docker\r\e[0Kdocker pull"
+    - time docker pull domjudge/gitlabci:1.0
+    - echo -e "section_end:`date +%s`:docker\r\e[0K"
+  image: docker:stable
+  services:
+    - docker:19-dind
+    - mariadb
+  variables:
+    MYSQL_ROOT_PASSWORD: password
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+  script:
+  - |
+    docker run --privileged \
+      -v $CI_PROJECT_DIR:$CI_PROJECT_DIR \
+      --net=host \
+      -e "TERM=xterm-256color" -e "HOME=$HOME" -e "USER=$USER" -e "MARIADB_PORT_3306_TCP_ADDR=$MARIADB_PORT_3306_TCP_ADDR" -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
+      domjudge/gitlabci:1.0 /bin/bash -eo pipefail -c "umask 0002; cd $CI_PROJECT_DIR; script --return -qfc \"./gitlab/html.sh\" /dev/null | ts \"[%F %T]\" "
+  artifacts:
+    when: always
+    paths:
+      - public
+      - w3cHtmlpublic.json
+
 run unit tests:
   stage: test
   image: domjudge/gitlabci:1.0

--- a/gitlab/html.sh
+++ b/gitlab/html.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+shopt -s expand_aliases
+alias trace_on='set -x'
+alias trace_off='{ set +x; } 2>/dev/null'
+
+function section_start_internal() {
+	echo -e "section_start:`date +%s`:$1\r\e[0K$2"
+	trace_on
+}
+
+function section_end_internal() {
+	echo -e "section_end:`date +%s`:$1\r\e[0K"
+	trace_on
+}
+
+alias section_start='trace_off ; section_start_internal '
+alias section_end='trace_off ; section_end_internal '
+
+set -euxo pipefail
+
+section_start setup "Setup and install"
+
+export PS4='(${BASH_SOURCE}:${LINENO}): - [$?] $ '
+
+DIR=$(pwd)
+GITSHA=$(git rev-parse HEAD || true)
+
+# Set up
+"$( dirname "${BASH_SOURCE[0]}" )"/base.sh
+
+# Add jury to dummy user
+echo "INSERT INTO userrole (userid, roleid) VALUES (3, 2);" | mysql domjudge
+
+# Add netrc file for dummy user login
+echo "machine localhost login dummy password dummy" > ~/.netrc
+
+LOGFILE="/opt/domjudge/domserver/webapp/var/log/prod.log"
+
+function log_on_err() {
+	echo -e "\\n\\n=======================================================\\n"
+	echo "Symfony log:"
+	if sudo test -f "$LOGFILE" ; then
+		sudo cat "$LOGFILE"
+	fi
+}
+
+trap log_on_err ERR
+
+cd /opt/domjudge/domserver
+
+# This needs to be done before we do any submission.
+# 8 hours as a helper so we can adjust contest start/endtime
+TIMEHELP=$((8*60*60))
+# Database changes to make the REST API and event feed match better.
+cat <<EOF | mysql domjudge
+DELETE FROM clarification;
+UPDATE contest SET starttime  = UNIX_TIMESTAMP()-$TIMEHELP WHERE cid = 2;
+UPDATE contest SET freezetime = UNIX_TIMESTAMP()+15        WHERE cid = 2;
+UPDATE contest SET endtime    = UNIX_TIMESTAMP()+$TIMEHELP WHERE cid = 2;
+UPDATE team_category SET visible = 1;
+EOF
+
+ADMINPASS=$(cat etc/initial_admin_password.secret)
+
+# configure and restart php-fpm
+sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.2/fpm/pool.d/domjudge-fpm.conf"
+sudo /usr/sbin/php-fpm7.2
+
+section_end setup
+
+ADMINPASS=$(cat etc/initial_admin_password.secret)
+export COOKIEJAR
+COOKIEJAR=$(mktemp --tmpdir)
+export CURLOPTS="--fail -sq -m 30 -b $COOKIEJAR"
+
+# Make an initial request which will get us a session id, and grab the csrf token from it
+CSRFTOKEN=$(curl $CURLOPTS -c $COOKIEJAR "http://localhost/domjudge/login" 2>/dev/null | sed -n 's/.*_csrf_token.*value="\(.*\)".*/\1/p')
+# Make a second request with our session + csrf token to actually log in
+curl $CURLOPTS -c $COOKIEJAR -F "_csrf_token=$CSRFTOKEN" -F "_username=admin" -F "_password=$ADMINPASS" "http://localhost/domjudge/login"
+
+cd $DIR
+
+cp $COOKIEJAR cookies.txt
+sed -i 's/#HttpOnly_//g' cookies.txt
+sed -i 's/\t0\t/\t1999999999\t/g' cookies.txt
+wget https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
+unzip -q vnu.linux.zip
+#RES=0
+FOUNDERR=0
+ACCEPTEDERR=1132
+for url in public
+do
+	mkdir $url
+	cd $url
+    cp $DIR/cookies.txt ./
+	httrack http://localhost/domjudge/$url --assume html=text/html -*doc* -*logout*
+	cd $DIR
+	$DIR/vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-html --format json $url 2> result.json #; RES=$((RES+$?))
+	NEWFOUNDERRORS=`$DIR/vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-html --format gnu $url 2>&1 | wc -l`
+	FOUNDERR=$((NEWFOUNDERRORS+FOUNDERR))
+	python3 -m "json.tool" < result.json > w3cHtml$url.json
+    trace_off
+    python3 gitlab/jsontogitlab.py w3cHtml$url.json
+    trace_on
+done
+# Do not hard error yet
+# exit $RES
+echo "Found: " $FOUNDERR
+[ "$FOUNDERR" -le "$ACCEPTEDERR" ]

--- a/gitlab/jsontogitlab.py
+++ b/gitlab/jsontogitlab.py
@@ -1,0 +1,55 @@
+import json
+import sys
+import time
+import hashlib
+
+storage1 ={}
+storage2 = {}
+
+def cleanHash(toHash):
+    return hashlib.sha224(toHash).hexdigest()
+
+def sec_start(job,header):
+    print('section_start:{}:{}{}{}'.format(int(time.time()),cleanHash(job),'\r\033[0K',header))
+
+def sec_end(job):
+    print('section_end:{}:{}'.format(int(time.time()),cleanHash(job)+'\r\033[0K'))
+
+with open(sys.argv[1],'r') as f:
+    data = json.load(f, encoding='utf-8')
+    for message in data['messages']:
+        mtyp = message['type'].encode('utf-8', 'ignore')
+        murl = message['url'].encode('utf-8', 'ignore')
+        mmes = message['message'].encode('utf-8', 'ignore')
+        if mtyp not in storage1.keys():
+            storage1[mtyp] = {"messages":{}, "cnt":0}
+            storage2[mtyp] = {"urls":{}, "cnt":0}
+        if mmes not in storage1[mtyp]["messages"].keys():
+            storage1[mtyp]["messages"][mmes] = {"urls":{}, "cnt":0}
+        if murl not in storage2[mtyp]["urls"].keys():
+            storage2[mtyp]["urls"][murl] = {"messages":{}, "cnt":0}
+        if murl not in storage1[mtyp]["messages"][mmes]["urls"].keys():
+            storage1[mtyp]["messages"][mmes]["urls"][murl] = 0
+        if mmes not in storage2[mtyp]["urls"][murl]["messages"].keys():
+            storage2[mtyp]["urls"][murl]["messages"][mmes] = 0
+        storage1[mtyp]["messages"][mmes]["urls"][murl] += 1
+        storage1[mtyp]["messages"][mmes]["cnt"] += 1
+        storage1[mtyp]["cnt"] += 1
+        storage2[mtyp]["urls"][murl]["messages"][mmes] += 1
+        storage2[mtyp]["urls"][murl]["cnt"] += 1
+        storage2[mtyp]["cnt"] += 1
+                                                                                                                                    # Stats
+for key,value in sorted(storage1.items(), key=lambda x:x[1]['cnt']):
+    print("Type: {}, Totalfound: {}".format(key, value["cnt"]))
+    for key2,value2 in sorted(storage1[key]["messages"].items(), key=lambda x:x[1]['cnt'], reverse=True):
+        sec_start(key+key2, key2)
+        print("[{}] [{}%] Message: {}".format(key, round(100*value2["cnt"]/value["cnt"],2), key2))
+        for key3,value3 in sorted(storage1[key]["messages"][key2]["urls"].items(), key=lambda x:x[1], reverse=True):
+            print("[{}%] URL: {}".format(round(100*value3/value2["cnt"],2), key3))
+        sec_end(key+key2)
+    for key2,value2 in sorted(storage2[key]["urls"].items(), key=lambda x:x[1]['cnt'], reverse=True):
+        sec_start(key+key2, key2)
+        print("[{}] [{}%] URL: {}".format(key, round(100*value2["cnt"]/value["cnt"],2), key2))
+        for key3,value3 in sorted(storage2[key]["urls"][key2]["messages"].items(), key=lambda x:x[1], reverse=True):
+            print("[{}%] Message: {}".format(round(100*value3/value2["cnt"],2), key3))
+        sec_end(key+key2)


### PR DESCRIPTION
This scrapes the testinstance to plain html and checks the usage of HTML not in line with W3C recommendations. Currently it would only break when more errors are found than currently in the main branch.

Improvement is possible in a number of ways;
- Testing with a user which has a team role, As I think the admin user does not have this.
- Some code is duplicated from the integration tests, it would help if these are moved to another file which can than be sourced, I'm fine with trying something like that but would think that should be in another PR

The output is now divided into sections both for the file and its problems and another for a problem and which files this occurs as I think fixing /public should be the 1st one but fixing 1 problem at a time might be safer to not get differences in the UI.

All these problems on itself can be labeled as "Good first time" issues in my opinion.

If this is accepted I'll fixup to only 1 commit.