### PR TITLE
This shorter syntax seems to work

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,26 +28,15 @@ check_w3c_css:
 
 check_w3c_html:
   stage: test
-  before_script:
-    # Takes about 1 minute to pull
-    - echo -e "section_start:`date +%s`:docker\r\e[0Kdocker pull"
-    - time docker pull domjudge/gitlabci:1.0
-    - echo -e "section_end:`date +%s`:docker\r\e[0K"
-  image: docker:stable
+  image: domjudge/gitlabci:1.0
   services:
-    - docker:19-dind
     - mariadb
   variables:
     MYSQL_ROOT_PASSWORD: password
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_DRIVER: overlay2
   script:
-  - |
-    docker run --privileged \
-      -v $CI_PROJECT_DIR:$CI_PROJECT_DIR \
-      --net=host \
-      -e "TERM=xterm-256color" -e "HOME=$HOME" -e "USER=$USER" -e "MARIADB_PORT_3306_TCP_ADDR=$MARIADB_PORT_3306_TCP_ADDR" -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
-      domjudge/gitlabci:1.0 /bin/bash -eo pipefail -c "umask 0002; cd $CI_PROJECT_DIR; script --return -qfc \"./gitlab/html.sh\" /dev/null | ts \"[%F %T]\" "
+  - ./gitlab/html.sh
   artifacts:
     when: always
     paths:
@@ -56,26 +45,15 @@ check_w3c_html:
 
 check_wcag:
   stage: test
-  before_script:
-    # Takes about 1 minute to pull
-    - echo -e "section_start:`date +%s`:docker\r\e[0Kdocker pull"
-    - time docker pull domjudge/gitlabci:1.0
-    - echo -e "section_end:`date +%s`:docker\r\e[0K"
-  image: docker:stable
+  image: domjudge/gitlabci:1.0
   services:
-    - docker:19-dind
     - mariadb
   variables:
     MYSQL_ROOT_PASSWORD: password
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_DRIVER: overlay2
   script:
-  - |
-    docker run --privileged \
-      -v $CI_PROJECT_DIR:$CI_PROJECT_DIR \
-      --net=host \
-      -e "TERM=xterm-256color" -e "HOME=$HOME" -e "USER=$USER" -e "MARIADB_PORT_3306_TCP_ADDR=$MARIADB_PORT_3306_TCP_ADDR" -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
-      domjudge/gitlabci:1.0 /bin/bash -eo pipefail -c "umask 0002; cd $CI_PROJECT_DIR; script --return -qfc \"./gitlab/wcag.sh\" /dev/null | ts \"[%F %T]\" "
+  - ./gitlab/wcag.sh
   artifacts:
     when: always
     paths:
@@ -108,26 +86,15 @@ run unit tests:
 
 integration:
   stage: test
-  before_script:
-    # Takes about 1 minute to pull
-    - echo -e "section_start:`date +%s`:docker[collapsed=true]\r\e[0Kdocker pull"
-    - time docker pull domjudge/gitlabci:1.0
-    - echo -e "section_end:`date +%s`:docker\r\e[0K"
-  image: docker:stable
+  image: domjudge/gitlabci:1.0
   services:
-    - docker:19-dind
     - mariadb
   variables:
     MYSQL_ROOT_PASSWORD: password
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_DRIVER: overlay2
   script:
-  - |
-    docker run --privileged \
-      -v $CI_PROJECT_DIR:$CI_PROJECT_DIR \
-      --net=host \
-      -e "TERM=xterm-256color" -e "HOME=$HOME" -e "USER=$USER" -e "MARIADB_PORT_3306_TCP_ADDR=$MARIADB_PORT_3306_TCP_ADDR" -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
-      domjudge/gitlabci:1.0 /bin/bash -eo pipefail -c "umask 0002; cd $CI_PROJECT_DIR; script --return -qfc \"./gitlab/integration.sh\" /dev/null | ts \"[%F %T]\" "
+    - gitlab/integration.sh
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
Updating the gitlabci:(1.0->2.0) would be slightly easier when we can use this so we do not have to pass a lot of the options.

As I'm not 100% why the other syntax is chosen we might need to check if something fails here.