### PR TITLE
Add support for specifying database port. Fixes DOMjudge/domjudge-packaging#37.

### DIFF
--- a/etc/gendbpasswords
+++ b/etc/gendbpasswords
@@ -11,4 +11,4 @@ echo "# Format: 'dummy:<db_host>:<db_name>:<user>:<password>'"
 
 printf "dummy:localhost:domjudge:domjudge:"
 	head -c12 /dev/urandom | base64 | head -c16 | tr '/+' 'Aa'
-echo
+echo ":3306"

--- a/gitlab/base.sh
+++ b/gitlab/base.sh
@@ -25,7 +25,7 @@ echo "GRANT SELECT, INSERT, UPDATE, DELETE ON \`domjudge\`.* TO 'domjudge'@'%' I
 echo "SET GLOBAL max_allowed_packet = 100*1024*1024;" | mysql
 
 # Generate a dbpasswords file
-echo "dummy:${MARIADB_PORT_3306_TCP_ADDR}:domjudge:domjudge:domjudge" > etc/dbpasswords.secret
+echo "dummy:${MARIADB_PORT_3306_TCP_ADDR}:domjudge:domjudge:domjudge:3306" > etc/dbpasswords.secret
 
 # Generate APP_SECRET for symfony
 ( cd etc ; ./gensymfonysecret > symfony_app.secret )

--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -62,9 +62,9 @@ mysql()
 		[ -n "$DBA_PASSWD" ]    && pass="-p$DBA_PASSWD"
 	fi
 	if [ -n "$pass" ]; then
-		command mysql $user "$pass" -h "$DBHOST" --silent --skip-column-names "$@"
+		command mysql $user "$pass" -h "$DBHOST" -P "$DBPORT" --silent --skip-column-names "$@"
 	else
-		command mysql $user -h "$DBHOST" --silent --skip-column-names "$@"
+		command mysql $user -h "$DBHOST" -P "$DBPORT" --silent --skip-column-names "$@"
 	fi
 }
 
@@ -117,9 +117,9 @@ symfony_console()
 
 		if [ -n "$DBA_USER" ]; then
 			if [ -n "$DBA_PASSWD" ]; then
-				DATABASE_URL=mysql://${DBA_USER}:${DBA_PASSWD}@${domjudge_DBHOST}:3306/${domjudge_DBNAME}
+				DATABASE_URL=mysql://${DBA_USER}:${DBA_PASSWD}@${domjudge_DBHOST}:${domjudge_DBPORT}/${domjudge_DBNAME}
 			else
-				DATABASE_URL=mysql://${DBA_USER}@${domjudge_DBHOST}:3306/${domjudge_DBNAME}
+				DATABASE_URL=mysql://${DBA_USER}@${domjudge_DBHOST}:${domjudge_DBPORT}/${domjudge_DBNAME}
 			fi
 		fi
 	fi
@@ -147,17 +147,25 @@ read_dbpasswords()
 	IFS=":"
 	# Don't pipe $PASSWDFILE into this while loop as that spawns a
 	# subshell and then variables are not retained in the original shell.
-	while read -r role host db user passwd; do
+	while read -r role host db user passwd port; do
 		# Skip lines beginning with a '#'
 		[ "x$role" != "x${role###}" ] && continue
 		domjudge_DBHOST=$host
+		domjudge_DBPORT=$port
 		domjudge_DBNAME=$db
 		domjudge_DBUSER=$user
 		domjudge_PASSWD=$passwd
 		DBHOST=$host
 		DBNAME=$db
+		DBPORT=$port
 	done < "$PASSWDFILE"
 	IFS="$OLDIFS"
+	if [ -z "$domjudge_DBPORT" ]; then
+		domjudge_DBPORT=3306
+	fi
+	if [ -z "$DBPORT" ]; then
+		DBPORT=3306
+	fi
 	if [ -z "$domjudge_PASSWD" ]; then
 		echo "Error: no login info found."
 		return 1

--- a/webapp/config/load_db_secrets.php
+++ b/webapp/config/load_db_secrets.php
@@ -17,11 +17,11 @@ function get_db_url()
         if ($line[0] == '#') {
             continue;
         }
-        list($dummy, $host, $db, $user, $pass) = explode(':', trim($line));
+        list($dummy, $host, $db, $user, $pass, $port) = explode(':', trim($line));
         break;
     }
 
-    return sprintf('mysql://%s:%s@%s:3306/%s', $user, $pass, $host, $db);
+    return sprintf('mysql://%s:%s@%s:%d/%s', $user, $pass, $host, $port ?? 3306, $db);
 }
 
 function get_app_secret()


### PR DESCRIPTION
The port *is* optional but we do append it by default when generating the DB secrets file.