### PR TITLE
Add fixtures for gatling load test

### DIFF
--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -31,6 +31,7 @@ Commands:
   bare-install     create database, setup defaults if not existing
   uninstall        remove database users and database, INCLUDING ALL DATA!
   install-examples install examples only
+  install-loadtest configure for load testing. WARNING: CREATES A LOT OF EXTRA ITEMS!
   upgrade          upgrade MySQL database schema to current version
 
 Options:
@@ -276,6 +277,11 @@ uninstall)
 install-examples)
 	read_dbpasswords
 	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
+	;;
+
+install-loadtest)
+  read_dbpasswords
+  DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-gatling-data
 	;;
 
 create-db-users)

--- a/webapp/src/Command/LoadGatlingDataCommand.php
+++ b/webapp/src/Command/LoadGatlingDataCommand.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class LoadGatlingDataCommand
+ * @package App\Command
+ */
+class LoadGatlingDataCommand extends Command
+{
+    /**
+     * @inheritDoc
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('domjudge:load-gatling-data')
+            ->setDescription('Load the gatling data(for load testing)');
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $command   = $this->getApplication()->find('doctrine:fixtures:load');
+        $arguments = [
+            'command'  => 'doctrine:fixtures:load',
+            '--group'  => ['gatling'],
+            '--append' => null,
+        ];
+
+        return $command->run(new ArrayInput($arguments), $output);
+    }
+}

--- a/webapp/src/DataFixtures/ExecutableFixture.php
+++ b/webapp/src/DataFixtures/ExecutableFixture.php
@@ -20,6 +20,14 @@ class ExecutableFixture extends AbstractExampleDataFixture
     protected $sqlDir;
 
     /**
+     * @inheritDoc
+     */
+    public static function getGroups(): array
+    {
+        return ['example', 'gatling'];
+    }
+
+    /**
      * ExecutableFixture constructor.
      * @param string $sqlDir
      */

--- a/webapp/src/DataFixtures/GatlingDataFixture.php
+++ b/webapp/src/DataFixtures/GatlingDataFixture.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Language;
+use App\Entity\Team;
+use App\Entity\TeamCategory;
+use App\Entity\Role;
+use App\Entity\User;
+
+/**
+ * Class GatlingDataFixture
+ * @package App\DataFixtures
+ */
+class GatlingDataFixture extends Fixture implements FixtureGroupInterface, DependentFixtureInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function getGroups(): array
+    {
+        return ['gatling'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function load(ObjectManager $manager)
+    {
+        $num_jury_accounts = 25;
+
+        // Enable a bunch of languages:
+        $langs = ["csharp", "adb", "f95", "hs", "lua", "pas", "py2", "py3", "rb", "scala", "kt"];
+        foreach($langs as $langid) {
+          $lang = $manager->getRepository(Language::class)->findOneBy(['langid' => $langid]);
+          $lang->setAllowSubmit(true);
+          $manager->persist($lang);
+        }
+
+
+        // Create a contest
+        $gatlingContest = new Contest();
+        $gatlingContest
+            ->setExternalid('gatling')
+            ->setName('gatling contest')
+            ->setShortname('gatling')
+            ->setStarttimeString(
+                sprintf(
+                    '%s-01-01 12:00:00 Europe/Amsterdam',
+                    date('Y')
+                )
+            )
+            ->setActivatetimeString('-00:30:00.123')
+            ->setFreezetimeString(
+                sprintf(
+                    '%s-01-01 16:00:00 Europe/Amsterdam',
+                    date('Y') + 2
+                )
+            )
+            ->setEndtimeString(
+                sprintf(
+                    '%s-01-01 17:00:00 Europe/Amsterdam',
+                    date('Y') + 2
+                )
+            )
+            ->setUnfreezetimeString(
+                sprintf(
+                    '%s-01-01 17:30:00 Europe/Amsterdam',
+                    date('Y') + 2
+                )
+            )
+            ->setDeactivatetimeString(
+                sprintf(
+                    '%s-01-01 18:30:00 Europe/Amsterdam',
+                    date('Y') + 2
+                )
+            );
+        $manager->persist($gatlingContest);
+
+        // Add problem to the contest
+        $helloDemo = new ContestProblem();
+        $helloDemo
+            ->setShortname('hello')
+            ->setContest($gatlingContest)
+            ->setProblem($this->getReference(ProblemFixture::HELLO_REFERENCE))
+            ->setColor('magenta');
+
+        $manager->persist($helloDemo);
+
+        // Create a category to associate the gatling stuff with
+        $category = new TeamCategory();
+        $category
+            ->setName('gatling')
+            ->setSortorder(1)
+            ->setColor('#ff9e2a') // This is gatling orange
+            ->setAllowSelfRegistration(true)
+            ->setVisible(true);
+
+        $manager->persist($category);
+
+        // Create some jury users for gatling to use
+        for($i=0; $i<$num_jury_accounts; $i++) {
+          $acct_name = sprintf('gatling_jury_%05d', $i);
+          $user = new User();
+          $user
+              ->setUsername($acct_name)
+              ->setName("gatling jury $i")
+              ->setPlainPassword($acct_name)
+              ->addUserRole($manager->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']));
+          $manager->persist($user);
+        }
+        $manager->flush();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDependencies()
+    {
+        return [ProblemFixture::class];
+    }
+}

--- a/webapp/src/DataFixtures/ProblemFixture.php
+++ b/webapp/src/DataFixtures/ProblemFixture.php
@@ -23,6 +23,14 @@ class ProblemFixture extends AbstractExampleDataFixture implements DependentFixt
     protected $projectDir;
 
     /**
+     * @inheritDoc
+     */
+    public static function getGroups(): array
+    {
+        return ['example', 'gatling'];
+    }
+
+    /**
      * ProblemFixture constructor.
      * @param string $projectDir
      */


### PR DESCRIPTION
Adds fixtures + updates scripts to create the required data for a gatling load test to be completed. This should not be used in
production, as running gatling will create a lot of users/teams/submissions/etc.

I've updated the gatling load test scripts(found at https://github.com/ubergeek42/domjudge-gatling) but they require some database elements to exist first. I used to have some hacky stuff to just do it inside gatling, but it seems saner to just have them as fixtures here. Now that I look at this code on github, it might be possible to make gatling work  with the demo contest, but it's probably still nice to have a separate category where all the users end up.

Maybe we should move the gatling code somewhere else(into the domjudge org? into this repo under some subdirectory?).