### PR TITLE
Repeat firefox request to warm up cache

### DIFF
--- a/gitlab/visualpr.sh
+++ b/gitlab/visualpr.sh
@@ -124,6 +124,9 @@ do
         urlpath=$(sed "s/$prefix//g"<<<$file)
         # Small risk of collision
         storepath=$(sed "s/\//_s_/g"<<<$urlpath)
+	# Sometimes not all images load, (See https://bugzilla.mozilla.org/show_bug.cgi?id=1412061)
+	# We first run the request to have a local cache of the page by disregarding the output
+	firefox -screenshot /dev/null http://localhost/$url/$urlpath
         firefox -screenshot $STORAGEDIR/$storepath-ff.png http://localhost/$url/$urlpath
     done
 done


### PR DESCRIPTION
Other alternatives would be to use:
- https://wkhtmltopdf.org/
- Different CI image where chromium does not use the snap version

Example of failure can be found at: https://gitlab.com/DOMjudge/domjudge/-/jobs/938481152/artifacts/file/screenshotsmaster/public.html-ff.png