### PR TITLE
Add API actions to add a single team, organization and group

### DIFF
--- a/webapp/src/Controller/API/AbstractRestController.php
+++ b/webapp/src/Controller/API/AbstractRestController.php
@@ -107,18 +107,14 @@ abstract class AbstractRestController extends AbstractFOSRestController
     /**
      * Render the given data using the correct groups
      *
-     * @param Request  $request
      * @param mixed    $data
-     * @param int      $statusCode
-     * @param string[] $headers
-     *
-     * @return Response
+     * @param string[] $extraheaders
      */
     protected function renderData(
         Request $request,
         $data,
         int $statusCode = Response::HTTP_OK,
-        array $headers = []
+        array $extraheaders = []
     ): Response {
         $view = $this->view($data);
 
@@ -134,19 +130,15 @@ abstract class AbstractRestController extends AbstractFOSRestController
 
         $response = $this->handleView($view);
         $response->setStatusCode($statusCode);
-        $response->headers->add($headers);
+        $response->headers->add($extraheaders);
         return $response;
     }
 
     /**
      * Render the given create data using the correct groups
      *
-     * @param Request    $request
      * @param mixed      $data
-     * @param string     $routeType
      * @param string|int $id
-     *
-     * @return Response
      */
     protected function renderCreateData(
         Request $request,

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -3,11 +3,15 @@
 namespace App\Controller\API;
 
 use App\Entity\TeamCategory;
+use App\Service\ImportExportService;
 use Doctrine\ORM\QueryBuilder;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * @Rest\Route("/contests/{cid}/groups")
@@ -64,6 +68,44 @@ class GroupController extends AbstractRestController
     public function singleAction(Request $request, string $id)
     {
         return parent::performSingleAction($request, $id);
+    }
+
+    /**
+     * Add a new group
+     *
+     * @param Request             $request
+     * @param ImportExportService $importExport
+     *
+     * @return Response
+     *
+     * @Rest\Post()
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_WRITER')")
+     * @OA\RequestBody(
+     *     required=true,
+     *     @OA\MediaType(
+     *         mediaType="multipart/form-data",
+     *         @OA\Schema(ref="#/components/schemas/TeamCategory")
+     *     ),
+     *     @OA\MediaType(
+     *         mediaType="application/json",
+     *         @OA\Schema(ref="#/components/schemas/TeamCategory")
+     *     )
+     * )
+     * @OA\Response(
+     *     response="200",
+     *     description="Returns the added group",
+     *     @Model(type=TeamCategory::class)
+     * )
+     */
+    public function addAction(Request $request, ImportExportService $importExport): Response
+    {
+        $saved = [];
+        $importExport->importGroupsJson([$request->request->all()], $message, $saved);
+        if (!empty($message)) {
+            throw new BadRequestHttpException("Error while adding group: $message");
+        }
+
+        return $this->renderData($request, $saved[0]);
     }
 
     /**

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\API;
 
+use App\Entity\TeamAffiliation;
 use App\Entity\TeamCategory;
 use App\Service\ImportExportService;
 use Doctrine\ORM\QueryBuilder;
@@ -92,7 +93,7 @@ class GroupController extends AbstractRestController
      *     )
      * )
      * @OA\Response(
-     *     response="200",
+     *     response="201",
      *     description="Returns the added group",
      *     @Model(type=TeamCategory::class)
      * )
@@ -105,7 +106,10 @@ class GroupController extends AbstractRestController
             throw new BadRequestHttpException("Error while adding group: $message");
         }
 
-        return $this->renderData($request, $saved[0]);
+        $group = $saved[0];
+        $id = $group->getCategoryid();
+
+        return $this->renderCreateData($request, $saved[0], 'group', $id);
     }
 
     /**

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -74,11 +74,6 @@ class GroupController extends AbstractRestController
     /**
      * Add a new group
      *
-     * @param Request             $request
-     * @param ImportExportService $importExport
-     *
-     * @return Response
-     *
      * @Rest\Post()
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_WRITER')")
      * @OA\RequestBody(

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\API;
 
+use App\Entity\Team;
 use App\Entity\TeamAffiliation;
 use App\Service\ImportExportService;
 use Doctrine\ORM\QueryBuilder;
@@ -92,7 +93,7 @@ class OrganizationController extends AbstractRestController
      *     )
      * )
      * @OA\Response(
-     *     response="200",
+     *     response="201",
      *     description="Returns the added organization",
      *     @Model(type=TeamAffiliation::class)
      * )
@@ -105,7 +106,12 @@ class OrganizationController extends AbstractRestController
             throw new BadRequestHttpException("Error while adding organization: $message");
         }
 
-        return $this->renderData($request, $saved[0]);
+        $organization = $saved[0];
+        $idField = $this->eventLogService->externalIdFieldForEntity(TeamAffiliation::class) ?? 'affilid';
+        $method = sprintf('get%s', ucfirst($idField));
+        $id = call_user_func([$organization, $method]);
+
+        return $this->renderCreateData($request, $saved[0], 'organization', $id);
     }
 
     /**

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -74,11 +74,6 @@ class OrganizationController extends AbstractRestController
     /**
      * Add a new organization
      *
-     * @param Request             $request
-     * @param ImportExportService $importExport
-     *
-     * @return Response
-     *
      * @Rest\Post()
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_WRITER')")
      * @OA\RequestBody(

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -87,11 +87,6 @@ class TeamController extends AbstractRestController
     /**
      * Add a new team
      *
-     * @param Request             $request
-     * @param ImportExportService $importExport
-     *
-     * @return Response
-     *
      * @Rest\Post()
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_WRITER')")
      * @OA\RequestBody(

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -106,7 +106,7 @@ class TeamController extends AbstractRestController
      *     )
      * )
      * @OA\Response(
-     *     response="200",
+     *     response="201",
      *     description="Returns the added team",
      *     @Model(type=Team::class)
      * )
@@ -119,7 +119,12 @@ class TeamController extends AbstractRestController
             throw new BadRequestHttpException("Error while adding team: $message");
         }
 
-        return $this->renderData($request, $saved[0]);
+        $team = $saved[0];
+        $idField = $this->eventLogService->externalIdFieldForEntity(Team::class) ?? 'teamid';
+        $method = sprintf('get%s', ucfirst($idField));
+        $id = call_user_func([$team, $method]);
+
+        return $this->renderCreateData($request, $saved[0], 'team', $id);
     }
 
     /**


### PR DESCRIPTION
This uses the existing ImportExportService to be able to add single entities. You can `POST` both JSON as well as form data.