### PR TITLE
Add help text to contest form

### DIFF
--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -30,7 +30,7 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('activatetimeString', TextType::class, [
             'label' => 'Activate time',
-            'help' => 'Time when the contest becomes visible for teams to join. Must be in the past to enable judging of jury submissions.',
+            'help' => 'Time when the contest becomes visible for teams to join. Must be in the past to enable submission of jury submissions.',
         ]);
         $builder->add('starttimeString', TextType::class, [
             'label' => 'Start time',

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -28,9 +28,11 @@ class ContestType extends AbstractExternalIdEntityType
         $builder->add('name', TextType::class);
         $builder->add('activatetimeString', TextType::class, [
             'label' => 'Activate time',
+            'help' => 'Time when the contest becomes visible for teams to join. Must be in the past to enable judging of jury submissions.',
         ]);
         $builder->add('starttimeString', TextType::class, [
             'label' => 'Start time',
+            'help' => 'Absolute time when the contest starts.',
         ]);
         $builder->add('starttimeEnabled', ChoiceType::class, [
             'label' => 'Start time enabled',
@@ -39,21 +41,26 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
+            'help' => 'Only John knows',
         ]);
         $builder->add('freezetimeString', TextType::class, [
             'label' => 'Scoreboard freeze time',
             'required' => false,
+            'help' => 'Time when the freeze starts: the results of submissions made after this time are not revealed until the scoreboard unfreeze time below has passed.',
         ]);
         $builder->add('endtimeString', TextType::class, [
             'label' => 'End time',
+            'help' => 'Time when the contest ends.',
         ]);
         $builder->add('unfreezetimeString', TextType::class, [
             'label' => 'Scoreboard unfreeze time',
             'required' => false,
+            'help' => 'Time when the final scoreboard is revealed. Usually a few hours after the contest ends, and the award ceremony is over.',
         ]);
         $builder->add('deactivatetimeString', TextType::class, [
             'label' => 'Deactivate time',
             'required' => false,
+            'help' => 'Time when the contest and scoreboard are hidden again. Usually a few hours/days after the contest ends.',
         ]);
         $builder->add('processBalloons', ChoiceType::class, [
             'expanded' => true,
@@ -61,6 +68,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
+            'help' => 'Enables the balloons page. (What is the advantage of disabling it?)',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,
@@ -69,6 +77,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
+            'help' => 'When true, the public scoreboard is enabled and everyone can see it without logging in. When false, only logged in users/teams participating in the contest can see the scoreboard.',
         ]);
         $builder->add('openToAllTeams', ChoiceType::class, [
             'expanded' => true,
@@ -77,6 +86,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
+            'help' => 'When true, any logged in team can join this contest, and the teams/categories listed below are added by default. When false, only the teams/categories listed below will participate.',
         ]);
         $builder->add('teams', EntityType::class, [
             'required' => false,
@@ -85,6 +95,7 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (Team $team) {
                 return sprintf('%s (t%d)', $team->getEffectiveName(), $team->getTeamid());
             },
+            'help' => 'List of teams participating in the contest, in case it is not open to all teams.',
         ]);
         $builder->add('teamCategories', EntityType::class, [
             'required' => false,
@@ -93,6 +104,7 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (TeamCategory $category) {
                 return $category->getName();
             },
+            'help' => 'List of team categories participating in the contest, in case it is not open to all teams.',
         ]);
         $builder->add('enabled', ChoiceType::class, [
             'expanded' => true,
@@ -100,6 +112,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
+            'help' => 'When false, the contest is hidden from teams (even when active) and judging is disabled. Disabling is a quick way to remove access to it without changing any other settings.',
         ]);
         $builder->add('problems', CollectionType::class, [
             'entry_type' => ContestProblemType::class,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -88,7 +88,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'When true, any logged in team can join this contest, and the teams/categories listed below are added by default. When false, only the teams/categories listed below will participate.',
+            'help' => 'When true, any logged in team is part of the contest. When false, only the teams/categories listed below are part of the contest.',
         ]);
         $builder->add('teams', EntityType::class, [
             'required' => false,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -39,11 +39,11 @@ class ContestType extends AbstractExternalIdEntityType
             'help' => 'Absolute time when the contest starts.',
         ]);
         $builder->add('starttimeEnabled', ChoiceType::class, [
-            'label' => 'Start time countdown',
+            'label' => 'Start time countdown enabled',
             'expanded' => true,
             'choices' => [
-                'Enabled' => true,
-                'Disabled' => false,
+                'Yes' => true,
+                'No' => false,
             ],
             'help' => 'Disable to delay the contest start and stop the countdown. Enable again after setting a new start time.',
             # What happens when the countdown is disabled, but the start time is in the past/time 'crosses' the start time?
@@ -71,8 +71,8 @@ class ContestType extends AbstractExternalIdEntityType
             'expanded' => true,
             'label' => 'Record balloons',
             'choices' => [
-                'Enabled' => true,
-                'Disabled' => false,
+                'Yes' => true,
+                'No' => false,
             ],
             'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
         ]);
@@ -80,8 +80,8 @@ class ContestType extends AbstractExternalIdEntityType
             'expanded' => true,
             'label' => 'Enable public scoreboard',
             'choices' => [
-                'Enabled' => true,
-                'Disabled' => false,
+                'Yes' => true,
+                'No' => false,
             ],
             'help' => 'When the public scoreboard is enabled, everyone can see it without logging in. When disabled, only logged in users/teams can see the scoreboard.',
         ]);
