### PR TITLE
Fix num teams query for contests.

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -305,9 +305,9 @@ class ContestController extends BaseController
             if ($contest->isOpenToAllTeams()) {
                 $contestdata['num_teams'] = ['value' => '<i>all</i>'];
             } else {
-                $teamCount = $em
+                $teamIds = $em
                     ->createQueryBuilder()
-                    ->select('COUNT(t.teamid) AS cnt')
+                    ->select('DISTINCT t.teamid')
                     ->from(Team::class, 't')
                     ->leftJoin('t.contests', 'c')
                     ->join('t.category', 'cat')
@@ -315,8 +315,8 @@ class ContestController extends BaseController
                     ->andWhere('c.cid = :cid OR cc.cid = :cid')
                     ->setParameter(':cid', $contest->getCid())
                     ->getQuery()
-                    ->getSingleScalarResult();
-                $contestdata['num_teams'] = ['value' => $teamCount];
+                    ->getArrayResult();
+                $contestdata['num_teams'] = ['value' => count($teamIds)];
             }
 
             if ($this->getParameter('removed_intervals')) {


### PR DESCRIPTION
We can't load it in one query, since we will get data double if you add both a team directly and through a category.

Feels a bit ugly to do 3 queries, but the only other option I see would be to do a DISTINCT instead of a count and I think that is even slower.