### PR TITLE
Change default Python interpreter to pypy

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -133,7 +133,7 @@ if [ "$DISTRO" = 'Debian' ]; then
 INCLUDEDEBS="ca-certificates"
 
 # Packages to install after upgrade (space separated):
-INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy python3 locales"
+INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy pypy3 python3 locales"
 # For C# support add: mono-runtime libmono-system2.0-cil
 # However running mono within chroot still gives errors...
 
@@ -162,7 +162,7 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
 INCLUDEDEBS=""
 
 # Packages to install after upgrade (space separated):
-INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy python3 locales"
+INSTALLDEBS="gcc g++ default-jdk-headless default-jre-headless pypy pypy3 python3 locales"
 # For C# support add: mono-mcs mono-devel
 # However running mono within chroot still gives errors...
 

--- a/sql/files/defaultdata/py3/run
+++ b/sql/files/defaultdata/py3/run
@@ -8,8 +8,10 @@
 # will execute the source with the correct interpreter syntax, thus
 # allowing this interpreted source to be used transparantly as if it
 # was compiled to a standalone binary.
+# Note that from version 8.0.0 the default Python 3 interpreter is
+# pypy 3 instead of CPython 3.
 #
-# This script requires that python3 is installed in the chroot.
+# This script requires that pypy3 is installed in the chroot.
 
 DEST="$1" ; shift
 MEMLIMIT="$1" ; shift
@@ -21,10 +23,11 @@ if [ -z "$ENTRY_POINT" ]; then
 fi
 
 # Check syntax
-python3 -m py_compile "$@"
+pypy3 -m py_compile "$@"
 EXITCODE=$?
 [ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 rm -f -- *.pyc
+rm -rf -- __pycache__
 
 # Check if entry point is valid
 if [ ! -r "$MAINSOURCE" ]; then
@@ -49,7 +52,7 @@ export HOME=/does/not/exist
 # debugging.
 # export ONLINE_JUDGE=1 DOMJUDGE=1
 
-exec python3 "$MAINSOURCE" "\$@"
+exec pypy3 "$MAINSOURCE" "\$@"
 EOF
 
 chmod a+x "$DEST"

--- a/webapp/src/Migrations/Version20190803123217.php
+++ b/webapp/src/Migrations/Version20190803123217.php
@@ -699,7 +699,7 @@ INSERT INTO `language` (`langid`, `externalid`, `name`, `extensions`, `require_e
     ('pl', 'pl', 'Perl', '["pl"]', 0, "Main file", 0, 1, 1, 'pl'),
     ('plg', 'prolog', 'Prolog', '["plg"]', 0, "Main file", 0, 1, 1, 'plg'),
     ('py2', 'python2', 'Python 2', '["py2","py"]', 0, "Main file", 0, 1, 1, 'py2'),
-    ('py3', 'python3', 'Python 3', '["py3"]', 0, "Main file", 0, 1, 1, 'py3'),
+    ('py3', 'python3', 'Python 3', '["py3"]', 0, "Main file", 1, 1, 1, 'py3'),
     ('r', 'r', 'R', '["R"]', 0, "Main file", 0, 1, 1, 'r'),
     ('rb', 'ruby', 'Ruby', '["rb"]', 0, "Main file", 0, 1, 1, 'rb'),
     ('scala', 'scala', 'Scala', '["scala"]', 0, NULL, 0, 1, 1, 'scala'),


### PR DESCRIPTION
We discussed in the slack that the default Python interpreter should be switched to pypy. I believe previously this wasn't done because pypy3 packages weren't readily available. They are now, and it seems many contests are using pypy3 already. 

This PR adds pypy3 to the chroot (and leaves python3 in place for contests that want to supply their own runscript for it), and changes the python interpreter in the run script.