### PR TITLE
Show judging verifier page for JURY permission, instead of ADMIN permission.

### DIFF
--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -241,7 +241,7 @@ class JuryMiscController extends BaseController
 
     /**
      * @Route("/judging-verifier", name="jury_judging_verifier")
-     * @IsGranted("ROLE_ADMIN")
+     * @IsGranted("ROLE_JURY")
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response|StreamedResponse
      */

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -36,6 +36,7 @@
                     <li><a href="{{ path('jury_teams') }}">Teams</a></li>
                     <li><a href="{{ path('jury_team_categories') }}">Team Categories</a></li>
                     <li><a href="{{ path('jury_team_affiliations') }}">Team Affiliations</a></li>
+                    <li><a href="{{ path('jury_judging_verifier') }}">Judging verifier</a></li>
                 </ul>
             </div>
         </div>
@@ -82,7 +83,6 @@
           <li><a href="{{ path('jury_import_export') }}">Import / export</a></li>
           <li><a href="{{ path('jury_generate_passwords') }}">Manage team passwords</a></li>
           <li><a href="{{ path('jury_refresh_cache') }}">Refresh scoreboard cache</a></li>
-          <li><a href="{{ path('jury_judging_verifier') }}">Judging verifier</a></li>
           <li><a href="{{ path('jury_auditlog') }}">Audit log</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Tested by
- starting a local instance
- (as JURY user) uploading a problem with submission containing EXPECTED_RESULTS tags
- going to the judging_verifier page (link now at the bottom of the `before contest` section)
- click the blue 'verify' button'
- submissions are correctly marked as verified.

![img-2020-12-08-190516](https://user-images.githubusercontent.com/6233682/101523297-b500dc00-3988-11eb-80bb-972777978a36.png)
![img-2020-12-08-190730](https://user-images.githubusercontent.com/6233682/101523305-b7633600-3988-11eb-8283-48109767e01f.png)
