### PR TITLE
Ignore failures to run fix_permissions script if you aren't root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install-domserver-l:
 		$(INSTALL_WEBSITE) -m 0775 -d $(DESTDIR)$(domserver_webappdir)/var/$$d ; \
 	done
 # Make sure that domjudge user and webserver group can write to var/{cache,log}:
-	DESTDIR=$(DESTDIR) $(DESTDIR)$(domserver_bindir)/fix_permissions
+	-DESTDIR=$(DESTDIR) $(DESTDIR)$(domserver_bindir)/fix_permissions
 # Special case create tmpdir here, only when FHS not enabled:
 ifneq "$(FHS_ENABLED)" "yes"
 	-$(INSTALL_WEBSITE) -m 0770 -d $(DESTDIR)$(domserver_tmpdir)


### PR DESCRIPTION
Because everything else has it and it should be possible to run install as non-root user.