### PR TITLE
Test remapping of expected results

### DIFF
--- a/tests/test-exitcode-2.c
+++ b/tests/test-exitcode-2.c
@@ -1,0 +1,10 @@
+/*
+ * This should fail with RUN-ERROR and tests remapping of error names (due to exitcode != 0)
+ *
+ * @EXPECTED_RESULTS@: RUN_TIME_ERROR
+ */
+
+int main()
+{
+	return 1;
+}

--- a/tests/test-exitcode-3.c
+++ b/tests/test-exitcode-3.c
@@ -1,0 +1,10 @@
+/*
+ * This should fail with RUN-ERROR and tests remapping of error names and string splitting/trimming (due to exitcode != 0)
+ *
+ * @EXPECTED_RESULTS@:   RUN_TIME_ERROR , ACCEPTED   
+ */
+
+int main()
+{
+	return 1;
+}

--- a/tests/test-exitcode-4.c
+++ b/tests/test-exitcode-4.c
@@ -1,0 +1,10 @@
+/*
+ * This should fail with RUN-ERROR and tests remapping of error names and string splitting (due to exitcode != 0)
+ *
+ * @EXPECTED_RESULTS@: RUN_TIME_ERROR,ACCEPTED
+ */
+
+int main()
+{
+	return 1;
+}

--- a/tests/test-float-2.c
+++ b/tests/test-float-2.c
@@ -1,0 +1,29 @@
+/*
+ * This should fail with WRONG-ANSWER (C doesn't give floating point
+ * errors when dividing by zero).
+ *
+ * This tests remapping from WRONG_ANSWER to WRONG-ANSWER.
+ *
+ * @EXPECTED_RESULTS@: WRONG_ANSWER
+ */
+
+#include <stdio.h>
+#include <math.h>
+
+/* To have M_PI constant available in ANSI C. */
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+int main()
+{
+	double a = M_PI/2;
+	double b;
+
+	b = tan(a);
+	a = exp(b);
+
+	printf("%lf\n%lf\n%lf\n%lf\n",b,a,1/a,acos(b));
+
+	return 0;
+}

--- a/tests/test-timelimit-2.c
+++ b/tests/test-timelimit-2.c
@@ -1,0 +1,16 @@
+/*
+ * This should give a TIMELIMIT.
+ *
+ * This tests remapping from TIME_LIMIT_EXCEEDED to TIMELIMIT.
+ *
+ * @EXPECTED_RESULTS@: TIME_LIMIT_EXCEEDED
+ */
+
+int main()
+{
+	int a = 0;
+
+	while ( 1 ) a++;
+
+	return 0;
+}


### PR DESCRIPTION
This adds some tests for remapping of expected results:

- `WRONG_ANSWER` -> `WRONG-ANSWER`
- `RUN_TIME_ERROR` -> `RUN-ERROR`
- `TIME_LIMIT_EXCEEDED` -> `TIMELIMIT`