### PR TITLE
Add contest name to title elements.

### DIFF
--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -1,6 +1,6 @@
 {% extends "jury/base.html.twig" %}
 
-{% block title %}Analysis - Contest{% endblock %}
+{% block title %}Analysis - Contest {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
 {{ parent() }}

--- a/webapp/templates/jury/analysis/problem.html.twig
+++ b/webapp/templates/jury/analysis/problem.html.twig
@@ -1,6 +1,6 @@
 {% extends "jury/base.html.twig" %}
 
-{% block title %}Analysis - Problem {{ problem.probid }}{% endblock %}
+{% block title %}Analysis - Problem {{ problem.probid }} {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
 {{ parent() }}

--- a/webapp/templates/jury/analysis/team.html.twig
+++ b/webapp/templates/jury/analysis/team.html.twig
@@ -1,6 +1,6 @@
 {% extends "jury/base.html.twig" %}
 
-{% block title %}Analysis - Team {{ team.effectiveName }}{% endblock %}
+{% block title %}Analysis - Team {{ team.effectiveName }} {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
 {{ parent() }}

--- a/webapp/templates/jury/balloons.html.twig
+++ b/webapp/templates/jury/balloons.html.twig
@@ -1,7 +1,7 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
-{% block title %}Balloons - {{ parent() }}{% endblock %}
+{% block title %}Balloons {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
     {{ parent() }}

--- a/webapp/templates/jury/scoreboard.html.twig
+++ b/webapp/templates/jury/scoreboard.html.twig
@@ -1,7 +1,7 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
-{% block title %}Scoreboard - {{ parent() }}{% endblock %}
+{% block title %}Scoreboard {{ contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
     {{ parent() }}

--- a/webapp/templates/jury/submissions.html.twig
+++ b/webapp/templates/jury/submissions.html.twig
@@ -1,7 +1,7 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
-{% block title %}Submissions - {{ parent() }}{% endblock %}
+{% block title %}Submissions {{ current_contest.shortname | default ('') }} - {{ parent() }}{% endblock %}
 
 {% block extrahead %}
     {{ parent() }}

--- a/webapp/templates/public/problems.html.twig
+++ b/webapp/templates/public/problems.html.twig
@@ -1,6 +1,6 @@
 {% extends "public/base.html.twig" %}
 
-{% block title %}Contest problems - {{ parent() }}{% endblock %}
+{% block title %}Contest problems {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     {% include 'partials/problem_list.html.twig' with {

--- a/webapp/templates/public/scoreboard.html.twig
+++ b/webapp/templates/public/scoreboard.html.twig
@@ -1,6 +1,6 @@
 {% extends "public/base.html.twig" %}
 
-{% block title %}Scoreboard - {{ parent() }}{% endblock %}
+{% block title %}Scoreboard {{ contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 {% block content %}
     {% set banner = 'images/banner.png' %}
     {% if bannerExists() %}

--- a/webapp/templates/team/problems.html.twig
+++ b/webapp/templates/team/problems.html.twig
@@ -1,6 +1,6 @@
 {% extends "team/base.html.twig" %}
 
-{% block title %}Contest problems - {{ parent() }}{% endblock %}
+{% block title %}Contest problems {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 
 {% block content %}
     {% include 'partials/problem_list.html.twig' with {

--- a/webapp/templates/team/scoreboard.html.twig
+++ b/webapp/templates/team/scoreboard.html.twig
@@ -1,6 +1,6 @@
 {% extends "team/base.html.twig" %}
 
-{% block title %}Scoreboard - {{ parent() }}{% endblock %}
+{% block title %}Scoreboard {{ contest.shortname | default('') }} - {{ parent() }}{% endblock %}
 {% block content %}
     <div data-ajax-refresh-target data-ajax-refresh-after="initializeScoreboard" class="mt-3">
         {% include 'partials/scoreboard.html.twig' with {jury: false, public: false, current_contest: current_team_contest} %}


### PR DESCRIPTION
So if you have multiple tabs open you can see which one is which.

I've done this for pages that are specific to a contest: scoreboard, problemset, submissions, balloons, analysis. It does not make sense to me to do it globally. e.g. "Configuration settings NWERC20" is not a good title since the configuration settings are not contest specific.