### PR TITLE
Use pkg-config to determine systemd unit files directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install-domserver-l:
 		$(INSTALL_WEBSITE) -m 0775 -d $(DESTDIR)$(domserver_webappdir)/var/$$d ; \
 	done
 # Make sure that domjudge user and webserver group can write to var/{cache,log}:
-	DESTDIR=$(DESTDIR) $(domserver_bindir)/fix_permissions
+	DESTDIR=$(DESTDIR) $(DESTDIR)$(domserver_bindir)/fix_permissions
 # Special case create tmpdir here, only when FHS not enabled:
 ifneq "$(FHS_ENABLED)" "yes"
 	-$(INSTALL_WEBSITE) -m 0770 -d $(DESTDIR)$(domserver_tmpdir)

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,25 @@ AX_WITH_COMMENT(7,[      ])
 
 # }}}
 
+# {{{ Directory for systemd unit files
+
+PKG_PROG_PKG_CONFIG
+AC_ARG_WITH([systemdsystemunitdir],
+     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
+     [with_systemdsystemunitdir=auto])
+AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"], [
+     def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+
+     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
+   [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
+    [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])])
+    with_systemdsystemunitdir=no],
+   [with_systemdsystemunitdir="$def_systemdsystemunitdir"])])
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
+      [AC_SUBST([systemd_unitdir], [$with_systemdsystemunitdir])])
+
+# }}}
+
 AC_MSG_CHECKING([baseurl])
 AC_ARG_WITH([baseurl], [AS_HELP_STRING([--with-baseurl=URL],
 [Base URL of the DOMjudge web interfaces. Example default:
@@ -389,6 +408,8 @@ echo "    - tmp..............: AX_VAR_EXPAND($judgehost_tmpdir)"
 echo "    - judge............: AX_VAR_EXPAND($judgehost_judgedir)"
 echo "    - chroot...........: AX_VAR_EXPAND($judgehost_chrootdir)"
 echo "    - cgroup...........: AX_VAR_EXPAND($judgehost_cgroupdir)"
+echo ""
+echo " * systemd unit files..: AX_VAR_EXPAND($systemd_unitdir)"
 echo ""
 echo "Run 'make' without arguments to get a list of (build) targets."
 echo ""

--- a/judge/Makefile
+++ b/judge/Makefile
@@ -32,10 +32,12 @@ install-judgehost:
 	$(INSTALL_DATA) -t $(DESTDIR)$(judgehost_libjudgedir) \
 		judgedaemon.main.php
 	$(INSTALL_PROG) -t $(DESTDIR)$(judgehost_bindir) \
-        judgedaemon runguard runpipe create_cgroups
-	$(INSTALL_DIR)     $(DESTDIR)$(libdir)/systemd/system/
-	$(INSTALL_DATA) -t $(DESTDIR)$(libdir)/systemd/system/ \
-        create-cgroups.service domjudge-judgehost.service
+		judgedaemon runguard runpipe create_cgroups
+ifneq ($(systemd_unitdir),)
+	$(INSTALL_DIR)     $(DESTDIR)$(systemd_unitdir)
+	$(INSTALL_DATA) -t $(DESTDIR)$(systemd_unitdir) \
+		create-cgroups.service domjudge-judgehost.service
+endif
 
 clean-l:
 	-rm -f $(TARGETS) $(TARGETS:%=%$(OBJEXT))

--- a/paths.mk.in
+++ b/paths.mk.in
@@ -115,6 +115,8 @@ judgehost_cgroupdir    = @judgehost_cgroupdir@
 
 domjudge_docdir        = @domjudge_docdir@
 
+systemd_unitdir        = @systemd_unitdir@
+
 # The tmpdir's are not in these lists, since they would otherwise get
 # their permissions overwritten in FHS install mode.
 domserver_dirs = $(domserver_bindir) $(domserver_etcdir) \
@@ -158,6 +160,7 @@ define substconfigvars
 	-e 's,@judgehost_chrootdir[@],@judgehost_chrootdir@,g' \
 	-e 's,@judgehost_cgroupdir[@],@judgehost_cgroupdir@,g' \
 	-e 's,@domjudge_docdir[@],@domjudge_docdir@,g' \
+	-e 's,@systemd_unitdir[@],@systemd_unitdir@,g' \
 	-e 's,@DOMJUDGE_USER[@],@DOMJUDGE_USER@,g' \
 	-e 's,@WEBSERVER_GROUP[@],@WEBSERVER_GROUP@,g' \
 	-e 's,@BEEP[@],@BEEP@,g' \


### PR DESCRIPTION
Follows https://www.freedesktop.org/software/systemd/man/daemon.html#Installing%20systemd%20Service%20Files
Allows overriding the default using --with-systemdsystemunitdir=DIR
If not detected or specified, don't install unit files.

Closes #834