### PR TITLE
Fix API exception renderer to display messages correctly for configured errors.

### DIFF
--- a/webapp/config/services.yaml
+++ b/webapp/config/services.yaml
@@ -59,7 +59,7 @@ services:
         public: true
         class: App\FosRestBundle\FlattenExceptionHandler
         arguments:
-            - '@fos_rest.exception.codes_map'
+            - '@fos_rest.exception.messages_map'
             - '%kernel.debug%'
 
     Metadata\MetadataFactoryInterface: '@jms_serializer.metadata_factory'

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -113,7 +113,7 @@ class SubmissionController extends AbstractRestController
      * @return int
      * @Rest\Post("")
      * @OA\Post()
-     * @IsGranted("ROLE_TEAM")
+     * @IsGranted("ROLE_TEAM", message="You need to have the Team Member role to add a submission")
      * Uploading an array of files in swagger is not supported, see
      * @OA\RequestBody(
      *     required=true,


### PR DESCRIPTION
Also display usable message when a team is not linked when submitting.

This is the better fix for #945.

In prod mode when you don't have the team permission you now get:

```bash
$ http --auth admin:admin POST http://localhost:12345/api/contests/2/submissions
HTTP/1.1 403 Forbidden
Access-Control-Allow-Origin: *
Cache-Control: no-cache, private
Connection: keep-alive
Content-Type: application/json
Date: Mon, 21 Dec 2020 16:41:17 GMT
Server: nginx/1.18.0 (Ubuntu)
Transfer-Encoding: chunked
Vary: Accept

{
    "code": 403,
    "message": "You need to be a team to add a submission"
}
```

And when you do have the permission but no team linked:

```bash
$ http --auth admin:admin POST http://localhost:12345/api/contests/2/submissions  problem=dummy language=dummy
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Cache-Control: no-cache, private
Connection: keep-alive
Content-Type: application/json
Date: Mon, 21 Dec 2020 16:42:08 GMT
Server: nginx/1.18.0 (Ubuntu)
Transfer-Encoding: chunked
Vary: Accept

{
    "code": 400,
    "message": "User does not belong to a team"
}
```

In dev mode you get the backtrace as well, but you also get this message.