### PR TITLE
Only display the relevant type of scripts in default_{compare,run} config option

### DIFF
--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -347,6 +347,23 @@ EOF;
     }
 
     /**
+     * Find list of options for configuration parameters that specify a known executable.
+     *
+     * @param string $type Any of "compare", "compile", "run"
+     *
+     * @return array
+     */
+    private function findExecutableOptions(string $type): array
+    {
+        $executables = $this->em->getRepository(Executable::class)->findBy(['type'=>$type]);
+        $options = [];
+        foreach ($executables as $executable) {
+            $options[$executable->getExecid()] = $executable->getDescription();
+        }
+        return $options;
+    }
+
+    /**
      * Add options to some items
      *
      * This method is used to add predefined options that need to be loaded
@@ -360,12 +377,10 @@ EOF;
     {
         switch ($item['name']) {
             case 'default_compare':
+                $item['options'] = $this->findExecutableOptions('compare');
+                break;
             case 'default_run':
-                $executables     = $this->em->getRepository(Executable::class)->findAll();
-                $item['options'] = [];
-                foreach ($executables as $executable) {
-                    $item['options'][$executable->getExecid()] = $executable->getDescription();
-                }
+                $item['options'] = $this->findExecutableOptions('run');
                 break;
             case 'results_prio':
             case 'results_remap':

--- a/webapp/tests/Service/ConfigurationServiceTest.php
+++ b/webapp/tests/Service/ConfigurationServiceTest.php
@@ -329,19 +329,35 @@ class ConfigurationServiceTest extends KernelTestCase
      * @dataProvider provideAddOptionsExecutables
      *
      * @param string $item
+     * @param array $item
      *
      * @throws Exception
      */
-    public function testAddOptionsExecutables(string $item)
+    public function testAddOptionsExecutables(string $item, array $expected)
     {
-        $executables = [
-            (new Executable())
-                ->setExecid('exec1')
-                ->setDescription('Descr 1'),
-            (new Executable())
-                ->setExecid('exec2')
-                ->setDescription('Descr 2')
-        ];
+        if($item == 'default_compare') {
+            $executables = [
+                (new Executable())
+                    ->setExecid('exec1')
+                    ->setType('compare')
+                    ->setDescription('Descr 1'),
+                (new Executable())
+                    ->setExecid('exec3')
+                    ->setType('compare')
+                    ->setDescription('Descr 3'),
+            ];
+        } elseif($item == 'default_compare') {
+            $executables = [
+                (new Executable())
+                    ->setExecid('exec2')
+                    ->setType('run')
+                    ->setDescription('Descr 2')
+                (new Executable())
+                    ->setExecid('exec5')
+                    ->setType('run')
+                    ->setDescription('Descr 5')
+            ];
+        }
 
         $execRepository = $this->createMock(ObjectRepository::class);
 
@@ -351,24 +367,26 @@ class ConfigurationServiceTest extends KernelTestCase
             ->willReturn($execRepository);
 
         $execRepository->expects($this->once())
-            ->method('findAll')
+            ->method('findBy')
             ->willReturn($executables);
 
         $spec = $this->config->getConfigSpecification()[$item];
         $this->assertArrayNotHasKey('options', $spec);
         $spec = $this->config->addOptions($spec);
 
-        $expected = [
-            'exec1' => 'Descr 1',
-            'exec2' => 'Descr 2',
-        ];
         $this->assertSame($expected, $spec['options']);
     }
 
     public function provideAddOptionsExecutables()
     {
-        yield ['default_compare'];
-        yield ['default_run'];
+        yield ['default_compare', [
+            'exec1' => 'Descr 1',
+            'exec3' => 'Descr 3',
+        ] ];
+        yield ['default_run', [
+            'exec2' => 'Descr 2',
+            'exec5' => 'Descr 5',
+        ] ];
     }
 
     /**

--- a/webapp/tests/Service/ConfigurationServiceTest.php
+++ b/webapp/tests/Service/ConfigurationServiceTest.php
@@ -346,7 +346,7 @@ class ConfigurationServiceTest extends KernelTestCase
                     ->setType('compare')
                     ->setDescription('Descr 3'),
             ];
-        } elseif($item == 'default_compare') {
+        } elseif($item == 'default_run') {
             $executables = [
                 (new Executable())
                     ->setExecid('exec2')

--- a/webapp/tests/Service/ConfigurationServiceTest.php
+++ b/webapp/tests/Service/ConfigurationServiceTest.php
@@ -351,11 +351,11 @@ class ConfigurationServiceTest extends KernelTestCase
                 (new Executable())
                     ->setExecid('exec2')
                     ->setType('run')
-                    ->setDescription('Descr 2')
+                    ->setDescription('Descr 2'),
                 (new Executable())
                     ->setExecid('exec5')
                     ->setType('run')
-                    ->setDescription('Descr 5')
+                    ->setDescription('Descr 5'),
             ];
         }
 


### PR DESCRIPTION
Thanks Jesse Geens for bringing this to our attention.