### PR TITLE
Remove explicit foreign key columns since they are not needed.

### DIFF
--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -1828,11 +1828,15 @@ class ImportEventFeedCommand extends Command
 
         $this->em->flush();
 
+        $contestId = $submission->getContest()->getCid();
+        $teamId = $submission->getTeam()->getTeamid();
+        $problemId = $submission->getProblem()->getProbid();
+
         // Now we need to update the scoreboard cache for this cell to get this judgement result in
         $this->em->clear();
-        $contest = $this->em->getRepository(Contest::class)->find($submission->getCid());
-        $team    = $this->em->getRepository(Team::class)->find($submission->getTeamid());
-        $problem = $this->em->getRepository(Problem::class)->find($submission->getProbid());
+        $contest = $this->em->getRepository(Contest::class)->find($contestId);
+        $team    = $this->em->getRepository(Team::class)->find($teamId);
+        $problem = $this->em->getRepository(Problem::class)->find($problemId);
         $this->scoreboardService->calculateScoreRow($contest, $team, $problem);
 
         $this->processPendingEvents('judgement', $judgement->getExternalid());
@@ -1990,14 +1994,18 @@ class ImportEventFeedCommand extends Command
     {
         $submission->setValid($valid);
 
+        $contestId = $submission->getContest()->getCid();
+        $teamId = $submission->getTeam()->getTeamid();
+        $problemId = $submission->getProblem()->getProbid();
+
         $this->em->flush();
         $this->eventLogService->log('submissions', $submission->getSubmitid(),
             $valid ? EventLogService::ACTION_CREATE : EventLogService::ACTION_DELETE,
             $this->contestId);
 
-        $contest = $this->em->getRepository(Contest::class)->find($submission->getCid());
-        $team = $this->em->getRepository(Team::class)->find($submission->getTeamid());
-        $problem = $this->em->getRepository(Problem::class)->find($submission->getProbid());
+        $contest = $this->em->getRepository(Contest::class)->find($contestId);
+        $team = $this->em->getRepository(Team::class)->find($teamId);
+        $problem = $this->em->getRepository(Problem::class)->find($problemId);
         $this->scoreboardService->calculateScoreRow($contest, $team, $problem);
     }
 }

