### PR TITLE
Don't swallow the first leading newline for program output.

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -608,14 +608,16 @@
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no validator output.</p>
                                 {% else %}
-                                    <pre class="output_text">{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
+                                    <pre class="output_text">
+{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
                                 {% endif %}
                             {% else %}
                                 <h5>Diff output</h5>
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no diff output.</p>
                                 {% else %}
-                                    <pre class="output_text">{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
+                                    <pre class="output_text">
+{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
                                 {% endif %}
 
                                 {% if run.firstJudgingRun.runresult != 'correct' %}
@@ -635,7 +637,8 @@
                                 {% if runsOutput[runIdx].output_run is empty %}
                                     <p class="nodata">There was no program output.</p>
                                 {% else %}
-                                    <pre class="output_text">{{ runsOutput[runIdx].output_run | parseRunDiff }}</pre>
+                                    <pre class="output_text">
+{{ runsOutput[runIdx].output_run | parseRunDiff }}</pre>
                                 {% endif %}
                             {% endif %}
 

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -100,21 +100,24 @@
 
                         <h6 class="mt-3">Program output</h6>
                         {% if run.output_run is not empty %}
-                            <pre class="output_text">{{ run.output_run }}</pre>
+                            <pre class="output_text">
+{{ run.output_run }}</pre>
                         {% else %}
                             <p class="nodata">There was no program output.</p>
                         {% endif %}
 
                         <h6 class="mt-3">Diff output</h6>
                         {% if run.output_diff is not empty %}
-                            <pre class="output_text">{{ run.output_diff }}</pre>
+                            <pre class="output_text">
+{{ run.output_diff }}</pre>
                         {% else %}
                             <p class="nodata">There was no diff output.</p>
                         {% endif %}
 
                         <h6 class="mt-3">Error output (info/debug/errors)</h6>
                         {% if run.output_error is not empty %}
-                            <pre class="output_text">{{ run.output_error }}</pre>
+                            <pre class="output_text">
+{{ run.output_error }}</pre>
                         {% else %}
                             <p class="nodata">There was no stderr output.</p>
                         {% endif %}


### PR DESCRIPTION
While the default validator typically ignores whitespace, it may be
configured differently. Also it can become confusing when looking at
debugging output.

Thanks to Kevin Thiotanry for reporting!