@@ -89,8 +89,8 @@ class ContestType extends AbstractExternalIdEntityType
             'expanded' => true,
             'label' => 'Open contest to all teams',
             'choices' => [
-                'Enabled' => true,
-                'Disabled' => false,
+                'Yes' => true,
+                'No' => false,
             ],
             'help' => 'When enabled, any logged in team is part of the contest. When disabled, only the teams/categories listed below are part of the contest.',
         ]);
@@ -116,8 +116,8 @@ class ContestType extends AbstractExternalIdEntityType
             'expanded' => true,
             'label' => 'Contest enabled',
             'choices' => [
-                'Enabled' => true,
-                'Disabled' => false,
+                'Yes' => true,
+                'No' => false,
             ],
             'help' => 'When disabled, the contest is hidden from teams (even when active) and judging is disabled. Disabling is a quick way to remove access to it without changing any other settings.',
         ]);

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -114,7 +114,7 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('enabled', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Contest enabled',
+            'label' => 'Enable contest',
             'choices' => [
                 'Yes' => true,
                 'No' => false,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -39,13 +39,14 @@ class ContestType extends AbstractExternalIdEntityType
             'help' => 'Absolute time when the contest starts.',
         ]);
         $builder->add('starttimeEnabled', ChoiceType::class, [
-            'label' => 'Start time enabled',
+            'label' => 'Start time countdown',
             'expanded' => true,
             'choices' => [
-                'Yes' => true,
-                'No' => false,
+                'Enabled' => true,
+                'Disabled' => false,
             ],
             'help' => 'Disable to delay the contest start and stop the countdown. Enable again after setting a new start time.',
+            # What happens when the countdown is disabled, but the start time is in the past/time 'crosses' the start time?
         ]);
         $builder->add('freezetimeString', TextType::class, [
             'label' => 'Scoreboard freeze time',
@@ -68,29 +69,30 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('processBalloons', ChoiceType::class, [
             'expanded' => true,
+            'label' => 'Record balloons',
             'choices' => [
-                'Yes' => true,
-                'No' => false,
+                'Enabled' => true,
+                'Disabled' => false,
             ],
-            'help' => 'Disable this to stop recording balloons. Usually you can just leave this to true.',
+            'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Contest visible on public scoreboard',
+            'label' => 'Enable public scoreboard',
             'choices' => [
-                'Yes' => true,
-                'No' => false,
+                'Enabled' => true,
+                'Disabled' => false,
             ],
-            'help' => 'When true, the public scoreboard is enabled and everyone can see it without logging in. When false, only logged in users/teams participating in the contest can see the scoreboard.',
+            'help' => 'When the public scoreboard is enabled, everyone can see it without logging in. When disabled, only logged in users/teams can see the scoreboard.',
         ]);
         $builder->add('openToAllTeams', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Contest open to all teams',
+            'label' => 'Open contest to all teams',
             'choices' => [
-                'Yes' => true,
-                'No' => false,
+                'Enabled' => true,
+                'Disabled' => false,
             ],
-            'help' => 'When true, any logged in team is part of the contest. When false, only the teams/categories listed below are part of the contest.',
+            'help' => 'When enabled, any logged in team is part of the contest. When disabled, only the teams/categories listed below are part of the contest.',
         ]);
         $builder->add('teams', EntityType::class, [
             'required' => false,
@@ -112,11 +114,12 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('enabled', ChoiceType::class, [
             'expanded' => true,
+            'label' => 'Contest enabled',
             'choices' => [
-                'Yes' => true,
-                'No' => false,
+                'Enabled' => true,
+                'Disabled' => false,
             ],
-            'help' => 'When false, the contest is hidden from teams (even when active) and judging is disabled. Disabling is a quick way to remove access to it without changing any other settings.',
+            'help' => 'When disabled, the contest is hidden from teams (even when active) and judging is disabled. Disabling is a quick way to remove access to it without changing any other settings.',
         ]);
         $builder->add('problems', CollectionType::class, [
             'entry_type' => ContestProblemType::class,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -25,7 +25,9 @@ class ContestType extends AbstractExternalIdEntityType
     {
         $this->addExternalIdField($builder, Contest::class);
         $builder->add('shortname', TextType::class);
-        $builder->add('name', TextType::class);
+        $builder->add('name', TextType::class, [
+            'help' => 'Contest name as shown in the top right.'
+        ]);
         $builder->add('activatetimeString', TextType::class, [
             'label' => 'Activate time',
             'help' => 'Time when the contest becomes visible for teams to join. Must be in the past to enable judging of jury submissions.',
@@ -41,7 +43,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Only John knows',
+            'help' => 'Disable to delay the contest start and stop the countdown. Enable again after setting a new start time.',
         ]);
         $builder->add('freezetimeString', TextType::class, [
             'label' => 'Scoreboard freeze time',
@@ -50,12 +52,12 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('endtimeString', TextType::class, [
             'label' => 'End time',
-            'help' => 'Time when the contest ends.',
+            'help' => 'Time when the contest ends. Submissions made after this time will be accepted but shown as \'too-late\' and not counted towards the score.',
         ]);
         $builder->add('unfreezetimeString', TextType::class, [
             'label' => 'Scoreboard unfreeze time',
             'required' => false,
-            'help' => 'Time when the final scoreboard is revealed. Usually a few hours after the contest ends, and the award ceremony is over.',
+            'help' => 'Time when the final scoreboard is revealed. Usually this is a few hours after the contest ends and the award ceremony is over.',
         ]);
         $builder->add('deactivatetimeString', TextType::class, [
             'label' => 'Deactivate time',
@@ -68,7 +70,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Enables the balloons page. (What is the advantage of disabling it?)',
+            'help' => 'Disable this to stop recording balloons. Usually you can just leave this to true.',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -46,7 +46,6 @@ class ContestType extends AbstractExternalIdEntityType
                 'No' => false,
             ],
             'help' => 'Disable to delay the contest start and stop the countdown. Enable again after setting a new start time.',
-            # What happens when the countdown is disabled, but the start time is in the past/time 'crosses' the start time?
         ]);
         $builder->add('freezetimeString', TextType::class, [
             'label' => 'Scoreboard freeze time',
@@ -55,7 +54,7 @@ class ContestType extends AbstractExternalIdEntityType
         ]);
         $builder->add('endtimeString', TextType::class, [
             'label' => 'End time',
-            'help' => 'Time when the contest ends. Submissions made after this time will be accepted but shown as \'too-late\' and not counted towards the score.',
+            'help' => 'Time when the contest ends. Submissions made after this time will be accepted and judged but shown (to teams and public) as \'too-late\' and not counted towards the score.',
         ]);
         $builder->add('unfreezetimeString', TextType::class, [
             'label' => 'Scoreboard unfreeze time',

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -24,13 +24,15 @@ class ContestType extends AbstractExternalIdEntityType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->addExternalIdField($builder, Contest::class);
-        $builder->add('shortname', TextType::class);
-        $builder->add('name', TextType::class, [
+        $builder->add('shortname', TextType::class, [
             'help' => 'Contest name as shown in the top right.'
+        ]);
+        $builder->add('name', TextType::class, [
+            'help' => 'Contest name in full as shown on the scoreboard.'
         ]);
         $builder->add('activatetimeString', TextType::class, [
             'label' => 'Activate time',
-            'help' => 'Time when the contest becomes visible for teams to join. Must be in the past to enable submission of jury submissions.',
+            'help' => 'Time when the contest becomes visible for teams. Must be in the past to enable submission of jury submissions.',
         ]);
         $builder->add('starttimeString', TextType::class, [
             'label' => 'Start time',

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -28,14 +28,14 @@
     </div>
     <div class="col-lg-4">
         <b>Specification of contest times:</b><br/>
-        Each of the contest times can be specified as absolute time or
-        relative to the start time (except for start time itself).
-        Use up to 6 subsecond decimals and a timezone from the
+        Each of the contest times can be specified as absolute time or relative<br/>
+        to the start time (except for start time itself). Use up to 6 subsecond<br/>
+        decimals and a timezone from the
         <a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
             time zone database
         </a>.<br/><br/>
-        Absolute time format: <span class="text-nowrap"><b><tt>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</tt></b></span><br/>
-        Relative time format: <span class="text-nowrap"><b><tt>±[HHH]H:MM[:SS[.uuuuuu]]</tt></b></span><br/>
+        Absolute time format: <b><tt>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</tt></b><br/>
+        Relative time format: <b><tt>±[HHH]H:MM[:SS[.uuuuuu]]</tt></b><br/>
     </div>
 </div>
 <table class="table table-sm table-striped">

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -28,14 +28,14 @@
     </div>
     <div class="col-lg-4">
         <b>Specification of contest times:</b><br/>
-        Each of the contest times can be specified as absolute time or relative<br/>
-        to the start time (except for start time itself). Use up to 6 subsecond<br/>
-        decimals and a timezone from the
+        Each of the contest times can be specified as absolute time or
+        relative to the start time (except for start time itself).
+        Use up to 6 subsecond decimals and a timezone from the
         <a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
             time zone database
         </a>.<br/><br/>
-        Absolute time format: <b><tt>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</tt></b><br/>
-        Relative time format: <b><tt>±[HHH]H:MM[:SS[.uuuuuu]]</tt></b><br/>
+        Absolute time format: <span class="text-nowrap"><b><tt>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</tt></b></span><br/>
+        Relative time format: <span class="text-nowrap"><b><tt>±[HHH]H:MM[:SS[.uuuuuu]]</tt></b></span><br/>
     </div>
 </div>
 <table class="table table-sm table-striped">


### PR DESCRIPTION
Remaining questions:
- what is the recommended set of settings to play with a contest without it being visible to anybody else (only jury/admins, not teams/public).
- what to put for `start time enabled`
- is `enabled: false` any different from it not being active?

Fix #911 