### PR TITLE
Retry runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,13 +10,32 @@ include:
   - template: SAST.gitlab-ci.yml
   - template: License-Scanning.gitlab-ci.yml
 
+.retry_config: &retry_job
+  retry:
+    max: 2
+    when:
+     - always
+
+.retry_time: &tiny_job
+  timeout: 5m
+
+.retry_time: &short_job
+  timeout: 10m
+
+.retry_time: &long_job
+  timeout: 20m
+
 check syntax:
+  <<: *retry_job
+  <<: *tiny_job
   stage: test
   image: domjudge/gitlabci:2.0
   script:
     - ./gitlab/syntax.sh
 
 check_w3c_css:
+  <<: *retry_job
+  <<: *tiny_job
   stage: test
   image: 
     name: cyb3rjak3/html5validator
@@ -28,6 +47,8 @@ check_w3c_css:
     - exit $RES
 
 check_w3c_html:
+  <<: *retry_job
+  <<: *long_job
   stage: test
   image: domjudge/gitlabci:2.0
   services:
@@ -45,6 +66,8 @@ check_w3c_html:
       - w3cHtmlpublic.json
 
 check_wcag:
+  <<: *retry_job
+  <<: *short_job
   stage: test
   image: domjudge/gitlabci:2.0
   services:
@@ -61,6 +84,8 @@ check_wcag:
       - public
 
 run unit tests:
+  <<: *retry_job
+  <<: *short_job
   stage: test
   image: domjudge/gitlabci:2.0
   # Disabled for now as it drastically speeds up running unit tests and we don't use it yet
@@ -86,6 +111,8 @@ run unit tests:
       - lib/vendor/
 
 integration:
+  <<: *retry_job
+  <<: *long_job
   stage: test
   image: domjudge/gitlabci:2.0
   services:
@@ -108,6 +135,8 @@ integration:
 #      - chroot
 
 visual_pr:
+  <<: *retry_job
+  <<: *short_job
   stage: test
   before_script:
     # Takes about 1 minute to pull
@@ -136,6 +165,8 @@ visual_pr:
      - public
 
 visual_master:
+  <<: *retry_job
+  <<: *short_job
   stage: test
   before_script:
     # Takes about 1 minute to pull
@@ -172,6 +203,8 @@ visual_master:
      - public
     
 visual_compare:
+  <<: *retry_job
+  <<: *tiny_job
   stage: compare
   image: domjudge/gitlabci:1.0
   needs:


### PR DESCRIPTION
Currently gitlab jobs do not always give the same result on the same code.
- sometimes a job needs a rerun before all the jobs succeed, which is a manual action

this has a timeout of an hour which could be pretty long when you expect something to pass. This PR does a restart and defines custom timeouts for the current jobs we have so a rerun will be triggered without manual intervention and more or less in the same time as normally we would get the response on a failed job.

We could be more specific with values from:
https://docs.gitlab.com/ce/ci/yaml/#retry

but I think only in the case of the integration I'm creating more issues (assuming something breaks for the correct reasons in >20m  (3*20=60, the current timeout value) as in this case you would only get this failure in more than the 60 min we now have. In all other cases we're still well in time for the 60min which we have chosen before.

If we do not want the always I propose to not retry on these cases:
always: Retry on any failure (default).
script_failure: Retry when the script failed.
missing_dependency_failure: Retry if a dependency was missing.
runner_unsupported: Retry if the runner was unsupported.
archived_failure: Retry if the job is archived and can’t be run.
unmet_prerequisites: Retry if the job failed to complete prerequisite tasks.

and do retry on these cases:
unknown_failure: Retry when the failure reason is unknown.
api_failure: Retry on API failure.
stuck_or_timeout_failure: Retry when the job got stuck or timed out.
runner_system_failure: Retry if there was a runner system failure (for example, job setup failed).
stale_schedule: Retry if a delayed job could not be executed.
job_execution_timeout: Retry if the script exceeded the maximum execution time set for the job.

Those I have no opinion on as I think they never happen, so are dead code:
    scheduler_failure: Retry if the scheduler failed to assign the job to a runner.
    data_integrity_failure: Retry if there was a structural integrity problem detected. 