### PR TITLE
The gitlabci has pa11y on different PATH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ include:
 
 check syntax:
   stage: test
-  image: domjudge/gitlabci:1.0
+  image: domjudge/gitlabci:2.0
   script:
     - ./gitlab/syntax.sh
 
@@ -28,7 +28,7 @@ check_w3c_css:
 
 check_w3c_html:
   stage: test
-  image: domjudge/gitlabci:1.0
+  image: domjudge/gitlabci:2.0
   services:
     - mariadb
   variables:
@@ -45,7 +45,7 @@ check_w3c_html:
 
 check_wcag:
   stage: test
-  image: domjudge/gitlabci:1.0
+  image: domjudge/gitlabci:2.0
   services:
     - mariadb
   variables:
@@ -61,7 +61,7 @@ check_wcag:
 
 run unit tests:
   stage: test
-  image: domjudge/gitlabci:1.0
+  image: domjudge/gitlabci:2.0
   # Disabled for now as it drastically speeds up running unit tests and we don't use it yet
   # before_script:
   #   - apt-get update -yqq
@@ -86,7 +86,7 @@ run unit tests:
 
 integration:
   stage: test
-  image: domjudge/gitlabci:1.0
+  image: domjudge/gitlabci:2.0
   services:
     - mariadb
   variables:

--- a/gitlab/html.sh
+++ b/gitlab/html.sh
@@ -64,8 +64,8 @@ EOF
 ADMINPASS=$(cat etc/initial_admin_password.secret)
 
 # configure and restart php-fpm
-sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.2/fpm/pool.d/domjudge-fpm.conf"
-sudo /usr/sbin/php-fpm7.2
+sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.4/fpm/pool.d/domjudge-fpm.conf"
+sudo /usr/sbin/php-fpm7.4
 
 section_end setup
 

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -34,6 +34,7 @@ function finish() {
 	cp /tmp/judgedaemon.log "$gitlabartifacts/judgedaemon.log"
 	cp /proc/cmdline "$gitlabartifacts/cmdline"
 	cp /chroot/domjudge/etc/apt/sources.list "$gitlabartifacts/sources.list"
+	cp /chroot/domjudge/debootstrap/debootstrap.log "$gitlabartifacts/debootstrap.log"
 	cp "${DIR}/misc-tools/icpctools/*json" "$gitlabartifacts/"
 }
 trap finish EXIT
@@ -70,8 +71,8 @@ EOF
 ADMINPASS=$(cat etc/initial_admin_password.secret)
 
 # configure and restart php-fpm
-sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.2/fpm/pool.d/domjudge-fpm.conf"
-sudo /usr/sbin/php-fpm7.2
+sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.4/fpm/pool.d/domjudge-fpm.conf"
+sudo /usr/sbin/php-fpm7.4
 
 section_end setup
 
@@ -109,6 +110,7 @@ sudo useradd -d /nonexistent -g nogroup -s /bin/false -u $((2000+(RANDOM%1000)))
 
 # start judgedaemon
 cd /opt/domjudge/judgehost/
+mount -t proc proc /proc
 sudo -u domjudge bin/judgedaemon -n 0 |& tee /tmp/judgedaemon.log &
 sleep 5
 
@@ -135,7 +137,7 @@ section_end submitting
 
 section_start judging "Waiting until all submissions are judged"
 # wait for and check results
-NUMSUBS=$(curl --fail http://admin:$ADMINPASS@localhost/domjudge/api/contests/2/submissions | python -mjson.tool | grep -c '"id":')
+NUMSUBS=$(curl --fail http://admin:$ADMINPASS@localhost/domjudge/api/contests/2/submissions | python3 -mjson.tool | grep -c '"id":')
 export COOKIEJAR
 COOKIEJAR=$(mktemp --tmpdir)
 export CURLOPTS="--fail -sq -m 30 -b $COOKIEJAR"

--- a/gitlab/wcag.sh
+++ b/gitlab/wcag.sh
@@ -13,7 +13,6 @@ function section_end_internal() {
 	echo -e "section_end:`date +%s`:$1\r\e[0K"
 	trace_on
 }
-
 alias section_start='trace_off ; section_start_internal '
 alias section_end='trace_off ; section_end_internal '
 
@@ -64,8 +63,8 @@ EOF
 ADMINPASS=$(cat etc/initial_admin_password.secret)
 
 # configure and restart php-fpm
-sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.2/fpm/pool.d/domjudge-fpm.conf"
-sudo /usr/sbin/php-fpm7.2
+sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/7.4/fpm/pool.d/domjudge-fpm.conf"
+sudo /usr/sbin/php-fpm7.4
 
 section_end setup
 
@@ -99,8 +98,8 @@ do
 	do
 		section_start ${file//\//} $file
 		# T is reasonable amount of errors to allow to not break
-		su domjudge -c "pa11y -T $ACCEPTEDERR -E '#menuDefault > a > button' --reporter json ./$file" | python -m json.tool
-	        ERR=`su domjudge -c "pa11y -T $ACCEPTEDERR -E '#menuDefault > a > button' --reporter csv ./$file" | wc -l`
+		su domjudge -c "/node_modules/.bin/pa11y -T $ACCEPTEDERR -E '#menuDefault > a > button' --reporter json ./$file" | python3 -m json.tool
+	        ERR=`su domjudge -c "/node_modules/.bin/pa11y -T $ACCEPTEDERR -E '#menuDefault > a > button' --reporter csv ./$file" | wc -l`
 		FOUNDERR=$((ERR+FOUNDERR-1)) # Remove header row
 		section_end $file
 	done


### PR DESCRIPTION
Due to a problem with puppeteer in docker the binary is installed in another location

This should only be merged when https://github.com/DOMjudge/domjudge-packaging/pull/68 is handled

The chroot error can be removed by unmounting earlier but is not problematic for actually terminating. As a bonus this updates everything to 2.0