### PR TITLE
Fix teams_submitted metric

### DIFF
--- a/webapp/src/Controller/API/MetricsController.php
+++ b/webapp/src/Controller/API/MetricsController.php
@@ -114,9 +114,8 @@ class MetricsController extends AbstractFOSRestController
                 $result = $s->getResult();
                 if ($s->getResult() == "correct") {
                     $teamids_correct[$s->getTeam()->getTeamid()] = 1;
-                } else {
-                    $teamids_submitted[$s->getTeam()->getTeamid()] = 1;
                 }
+                $teamids_submitted[$s->getTeam()->getTeamid()] = 1;
             }
             $m['teams_submitted']->set(count($teamids_submitted), $labels);
             $m['teams_correct']->set(count($teamids_correct), $labels);


### PR DESCRIPTION
Previously it was only counting teams that had submitted and gotten at least one judgement incorrect, which is quite a useless metric. It also overlapped with the teams_correct metric, so you couldn't do something like `teams_correct`+`teams_submitted` to get the total number of teams that had submitted something(whether successfully or not)