### PR TITLE
Demo w3c validation on CSS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,17 @@ check syntax:
   script:
     - ./gitlab/syntax.sh
 
+check_w3c_css:
+  stage: test
+  image: 
+    name: cyb3rjak3/html5validator
+    entrypoint: [""]
+  script:
+    - JAR=`find /usr/local/lib -name vnu.jar|tail -n1`
+    - java -jar $JAR --format json --skip-non-css webapp 2>result; RES=$?
+    - python3 -m json.tool < result
+    - exit $RES
+
 run unit tests:
   stage: test
   image: domjudge/gitlabci:1.0


### PR DESCRIPTION
The pipeline should break to demonstrate the output when something is wrong. So if this is acceptable I'll do a fixup to remove the demostage.

More PRs will be following for other tests independent on this one so this doesn't need to be merged directly. But approval might be nice for my tree...

I will fix the merge conflicts when the code is accepted.