### PR TITLE
Add 'retrieve' flag for DataTables initialisation.

### DIFF
--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -140,6 +140,7 @@
         $().ready(function () {
             $('.data-table').DataTable({
                 "paging": false,
+                "retrieve": true,
                 "searching": {{ options.searching | default('true') }},
                 "ordering": {{ options.ordering | default('true') }},
                 "order": [[ {{ default_sort }}, '{{ default_sort_order }}']],


### PR DESCRIPTION
This attempts to fix #885. It is only based on reading documentation, since I cannot reproduce the reported issue but the documented behaviour does match what we do and what this should fix.

See: https://datatables.net/manual/tech-notes/3#retrieve