--- a/webapp/src/Controller/API/AbstractRestController.php
+++ b/webapp/src/Controller/API/AbstractRestController.php
@@ -150,12 +150,12 @@ abstract class AbstractRestController extends AbstractFOSRestController
 
         // Filter on contests this user has access to
         if (!$this->dj->checkrole('api_reader') && !$this->dj->checkrole('judgehost')) {
-            if ($this->dj->checkrole('team') && $this->dj->getUser()->getTeamid()) {
+            if ($this->dj->checkrole('team') && $this->dj->getUser()->getTeam()) {
                 $qb->leftJoin('c.teams', 'ct')
                     ->leftJoin('c.team_categories', 'tc')
                     ->leftJoin('tc.teams', 'tct')
                     ->andWhere('ct.teamid = :teamid OR tct.teamid = :teamid OR c.openToAllTeams = 1')
-                    ->setParameter(':teamid', $this->dj->getUser()->getTeamid());
+                    ->setParameter(':teamid', $this->dj->getUser()->getTeam());
             } else {
                 $qb->andWhere('c.public = 1');
             }

--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -126,8 +126,8 @@ class AwardsController extends AbstractRestController
         foreach ($scoreboard->getTeams() as $team) {
             $teamid = (string)$team->getApiId($this->eventLogService);
             if ($scoreboard->isBestInCategory($team)) {
-                $group_winners[$team->getCategoryId()][] = $teamid;
-                $groups[$team->getCategoryid()] = $team->getCategory()->getName();
+                $group_winners[$team->getCategory()->getCategoryId()][] = $teamid;
+                $groups[$team->getCategory()->getCategoryid()] = $team->getCategory()->getName();
             }
             foreach($scoreboard->getProblems() as $problem) {
                 $probid = (string)$problem->getApiId($this->eventLogService);

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -85,7 +85,7 @@ class ClarificationController extends AbstractRestController
             ->leftJoin('clar.recipient', 'r')
             ->leftJoin('clar.problem', 'p')
             ->select('clar, c, r, reply, p')
-            ->andWhere('clar.cid = :cid')
+            ->andWhere('clar.contest = :cid')
             ->setParameter(':cid', $this->getContestId($request));
 
         if (!$this->dj->checkrole('api_reader') &&

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -384,7 +384,7 @@ class ContestController extends AbstractRestController
             $since_id = $request->query->getInt('since_id');
             $event    = $this->em->getRepository(Event::class)->findOneBy([
                 'eventid' => $since_id,
-                'cid' => $contest->getCid(),
+                'contest' => $contest,
             ]);
             if ($event === null) {
                 return new Response('Invalid parameter "since_id" requested.', Response::HTTP_BAD_REQUEST);
@@ -460,7 +460,7 @@ class ContestController extends AbstractRestController
                     ->select('e')
                     ->andWhere('e.eventid > :lastIdSent')
                     ->setParameter('lastIdSent', $lastIdSent)
-                    ->andWhere('e.cid = :cid')
+                    ->andWhere('e.contest = :cid')
                     ->setParameter('cid', $contest->getCid())
                     ->orderBy('e.eventid', 'ASC');
 

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -164,8 +164,8 @@ class GeneralInfoController extends AbstractFOSRestController
     {
         if ($this->dj->checkrole('jury')) {
             $onlyOfTeam = null;
-        } elseif ($this->dj->checkrole('team') && $this->dj->getUser()->getTeamid()) {
-            $onlyOfTeam = $this->dj->getUser()->getTeamid();
+        } elseif ($this->dj->checkrole('team') && $this->dj->getUser()->getTeam()) {
+            $onlyOfTeam = $this->dj->getUser()->getTeam();
         } else {
             $onlyOfTeam = -1;
         }

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -121,7 +121,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
             ->leftJoin('j.submission', 's')
             ->leftJoin('j.rejudging', 'r')
             ->leftJoin('j.runs', 'jr')
-            ->andWhere('j.cid = :cid')
+            ->andWhere('j.contest = :cid')
             ->setParameter(':cid', $this->getContestId($request))
             ->groupBy('j.judgingid')
             ->orderBy('j.judgingid');
@@ -138,13 +138,13 @@ class JudgementController extends AbstractRestController implements QueryObjectT
 
         if (!$roleAllowsVisibility) {
             $queryBuilder
-                ->andWhere('s.teamid = :team')
-                ->setParameter(':team', $this->dj->getUser()->getTeamid());
+                ->andWhere('s.team = :team')
+                ->setParameter(':team', $this->dj->getUser()->getTeam());
         }
 
         if ($request->query->has('submission_id')) {
             $queryBuilder
-                ->andWhere('j.submitid = :submission')
+                ->andWhere('j.submission = :submission')
                 ->setParameter(':submission', $request->query->get('submission_id'));
         }
 

--- a/webapp/src/Controller/API/MetricsController.php
+++ b/webapp/src/Controller/API/MetricsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\API;
 
+use App\Entity\Submission;
 use App\Service\DOMJudgeService;
 use App\Service\SubmissionService;
 use App\Entity\Team;
@@ -101,6 +102,7 @@ class MetricsController extends AbstractFOSRestController
             $labels = [$contest->getShortname()];
 
             // Get submissions stats for the contest
+            /** @var Submission[] $submissions */
             list($submissions, $submissionCounts) = $this->submissionService->getSubmissionList([$contest->getCid() => $contest], [], 0);
             foreach ($submissionCounts as $kind => $count) {
                 $m['submissions_' . $kind]->set($count, $labels);
@@ -111,9 +113,9 @@ class MetricsController extends AbstractFOSRestController
             foreach($submissions as $s) {
                 $result = $s->getResult();
                 if ($s->getResult() == "correct") {
-                    $teamids_correct[$s->getTeamid()] = 1;
+                    $teamids_correct[$s->getTeam()->getTeamid()] = 1;
                 } else {
-                    $teamids_submitted[$s->getTeamid()] = 1;
+                    $teamids_submitted[$s->getTeam()->getTeamid()] = 1;
                 }
             }
             $m['teams_submitted']->set(count($teamids_submitted), $labels);

--- a/webapp/src/Controller/API/RunController.php
+++ b/webapp/src/Controller/API/RunController.php
@@ -134,7 +134,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
             ->leftJoin('j.submission', 's')
             ->leftJoin('j.contest', 'c')
             ->select('jr, j, tc, c')
-            ->andWhere('j.cid = :cid')
+            ->andWhere('j.contest = :cid')
             ->setParameter(':cid', $this->getContestId($request));
 
         if ($request->query->has('first_id')) {
@@ -151,7 +151,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
 
         if ($request->query->has('judging_id')) {
             $queryBuilder
-                ->andWhere('jr.judgingid = :judging_id')
+                ->andWhere('jr.judging = :judging_id')
                 ->setParameter(':judging_id', $request->query->get('judging_id'));
         }
 
@@ -163,7 +163,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
         if (!$request->attributes->has('id') && !$request->query->has('ids')) {
             $queryBuilder
                 ->andWhere('s.submittime < c.endtime')
-                ->andWhere('j.rejudgingid IS NULL OR j.valid = 1');
+                ->andWhere('j.rejudging IS NULL OR j.valid = 1');
             if ($this->config->get('verification_required')) {
                 $queryBuilder->andWhere('j.verified = 1');
             }

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -298,7 +298,7 @@ class SubmissionController extends AbstractRestController
             ->from(SubmissionFile::class, 'f')
             ->join('f.submission', 's')
             ->select('f, s')
-            ->andWhere('s.cid = :cid')
+            ->andWhere('s.contest = :cid')
             ->andWhere('s.submitid = :submitid')
             ->setParameter(':cid', $this->getContestId($request))
             ->setParameter(':submitid', $id)
@@ -315,7 +315,7 @@ class SubmissionController extends AbstractRestController
         foreach ($files as $file) {
             $result[]   = [
                 'id' => (string)$file->getSubmitfileid(),
-                'submission_id' => (string)$file->getSubmitid(),
+                'submission_id' => (string)$file->getSubmission()->getSubmitid(),
                 'filename' => $file->getFilename(),
                 'source' => base64_encode($file->getSourcecode()),
             ];
@@ -338,14 +338,14 @@ class SubmissionController extends AbstractRestController
             ->join('s.team', 't')
             ->select('s')
             ->andWhere('s.valid = 1')
-            ->andWhere('s.cid = :cid')
+            ->andWhere('s.contest = :cid')
             ->andWhere('t.enabled = 1')
             ->setParameter(':cid', $cid)
             ->orderBy('s.submitid');
 
         if ($request->query->has('language_id')) {
             $queryBuilder
-                ->andWhere('s.langid = :langid')
+                ->andWhere('s.language = :langid')
                 ->setParameter(':langid', $request->query->get('language_id'));
         }
 

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -94,13 +94,13 @@ class TeamController extends AbstractRestController
 
         if ($request->query->has('category')) {
             $queryBuilder
-                ->andWhere('t.categoryid = :category')
+                ->andWhere('t.category = :category')
                 ->setParameter(':category', $request->query->get('category'));
         }
 
         if ($request->query->has('affiliation')) {
             $queryBuilder
-                ->andWhere('t.affilid = :affiliation')
+                ->andWhere('t.affiliation = :affiliation')
                 ->setParameter(':affiliation', $request->query->get('affiliation'));
         }
 

--- a/webapp/src/Controller/API/TestcaseController.php
+++ b/webapp/src/Controller/API/TestcaseController.php
@@ -76,8 +76,8 @@ class TestcaseController extends AbstractFOSRestController
         $queryBuilder = $this->em->createQueryBuilder()
             ->from(Testcase::class, 't')
             ->select('t')
-            ->andWhere('t.probid = :probid')
-            ->setParameter(':probid', $judging->getSubmission()->getProbid())
+            ->andWhere('t.problem = :probid')
+            ->setParameter(':probid', $judging->getSubmission()->getProblem())
             ->orderBy('t.rank')
             ->setMaxResults(1);
 
@@ -85,7 +85,7 @@ class TestcaseController extends AbstractFOSRestController
             $testcasesToSkip = [];
             /** @var JudgingRun $run */
             foreach ($judging->getRuns() as $run) {
-                $testcasesToSkip[] = $run->getTestcaseid();
+                $testcasesToSkip[] = $run->getTestcase()->getTestcaseid();
             }
 
             $queryBuilder

--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -65,8 +65,7 @@ class AnalysisController extends AbstractController
         $delayedTimeDiff = 5;
         $delayedJudgings = $em->createQueryBuilder()
             ->from(Submission::class, 's')
-            ->innerJoin(Judging::class, 'j', Expr\Join::WITH,
-                's.submitid = j.submitid')
+            ->innerJoin(Judging::class, 'j', Expr\Join::WITH, 's.submitid = j.submission')
             ->select('s.submitid, MIN(j.judgingid) AS judgingid, s.submittime, MIN(j.starttime) - s.submittime AS timediff, COUNT(j.judgingid) AS num_judgings')
             ->andWhere('s.contest = :contest')
             ->setParameter('contest', $contest)

--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -195,7 +195,7 @@ class AuditLogController extends AbstractController
             case 'testcase':
                 $testcase = $this->em->getRepository(Testcase::class)->find($id);
                 if ($testcase) {
-                    return $this->generateUrl('jury_problem_testcases', ['probId' => $testcase->getProbid()]);
+                    return $this->generateUrl('jury_problem_testcases', ['probId' => $testcase->getProblem()->getProbid()]);
                 }
                 break;
         }

--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -93,7 +93,7 @@ class ClarificationController extends AbstractController
             ->leftJoin('clar.problem', 'p')
             ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = clar.contest')
             ->select('clar', 'p', 'cp')
-            ->andWhere('clar.cid in (:contestIds)')
+            ->andWhere('clar.contest in (:contestIds)')
             ->setParameter(':contestIds', $contestIds)
             ->orderBy('clar.submittime', 'DESC')
             ->addOrderBy('clar.clarid', 'DESC');
@@ -117,7 +117,7 @@ class ClarificationController extends AbstractController
         $wheres            = [
             'new' => 'clar.sender IS NOT NULL AND clar.answered = 0',
             'old' => 'clar.sender IS NOT NULL AND clar.answered != 0',
-            'general' => 'clar.sender IS NULL AND (clar.respid IS NULL OR clar.recipient IS NULL)',
+            'general' => 'clar.sender IS NULL AND (clar.recipient IS NULL OR clar.recipient IS NULL)',
         ];
         foreach ($wheres as $type => $where) {
             $clarifications = (clone $queryBuilder)
@@ -206,8 +206,8 @@ class ClarificationController extends AbstractController
             $contest = $clar->getContest();
             $data['contest'] = $contest;
             $clarcontest = $contest->getShortname();
-            if ( $clar->getProbId() ) {
-                $concernssubject = $contest->getCid() . "-" . $clar->getProbId();
+            if ( $clar->getProblem() ) {
+                $concernssubject = $contest->getCid() . "-" . $clar->getProblem()->getProbid();
             } elseif ( $clar->getCategory() ) {
                 $concernssubject = $contest->getCid() . "-" . $clar->getCategory();
             } else {
@@ -452,7 +452,6 @@ class ClarificationController extends AbstractController
             $this->addFlash('danger', $message);
             return $this->redirectToRoute('jury_clarification_send');
         } else {
-            $clarification->setRecipientId($sendto);
             $team = $this->em->getReference(Team::class, $sendto);
             $clarification->setRecipient($team);
         }

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -228,11 +228,15 @@ class ContestController extends BaseController
         if ($this->getParameter('removed_intervals')) {
             $table_fields['num_removed_intervals'] = ['title' => '# removed<br/>intervals', 'sort' => true];
             $removedIntervals                      = $em->createQueryBuilder()
-                ->from(RemovedInterval::class, 'i', 'i.cid')
-                ->select('COUNT(i.intervalid) AS num_removed_intervals', 'i.cid')
-                ->groupBy('i.cid')
+                ->from(RemovedInterval::class, 'i')
+                ->join('i.contest', 'c')
+                ->select('COUNT(i.intervalid) AS num_removed_intervals', 'c.cid')
+                ->groupBy('i.contest')
                 ->getQuery()
                 ->getResult();
+            $removedIntervals = Utils::reindex($removedIntervals, function($data) {
+                return $data['cid'];
+            });
         } else {
             $removedIntervals = [];
         }

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -410,7 +410,7 @@ class ImportExportController extends BaseController
                 'time' => null,
             ];
             foreach ($teams as $team) {
-                if (!isset($categories[$team->getCategoryid()]) || $team->getCategory()->getSortorder() !== $sortOrder) {
+                if (!isset($categories[$team->getCategory()->getCategoryid()]) || $team->getCategory()->getSortorder() !== $sortOrder) {
                     continue;
                 }
 
@@ -492,11 +492,12 @@ class ImportExportController extends BaseController
         /** @var Clarification[] $clarifications */
         $clarifications = $this->em->createQueryBuilder()
             ->from(Clarification::class, 'c')
+            ->join('c.problem', 'p')
             ->select('c')
             ->andWhere('c.contest = :contest')
             ->setParameter(':contest', $contest)
             ->addOrderBy('c.category')
-            ->addOrderBy('c.probid')
+            ->addOrderBy('p.probid')
             ->addOrderBy('c.submittime')
             ->addOrderBy('c.clarid')
             ->getQuery()

--- a/webapp/src/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/Controller/Jury/InternalErrorController.php
@@ -45,6 +45,7 @@ class InternalErrorController extends BaseController
         /** @var InternalError[] $internalErrors */
         $internalErrors = $this->em->createQueryBuilder()
             ->from(InternalError::class, 'e')
+            ->join('e.judging', 'j')
             ->select('e')
             ->orderBy('e.status')
             ->addOrderBy('e.errorid')
@@ -52,7 +53,7 @@ class InternalErrorController extends BaseController
 
         $table_fields = [
             'errorid' => ['title' => 'ID'],
-            'judgingid' => ['title' => 'jid'],
+            'judging.judgingid' => ['title' => 'jid'],
             'description' => ['title' => 'description'],
             'time' => ['title' => 'time'],
             'status' => ['title' => 'status'],

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -132,10 +132,10 @@ class UserController extends BaseController
 
             if ($u->getTeam()) {
                 $userdata['team'] = [
-                    'value' => $u->getTeamid(),
-                    'sortvalue' => $u->getTeamid(),
+                    'value' => $u->getTeam()->getTeamid(),
+                    'sortvalue' => $u->getTeam()->getTeamid(),
                     'link' => $this->generateUrl('jury_team', [
-                        'teamId' => $u->getTeamid(),
+                        'teamId' => $u->getTeam()->getTeamid(),
                     ]),
                     'title' => $u->getTeam()->getEffectiveName(),
                 ];
@@ -336,7 +336,7 @@ class UserController extends BaseController
                  $isadmin = in_array('admin', $roles);
 
                  if ( in_array('team', $groups) || in_array('team_nopass', $groups) ) {
-                     if ( $user->getTeamid() && ! $isjury && ! $isadmin ) {
+                     if ( $user->getTeam() && ! $isjury && ! $isadmin ) {
                          if ( in_array('team', $groups) || empty($user->getPassword()) ) {
                              $doit = true;
                              $role = 'team';

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -281,7 +281,7 @@ class PublicController extends BaseController
             ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
             ->join('tc.content', 'tcc')
             ->select('tc', 'tcc')
-            ->andWhere('tc.probid = :problem')
+            ->andWhere('tc.problem = :problem')
             ->andWhere('tc.sample = 1')
             ->andWhere('cp.allowSubmit = 1')
             ->setParameter(':problem', $probId)

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -88,8 +88,9 @@ class ClarificationController extends BaseController
         $clarification = $this->em->createQueryBuilder()
             ->from(Clarification::class, 'c')
             ->leftJoin('c.problem', 'p')
+            ->leftJoin('c.contest', 'co')
             ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
-            ->select('c')
+            ->select('c, p, co')
             ->andWhere('c.contest = :contest')
             ->andWhere('c.clarid = :clarId')
             ->setParameter(':contest', $contest)
@@ -99,10 +100,10 @@ class ClarificationController extends BaseController
 
         $formData = [];
         if ($clarification) {
-            if ($clarification->getProbid()) {
-                $formData['subject'] = sprintf('%d-%d', $clarification->getCid(), $clarification->getProbid());
+            if ($clarification->getProblem()) {
+                $formData['subject'] = sprintf('%d-%d', $clarification->getContest()->getCid(), $clarification->getProblem()->getProbid());
             } else {
-                $formData['subject'] = sprintf('%d-%s', $clarification->getCid(), $clarification->getQueue());
+                $formData['subject'] = sprintf('%d-%s', $clarification->getContest()->getCid(), $clarification->getQueue());
             }
 
             $message = '';

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -78,7 +78,7 @@ class ProblemController extends BaseController
     public function problemsAction()
     {
         return $this->render('team/problems.html.twig',
-            $this->dj->getTwigDataForProblemsAction($this->dj->getUser()->getTeamid(), $this->stats));
+            $this->dj->getTwigDataForProblemsAction($this->dj->getUser()->getTeam()->getTeamid(), $this->stats));
     }
 
 
@@ -90,7 +90,7 @@ class ProblemController extends BaseController
     public function problemTextAction(int $probId)
     {
         $user    = $this->dj->getUser();
-        $contest = $this->dj->getCurrentContest($user->getTeamid());
+        $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
@@ -148,7 +148,7 @@ class ProblemController extends BaseController
     public function sampleTestcaseAction(int $probId, int $index, string $type)
     {
         $user    = $this->dj->getUser();
-        $contest = $this->dj->getCurrentContest($user->getTeamid());
+        $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
         }
@@ -168,7 +168,7 @@ class ProblemController extends BaseController
             ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
             ->join('tc.content', 'tcc')
             ->select('tc', 'tcc')
-            ->andWhere('tc.probid = :problem')
+            ->andWhere('tc.problem = :problem')
             ->andWhere('tc.sample = 1')
             ->andWhere('cp.allowSubmit = 1')
             ->setParameter(':problem', $probId)
@@ -216,7 +216,7 @@ class ProblemController extends BaseController
     public function sampleZipAction(int $probId)
     {
         $user    = $this->dj->getUser();
-        $contest = $this->dj->getCurrentContest($user->getTeamid());
+        $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         $notfound_msg = sprintf('Problem p%d not found or not available', $probId);
         if (!$contest || !$contest->getFreezeData()->started()) {
             throw new NotFoundHttpException($notfound_msg);

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -75,12 +75,12 @@ class ScoreboardController extends BaseController
     {
         $user       = $this->dj->getUser();
         $response   = new Response();
-        $contest    = $this->dj->getCurrentContest($user->getTeamid());
+        $contest    = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         $refreshUrl = $this->generateUrl('team_scoreboard');
         $data       = $this->scoreboardService->getScoreboardTwigData(
             $request, $response, $refreshUrl, false, false, false, $contest
         );
-        $data['myTeamId'] = $user->getTeamid();
+        $data['myTeamId'] = $user->getTeam()->getTeamid();
 
         if ($request->isXmlHttpRequest()) {
             $data['current_contest'] = $contest;

--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -83,7 +83,7 @@ class SubmissionController extends BaseController
     {
         $user    = $this->dj->getUser();
         $team    = $user->getTeam();
-        $contest = $this->dj->getCurrentContest($user->getTeamid());
+        $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         $form    = $this->formFactory
             ->createBuilder(SubmitProblemType::class)
             ->setAction($this->generateUrl('team_submit'))
@@ -159,7 +159,7 @@ class SubmissionController extends BaseController
             ->join('cp.problem', 'p')
             ->join('s.language', 'l')
             ->select('j', 's', 'cp', 'p', 'l')
-            ->andWhere('j.submitid = :submitId')
+            ->andWhere('j.submission = :submitId')
             ->andWhere('j.valid = 1')
             ->andWhere('s.team = :team')
             ->setParameter(':submitId', $submitId)

--- a/webapp/src/Entity/Balloon.php
+++ b/webapp/src/Entity/Balloon.php
@@ -25,14 +25,6 @@ class Balloon
     private $balloonid;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="submitid",
-     *     options={"comment"="Submission for which balloon was earned","unsigned"=true},
-     *     nullable=false)
-     */
-    private $submitid;
-
-    /**
      * @var boolean
      * @ORM\Column(type="boolean", name="done",
      *     options={"comment"="Has been handed out yet?","default"="0"},
@@ -55,30 +47,6 @@ class Balloon
     public function getBalloonid()
     {
         return $this->balloonid;
-    }
-
-    /**
-     * Set submitid
-     *
-     * @param integer $submitid
-     *
-     * @return Balloon
-     */
-    public function setSubmitid($submitid)
-    {
-        $this->submitid = $submitid;
-
-        return $this;
-    }
-
-    /**
-     * Get submitid
-     *
-     * @return integer
-     */
-    public function getSubmitid()
-    {
-        return $this->submitid;
     }
 
     /**

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -51,50 +51,11 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     protected $externalid;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="cid",
-     *     options={"comment"="Contest ID","unsigned"=true},
-     *     nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $cid;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="respid",
-     *     options={"comment"="In reply to clarification ID","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\SerializedName("reply_to_id")
-     * @Serializer\Type("string")
-     */
-    private $respid;
-
-    /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="submittime", options={"comment"="Time sent", "unsigned"=true}, nullable=false)
      * @Serializer\Exclude()
      */
     private $submittime;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="sender",
-     *     options={"comment"="Team ID, null means jury","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\SerializedName("from_team_id")
-     * @Serializer\Type("string")
-     */
-    private $sender_id;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="recipient",
-     *     options={"comment"="Team ID, null means to jury or to all","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\SerializedName("to_team_id")
-     * @Serializer\Type("string")
-     */
-    private $recipient_id;
 
     /**
      * @var string
@@ -104,17 +65,6 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
      * @Serializer\Exclude()
      */
     private $jury_member;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="probid",
-     *     options={"comment"="Problem associated to this clarification","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\SerializedName("problem_id")
-     * @Serializer\Type("string")
-     */
-    private $probid;
 
     /**
      * @var string
@@ -275,30 +225,6 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     }
 
     /**
-     * Set respid
-     *
-     * @param integer $respid
-     *
-     * @return Clarification
-     */
-    public function setRespid($respid)
-    {
-        $this->respid = $respid;
-
-        return $this;
-    }
-
-    /**
-     * Get respid
-     *
-     * @return integer
-     */
-    public function getRespid()
-    {
-        return $this->respid;
-    }
-
-    /**
      * Set submittime
      *
      * @param double $submittime
@@ -349,54 +275,6 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     }
 
     /**
-     * Set senderId
-     *
-     * @param integer $senderId
-     *
-     * @return Clarification
-     */
-    public function setSenderId($senderId)
-    {
-        $this->sender_id = $senderId;
-
-        return $this;
-    }
-
-    /**
-     * Get senderId
-     *
-     * @return integer
-     */
-    public function getSenderId()
-    {
-        return $this->sender_id;
-    }
-
-    /**
-     * Set recipientId
-     *
-     * @param integer $recipientId
-     *
-     * @return Clarification
-     */
-    public function setRecipientId($recipientId)
-    {
-        $this->recipient_id = $recipientId;
-
-        return $this;
-    }
-
-    /**
-     * Get recipientId
-     *
-     * @return integer
-     */
-    public function getRecipientId()
-    {
-        return $this->recipient_id;
-    }
-
-    /**
      * Set juryMember
      *
      * @param string $juryMember
@@ -418,30 +296,6 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     public function getJuryMember()
     {
         return $this->jury_member;
-    }
-
-    /**
-     * Set probid
-     *
-     * @param integer $probid
-     *
-     * @return Clarification
-     */
-    public function setProbid($probid)
-    {
-        $this->probid = $probid;
-
-        return $this;
-    }
-
-    /**
-     * Get probid
-     *
-     * @return integer
-     */
-    public function getProbid()
-    {
-        return $this->probid;
     }
 
     /**
@@ -565,6 +419,17 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     }
 
     /**
+     * @return int|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("problem_id")
+     * @Serializer\Type("string")
+     */
+    public function getProblemId(): ?int
+    {
+        return $this->getProblem() ? $this->getProblem()->getProbid() : null;
+    }
+
+    /**
      * Set contest
      *
      * @param \App\Entity\Contest $contest
@@ -610,6 +475,17 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     public function getInReplyTo()
     {
         return $this->in_reply_to;
+    }
+
+    /**
+     * @return int|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("reply_to_id")
+     * @Serializer\Type("string")
+     */
+    public function getInReployToId(): ?int
+    {
+        return $this->getInReplyTo() ? $this->getInReplyTo()->getClarid() : null;
     }
 
     /**
@@ -671,6 +547,17 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     }
 
     /**
+     * @return int|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("from_team_id")
+     * @Serializer\Type("string")
+     */
+    public function getSenderId(): ?int
+    {
+        return $this->getSender() ? $this->getSender()->getTeamid() : null;
+    }
+
+    /**
      * Set recipient
      *
      * @param \App\Entity\Team $recipient
@@ -692,6 +579,17 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
     public function getRecipient()
     {
         return $this->recipient;
+    }
+
+    /**
+     * @return int|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("to_team_id")
+     * @Serializer\Type("string")
+     */
+    public function getRecipientId(): ?int
+    {
+        return $this->getRecipient() ? $this->getRecipient()->getTeamid() : null;
     }
 
     /**

--- a/webapp/src/Entity/Event.php
+++ b/webapp/src/Entity/Event.php
@@ -70,14 +70,6 @@ class Event
     private $content;
 
     /**
-     * @var integer
-     *
-     * @ORM\Column(type="integer", name="cid", length=4,
-     *     options={"comment"="Contest ID","unsigned"=true}, nullable=false)
-     */
-    private $cid;
-
-    /**
      * @var Contest
      *
      * @ORM\ManyToOne(targetEntity="Contest", inversedBy="problems")
@@ -131,30 +123,6 @@ class Event
     public function getEventtime()
     {
         return $this->eventtime;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return Event
-     */
-    public function setCid($cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
-    {
-        return $this->cid;
     }
 
     /**

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -112,31 +112,12 @@ class ExternalJudgement
     private $valid = true;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="cid",
-     *     options={"comment"="Contest ID", "unsigned"=true},
-     *     nullable=false, length=4)
-     */
-    private $cid;
-
-    /**
      * @var Contest
      *
      * @ORM\ManyToOne(targetEntity="App\Entity\Contest")
      * @ORM\JoinColumn(name="cid", referencedColumnName="cid", onDelete="CASCADE")
      */
     private $contest;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", length=4, name="submitid",
-     *     options={"comment"="Submission ID being judged by external system",
-     *              "unsigned"=true},
-     *     nullable=false)
-     */
-    private $submitid;
 
     /**
      * @var Submission
@@ -362,30 +343,6 @@ class ExternalJudgement
     }
 
     /**
-     * Set cid
-     *
-     * @param int $cid
-     *
-     * @return ExternalJudgement
-     */
-    public function setCid(int $cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return int
-     */
-    public function getCid()
-    {
-        return $this->cid;
-    }
-
-    /**
      * Set contest
      *
      * @param Contest $contest
@@ -407,30 +364,6 @@ class ExternalJudgement
     public function getContest()
     {
         return $this->contest;
-    }
-
-    /**
-     * Set submitid
-     *
-     * @param int $submitid
-     *
-     * @return ExternalJudgement
-     */
-    public function setSubmitid(int $submitid)
-    {
-        $this->submitid = $submitid;
-
-        return $this;
-    }
-
-    /**
-     * Get submitid
-     *
-     * @return int
-     */
-    public function getSubmitid()
-    {
-        return $this->submitid;
     }
 
     /**

--- a/webapp/src/Entity/ExternalRun.php
+++ b/webapp/src/Entity/ExternalRun.php
@@ -66,14 +66,6 @@ class ExternalRun
     private $runtime;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="extjudgementid", length=4,
-     *     options={"comment"="Judging ID this run belongs to","unsigned"=true},
-     *     nullable=false)
-     */
-    private $extjudgementid;
-
-    /**
      * @var ExternalJudgement
      *
      * @ORM\ManyToOne(targetEntity="ExternalJudgement", inversedBy="external_runs")
@@ -82,30 +74,12 @@ class ExternalRun
     private $external_judgement;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="testcaseid", length=4,
-     *     options={"comment"="Testcase ID","unsigned"=true},
-     *     nullable=false)
-     */
-    private $testcaseid;
-
-    /**
      * @var Testcase
      *
      * @ORM\ManyToOne(targetEntity="Testcase", inversedBy="external_runs")
      * @ORM\JoinColumn(name="testcaseid", referencedColumnName="testcaseid", onDelete="CASCADE")
      */
     private $testcase;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="cid",
-     *     options={"comment"="Contest ID", "unsigned"=true},
-     *     nullable=false, length=4)
-     */
-    protected $cid;
 
     /**
      * @var Contest
@@ -222,30 +196,6 @@ class ExternalRun
     }
 
     /**
-     * Set externalJudgementId
-     *
-     * @param int $extjudgementid
-     *
-     * @return ExternalRun
-     */
-    public function setExtjudgementid(int $extjudgementid)
-    {
-        $this->extjudgementid = $extjudgementid;
-
-        return $this;
-    }
-
-    /**
-     * Get externalJudgementId
-     *
-     * @return int
-     */
-    public function getExtjudgementid()
-    {
-        return $this->extjudgementid;
-    }
-
-    /**
      * Set externalJudgement
      *
      * @param ExternalJudgement $externalJudgement
@@ -270,30 +220,6 @@ class ExternalRun
     }
 
     /**
-     * Set testcase ID
-     *
-     * @param int $testcaseid
-     *
-     * @return ExternalRun
-     */
-    public function setTestcaseid(int $testcaseid)
-    {
-        $this->testcaseid = $testcaseid;
-
-        return $this;
-    }
-
-    /**
-     * Get testcase ID
-     *
-     * @return int
-     */
-    public function getTestcaseid()
-    {
-        return $this->testcaseid;
-    }
-
-    /**
      * Set testcase
      *
      * @param Testcase $testcase
@@ -315,30 +241,6 @@ class ExternalRun
     public function getTestcase()
     {
         return $this->testcase;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param int $cid
-     *
-     * @return ExternalRun
-     */
-    public function setCid(int $cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return int
-     */
-    public function getCid()
-    {
-        return $this->cid;
     }
 
     /**

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -28,22 +28,6 @@ class InternalError
     private $errorid;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="judgingid",
-     *     options={"comment"="Judging ID","unsigned"=true},
-     *     nullable=true)
-     */
-    private $judgingid;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="cid",
-     *     options={"comment"="Contest ID","unsigned"=true},
-     *     nullable=true)
-     */
-    private $cid;
-
-    /**
      * @var string
      * @ORM\Column(type="string", length=255, name="description",
      *     options={"comment"="Description of the error"},
@@ -118,54 +102,6 @@ class InternalError
     public function getErrorid()
     {
         return $this->errorid;
-    }
-
-    /**
-     * Set judgingid
-     *
-     * @param integer $judgingid
-     *
-     * @return InternalError
-     */
-    public function setJudgingid($judgingid)
-    {
-        $this->judgingid = $judgingid;
-
-        return $this;
-    }
-
-    /**
-     * Get judgingid
-     *
-     * @return integer
-     */
-    public function getJudgingid()
-    {
-        return $this->judgingid;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return InternalError
-     */
-    public function setCid($cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
-    {
-        return $this->cid;
     }
 
     /**

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -45,16 +45,6 @@ class Judgehost
     private $polltime;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="restrictionid",
-     *     options={"comment"="Optional set of restrictions for this judgehost",
-     *              "unsigned"=true},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $restrictionid;
-
-    /**
      * @ORM\ManyToOne(targetEntity="JudgehostRestriction", inversedBy="judgehosts")
      * @ORM\JoinColumn(name="restrictionid", referencedColumnName="restrictionid", onDelete="SET NULL")
      * @Serializer\Exclude()
@@ -141,38 +131,13 @@ class Judgehost
     }
 
     /**
-     * Set restrictionid
-     *
-     * @param integer $restrictionid
-     *
-     * @return Judgehost
-     */
-    public function setRestrictionid($restrictionid)
-    {
-        $this->restrictionid = $restrictionid;
-
-        return $this;
-    }
-
-    /**
-     * Get restrictionid
-     *
-     * @return integer
-     */
-    public function getRestrictionid()
-    {
-        return $this->restrictionid;
-    }
-
-    /**
      * Set restriction
      *
-     * @param \App\Entity\JudgehostRestriction $restriction
+     * @param JudgehostRestriction|null $restriction
      *
      * @return Judgehost
      */
-    public function setRestriction(
-        \App\Entity\JudgehostRestriction $restriction = null)
+    public function setRestriction(JudgehostRestriction $restriction = null)
     {
         $this->restriction = $restriction;
 
@@ -182,7 +147,7 @@ class Judgehost
     /**
      * Get restriction
      *
-     * @return \App\Entity\JudgehostRestriction
+     * @return JudgehostRestriction
      */
     public function getRestriction()
     {
@@ -193,17 +158,17 @@ class Judgehost
      */
     public function __construct()
     {
-        $this->judgings = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->judgings = new ArrayCollection();
     }
 
     /**
      * Add judging
      *
-     * @param \App\Entity\Judging $judging
+     * @param Judging $judging
      *
      * @return Judgehost
      */
-    public function addJudging(\App\Entity\Judging $judging)
+    public function addJudging(Judging $judging)
     {
         $this->judgings[] = $judging;
 
@@ -213,9 +178,9 @@ class Judgehost
     /**
      * Remove judging
      *
-     * @param \App\Entity\Judging $judging
+     * @param Judging $judging
      */
-    public function removeJudging(\App\Entity\Judging $judging)
+    public function removeJudging(Judging $judging)
     {
         $this->judgings->removeElement($judging);
     }
@@ -223,7 +188,7 @@ class Judgehost
     /**
      * Get judgings
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getJudgings()
     {

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -40,27 +40,6 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     protected $judgingid;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="cid", length=4,
-     *     options={"comment"="Contest ID","unsigned"=true,"default"="0"},
-     *     nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $cid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="submitid", length=4,
-     *     options={"comment"="Submission ID being judged","unsigned"=true},
-     *     nullable=false)
-     * @Serializer\SerializedName("submission_id")
-     * @Serializer\Type("string")
-     */
-    private $submitid;
-
-    /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="starttime",
      *     options={"comment"="Time judging started", "unsigned"=true},
@@ -150,36 +129,6 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     private $seen = false;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="rejudgingid", length=4,
-     *     options={"comment"="Rejudging ID (if rejudge)","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $rejudgingid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="prevjudgingid",
-     *     options={"comment"="Previous valid judging (if rejudge)","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $prevjudgingid;
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="judgehost", length=64,
-     *     options={"comment"="Judgehost that performed the judging"},
-     *     nullable=false)
-     * @Serializer\Expose(if="context.getAttribute('domjudge_service').checkrole('jury')")
-     * @Serializer\SerializedName("judgehost")
-     */
-    private $judgehost_name;
-
-    /**
      * @ORM\ManyToOne(targetEntity="Contest")
      * @ORM\JoinColumn(name="cid", referencedColumnName="cid", onDelete="CASCADE")
      * @Serializer\Exclude()
@@ -256,54 +205,6 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     public function getJudgingid()
     {
         return $this->judgingid;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return Judging
-     */
-    public function setCid($cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
-    {
-        return $this->cid;
-    }
-
-    /**
-     * Set submitid
-     *
-     * @param integer $submitid
-     *
-     * @return Judging
-     */
-    public function setSubmitid($submitid)
-    {
-        $this->submitid = $submitid;
-
-        return $this;
-    }
-
-    /**
-     * Get submitid
-     *
-     * @return integer
-     */
-    public function getSubmitid()
-    {
-        return $this->submitid;
     }
 
     /**
@@ -581,78 +482,6 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     }
 
     /**
-     * Set rejudgingid
-     *
-     * @param integer $rejudgingid
-     *
-     * @return Judging
-     */
-    public function setRejudgingid($rejudgingid)
-    {
-        $this->rejudgingid = $rejudgingid;
-
-        return $this;
-    }
-
-    /**
-     * Get rejudgingid
-     *
-     * @return integer
-     */
-    public function getRejudgingid()
-    {
-        return $this->rejudgingid;
-    }
-
-    /**
-     * Set prevjudgingid
-     *
-     * @param integer $prevjudgingid
-     *
-     * @return Judging
-     */
-    public function setPrevjudgingid($prevjudgingid)
-    {
-        $this->prevjudgingid = $prevjudgingid;
-
-        return $this;
-    }
-
-    /**
-     * Get prevjudgingid
-     *
-     * @return integer
-     */
-    public function getPrevjudgingid()
-    {
-        return $this->prevjudgingid;
-    }
-
-    /**
-     * Get judgehost name
-     *
-     * @param string $judgehost_name
-     *
-     * @return Judging
-     */
-    public function setJudgehostName(string $judgehost_name)
-    {
-        $this->judgehost_name = $judgehost_name;
-
-        return $this;
-    }
-
-    /**
-     * Set judgehost name
-     *
-     * @return string
-     */
-    public function getJudgehostName(): string
-    {
-        return $this->judgehost_name;
-    }
-
-    /**
      * Set submission
      *
      * @param \App\Entity\Submission $submission
@@ -674,6 +503,17 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     public function getSubmission()
     {
         return $this->submission;
+    }
+
+    /**
+     * @return int
+     * @Serializer\VirtualProperty
+     * @Serializer\SerializedName("submission_id")
+     * @Serializer\Type("string")
+     */
+    public function getSubmissionId()
+    {
+        return $this->getSubmission()->getSubmitid();
     }
 
     /**
@@ -771,6 +611,20 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     {
         return $this->judgehost;
     }
+
+    /**
+     * Get judgehost name
+     *
+     * @return string|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\Expose(if="context.getAttribute('domjudge_service').checkrole('jury')")
+     * @Serializer\SerializedName("judgehost")
+     */
+    public function getJudgehostName(): ?string
+    {
+        return $this->getJudgehost() ? $this->getJudgehost()->getHostname() : null;
+    }
+
     /**
      * Constructor
      */

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -37,25 +37,6 @@ class JudgingRun extends BaseApiEntity
     protected $runid;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="judgingid", length=4,
-     *     options={"comment"="Judging ID","unsigned"=true},
-     *     nullable=false)
-     * @Serializer\SerializedName("judgement_id")
-     * @Serializer\Type("string")
-     */
-    private $judgingid;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="testcaseid", length=4,
-     *     options={"comment"="Testcase ID","unsigned"=true},
-     *     nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $testcaseid;
-
-    /**
      * @var string
      * @ORM\Column(type="string", name="runresult", length=32,
      *     options={"comment"="Result of this run, NULL if not finished yet"},
@@ -120,54 +101,6 @@ class JudgingRun extends BaseApiEntity
     public function getRunid()
     {
         return $this->runid;
-    }
-
-    /**
-     * Set judgingid
-     *
-     * @param integer $judgingid
-     *
-     * @return JudgingRun
-     */
-    public function setJudgingid($judgingid)
-    {
-        $this->judgingid = $judgingid;
-
-        return $this;
-    }
-
-    /**
-     * Get judgingid
-     *
-     * @return integer
-     */
-    public function getJudgingid()
-    {
-        return $this->judgingid;
-    }
-
-    /**
-     * Set testcaseid
-     *
-     * @param integer $testcaseid
-     *
-     * @return JudgingRun
-     */
-    public function setTestcaseid($testcaseid)
-    {
-        $this->testcaseid = $testcaseid;
-
-        return $this;
-    }
-
-    /**
-     * Get testcaseid
-     *
-     * @return integer
-     */
-    public function getTestcaseid()
-    {
-        return $this->testcaseid;
     }
 
     /**
@@ -293,6 +226,17 @@ class JudgingRun extends BaseApiEntity
     public function getJudging()
     {
         return $this->judging;
+    }
+
+    /**
+     * @return int
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("judgement_id")
+     * @Serializer\Type("string")
+     */
+    public function getJudgingId(): int
+    {
+        return $this->getJudging()->getJudgingid();
     }
 
     /**

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -105,15 +105,6 @@ class Language extends BaseApiEntity
     private $timeFactor = 1;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", name="compile_script", length=32,
-     *     options={"comment"="Script to compile source code for this language"},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $compile_script;
-
-    /**
      * @var bool
      * @ORM\Column(type="boolean", name="require_entry_point",
      *     options={"comment"="Whether submissions require a code entry point to be specified.","default":"0"},
@@ -334,30 +325,6 @@ class Language extends BaseApiEntity
     public function getTimeFactor()
     {
         return $this->timeFactor;
-    }
-
-    /**
-     * Set compileScript
-     *
-     * @param string $compileScript
-     *
-     * @return Language
-     */
-    public function setCompileScript($compileScript)
-    {
-        $this->compile_script = $compileScript;
-
-        return $this;
-    }
-
-    /**
-     * Get compileScript
-     *
-     * @return string
-     */
-    public function getCompileScript()
-    {
-        return $this->compile_script;
     }
 
     /**

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -86,21 +86,6 @@ class Problem extends BaseApiEntity
      */
     private $outputlimit;
 
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="special_run", length=32, options={"comment"="Script to run submissions for this problem"}, nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $special_run;
-
-    /**
-     * @var string
-     * @ORM\Column(type="string", name="special_compare", length=32, options={"comment"="Script to compare problem and jury output for this problem"}, nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $special_compare;
-
     /**
      * @var string
      * @ORM\Column(type="string", name="special_compare_args", length=255,
@@ -334,54 +319,6 @@ class Problem extends BaseApiEntity
     public function getOutputlimit()
     {
         return $this->outputlimit;
-    }
-
-    /**
-     * Set specialRun
-     *
-     * @param string $specialRun
-     *
-     * @return Problem
-     */
-    public function setSpecialRun($specialRun)
-    {
-        $this->special_run = $specialRun;
-
-        return $this;
-    }
-
-    /**
-     * Get specialRun
-     *
-     * @return string
-     */
-    public function getSpecialRun()
-    {
-        return $this->special_run;
-    }
-
-    /**
-     * Set specialCompare
-     *
-     * @param string $specialCompare
-     *
-     * @return Problem
-     */
-    public function setSpecialCompare($specialCompare)
-    {
-        $this->special_compare = $specialCompare;
-
-        return $this;
-    }
-
-    /**
-     * Get specialCompare
-     *
-     * @return string
-     */
-    public function getSpecialCompare()
-    {
-        return $this->special_compare;
     }
 
     /**

--- a/webapp/src/Entity/Rejudging.php
+++ b/webapp/src/Entity/Rejudging.php
@@ -30,26 +30,6 @@ class Rejudging
      */
     private $rejudgingid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="userid_start", length=4,
-     *     options={"comment"="User ID of user who started the rejudge",
-     *              "unsigned"=true},
-     *     nullable=true)
-     */
-    private $userid_start;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="userid_finish",
-     *     options={"comment"="User ID of user who accepted or canceled the rejudge",
-     *              "unsigned"=true},
-     *     nullable=true)
-     */
-    private $userid_finish;
-
 
     /**
      * @var double
@@ -130,16 +110,6 @@ class Rejudging
     private $repeat;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="repeat_rejudgingid",
-     *     options={"comment"="In case repeat is set, this will mark the first rejudgingid.",
-     *              "unsigned"=true},
-     *     nullable=true)
-     */
-    private $repeat_rejudgingid;
-
-    /**
      * @ORM\ManyToOne(targetEntity="Rejudging")
      * @ORM\JoinColumn(name="repeat_rejudgingid", referencedColumnName="rejudgingid", onDelete="SET NULL")
      * @Serializer\Exclude()
@@ -151,8 +121,8 @@ class Rejudging
      */
     public function __construct()
     {
-        $this->judgings = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->submissions = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->judgings = new ArrayCollection();
+        $this->submissions = new ArrayCollection();
     }
 
     /**
@@ -163,54 +133,6 @@ class Rejudging
     public function getRejudgingid()
     {
         return $this->rejudgingid;
-    }
-
-    /**
-     * Set useridStart
-     *
-     * @param integer $useridStart
-     *
-     * @return Rejudging
-     */
-    public function setUseridStart($useridStart)
-    {
-        $this->userid_start = $useridStart;
-
-        return $this;
-    }
-
-    /**
-     * Get useridStart
-     *
-     * @return integer
-     */
-    public function getUseridStart()
-    {
-        return $this->userid_start;
-    }
-
-    /**
-     * Set useridFinish
-     *
-     * @param integer $useridFinish
-     *
-     * @return Rejudging
-     */
-    public function setUseridFinish($useridFinish)
-    {
-        $this->userid_finish = $useridFinish;
-
-        return $this;
-    }
-
-    /**
-     * Get useridFinish
-     *
-     * @return integer
-     */
-    public function getUseridFinish()
-    {
-        return $this->userid_finish;
     }
 
     /**
@@ -474,26 +396,26 @@ class Rejudging
     }
 
     /**
-     * Set repeat_rejudgingid
+     * Set repeated rejudging
      *
-     * @param int $repeat_rejudgingid
+     * @param Rejudging|null $repeatedRejudging
      *
      * @return Rejudging
      */
-    public function setRepeatRejudgingId(int $repeatRejudgingId)
+    public function setRepeatedRejudging(?Rejudging $repeatedRejudging)
     {
-        $this->repeat_rejudgingid = $repeatRejudgingId;
+        $this->repeatedRejudging = $repeatedRejudging;
 
         return $this;
     }
 
     /**
-     * Get repeat
+     * Get repeated rejudging
      *
-     * @return int
+     * @return Rejudging|null
      */
-    public function getRepeatRejudgingId()
+    public function getRepeatedRejudging()
     {
-        return $this->repeat_rejudgingid;
+        return $this->repeatedRejudging;
     }
 }

--- a/webapp/src/Entity/RemovedInterval.php
+++ b/webapp/src/Entity/RemovedInterval.php
@@ -29,14 +29,6 @@ class RemovedInterval
     private $intervalid;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="cid", length=4,
-     *     options={"comment"="Contest ID","unsigned"=true}, nullable=false)
-     */
-    private $cid;
-
-    /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="starttime",
      *     options={"comment"="Initial time of removed interval", "unsigned"=true},
@@ -84,30 +76,6 @@ class RemovedInterval
     public function getIntervalid()
     {
         return $this->intervalid;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return RemovedInterval
-     */
-    public function setCid($cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
-    {
-        return $this->cid;
     }
 
     /**

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -56,55 +56,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     protected $externalid;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="origsubmitid",
-     *     options={"comment"="If set, specifies original submission in case of edit/resubmit",
-     *              "unsigned"=true},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $origsubmitid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="cid",
-     *     options={"comment"="Contest ID","unsigned"=true}, nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $cid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="teamid",
-     *     options={"comment"="Team ID","unsigned"=true}, nullable=false)
-     * @Serializer\SerializedName("team_id")
-     * @Serializer\Type("string")
-     */
-    private $teamid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="probid",
-     *     options={"comment"="Problem ID","unsigned"=true}, nullable=false)
-     * @Serializer\SerializedName("problem_id")
-     * @Serializer\Type("string")
-     */
-    private $probid;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(type="string", length=32, name="langid",
-     *     options={"comment"="Language ID"}, nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $langid;
-
-    /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="submittime", options={"comment"="Time submitted",
      *                             "unsigned"=true}, nullable=false)
@@ -123,16 +74,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     private $valid = true;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="rejudgingid",
-     *     options={"comment"="Rejudging ID (if rejudge)","unsigned"=true},
-     *     nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $rejudgingid;
-
-    /**
      * @var array
      * @ORM\Column(type="json", name="expected_results", length=255,
      *     options={"comment"="JSON encoded list of expected results - used to validate jury submissions"},
@@ -149,15 +90,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
      * @Serializer\Expose(if="context.getAttribute('domjudge_service').checkrole('jury')")
      */
     private $entry_point;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(type="string", name="judgehost", length=64,
-     *     options={"comment"="Current/last judgehost judging this submission"}, nullable=true)
-     * @Serializer\Exclude()
-     */
-    private $judgehost_as_string;
 
     /**
      * @var Judgehost|null
@@ -305,126 +237,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     }
 
     /**
-     * Set origsubmitid
-     *
-     * @param integer $origsubmitid
-     *
-     * @return Submission
-     */
-    public function setOrigsubmitid($origsubmitid)
-    {
-        $this->origsubmitid = $origsubmitid;
-
-        return $this;
-    }
-
-    /**
-     * Get origsubmitid
-     *
-     * @return integer
-     */
-    public function getOrigsubmitid()
-    {
-        return $this->origsubmitid;
-    }
-
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return Submission
-     */
-    public function setCid($cid)
-    {
-        $this->cid = $cid;
-
-        return $this;
-    }
-
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
-    {
-        return $this->cid;
-    }
-
-    /**
-     * Set teamid
-     *
-     * @param integer $teamid
-     *
-     * @return Submission
-     */
-    public function setTeamid($teamid)
-    {
-        $this->teamid = $teamid;
-
-        return $this;
-    }
-
-    /**
-     * Get teamid
-     *
-     * @return integer
-     */
-    public function getTeamid()
-    {
-        return $this->teamid;
-    }
-
-    /**
-     * Set probid
-     *
-     * @param integer $probid
-     *
-     * @return Submission
-     */
-    public function setProbid($probid)
-    {
-        $this->probid = $probid;
-
-        return $this;
-    }
-
-    /**
-     * Get probid
-     *
-     * @return integer
-     */
-    public function getProbid()
-    {
-        return $this->probid;
-    }
-
-    /**
-     * Set langid
-     *
-     * @param string $langid
-     *
-     * @return Submission
-     */
-    public function setLangid($langid)
-    {
-        $this->langid = $langid;
-
-        return $this;
-    }
-
-    /**
-     * Get langid
-     *
-     * @return string
-     */
-    public function getLangid()
-    {
-        return $this->langid;
-    }
-
-    /**
      * Get the language ID
      * @return string
      * @Serializer\VirtualProperty()
@@ -487,30 +299,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     }
 
     /**
-     * Set judgehost as string
-     *
-     * @param string|null $judgehost
-     *
-     * @return Submission
-     */
-    public function setJudgehostAsString(?string $judgehost)
-    {
-        $this->judgehost_as_string = $judgehost;
-
-        return $this;
-    }
-
-    /**
-     * Get judgehost as string
-     *
-     * @return string|null
-     */
-    public function getJudgehostAsString(): ?string
-    {
-        return $this->judgehost_as_string;
-    }
-
-    /**
      * Set judgehost
      *
      * @param Judgehost|null $judgehost
@@ -556,30 +344,6 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     public function getValid()
     {
         return $this->valid;
-    }
-
-    /**
-     * Set rejudgingid
-     *
-     * @param integer $rejudgingid
-     *
-     * @return Submission
-     */
-    public function setRejudgingid($rejudgingid)
-    {
-        $this->rejudgingid = $rejudgingid;
-
-        return $this;
-    }
-
-    /**
-     * Get rejudgingid
-     *
-     * @return integer
-     */
-    public function getRejudgingid()
-    {
-        return $this->rejudgingid;
     }
 
     /**
@@ -652,6 +416,18 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     public function getTeam()
     {
         return $this->team;
+    }
+
+    /**
+     * Get the team ID
+     * @return string
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("team_id")
+     * @Serializer\Type("string")
+     */
+    public function getTeamId()
+    {
+        return $this->getTeam()->getTeamid();
     }
 
     /**
@@ -838,6 +614,18 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     public function getProblem()
     {
         return $this->problem;
+    }
+
+    /**
+     * Get the problem ID
+     * @return string
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("problem_id")
+     * @Serializer\Type("string")
+     */
+    public function getProblemId()
+    {
+        return $this->getProblem()->getProbid();
     }
 
     /**

--- a/webapp/src/Entity/SubmissionFile.php
+++ b/webapp/src/Entity/SubmissionFile.php
@@ -30,14 +30,6 @@ class SubmissionFile
     private $submitfileid;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="submitid", length=4,
-     *     options={"comment"="Submission this file belongs to","unsigned"=true},
-     *     nullable=false)
-     */
-    private $submitid;
-
-    /**
      * @var string
      * @ORM\Column(type="string", name="filename", length=255, options={"comment"="Filename as submitted"}, nullable=false)
      */
@@ -72,30 +64,6 @@ class SubmissionFile
     public function getSubmitfileid()
     {
         return $this->submitfileid;
-    }
-
-    /**
-     * Set submitid
-     *
-     * @param integer $submitid
-     *
-     * @return SubmissionFile
-     */
-    public function setSubmitid($submitid)
-    {
-        $this->submitid = $submitid;
-
-        return $this;
-    }
-
-    /**
-     * Get submitid
-     *
-     * @return integer
-     */
-    public function getSubmitid()
-    {
-        return $this->submitid;
     }
 
     /**

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -60,21 +60,6 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     private $display_name;
 
     /**
-     * @var int
-     * @ORM\Column(type="integer", name="categoryid", options={"comment"="Team category ID","unsigned"="true","default"=0}, nullable=false)
-     * @Serializer\Exclude()
-     */
-    private $categoryid = 0;
-
-    /**
-     * @var int
-     * @ORM\Column(type="integer", name="affilid", options={"comment"="Team affiliation ID","unsigned"="true"}, nullable=true)
-     * @Serializer\SerializedName("organization_id")
-     * @Serializer\Type("string")
-     */
-    private $affilid;
-
-    /**
      * @var boolean
      * @ORM\Column(type="boolean", name="enabled",
      *     options={"comment"="Whether the team is visible and operational",
@@ -291,54 +276,6 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     }
 
     /**
-     * Set categoryid
-     *
-     * @param integer $categoryid
-     *
-     * @return Team
-     */
-    public function setCategoryid($categoryid)
-    {
-        $this->categoryid = $categoryid;
-
-        return $this;
-    }
-
-    /**
-     * Get categoryid
-     *
-     * @return integer
-     */
-    public function getCategoryid()
-    {
-        return $this->categoryid;
-    }
-
-    /**
-     * Set affilid
-     *
-     * @param integer $affilid
-     *
-     * @return Team
-     */
-    public function setAffilid($affilid)
-    {
-        $this->affilid = $affilid;
-
-        return $this;
-    }
-
-    /**
-     * Get affilid
-     *
-     * @return integer
-     */
-    public function getAffilid()
-    {
-        return $this->affilid;
-    }
-
-    /**
      * Set enabled
      *
      * @param boolean $enabled
@@ -524,6 +461,19 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     public function getAffiliation()
     {
         return $this->affiliation;
+    }
+
+    /**
+     * Get affiliation ID
+     *
+     * @return int|null
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("organization_id")
+     * @Serializer\Type("string")
+     */
+    public function getAffiliationId(): ?int
+    {
+        return $this->getAffiliation() ? $this->getAffiliation()->getAffilid() : null;
     }
 
     /**
@@ -785,7 +735,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
      */
     public function getGroupIds(): array
     {
-        return $this->getCategoryid() ? [$this->getCategoryid()] : [];
+        return $this->getCategory()->getCategoryid() ? [$this->getCategory()->getCategoryid()] : [];
     }
 
     /**
@@ -821,8 +771,8 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
      */
     public function canViewClarification(Clarification $clarification)
     {
-        return ($clarification->getSenderId() === $this->getTeamid() ||
-            $clarification->getRecipientId() === $this->getTeamid() ||
+        return (($clarification->getSender() && $clarification->getSender()->getTeamid() === $this->getTeamid()) ||
+            ($clarification->getRecipient() && $clarification->getRecipient()->getTeamid() === $this->getTeamid()) ||
             ($clarification->getSender() === null && $clarification->getRecipient() === null));
     }
 

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -50,14 +50,6 @@ class Testcase
 
     /**
      * @var int
-     * @ORM\Column(type="integer", name="probid", length=4,
-     *     options={"comment"="Corresponding problem ID", "unsigned"=true},
-     *     nullable=true)
-     */
-    private $probid;
-
-    /**
-     * @var int
      * @ORM\Column(type="integer", name="rank", length=4,
      *     options={"comment"="Determines order of the testcases in judging",
      *              "unsigned"=true},
@@ -210,30 +202,6 @@ class Testcase
     public function getMd5sumOutput()
     {
         return $this->md5sum_output;
-    }
-
-    /**
-     * Set probid
-     *
-     * @param integer $probid
-     *
-     * @return Testcase
-     */
-    public function setProbid($probid)
-    {
-        $this->probid = $probid;
-
-        return $this;
-    }
-
-    /**
-     * Get probid
-     *
-     * @return integer
-     */
-    public function getProbid()
-    {
-        return $this->probid;
     }
 
     /**

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -121,17 +121,6 @@ class User implements UserInterface, EquatableInterface, \Serializable
     private $enabled = true;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(type="integer", name="teamid", length=4,
-     *     options={"comment"="Team associated with this user", "unsigned"=true},
-     *     nullable=true)
-     * @Serializer\SerializedName("team_id")
-     * @Serializer\Type("string")
-     */
-    private $teamid;
-
-    /**
      * @ORM\ManyToOne(targetEntity="Team", inversedBy="users")
      * @ORM\JoinColumn(name="teamid", referencedColumnName="teamid", onDelete="SET NULL")
      * @Serializer\Exclude()
@@ -454,30 +443,6 @@ class User implements UserInterface, EquatableInterface, \Serializable
     public function getEnabled()
     {
         return $this->enabled;
-    }
-
-    /**
-     * Set teamid
-     *
-     * @param integer $teamid
-     *
-     * @return User
-     */
-    public function setTeamid($teamid)
-    {
-        $this->teamid = $teamid;
-
-        return $this;
-    }
-
-    /**
-     * Get teamid
-     *
-     * @return integer
-     */
-    public function getTeamid()
-    {
-        return $this->teamid;
     }
 
     /**

--- a/webapp/src/Form/Type/SubmitProblemType.php
+++ b/webapp/src/Form/Type/SubmitProblemType.php
@@ -48,7 +48,7 @@ class SubmitProblemType extends AbstractType
     {
         $allowMultipleFiles = $this->config->get('sourcefiles_limit') > 1;
         $user               = $this->dj->getUser();
-        $contest            = $this->dj->getCurrentContest($user->getTeamid());
+        $contest            = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
 
         $builder->add('code', BootstrapFileType::class, [
             'label' => 'Source file' . ($allowMultipleFiles ? 's' : ''),

--- a/webapp/src/Form/Type/TeamClarificationType.php
+++ b/webapp/src/Form/Type/TeamClarificationType.php
@@ -47,7 +47,7 @@ class TeamClarificationType extends AbstractType
         /** @var string[] $categories */
         $categories = $this->config->get('clar_categories');
         $user       = $this->dj->getUser();
-        $contest    = $this->dj->getCurrentContest($user->getTeamid());
+        $contest    = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         foreach ($categories as $categoryId => $categoryName) {
             $subjects[$categoryName] = sprintf('%d-%s', $contest->getCid(), $categoryId);
         }

--- a/webapp/src/Migrations/Version20201110113446.php
+++ b/webapp/src/Migrations/Version20201110113446.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20201110113446 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Remove explicit column definitions for foreign keys.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE language CHANGE compile_script compile_script VARCHAR(32) DEFAULT NULL COMMENT \'Executable ID (string)\'');
+        $this->addSql('ALTER TABLE problem CHANGE special_run special_run VARCHAR(32) DEFAULT NULL COMMENT \'Executable ID (string)\', CHANGE special_compare special_compare VARCHAR(32) DEFAULT NULL COMMENT \'Executable ID (string)\'');
+        $this->addSql('ALTER TABLE team CHANGE categoryid categoryid INT UNSIGNED DEFAULT NULL COMMENT \'Team category ID\'');
+        $this->addSql('ALTER TABLE submission CHANGE origsubmitid origsubmitid INT UNSIGNED DEFAULT NULL COMMENT \'Submission ID\', CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\', CHANGE teamid teamid INT UNSIGNED DEFAULT NULL COMMENT \'Team ID\', CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Problem ID\', CHANGE langid langid VARCHAR(32) DEFAULT NULL COMMENT \'Language ID (string)\', CHANGE judgehost judgehost VARCHAR(64) DEFAULT NULL COMMENT \'Resolvable hostname of judgehost\', CHANGE rejudgingid rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Rejudging ID\'');
+        $this->addSql('ALTER TABLE clarification CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\', CHANGE respid respid INT UNSIGNED DEFAULT NULL COMMENT \'Clarification ID\', CHANGE sender sender INT UNSIGNED DEFAULT NULL COMMENT \'Team ID\', CHANGE recipient recipient INT UNSIGNED DEFAULT NULL COMMENT \'Team ID\', CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Problem ID\'');
+        $this->addSql('ALTER TABLE submission_file CHANGE submitid submitid INT UNSIGNED DEFAULT NULL COMMENT \'Submission ID\'');
+        $this->addSql('ALTER TABLE judging CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\', CHANGE submitid submitid INT UNSIGNED DEFAULT NULL COMMENT \'Submission ID\', CHANGE judgehost judgehost VARCHAR(64) DEFAULT NULL COMMENT \'Resolvable hostname of judgehost\', CHANGE rejudgingid rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Rejudging ID\', CHANGE prevjudgingid prevjudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Judging ID\'');
+        $this->addSql('ALTER TABLE external_run CHANGE extjudgementid extjudgementid INT UNSIGNED DEFAULT NULL COMMENT \'External judgement ID\', CHANGE testcaseid testcaseid INT UNSIGNED DEFAULT NULL COMMENT \'Testcase ID\', CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE event CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE balloon CHANGE submitid submitid INT UNSIGNED DEFAULT NULL COMMENT \'Submission ID\'');
+        $this->addSql('ALTER TABLE judging_run CHANGE judgingid judgingid INT UNSIGNED DEFAULT NULL COMMENT \'Judging ID\', CHANGE testcaseid testcaseid INT UNSIGNED DEFAULT NULL COMMENT \'Testcase ID\'');
+        $this->addSql('ALTER TABLE user CHANGE teamid teamid INT UNSIGNED DEFAULT NULL COMMENT \'Team ID\'');
+        $this->addSql('ALTER TABLE removed_interval CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE external_judgement CHANGE cid cid INT UNSIGNED DEFAULT NULL COMMENT \'Contest ID\', CHANGE submitid submitid INT UNSIGNED DEFAULT NULL COMMENT \'Submission ID\'');
+        $this->addSql('ALTER TABLE judgehost CHANGE restrictionid restrictionid INT UNSIGNED DEFAULT NULL COMMENT \'Judgehost restriction ID\'');
+        $this->addSql('ALTER TABLE rejudging CHANGE userid_start userid_start INT UNSIGNED DEFAULT NULL COMMENT \'User ID\', CHANGE userid_finish userid_finish INT UNSIGNED DEFAULT NULL COMMENT \'User ID\', CHANGE repeat_rejudgingid repeat_rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Rejudging ID\'');
+        $this->addSql('ALTER TABLE testcase CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Problem ID\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE balloon CHANGE submitid submitid INT UNSIGNED NOT NULL COMMENT \'Submission for which balloon was earned\'');
+        $this->addSql('ALTER TABLE clarification CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Problem associated to this clarification\', CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\', CHANGE respid respid INT UNSIGNED DEFAULT NULL COMMENT \'In reply to clarification ID\', CHANGE sender sender INT UNSIGNED DEFAULT NULL COMMENT \'Team ID, null means jury\', CHANGE recipient recipient INT UNSIGNED DEFAULT NULL COMMENT \'Team ID, null means to jury or to all\'');
+        $this->addSql('ALTER TABLE event CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE external_judgement CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\', CHANGE submitid submitid INT UNSIGNED NOT NULL COMMENT \'Submission ID being judged by external system\'');
+        $this->addSql('ALTER TABLE external_run CHANGE extjudgementid extjudgementid INT UNSIGNED NOT NULL COMMENT \'Judging ID this run belongs to\', CHANGE testcaseid testcaseid INT UNSIGNED NOT NULL COMMENT \'Testcase ID\', CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE judgehost CHANGE restrictionid restrictionid INT UNSIGNED DEFAULT NULL COMMENT \'Optional set of restrictions for this judgehost\'');
+        $this->addSql('ALTER TABLE judging CHANGE cid cid INT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Contest ID\', CHANGE submitid submitid INT UNSIGNED NOT NULL COMMENT \'Submission ID being judged\', CHANGE judgehost judgehost VARCHAR(64) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Judgehost that performed the judging\', CHANGE rejudgingid rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Rejudging ID (if rejudge)\', CHANGE prevjudgingid prevjudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Previous valid judging (if rejudge)\'');
+        $this->addSql('ALTER TABLE judging_run CHANGE judgingid judgingid INT UNSIGNED NOT NULL COMMENT \'Judging ID\', CHANGE testcaseid testcaseid INT UNSIGNED NOT NULL COMMENT \'Testcase ID\'');
+        $this->addSql('ALTER TABLE language CHANGE compile_script compile_script VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Script to compile source code for this language\'');
+        $this->addSql('ALTER TABLE problem CHANGE special_compare special_compare VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Script to compare problem and jury output for this problem\', CHANGE special_run special_run VARCHAR(32) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Script to run submissions for this problem\'');
+        $this->addSql('ALTER TABLE rejudging CHANGE userid_start userid_start INT UNSIGNED DEFAULT NULL COMMENT \'User ID of user who started the rejudge\', CHANGE userid_finish userid_finish INT UNSIGNED DEFAULT NULL COMMENT \'User ID of user who accepted or canceled the rejudge\', CHANGE repeat_rejudgingid repeat_rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'In case repeat is set, this will mark the first rejudgingid.\'');
+        $this->addSql('ALTER TABLE removed_interval CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\'');
+        $this->addSql('ALTER TABLE submission CHANGE judgehost judgehost VARCHAR(64) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Current/last judgehost judging this submission\', CHANGE cid cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\', CHANGE langid langid VARCHAR(32) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'Language ID\', CHANGE teamid teamid INT UNSIGNED NOT NULL COMMENT \'Team ID\', CHANGE probid probid INT UNSIGNED NOT NULL COMMENT \'Problem ID\', CHANGE rejudgingid rejudgingid INT UNSIGNED DEFAULT NULL COMMENT \'Rejudging ID (if rejudge)\', CHANGE origsubmitid origsubmitid INT UNSIGNED DEFAULT NULL COMMENT \'If set, specifies original submission in case of edit/resubmit\'');
+        $this->addSql('ALTER TABLE submission_file CHANGE submitid submitid INT UNSIGNED NOT NULL COMMENT \'Submission this file belongs to\'');
+        $this->addSql('ALTER TABLE team CHANGE categoryid categoryid INT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Team category ID\'');
+        $this->addSql('ALTER TABLE testcase CHANGE probid probid INT UNSIGNED DEFAULT NULL COMMENT \'Corresponding problem ID\'');
+        $this->addSql('ALTER TABLE user CHANGE teamid teamid INT UNSIGNED DEFAULT NULL COMMENT \'Team associated with this user\'');
+    }
+}

--- a/webapp/src/Service/BalloonService.php
+++ b/webapp/src/Service/BalloonService.php
@@ -75,15 +75,15 @@ class BalloonService
         // prevent duplicate balloons in case of multiple correct submissions
         $numCorrect = $this->em->createQueryBuilder()
             ->from(Balloon::class, 'b')
-            ->select('COUNT(b.submitid) AS numBalloons')
             ->join('b.submission', 's')
+            ->select('COUNT(b.submission) AS numBalloons')
             ->andWhere('s.valid = 1')
-            ->andWhere('s.probid = :probid')
-            ->andWhere('s.teamid = :teamid')
-            ->andWhere('s.cid = :cid')
-            ->setParameter(':probid', $submission->getProbid())
-            ->setParameter(':teamid', $submission->getTeamid())
-            ->setParameter(':cid', $submission->getCid())
+            ->andWhere('s.problem = :probid')
+            ->andWhere('s.team = :teamid')
+            ->andWhere('s.contest = :cid')
+            ->setParameter(':probid', $submission->getProblem())
+            ->setParameter(':teamid', $submission->getTeam())
+            ->setParameter(':cid', $submission->getContest())
             ->getQuery()
             ->getSingleScalarResult();
 
@@ -115,7 +115,7 @@ class BalloonService
             ->select('b', 's.submittime', 'p.probid',
                 't.teamid', 't.name AS teamname', 't.room',
                 'c.name AS catname',
-                's.cid', 'co.shortname',
+                'co.cid', 'co.shortname',
                 'cp.shortname AS probshortname', 'cp.color',
                 'a.affilid AS affilid', 'a.shortname AS affilshort')
             ->from(Balloon::class, 'b')

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -409,8 +409,8 @@ class CheckConfigService
             $problemerrors[$probid] = $errors;
 
             $moreproblemerrors[$probid] = '';
-            if ($special_compare = $problem->getSpecialCompare()) {
-                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_compare]);
+            if ($special_compare = $problem->getCompareExecutable()) {
+                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_compare->getExecid()]);
                 if (!$exec) {
                     $result = 'E';
                     $moreproblemerrors[$probid] .= sprintf("Special compare script %s not found for p%s\n", $special_compare, $probid);
@@ -419,8 +419,8 @@ class CheckConfigService
                     $moreproblemerrors[$probid] .= sprintf("Special compare script %s exists but is of wrong type (%s instead of compare) for p%s\n", $special_compare, $exec->getType(), $probid);
                 }
             }
-            if ($special_run = $problem->getSpecialRun()) {
-                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_run]);
+            if ($special_run = $problem->getRunExecutable()) {
+                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_run->getExecid()]);
                 if (!$exec) {
                     $result = 'E';
                     $moreproblemerrors[$probid] .= sprintf("Special run script %s not found for p%s\n", $special_run, $probid);
@@ -440,7 +440,7 @@ class CheckConfigService
                 ->select('tc.testcaseid', 'tc.rank', 'length(tcc.output) as output_size' )
                 ->from(Testcase::class, 'tc')
                 ->join('tc.content', 'tcc')
-                ->andWhere('tc.probid = :probid')
+                ->andWhere('tc.problem = :probid')
                 ->setParameter(':probid', $probid)
                 ->getQuery()
                 ->getResult();
@@ -493,7 +493,7 @@ class CheckConfigService
             $languageerrors[$langid] = $errors;
 
             $morelanguageerrors[$langid] = '';
-            if ($compile = $language->getCompileScript()) {
+            if ($compile = $language->getCompileExecutable()->getExecid()) {
                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $compile]);
                if (!$exec) {
                    $result = 'E';
@@ -527,7 +527,7 @@ class CheckConfigService
         $judgehosts = $this->em->getRepository(Judgehost::class)->findBy(['active' => 1]);
 
         foreach ($judgehosts as $judgehost) {
-            if ($judgehost->getRestrictionid() === null) {
+            if ($judgehost->getRestriction() === null) {
                 return ['caption' => 'Problem, language and contest judgability',
                     'result' => 'O',
                     'desc' => sprintf("At least one judgehost (%s) is active and unrestricted.", $judgehost->getHostname())];

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -413,7 +413,7 @@ class CheckConfigService
                 $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_compare->getExecid()]);
                 if (!$exec) {
                     $result = 'E';
-                    $moreproblemerrors[$probid] .= sprintf("Special compare script %s not found for p%s\n", $special_compare, $probid);
+                    $moreproblemerrors[$probid] .= sprintf("Special compare script %s not found for p%s\n", $special_compare->getExecid(), $probid);
                 } elseif ($exec->getType() !== "compare") {
                     $result = 'E';
                     $moreproblemerrors[$probid] .= sprintf("Special compare script %s exists but is of wrong type (%s instead of compare) for p%s\n", $special_compare, $exec->getType(), $probid);
@@ -423,7 +423,7 @@ class CheckConfigService
                 $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $special_run->getExecid()]);
                 if (!$exec) {
                     $result = 'E';
-                    $moreproblemerrors[$probid] .= sprintf("Special run script %s not found for p%s\n", $special_run, $probid);
+                    $moreproblemerrors[$probid] .= sprintf("Special run script %s not found for p%s\n", $special_run->getExecid(), $probid);
                 } elseif ($exec->getType() !== "run") {
                     $result = 'E';
                     $moreproblemerrors[$probid] .= sprintf("Special run script %s exists but is of wrong type (%s instead of run) for p%s\n", $special_run, $exec->getType(), $probid);

--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -316,7 +316,7 @@ EOF;
 
         $judgings_per_contest = [];
         foreach ($judgings as $judging) {
-            $judgings_per_contest[$judging->getCid()][] = $judging->getJudgingid();
+            $judgings_per_contest[$judging->getContest()->getCid()][] = $judging->getJudgingid();
         }
 
         // Log to event table; normal cases are handled in:

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -761,15 +761,15 @@ class DOMJudgeService
             ->createQuery(
                 'SELECT COUNT(s)
                 FROM App\Entity\Submission s
-                WHERE s.cid = :cid')
+                WHERE s.contest = :cid')
             ->setParameter(':cid', $contest->getCid())
             ->getSingleScalarResult();
         $stats['num_queued'] = (int)$this->em
             ->createQuery(
                 'SELECT COUNT(s)
                 FROM App\Entity\Submission s
-                LEFT JOIN App\Entity\Judging j WITH (j.submitid = s.submitid AND j.valid != 0)
-                WHERE s.cid = :cid
+                LEFT JOIN App\Entity\Judging j WITH (j.submission = s.submitid AND j.valid != 0)
+                WHERE s.contest = :cid
                 AND j.result IS NULL
                 AND s.valid = 1')
             ->setParameter(':cid', $contest->getCid())
@@ -778,8 +778,8 @@ class DOMJudgeService
             ->createQuery(
                 'SELECT COUNT(s)
                 FROM App\Entity\Submission s
-                LEFT JOIN App\Entity\Judging j WITH (j.submitid = s.submitid)
-                WHERE s.cid = :cid
+                LEFT JOIN App\Entity\Judging j WITH (j.submission = s.submitid)
+                WHERE s.contest = :cid
                 AND j.result IS NULL
                 AND j.valid = 1
                 AND s.valid = 1')

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -319,7 +319,7 @@ class ImportExportService
             $data[] = [
                 $team->getTeamid(),
                 $team->getIcpcid(),
-                $team->getCategoryid(),
+                $team->getCategory()->getCategoryid(),
                 $team->getEffectiveName(),
                 $team->getAffiliation() ? $team->getAffiliation()->getName() : '',
                 $team->getAffiliation() ? $team->getAffiliation()->getShortname() : '',
@@ -482,7 +482,7 @@ class ImportExportService
             }
 
             $groupWinner = "";
-            $categoryId  = $teamScore->team->getCategoryid();
+            $categoryId  = $teamScore->team->getCategory()->getCategoryid();
             if (!isset($groupWinners[$categoryId])) {
                 $groupWinners[$categoryId] = true;
                 $groupWinner               = $teamScore->team->getCategory()->getName();

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -647,7 +647,7 @@ class ImportProblemService
                     } elseif (!empty($expectedResult)) {
                         $results = [$expectedResult];
                     }
-                    $jury_team_id = $this->dj->getUser()->getTeamid();
+                    $jury_team_id = $this->dj->getUser()->getTeam() ? $this->dj->getUser()->getTeam()->getTeamid() : null;
                     if (isset($submission_details[$path]['team'])) {
                         $json_team = $this->em->getRepository(Team::class)
                             ->findOneBy(['name' => $submission_details[$path]['team']]);

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -332,14 +332,14 @@ class ScoreboardService
             ->from(Submission::class, 's')
             ->select('s, c')
             ->leftJoin('s.contest', 'c')
-            ->andWhere('s.teamid = :teamid')
-            ->andWhere('s.probid = :probid')
-            ->andWhere('s.cid = :cid')
+            ->andWhere('s.team = :teamid')
+            ->andWhere('s.problem = :probid')
+            ->andWhere('s.contest = :cid')
             ->andWhere('s.valid = 1')
             ->andWhere('s.submittime < c.endtime')
-            ->setParameter(':teamid', $team->getTeamid())
-            ->setParameter(':probid', $problem->getProbid())
-            ->setParameter(':cid', $contest->getCid())
+            ->setParameter(':teamid', $team)
+            ->setParameter(':probid', $problem)
+            ->setParameter(':cid', $contest)
             ->orderBy('s.submittime');
 
         if ($useExternalJudgements) {
@@ -1006,13 +1006,13 @@ class ScoreboardService
         if ($filter) {
             if ($filter->affiliations) {
                 $queryBuilder
-                    ->andWhere('t.affilid IN (:affiliations)')
+                    ->andWhere('t.affiliation IN (:affiliations)')
                     ->setParameter(':affiliations', $filter->affiliations);
             }
 
             if ($filter->categories) {
                 $queryBuilder
-                    ->andWhere('t.categoryid IN (:categories)')
+                    ->andWhere('t.category IN (:categories)')
                     ->setParameter(':categories', $filter->categories);
             }
 

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -467,7 +467,7 @@ class StatisticsService
         //   - The judging submission matches the problem we're analyzing
         //   - The submission was made by a team in a visible category
         $judgingsQueryBuilder = $this->em->createQueryBuilder()
-            ->select('COUNT(j) AS count, s.probid')
+            ->select('COUNT(j) AS count, p.probid')
             ->from(Judging::class, 'j')
             ->join('j.submission', 's')
             ->join('s.problem', 'p')

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -195,15 +195,15 @@ class StatisticsService
                 $misc['total_submissions']++;
                 $teamStats['total_submitted']++;
                 static::setOrIncrement($misc['problem_attempts'],
-                    $s->getProbId());
+                    $s->getProblem()->getProbId());
                 static::setOrIncrement($teamStats['problems_submitted'],
-                    $s->getProbId());
-                $misc['problem_stats']['teams_attempted'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
+                    $s->getProblem()->getProbId());
+                $misc['problem_stats']['teams_attempted'][$s->getProblem()->getProbId()][$team->getTeamId()] = $team->getTeamId();
 
 
                 static::setOrIncrement($misc['language_stats']['total_submissions'],
-                    $s->getLangid());
-                $misc['language_stats']['teams_attempted'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
+                    $s->getLanguage()->getLangid());
+                $misc['language_stats']['teams_attempted'][$s->getLanguage()->getLangid()][$team->getTeamId()] = $team->getTeamId();
 
                 if ($s->getResult() != 'correct') {
                     continue;
@@ -211,14 +211,14 @@ class StatisticsService
                 $misc['total_accepted']++;
                 $teamStats['total_accepted']++;
                 static::setOrIncrement($teamStats['problems_accepted'],
-                    $s->getProbId());
+                    $s->getProblem()->getProbId());
                 static::setOrIncrement($misc['problem_solutions'],
-                    $s->getProbId());
-                $misc['problem_stats']['teams_solved'][$s->getProbId()][$team->getTeamId()] = $team->getTeamId();
+                    $s->getProblem()->getProbId());
+                $misc['problem_stats']['teams_solved'][$s->getProblem()->getProbId()][$team->getTeamId()] = $team->getTeamId();
 
-                $misc['language_stats']['teams_solved'][$s->getLangid()][$team->getTeamId()] = $team->getTeamId();
+                $misc['language_stats']['teams_solved'][$s->getLanguage()->getLangid()][$team->getTeamId()] = $team->getTeamId();
                 static::setOrIncrement($misc['language_stats']['total_solutions'],
-                    $s->getLangid());
+                    $s->getLanguage()->getLangid());
 
                 if ($lastSubmission == null || $s->getSubmitTime() > $lastSubmission->getSubmitTime()) {
                     $lastSubmission = $s;
@@ -368,6 +368,7 @@ class StatisticsService
         //   - The judging submission is part of the selected contest
         //   - The judging submission matches the problem we're analyzing
         //   - The submission was made by a team in a visible category
+        /** @var Judging[] $judgings */
         $judgings = $this->applyFilter($this->em->createQueryBuilder()
             ->select('j, jr', 's', 'team', 'sj')
             ->from(Judging::class, 'j')
@@ -417,9 +418,9 @@ class StatisticsService
         $teamsAttempted = [];
         foreach ($judgings as $judging) {
             $s = $judging->getSubmission();
-            $teamsAttempted[$s->getTeamID()] = $s->getTeamID();
+            $teamsAttempted[$s->getTeam()->getTeamid()] = $s->getTeam()->getTeamid();
             if ($judging->getResult() == 'correct') {
-                $teamsCorrect[$s->getTeamID()] = $s->getTeamID();
+                $teamsCorrect[$s->getTeam()->getTeamid()] = $s->getTeam()->getTeamid();
             }
         }
         $misc['num_teams_attempted'] = count($teamsAttempted);
@@ -634,12 +635,12 @@ class StatisticsService
     {
         // Figure out how many submissions each team has
         $results = $this->applyFilter($this->em->createQueryBuilder()
-            ->select('s.teamid as teamid, count(s.teamid) as num_submissions')
+            ->select('t.teamid as teamid, count(t.teamid) as num_submissions')
             ->from(Submission::class, 's')
             ->join('s.team', 't')
             ->join('t.category', 'tc')
             ->andWhere('s.contest = :contest'), $filter)
-            ->groupBy('s.teamid')
+            ->groupBy('t.teamid')
             ->setParameter('contest', $contest)
             ->getQuery()->getResult();
         $numSubmissions = [];

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -121,7 +121,7 @@ class SubmissionService
             ->select('s', 'j', 'cp')
             ->join('s.team', 't')
             ->join('s.contest_problem', 'cp')
-            ->andWhere('s.cid IN (:contests)')
+            ->andWhere('s.contest IN (:contests)')
             ->setParameter(':contests', array_keys($contests))
             ->orderBy('s.submittime', 'DESC')
             ->addOrderBy('s.submitid', 'DESC');
@@ -132,11 +132,11 @@ class SubmissionService
 
         if (isset($restrictions['rejudgingid'])) {
             $queryBuilder
-                ->leftJoin('s.judgings', 'j', Join::WITH, 'j.rejudgingid = :rejudgingid')
+                ->leftJoin('s.judgings', 'j', Join::WITH, 'j.rejudging = :rejudgingid')
                 ->leftJoin(Judging::class, 'jold', Join::WITH,
-                           'j.prevjudgingid IS NULL AND s.submitid = jold.submitid AND jold.valid = 1 OR j.prevjudgingid = jold.judgingid')
+                           'j.original_judging IS NULL AND s.submitid = jold.submission AND jold.valid = 1 OR j.original_judging = jold.judgingid')
                 ->addSelect('jold.result AS oldresult')
-                ->andWhere('s.rejudgingid = :rejudgingid OR j.rejudgingid = :rejudgingid')
+                ->andWhere('s.rejudging = :rejudgingid OR j.rejudging = :rejudgingid')
                 ->setParameter(':rejudgingid', $restrictions['rejudgingid']);
 
             if (isset($restrictions['rejudgingdiff'])) {
@@ -210,25 +210,25 @@ class SubmissionService
 
         if (isset($restrictions['teamid'])) {
             $queryBuilder
-                ->andWhere('s.teamid = :teamid')
+                ->andWhere('s.team = :teamid')
                 ->setParameter(':teamid', $restrictions['teamid']);
         }
 
         if (isset($restrictions['categoryid'])) {
             $queryBuilder
-                ->andWhere('t.categoryid = :categoryid')
+                ->andWhere('t.category = :categoryid')
                 ->setParameter(':categoryid', $restrictions['categoryid']);
         }
 
         if (isset($restrictions['probid'])) {
             $queryBuilder
-                ->andWhere('s.probid = :probid')
+                ->andWhere('s.problem = :probid')
                 ->setParameter(':probid', $restrictions['probid']);
         }
 
         if (isset($restrictions['langid'])) {
             $queryBuilder
-                ->andWhere('s.langid = :langid')
+                ->andWhere('s.language = :langid')
                 ->setParameter(':langid', $restrictions['langid']);
         }
 

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -202,8 +202,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             'refresh_flag' => $refresh_flag,
             'icat_url' => $this->config->get('icat_url'),
             'external_ccs_submission_url' => $this->config->get('external_ccs_submission_url'),
-            'current_team_contest' => $team ? $this->dj->getCurrentContest($user->getTeamid()) : null,
-            'current_team_contests' => $team ? $this->dj->getCurrentContests($user->getTeamid()) : null,
+            'current_team_contest' => $team ? $this->dj->getCurrentContest($team->getTeamid()) : null,
+            'current_team_contests' => $team ? $this->dj->getCurrentContests($team->getTeamid()) : null,
             'submission_languages' => $this->em->createQueryBuilder()
                 ->from(Language::class, 'l')
                 ->select('l')
@@ -387,7 +387,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             /** @var ExternalJudgement|null $externalJudgement */
             $externalJudgement   = $submission->getExternalJudgements()->first();
             $externalJudgementId = $externalJudgement ? $externalJudgement->getExtjudgementid() : null;
-            $probId              = $submission->getProbid();
+            $probId              = $submission->getProblem()->getProbid();
             $testcases           = $this->em->getConnection()->fetchAll(
                 'SELECT er.result as runresult, t.rank, t.description
                   FROM testcase t
@@ -401,7 +401,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             /** @var Judging|null $judging */
             $judging   = $submission->getJudgings()->first();
             $judgingId = $judging ? $judging->getJudgingid() : null;
-            $probId    = $submission->getProbid();
+            $probId    = $submission->getProblem()->getProbid();
             $testcases = $this->em->getConnection()->fetchAll(
                 'SELECT r.runresult, t.rank, t.description
                   FROM testcase t

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -474,14 +474,14 @@ class Scoreboard
                     continue;
                 }
 
-                $categoryId = $score->team->getCategoryid();
+                $categoryId = $score->team->getCategory()->getCategoryid();
                 if (!isset($this->bestInCategoryData[$categoryId])) {
                     $this->bestInCategoryData[$categoryId] = $score->team->getTeamid();
                 }
             }
         }
 
-        $categoryId = $team->getCategoryid();
+        $categoryId = $team->getCategory()->getCategoryid();
         // Only check the scores when the team has points
         if ($this->scores[$team->getTeamid()]->numPoints > 0) {
             // If the rank of this team is equal to the best team for this

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -1,9 +1,7 @@
 <?php declare(strict_types=1);
 namespace App\Utils;
 
-use App\Entity\SubmissionFile;
 use DateTime;
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -1110,5 +1108,21 @@ class Utils
     public static function parseTsvLine(string $line) : array
     {
         return array_map('stripcslashes', explode("\t", rtrim($line, "\r\n")));
+    }
+
+    /**
+     * Reindex the given array by applying the callback to each item
+     * @param array    $array
+     * @param callable $callback
+     *
+     * @return array
+     */
+    public static function reindex(array $array, callable $callback)
+    {
+        $reindexed = [];
+        array_walk($array, function ($item, $key) use (&$reindexed, $callback) {
+            $reindexed[$callback($item, $key)] = $item;
+        });
+        return $reindexed;
     }
 }

--- a/webapp/templates/jury/export/clarifications.html.twig
+++ b/webapp/templates/jury/export/clarifications.html.twig
@@ -51,7 +51,7 @@
                     </td>
                     <td>
                         {% if clarification.problem %}
-                            {{ problems[clarification.probid].shortName }}: {{ clarification.problem.name }}
+                            {{ problems[clarification.problem.probid].shortName }}: {{ clarification.problem.name }}
                         {% elseif clarification.category and categories[clarification.category] is defined %}
                             {{ categories[clarification.category] }}
                         {% else %}

--- a/webapp/templates/jury/internal_error.html.twig
+++ b/webapp/templates/jury/internal_error.html.twig
@@ -33,22 +33,22 @@
                     <th>Status</th>
                     <td>{{ internalError.status | capitalize }}</td>
                 </tr>
-                {% if internalError.judgingid is not null %}
+                {% if internalError.judging is not null %}
                     <tr>
                         <th>Related judging</th>
                         <td>
-                            <a href="{{ path('jury_submission_by_judging', {jid: internalError.judgingid}) }}">
-                                j{{ internalError.judgingid }}
+                            <a href="{{ path('jury_submission_by_judging', {jid: internalError.judging.judgingid}) }}">
+                                j{{ internalError.judging.judgingid }}
                             </a>
                         </td>
                     </tr>
                 {% endif %}
-                {% if internalError.cid is not null %}
+                {% if internalError.contest is not null %}
                     <tr>
                         <th>Related contest</th>
                         <td>
-                            <a href="{{ path('jury_contest', {'contestId': internalError.cid}) }}">
-                                c{{ internalError.cid }}
+                            <a href="{{ path('jury_contest', {'contestId': internalError.contest.cid}) }}">
+                                c{{ internalError.contest.cid }}
                             </a>
                         </td>
                     </tr>

--- a/webapp/templates/jury/judgehost.html.twig
+++ b/webapp/templates/jury/judgehost.html.twig
@@ -29,7 +29,7 @@
                         {% if not judgehost.restriction %}
                             <i>None</i>
                         {% else %}
-                            <a href="{{ path('jury_judgehost_restriction', {restrictionId: judgehost.restrictionid}) }}">
+                            <a href="{{ path('jury_judgehost_restriction', {restrictionId: judgehost.restriction.restrictionid}) }}">
                                 {{ judgehost.restriction.name }}
                             </a>
                         {% endif %}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -73,9 +73,9 @@
             {%- endif %}
 
             <tr class="{% if not submission.valid %}ignore{% endif %}"
-                data-problem-id="{{ submission.probid }}"
-                data-team-id="{{ submission.teamid }}"
-                data-language-id="{{ submission.langid }}"
+                data-problem-id="{{ submission.problem.probid }}"
+                data-team-id="{{ submission.team.teamid }}"
+                data-language-id="{{ submission.language.langid }}"
                 data-submission-id="{{ submission.submitid }}">
                 {% if showExternalResult and showExternalTestcases %}
                     <td class="{{ tdExtraClass }}">
@@ -88,7 +88,7 @@
                     <a href="{{ link }}">s{{ submission.submitid }}</a>
                 </td>
                 {%- if showContest %}
-                    <td class="{{ tdExtraClass }}"><a href="{{ link }}">c{{ submission.cid }}</a></td>
+                    <td class="{{ tdExtraClass }}"><a href="{{ link }}">c{{ submission.contest.cid }}</a></td>
                 {%- endif %}
 
                 <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
@@ -96,7 +96,7 @@
                 </td>
                 <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
                     <a href="{{ link }}"
-                       title="t{{ submission.teamid }}">{{ submission.team.name | truncate(30) }}</a>
+                       title="t{{ submission.team.teamid }}">{{ submission.team.name | truncate(30) }}</a>
                 </td>
                 <td class="probid{{ tdExtraClass }}" rowspan="{{ rowSpan }}">
                     <a href="{{ link }}"
@@ -104,7 +104,7 @@
                 </td>
                 <td class="langid{{ tdExtraClass }}" rowspan="{{ rowSpan }}">
                     <a href="{{ link }}"
-                       title="{{ submission.language.name }}">{{ submission.langid }}</a>
+                       title="{{ submission.language.name }}">{{ submission.language.langid }}</a>
                 </td>
                 {% if showExternalResult and showExternalTestcases %}
                     <td class="{{ tdExtraClass }}">

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -247,7 +247,7 @@
                     <td>
                         <a href="{{ link }}">
                             {% if judging.rejudging is not null %}
-                                r{{ judging.rejudgingid }} ({{ judging.rejudging.reason }})
+                                r{{ judging.rejudging.rejudgingid }} ({{ judging.rejudging.reason }})
                             {% endif %}
                         </a>
                     </td>
@@ -279,8 +279,8 @@
                     Judging j{{ selectedJudging.judgingid }}
                     {% if selectedJudging.rejudging %}
                         (rejudging
-                        <a href="{{ path('jury_rejudging', {rejudgingId: selectedJudging.rejudgingid}) }}">
-                            r{{ selectedJudging.rejudgingid }}</a>, reason: {{ selectedJudging.rejudging.reason }})
+                        <a href="{{ path('jury_rejudging', {rejudgingId: selectedJudging.rejudging.rejudgingid}) }}">
+                            r{{ selectedJudging.rejudging.rejudgingid }}</a>, reason: {{ selectedJudging.rejudging.reason }})
                     {% elseif not selectedJudging.valid %}
                         (Invalid)
                     {% endif %}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -88,21 +88,21 @@
     <div class="submission-summary mb-2">
         <span>
             <i class="fas fa-users" title="Team:"></i>
-            <a href="{{ path('jury_team', {teamId: submission.teamid, cid: submission.cid}) }}">
-                {{ submission.team.effectiveName }} (t{{ submission.teamid }})
+            <a href="{{ path('jury_team', {teamId: submission.team.teamid, cid: submission.contest.cid}) }}">
+                {{ submission.team.effectiveName }} (t{{ submission.team.teamid }})
             </a>
         </span>
 
         <span>
             <i class="fas fa-trophy" title="Contest:"></i>
-            <a href="{{ path('jury_contest', {'contestId': submission.cid}) }}">
+            <a href="{{ path('jury_contest', {'contestId': submission.contest.cid}) }}">
                 {{ submission.contest.shortname }}
             </a>
         </span>
 
         <span>
             <i class="fas fa-book-open" title="Problem:"></i>
-            <a href="{{ path('jury_problem', {'probId': submission.probid}) }}">
+            <a href="{{ path('jury_problem', {'probId': submission.problem.probid}) }}">
                 {% if submission.contestProblem %}
                     {{ submission.contestProblem.shortname }}: {{ submission.problem.name }}
                 {% else %}
@@ -113,7 +113,7 @@
 
         <span>
             <i class="fas fa-comments" title="Language:"></i>
-            <a href="{{ path('jury_language', {'langId': submission.langid}) }}">
+            <a href="{{ path('jury_language', {'langId': submission.language.langid}) }}">
                 {{ submission.language.name }}
             </a>
         </span>
@@ -435,7 +435,7 @@
                             postVerifyCommentToICAT(
                                 '{{ icat_url }}/insert_entry.php',
                                 '{{ app.user.username }}',
-                                '{{ submission.teamid }}',
+                                '{{ submission.team.teamid }}',
                                 '{{ submission.contestProblem.shortname }}',
                                 '{{ submission.externalid }}'
                             );
@@ -528,20 +528,20 @@
                             {% endif %}
                         {% endif %}
                         <span style="float: right;">
-                            <a href="{{ path('jury_problem_testcase_fetch', {'probId': submission.probid, 'rank': run.rank, 'type': 'input'}) }}">
+                            <a href="{{ path('jury_problem_testcase_fetch', {'probId': submission.problem.probid, 'rank': run.rank, 'type': 'input'}) }}">
                                 <button class="btn btn-sm btn-outline-secondary" >
                                     <i class="fas fa-download"></i>
                                     Input
                                 </button>
                             </a>
-                            <a href="{{ path('jury_problem_testcase_fetch', {'probId': submission.probid, 'rank': run.rank, 'type': 'output'}) }}">
+                            <a href="{{ path('jury_problem_testcase_fetch', {'probId': submission.problem.probid, 'rank': run.rank, 'type': 'output'}) }}">
                                 <button class="btn btn-sm btn-outline-secondary" >
                                     <i class="fas fa-download"></i>
                                     Reference Output
                                 </button>
                             </a>
                             {% if run.firstJudgingRun is not null %}
-                                <a href="{{ path('jury_submission_team_output', {'submission': submission.submitid, 'run': run.firstJudgingRun.runid, 'contest': submission.cid}) }}">
+                                <a href="{{ path('jury_submission_team_output', {'submission': submission.submitid, 'run': run.firstJudgingRun.runid, 'contest': submission.contest.cid}) }}">
                                     <button class="btn btn-sm btn-outline-secondary" >
                                         <i class="fas fa-download"></i>
                                         Team Output
@@ -582,7 +582,7 @@
                     {% endif %}
                     {% if runsOutput[runIdx].image_thumb %}
                         <span style="float:right; border: 3px solid #438ec3; margin: 5px; padding: 5px;">
-                            {% set imgUrl = path('jury_problem_testcase_fetch', {'probId': submission.probid, 'rank': run.rank, 'type': 'image'}) %}
+                            {% set imgUrl = path('jury_problem_testcase_fetch', {'probId': submission.problem.probid, 'rank': run.rank, 'type': 'image'}) %}
                             <a href="{{ imgUrl }}">
                                 <img src="data:image/{{ run.imageType }};base64,{{ runsOutput[runIdx].image_thumb | base64 }}"/>
                             </a>

--- a/webapp/templates/jury/submission_source.html.twig
+++ b/webapp/templates/jury/submission_source.html.twig
@@ -19,7 +19,7 @@
         {% if submission.resubmissions is not empty %}
             (resubmitted as
             {%- for resubmission in submission.resubmissions %}
-                <a href="{{ path('jury_submission', {submitId: resubmission.origsubmitid}) }}">s{{ resubmission.submitid }}</a>
+                <a href="{{ path('jury_submission', {submitId: resubmission.originalSubmission.submitid}) }}">s{{ resubmission.submitid }}</a>
                 {%- if not loop.last -%},{%- endif -%}
             {%- endfor -%}
             )
@@ -37,7 +37,7 @@
         <p><a href="#diff">Go to diff to previous submission</a></p>
     {%- endif %}
 
-    {%- if submission.origsubmitid %}
+    {%- if submission.originalSubmission %}
 
         <p><a href="#origdiff">Go to diff to original submission</a></p>
     {%- endif %}

--- a/webapp/templates/jury/team_affiliation.html.twig
+++ b/webapp/templates/jury/team_affiliation.html.twig
@@ -54,7 +54,7 @@
                         <th>Country</th>
                         <td>
                             {% if teamAffiliation.country is not empty %}
-                                <img src="{{ asset('images/countries/' ~ team.affiliation.country ~ '.png') }}" alt="{{ alpha3_countries[teamAffiliation.country] }}"
+                                <img src="{{ asset('images/countries/' ~ teamAffiliation.country ~ '.png') }}" alt="{{ alpha3_countries[teamAffiliation.country] }}"
                                      title="{{ alpha3_countries[teamAffiliation.country] }}" class="countryflag"/>
                             {% endif %}
                             {{ alpha3_countries[teamAffiliation.country] }}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -137,7 +137,7 @@
                     {% if score.team.affiliation %}
                         {% set link = null %}
                         {% if jury %}
-                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affilid}) %}
+                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
                         {% endif %}
                         <a {% if link %}href="{{ link }}"{% endif %}>
                             {% if score.team.affiliation.country %}
@@ -154,7 +154,7 @@
                     {% if score.team.affiliation %}
                         {% set link = null %}
                         {% if jury %}
-                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affilid}) %}
+                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
                         {% endif %}
                         <a {% if link %}href="{{ link }}"{% endif %}>
                             {% set affiliationId = score.team.affiliation.affilid %}

--- a/webapp/templates/team/clarification.html.twig
+++ b/webapp/templates/team/clarification.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <h1 class="text-center mt-4">Clarification
-    {% if clarification.senderId == team.teamid %}Request{% endif%}</h1>
+    {% if clarification.sender and clarification.sender.teamid == team.teamid %}Request{% endif%}</h1>
 
     {% include 'team/partials/clarification_content.html.twig' %}
 

--- a/webapp/templates/team/clarification_modal.html.twig
+++ b/webapp/templates/team/clarification_modal.html.twig
@@ -1,7 +1,7 @@
 {% extends "partials/modal.html.twig" %}
 
 {% block title %}
-{% if clarification.senderId == team.teamid %}
+{% if clarification.sender and clarification.sender.teamid == team.teamid %}
 Clarification Request
 {% else %}
 View clarification

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -40,7 +40,7 @@
                 </td>
                 <td class="langid">
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %} title="{{ submission.language.name }}">
-                        {{ submission.langid }}
+                        {{ submission.language.langid }}
                     </a>
                 </td>
                 <td>

--- a/webapp/tests/Integration/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Integration/ScoreboardIntegrationTest.php
@@ -318,7 +318,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         $team = $this->teams[0];
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+15.053, 'correct', true)
-            ->getJudgings()[0]->setRejudgingid($this->rejudging->getRejudgingid());
+            ->getJudgings()[0]->setRejudging($this->rejudging);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+57.240, null);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+59.841, 'wrong-answer');
         $this->createSubmission($lang, $this->problems[1], $team, 61*60+00.000, 'correct', true);
@@ -351,7 +351,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         $team = $this->teams[0];
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+15.053, 'correct', true)
-            ->getJudgings()[0]->setRejudgingid($this->rejudging->getRejudgingid());
+            ->getJudgings()[0]->setRejudging($this->rejudging);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+57.240, null);
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+59.841, 'wrong-answer');
         $this->createSubmission($lang, $this->problems[1], $team, 61*60+00.000, 'correct', true);
@@ -388,7 +388,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
         $team = $this->teams[0];
         $this->createSubmission($lang, $this->problems[0], $team, 53*60+15.053, 'wrong-answer')
             ->setJudgehost(null)
-            ->setRejudgingid($this->rejudging->getRejudgingid());
+            ->setRejudging($this->rejudging);
 
         $this->createSubmission($lang, $this->problems[0], $team, 55*60+59.841, 'correct');
 

--- a/webapp/tests/Utils/UtilsTest.php
+++ b/webapp/tests/Utils/UtilsTest.php
@@ -2,9 +2,9 @@
 
 namespace App\Tests\Utils;
 
+use App\Entity\TeamAffiliation;
 use App\Utils\Utils;
 use PHPUnit\Framework\TestCase;
-use App\Entity\TeamAffiliation;
 
 class UtilsTest extends TestCase
 {
@@ -877,5 +877,18 @@ part.";
         $this->assertEquals(["tea\\mname", "rank"],   Utils::parseTsvLine("tea".$bs.$bs."mname".$tab."rank"));
         $this->assertEquals(["team nåme…", "rank"],   Utils::parseTsvLine("team nåme…".$tab."rank"));
         $this->assertEquals(["team🎈name", "rank"],   Utils::parseTsvLine("team🎈name".$tab."rank"));
+    }
+
+    /**
+     * Test that reindexing an array works
+     */
+    public function testReindex()
+    {
+        $input = [1, 2, 3];
+        $expectedOutput = [2 => 1, 4 => 2, 6 => 3];
+        $doubled = function ($item) {
+            return $item * 2;
+        };
+        $this->assertEquals($expectedOutput, Utils::reindex($input, $doubled));
     }
 }


### PR DESCRIPTION
Oh man, this was a biggie.

Locally my unit tests work and I seem to be able to submit stuff, etc.
But I totally expect that I missed some twig file.
I did check usages for all fields so all PHP should be handled if we have proper type hints, but for Twig I manually checked usages. Most changed usages where from `bla.someid` to `bla.some.someid`.
I do like we can remove a lot of stuff and still have the same result.