### PR TITLE
Enable caching of integration job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,12 +186,15 @@ visual_compare:
     when: always
     paths:
       - gitlabartifacts
+  cache:
+    key: integration
+    paths:
+      - lib/vendor/
 
 # TODO: Re-enable when gitlab is in better shape...
 #  cache:
 #    key: integration
 #    paths:
-#      - lib/vendor/
 #      - chroot
 
 integration_mysql:

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -110,7 +110,13 @@ sudo useradd -d /nonexistent -g nogroup -s /bin/false -u $((2000+(RANDOM%1000)))
 
 # start judgedaemon
 cd /opt/domjudge/judgehost/
+
+# Since ubuntu20.04 gitlabci image this is sometimes needed
+# It should be safe to remove this when it creates issues
+set +e
 mount -t proc proc /proc
+set -e
+
 sudo -u domjudge bin/judgedaemon -n 0 |& tee /tmp/judgedaemon.log &
 sleep 5
 


### PR DESCRIPTION
As I'm not 100% sure if it will indeed speedup currently

As discussed with @nickygerritsen this was disabled as Gitlab had issues but this should store the caches on S3 to speedup the downloading steps in the integration job