### PR TITLE
Clean up all entities.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -889,7 +889,7 @@ class JudgehostController extends AbstractFOSRestController
             $judgingRun->setOutput($judgingRunOutput);
             $judgingRun
                 ->setRunresult($runResult)
-                ->setRuntime($runTime)
+                ->setRuntime((float)$runTime)
                 ->setEndtime(Utils::now());
             $judgingRunOutput
                 ->setOutputRun(base64_decode($outputRun))

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -155,7 +155,7 @@ class ContestController extends BaseController
                 return $this->redirectToRoute('jury_contests');
             }
 
-            $juryTimeData = $contest->getJuryTimeData();
+            $juryTimeData = $contest->getDataForJuryInterface();
             if (!$juryTimeData[$time]['show_button']) {
                 throw new BadRequestHttpException(
                     sprintf('Cannot update %s time at this moment', $time)

--- a/webapp/src/Entity/AuditLog.php
+++ b/webapp/src/Entity/AuditLog.php
@@ -108,13 +108,13 @@ class AuditLog
         return $this->cid;
     }
 
-    public function setUser(string $user): AuditLog
+    public function setUser(?string $user): AuditLog
     {
         $this->user = $user;
         return $this;
     }
 
-    public function getUser(): string
+    public function getUser(): ?string
     {
         return $this->user;
     }

--- a/webapp/src/Entity/AuditLog.php
+++ b/webapp/src/Entity/AuditLog.php
@@ -5,7 +5,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Log of all actions performed
+ * Log of all actions performed.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="auditlog",
@@ -78,180 +79,86 @@ class AuditLog
      */
     private $extrainfo;
 
-    /**
-     * Get logid
-     *
-     * @return integer
-     */
-    public function getLogid()
+    public function getLogid(): int
     {
         return $this->logid;
     }
 
-    /**
-     * Set logtime
-     *
-     * @param string $logtime
-     *
-     * @return AuditLog
-     */
-    public function setLogtime($logtime)
+    /** @param string|float $logtime */
+    public function setLogtime($logtime): AuditLog
     {
         $this->logtime = $logtime;
-
         return $this;
     }
 
-    /**
-     * Get logtime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getLogtime()
     {
         return $this->logtime;
     }
 
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return AuditLog
-     */
-    public function setCid($cid)
+    public function setCid(?int $cid): AuditLog
     {
         $this->cid = $cid;
-
         return $this;
     }
 
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
+    public function getCid(): ?int
     {
         return $this->cid;
     }
 
-    /**
-     * Set user
-     *
-     * @param string $user
-     *
-     * @return AuditLog
-     */
-    public function setUser($user)
+    public function setUser(string $user): AuditLog
     {
         $this->user = $user;
-
         return $this;
     }
 
-    /**
-     * Get user
-     *
-     * @return string
-     */
-    public function getUser()
+    public function getUser(): string
     {
         return $this->user;
     }
 
-    /**
-     * Set datatype
-     *
-     * @param string $datatype
-     *
-     * @return AuditLog
-     */
-    public function setDatatype($datatype)
+    public function setDatatype(string $datatype): AuditLog
     {
         $this->datatype = $datatype;
-
         return $this;
     }
 
-    /**
-     * Get datatype
-     *
-     * @return string
-     */
-    public function getDatatype()
+    public function getDatatype(): string
     {
         return $this->datatype;
     }
 
-    /**
-     * Set dataid
-     *
-     * @param string $dataid
-     *
-     * @return AuditLog
-     */
-    public function setDataid($dataid)
+    public function setDataid(string $dataid): AuditLog
     {
         $this->dataid = $dataid;
-
         return $this;
     }
 
-    /**
-     * Get dataid
-     *
-     * @return string
-     */
-    public function getDataid()
+    public function getDataid(): string
     {
         return $this->dataid;
     }
 
-    /**
-     * Set action
-     *
-     * @param string $action
-     *
-     * @return AuditLog
-     */
-    public function setAction($action)
+    public function setAction(string $action): AuditLog
     {
         $this->action = $action;
-
         return $this;
     }
 
-    /**
-     * Get action
-     *
-     * @return string
-     */
-    public function getAction()
+    public function getAction(): string
     {
         return $this->action;
     }
 
-    /**
-     * Set extrainfo
-     *
-     * @param string $extrainfo
-     *
-     * @return AuditLog
-     */
-    public function setExtrainfo($extrainfo)
+    public function setExtrainfo(?string $extrainfo): AuditLog
     {
         $this->extrainfo = $extrainfo;
-
         return $this;
     }
 
-    /**
-     * Get extrainfo
-     *
-     * @return string
-     */
-    public function getExtrainfo()
+    public function getExtrainfo(): ?string
     {
         return $this->extrainfo;
     }

--- a/webapp/src/Entity/Balloon.php
+++ b/webapp/src/Entity/Balloon.php
@@ -4,7 +4,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Balloons to be handed out
+ * Balloons to be handed out.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="balloon",
@@ -38,61 +39,29 @@ class Balloon
      */
     private $submission;
 
-
-    /**
-     * Get balloonid
-     *
-     * @return integer
-     */
-    public function getBalloonid()
+    public function getBalloonid(): int
     {
         return $this->balloonid;
     }
 
-    /**
-     * Set done
-     *
-     * @param boolean $done
-     *
-     * @return Balloon
-     */
-    public function setDone($done)
+    public function setDone(bool $done): Balloon
     {
         $this->done = $done;
-
         return $this;
     }
 
-    /**
-     * Get done
-     *
-     * @return boolean
-     */
     public function getDone()
     {
         return $this->done;
     }
 
-    /**
-     * Set submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Balloon
-     */
-    public function setSubmission(\App\Entity\Submission $submission = null)
+    public function setSubmission(Submission $submission = null): Balloon
     {
         $this->submission = $submission;
-
         return $this;
     }
 
-    /**
-     * Get submission
-     *
-     * @return \App\Entity\Submission
-     */
-    public function getSubmission()
+    public function getSubmission(): Submission
     {
         return $this->submission;
     }

--- a/webapp/src/Entity/BaseApiEntity.php
+++ b/webapp/src/Entity/BaseApiEntity.php
@@ -15,19 +15,18 @@ use Exception;
 abstract class BaseApiEntity
 {
     /**
-     * Get the API ID field name for this entity
-     * @param EventLogService $eventLogService
-     * @return string
+     * Get the API ID field name for this entity.
+     *
      * @throws Exception
      */
-    public function getApiIdField(EventLogService $eventLogService)
+    public function getApiIdField(EventLogService $eventLogService): string
     {
         return $eventLogService->apiIdFieldForEntity($this);
     }
 
     /**
-     * Get the API ID for this entity
-     * @param EventLogService $eventLogService
+     * Get the API ID for this entity.
+     *
      * @return mixed
      * @throws Exception
      */

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -9,7 +9,8 @@ use JMS\Serializer\Annotation as Serializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
- * Clarification requests by teams and responses by the jury
+ * Clarification requests by teams and responses by the jury.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="clarification",
@@ -143,283 +144,144 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
      */
     private $recipient;
 
-
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->replies = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->replies = new ArrayCollection();
     }
 
-    /**
-     * Set clarid
-     *
-     * @param integer $clarid
-     *
-     * @return Clarification
-     */
-    public function setClarid($clarid)
+    public function setClarid(int $clarid): Clarification
     {
         $this->clarid = $clarid;
-
         return $this;
     }
 
-    /**
-     * Get clarid
-     *
-     * @return integer
-     */
-    public function getClarid()
+    public function getClarid(): int
     {
         return $this->clarid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return Clarification
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): Clarification
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): ?string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set cid
-     *
-     * @param integer $cid
-     *
-     * @return Clarification
-     */
-    public function setCid($cid)
+    public function setCid(int $cid): Clarification
     {
         $this->cid = $cid;
-
         return $this;
     }
 
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
+    public function getCid(): int
     {
         return $this->cid;
     }
 
-    /**
-     * Set submittime
-     *
-     * @param double $submittime
-     *
-     * @return Clarification
-     */
-    public function setSubmittime($submittime)
+    /** @param string|float $submittime */
+    public function setSubmittime($submittime): Clarification
     {
         $this->submittime = $submittime;
-
         return $this;
     }
 
-    /**
-     * Get submittime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getSubmittime()
     {
         return $this->submittime;
     }
 
     /**
-     * Get the absolute submit time for this clarification
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("time")
      * @Serializer\Type("string")
      */
-    public function getAbsoluteSubmitTime()
+    public function getAbsoluteSubmitTime(): string
     {
         return Utils::absTime($this->getSubmittime());
     }
 
     /**
-     * Get the relative submit time for this clarification
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("contest_time")
      * @Serializer\Type("string")
      */
-    public function getRelativeSubmitTime()
+    public function getRelativeSubmitTime(): string
     {
         return Utils::relTime($this->getSubmittime() - $this->getContest()->getStarttime());
     }
 
-    /**
-     * Set juryMember
-     *
-     * @param string $juryMember
-     *
-     * @return Clarification
-     */
-    public function setJuryMember($juryMember)
+    public function setJuryMember(string $juryMember): Clarification
     {
         $this->jury_member = $juryMember;
-
         return $this;
     }
 
-    /**
-     * Get juryMember
-     *
-     * @return string
-     */
-    public function getJuryMember()
+    public function getJuryMember(): string
     {
         return $this->jury_member;
     }
 
-    /**
-     * Set category
-     *
-     * @param string $category
-     *
-     * @return Clarification
-     */
-    public function setCategory($category)
+    public function setCategory(?string $category): Clarification
     {
         $this->category = $category;
-
         return $this;
     }
 
-    /**
-     * Get category
-     *
-     * @return string
-     */
-    public function getCategory()
+    public function getCategory(): string
     {
         return $this->category;
     }
 
-    /**
-     * Set queue
-     *
-     * @param string $queue
-     *
-     * @return Clarification
-     */
-    public function setQueue($queue)
+    public function setQueue(?string $queue): Clarification
     {
         $this->queue = $queue;
-
         return $this;
     }
 
-    /**
-     * Get queue
-     *
-     * @return string
-     */
-    public function getQueue()
+    public function getQueue(): ?string
     {
         return $this->queue;
     }
 
-    /**
-     * Set body
-     *
-     * @param string $body
-     *
-     * @return Clarification
-     */
-    public function setBody($body)
+    public function setBody(string $body): Clarification
     {
         $this->body = $body;
-
         return $this;
     }
 
-    /**
-     * Get body
-     *
-     * @return string
-     */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
 
-    /**
-     * Set answered
-     *
-     * @param boolean $answered
-     *
-     * @return Clarification
-     */
-    public function setAnswered($answered)
+    public function setAnswered(bool $answered): Clarification
     {
         $this->answered = $answered;
-
         return $this;
     }
 
-    /**
-     * Get answered
-     *
-     * @return boolean
-     */
-    public function getAnswered()
+    public function getAnswered(): bool
     {
         return $this->answered;
     }
 
-    /**
-     * Set problem
-     *
-     * @param \App\Entity\Problem $problem
-     *
-     * @return Clarification
-     */
-    public function setProblem(\App\Entity\Problem $problem = null)
+    public function setProblem(Problem $problem = null): Clarification
     {
         $this->problem = $problem;
-
         return $this;
     }
 
-    /**
-     * Get problem
-     *
-     * @return \App\Entity\Problem
-     */
-    public function getProblem()
+    public function getProblem(): ?Problem
     {
         return $this->problem;
     }
 
     /**
-     * @return int|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("problem_id")
      * @Serializer\Type("string")
@@ -429,56 +291,29 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         return $this->getProblem() ? $this->getProblem()->getProbid() : null;
     }
 
-    /**
-     * Set contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return Clarification
-     */
-    public function setContest(\App\Entity\Contest $contest = null)
+    public function setContest(Contest $contest = null): Clarification
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return \App\Entity\Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set inReplyTo
-     *
-     * @param \App\Entity\Clarification $inReplyTo
-     *
-     * @return Clarification
-     */
-    public function setInReplyTo(\App\Entity\Clarification $inReplyTo = null)
+    public function setInReplyTo(Clarification $inReplyTo = null): Clarification
     {
         $this->in_reply_to = $inReplyTo;
-
         return $this;
     }
 
-    /**
-     * Get inReplyTo
-     *
-     * @return \App\Entity\Clarification
-     */
-    public function getInReplyTo()
+    public function getInReplyTo(): ?Clarification
     {
         return $this->in_reply_to;
     }
 
     /**
-     * @return int|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("reply_to_id")
      * @Serializer\Type("string")
@@ -488,66 +323,34 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         return $this->getInReplyTo() ? $this->getInReplyTo()->getClarid() : null;
     }
 
-    /**
-     * Add reply
-     *
-     * @param \App\Entity\Clarification $reply
-     *
-     * @return Clarification
-     */
-    public function addReply(\App\Entity\Clarification $reply)
+    public function addReply(Clarification $reply): Clarification
     {
         $this->replies[] = $reply;
-
         return $this;
     }
 
-    /**
-     * Remove reply
-     *
-     * @param \App\Entity\Clarification $reply
-     */
-    public function removeReply(\App\Entity\Clarification $reply)
+    public function removeReply(Clarification $reply)
     {
         $this->replies->removeElement($reply);
     }
 
-    /**
-     * Get replies
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getReplies()
+    public function getReplies(): Collection
     {
         return $this->replies;
     }
 
-    /**
-     * Set sender
-     *
-     * @param \App\Entity\Team $sender
-     *
-     * @return Clarification
-     */
-    public function setSender(\App\Entity\Team $sender = null)
+    public function setSender(Team $sender = null): Clarification
     {
         $this->sender = $sender;
-
         return $this;
     }
 
-    /**
-     * Get sender
-     *
-     * @return \App\Entity\Team
-     */
-    public function getSender()
+    public function getSender(): ?Team
     {
         return $this->sender;
     }
 
     /**
-     * @return int|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("from_team_id")
      * @Serializer\Type("string")
@@ -557,32 +360,18 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         return $this->getSender() ? $this->getSender()->getTeamid() : null;
     }
 
-    /**
-     * Set recipient
-     *
-     * @param \App\Entity\Team $recipient
-     *
-     * @return Clarification
-     */
-    public function setRecipient(\App\Entity\Team $recipient = null)
+    public function setRecipient(Team $recipient = null): Clarification
     {
         $this->recipient = $recipient;
-
         return $this;
     }
 
-    /**
-     * Get recipient
-     *
-     * @return \App\Entity\Team
-     */
-    public function getRecipient()
+    public function getRecipient(): ?Team
     {
         return $this->recipient;
     }
 
     /**
-     * @return int|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("to_team_id")
      * @Serializer\Type("string")
@@ -597,25 +386,20 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
      *
      * This method should return an array with as keys the JSON field names and as values the actual entity
      * objects that the SetExternalIdVisitor should check for applicable external ID's
-     * @return array
      */
     public function getExternalRelationships(): array
     {
         return [
             'from_team_id' => $this->getSender(),
-            'to_team_id' => $this->getRecipient(),
-            'problem_id' => $this->getProblem(),
-            'reply_to_id' => $this->getInReplyTo()
+            'to_team_id'   => $this->getRecipient(),
+            'problem_id'   => $this->getProblem(),
+            'reply_to_id'  => $this->getInReplyTo()
         ];
     }
 
-    /**
-     * Get the summary for this clarification
-     * @return string
-     */
     public function getSummary(): string
     {
-        // when making a summary, try to ignore the quoted text, and replace newlines by spaces.
+        // When compiling a summary, try to ignore the quoted text, and replace newlines by spaces.
         $split = explode("\n", $this->getBody());
         $newBody = '';
         foreach ($split as $line) {

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -221,7 +221,7 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         return $this;
     }
 
-    public function getJuryMember(): string
+    public function getJuryMember(): ?string
     {
         return $this->jury_member;
     }
@@ -232,7 +232,7 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
         return $this;
     }
 
-    public function getCategory(): string
+    public function getCategory(): ?string
     {
         return $this->category;
     }

--- a/webapp/src/Entity/Configuration.php
+++ b/webapp/src/Entity/Configuration.php
@@ -4,7 +4,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Compile, compare, and run script executable bundles
+ * Compile, compare, and run script executable bundles.
+ *
  * @ORM\Entity()
  * @ORM\Table(name="configuration",
  *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Global configuration variables"},
@@ -36,48 +37,26 @@ class Configuration
      */
     private $value;
 
-    /**
-     * Get configid
-     *
-     * @return integer
-     */
-    public function getConfigid()
+    public function getConfigid(): int
     {
         return $this->configid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return Configuration
-     */
-    public function setName($name)
+    public function setName(string $name): Configuration
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * Set value
-     *
      * @param mixed $value
-     *
-     * @return Configuration
      */
-    public function setValue($value)
+    public function setValue($value): Configuration
     {
         // Do not use 'True'/'False' but 1/0 since the former cannot be parsed by the old code.
         if ($value === TRUE) {
@@ -87,13 +66,10 @@ class Configuration
         }
 
         $this->value = $value;
-
         return $this;
     }
 
     /**
-     * Get value
-     *
      * @return mixed
      */
     public function getValue()

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -15,7 +15,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
- * Contests that will be run with this install
+ * Contests that will be run with this install.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="contest",
@@ -329,132 +330,73 @@ class Contest extends BaseApiEntity
      */
     private $removedIntervals;
 
-
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->problems         = new ArrayCollection();
         $this->teams            = new ArrayCollection();
         $this->removedIntervals = new ArrayCollection();
-        $this->clarifications = new ArrayCollection();
-        $this->submissions = new ArrayCollection();
-        $this->internal_errors = new ArrayCollection();
-        $this->team_categories = new ArrayCollection();
+        $this->clarifications   = new ArrayCollection();
+        $this->submissions      = new ArrayCollection();
+        $this->internal_errors  = new ArrayCollection();
+        $this->team_categories  = new ArrayCollection();
     }
 
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
+    public function getCid(): int
     {
         return $this->cid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return Contest
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): Contest
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return Contest
-     */
-    public function setName($name)
+    public function setName(string $name): Contest
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set shortname
-     *
-     * @param string $shortname
-     *
-     * @return Contest
-     */
-    public function setShortname($shortname)
+    public function setShortname(string $shortname): Contest
     {
         $this->shortname = $shortname;
-
         return $this;
     }
 
-    /**
-     * Get shortname
-     *
-     * @return string
-     */
-    public function getShortname()
+    public function getShortname(): string
     {
         return $this->shortname;
     }
 
-    /**
-     * Get activatetime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getActivatetime()
     {
         return $this->activatetime;
     }
 
-    /**
-     * Set starttime
-     *
-     * @param double $starttime
-     *
-     * @return Contest
-     */
-    public function setStarttime($starttime)
+    /** @param string|float $starttime */
+    public function setStarttime($starttime): Contest
     {
         $this->starttime = $starttime;
-
         return $this;
     }
 
     /**
-     * Get starttime, or NULL if disabled
+     * Get starttime, or NULL if disabled.
      *
-     * @param bool $nullWhenDisabled If true, return null if the start time is disabled
-     * @return double
+     * @param bool $nullWhenDisabled If true, return null if the start time is disabled, defaults to true.
+     * @return string|float|null
      */
     public function getStarttime(bool $nullWhenDisabled = true)
     {
@@ -466,192 +408,108 @@ class Contest extends BaseApiEntity
     }
 
     /**
-     * Get the start time for this contest
-     *
-     * @return \DateTime|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("start_time")
      * @Serializer\Type("DateTime")
      */
-    public function getStartTimeObject()
+    public function getStartTimeObject(): ?\DateTime
     {
         return $this->getStarttime() ? new \DateTime(Utils::absTime($this->getStarttime())) : null;
     }
 
-    /**
-     * Set starttime_enabled
-     *
-     * @param boolean $starttimeEnabled
-     *
-     * @return Contest
-     */
-    public function setStarttimeEnabled($starttimeEnabled)
+    public function setStarttimeEnabled(bool $starttimeEnabled): Contest
     {
         $this->starttimeEnabled = $starttimeEnabled;
-
         return $this;
     }
 
-    /**
-     * Get starttime_enabled
-     *
-     * @return boolean
-     */
-    public function getStarttimeEnabled()
+    public function getStarttimeEnabled(): bool
     {
         return $this->starttimeEnabled;
     }
 
-    /**
-     * Get freezetime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getFreezetime()
     {
         return $this->freezetime;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
     /**
-     * Get the end time for this contest
-     *
-     * @return \DateTime|null
      * @throws \Exception
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("end_time")
      * @Serializer\Type("DateTime")
      * @Serializer\Groups({"Nonstrict"})
      */
-    public function getEndTimeObject()
+    public function getEndTimeObject(): ?\DateTime
     {
         return $this->getEndtime() ? new \DateTime(Utils::absTime($this->getEndtime())) : null;
     }
 
-    /**
-     * Get unfreezetime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getUnfreezetime()
     {
         return $this->unfreezetime;
     }
 
-    /**
-     * Get finalizetime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getFinalizetime()
     {
         return $this->finalizetime;
     }
 
-    /**
-     * Set finalizetime
-     *
-     * @param double $finalizetimeString
-     *
-     * @return Contest
-     */
-    public function setFinalizetime($finalizetimeString)
+    /** @param string|float $finalizetimeString */
+    public function setFinalizetime($finalizetimeString): Contest
     {
         $this->finalizetime = $finalizetimeString;
         return $this;
     }
 
-    /**
-     * Get finalizecomment
-     *
-     * @return string|null
-     */
-    public function getFinalizecomment()
+    public function getFinalizecomment(): ?string
     {
         return $this->finalizecomment;
     }
 
-    /**
-     * Set finalizecomment
-     *
-     * @param string|null $finalizecomment
-     */
-    public function setFinalizecomment($finalizecomment)
+    public function setFinalizecomment(?string $finalizecomment)
     {
         $this->finalizecomment = $finalizecomment;
     }
 
-    /**
-     * Get b
-     *
-     * @return int|null
-     */
-    public function getB()
+    public function getB(): ?int
     {
         return $this->b;
     }
 
-    /**
-     * Set b
-     * @param int|null $b
-     */
-    public function setB($b)
+    public function setB(?int $b)
     {
         $this->b = $b;
     }
 
-    /**
-     * Get deactivatetime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getDeactivatetime()
     {
         return $this->deactivatetime;
     }
 
-    /**
-     * Set activatetimeString
-     *
-     * @param string $activatetimeString
-     *
-     * @return Contest
-     */
-    public function setActivatetimeString($activatetimeString)
+    public function setActivatetimeString(?string $activatetimeString): Contest
     {
         $this->activatetimeString = $activatetimeString;
         $this->activatetime       = $this->getAbsoluteTime($activatetimeString);
-
         return $this;
     }
 
-    /**
-     * Get activatetimeString
-     *
-     * @return string
-     */
-    public function getActivatetimeString()
+    public function getActivatetimeString(): ?string
     {
         return $this->activatetimeString;
     }
 
-    /**
-     * Set starttimeString
-     *
-     * @param string $starttimeString
-     *
-     * @return Contest
-     */
-    public function setStarttimeString($starttimeString)
+    public function setStarttimeString(string $starttimeString): Contest
     {
         $this->starttimeString = $starttimeString;
 
@@ -664,266 +522,123 @@ class Contest extends BaseApiEntity
         return $this;
     }
 
-    /**
-     * Get starttimeString
-     *
-     * @return string
-     */
-    public function getStarttimeString()
+    public function getStarttimeString(): string
     {
         return $this->starttimeString;
     }
 
-    /**
-     * Set freezetimeString
-     *
-     * @param string $freezetimeString
-     *
-     * @return Contest
-     */
-    public function setFreezetimeString($freezetimeString)
+    public function setFreezetimeString(?string $freezetimeString): Contest
     {
         $this->freezetimeString = $freezetimeString;
         $this->freezetime       = $this->getAbsoluteTime($freezetimeString);
-
         return $this;
     }
 
-    /**
-     * Get freezetimeString
-     *
-     * @return string
-     */
-    public function getFreezetimeString()
+    public function getFreezetimeString(): ?string
     {
         return $this->freezetimeString;
     }
 
-    /**
-     * Set endtimeString
-     *
-     * @param string $endtimeString
-     *
-     * @return Contest
-     */
-    public function setEndtimeString($endtimeString)
+    public function setEndtimeString(?string $endtimeString): Contest
     {
         $this->endtimeString = $endtimeString;
         $this->endtime       = $this->getAbsoluteTime($endtimeString);
-
         return $this;
     }
 
-    /**
-     * Get endtimeString
-     *
-     * @return string
-     */
-    public function getEndtimeString()
+    public function getEndtimeString(): ?string
     {
         return $this->endtimeString;
     }
 
-    /**
-     * Set unfreezetimeString
-     *
-     * @param string $unfreezetimeString
-     *
-     * @return Contest
-     */
-    public function setUnfreezetimeString($unfreezetimeString)
+    public function setUnfreezetimeString(?string $unfreezetimeString): Contest
     {
         $this->unfreezetimeString = $unfreezetimeString;
         $this->unfreezetime       = $this->getAbsoluteTime($unfreezetimeString);
-
         return $this;
     }
 
-    /**
-     * Get unfreezetimeString
-     *
-     * @return string
-     */
-    public function getUnfreezetimeString()
+    public function getUnfreezetimeString(): ?string
     {
         return $this->unfreezetimeString;
     }
 
-    /**
-     * Set deactivatetimeString
-     *
-     * @param string $deactivatetimeString
-     *
-     * @return Contest
-     */
-    public function setDeactivatetimeString($deactivatetimeString)
+    public function setDeactivatetimeString(?string $deactivatetimeString): Contest
     {
         $this->deactivatetimeString = $deactivatetimeString;
         $this->deactivatetime       = $this->getAbsoluteTime($deactivatetimeString);
-
         return $this;
     }
 
-    /**
-     * Get deactivatetimeString
-     *
-     * @return string
-     */
-    public function getDeactivatetimeString()
+    public function getDeactivatetimeString(): ?string
     {
         return $this->deactivatetimeString;
     }
 
-    /**
-     * Set activatetime
-     *
-     * @param string $activatetime
-     *
-     * @return Contest
-     */
-    public function setActivatetime($activatetime)
+    public function setActivatetime(string $activatetime): Contest
     {
         $this->activatetime = $activatetime;
-
         return $this;
     }
 
-    /**
-     * Set freezetime
-     *
-     * @param string $freezetime
-     *
-     * @return Contest
-     */
-    public function setFreezetime($freezetime)
+    public function setFreezetime(string $freezetime): Contest
     {
         $this->freezetime = $freezetime;
-
         return $this;
     }
 
-    /**
-     * Set endtime
-     *
-     * @param string $endtime
-     *
-     * @return Contest
-     */
-    public function setEndtime($endtime)
+    public function setEndtime(string $endtime): Contest
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Set unfreezetime
-     *
-     * @param string $unfreezetime
-     *
-     * @return Contest
-     */
-    public function setUnfreezetime($unfreezetime)
+    public function setUnfreezetime(string $unfreezetime): Contest
     {
         $this->unfreezetime = $unfreezetime;
-
         return $this;
     }
 
-    /**
-     * Set deactivatetime
-     *
-     * @param string $deactivatetime
-     *
-     * @return Contest
-     */
-    public function setDeactivatetime($deactivatetime)
+    public function setDeactivatetime(string $deactivatetime): Contest
     {
         $this->deactivatetime = $deactivatetime;
-
         return $this;
     }
 
-    /**
-     * Set enabled
-     *
-     * @param boolean $enabled
-     *
-     * @return Contest
-     */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): Contest
     {
         $this->enabled = $enabled;
-
         return $this;
     }
 
-    /**
-     * Get enabled
-     *
-     * @return boolean
-     */
-    public function getEnabled()
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    /**
-     * Set processBalloons
-     *
-     * @param boolean $processBalloons
-     *
-     * @return Contest
-     */
-    public function setProcessBalloons($processBalloons)
+    public function setProcessBalloons(bool $processBalloons): Contest
     {
         $this->processBalloons = $processBalloons;
-
         return $this;
     }
 
-    /**
-     * Get processBalloons
-     *
-     * @return boolean
-     */
-    public function getProcessBalloons()
+    public function getProcessBalloons(): bool
     {
         return $this->processBalloons;
     }
 
-    /**
-     * Set public
-     *
-     * @param boolean $public
-     *
-     * @return Contest
-     */
-    public function setPublic($public)
+    public function setPublic(bool $public): Contest
     {
         $this->public = $public;
-
         return $this;
     }
 
-    /**
-     * Get public
-     *
-     * @return boolean
-     */
-    public function getPublic()
+    public function getPublic(): bool
     {
         return $this->public;
     }
 
-    /**
-     * Set open to all teams
-     *
-     * @param boolean $openToAllTeams
-     *
-     * @return Contest
-     */
-    public function setOpenToAllTeams($openToAllTeams)
+    public function setOpenToAllTeams(bool $openToAllTeams): Contest
     {
         $this->openToAllTeams = $openToAllTeams;
         if ($this->openToAllTeams) {
@@ -934,206 +649,105 @@ class Contest extends BaseApiEntity
         return $this;
     }
 
-    /**
-     * Get open to all teams
-     *
-     * @return boolean
-     */
-    public function isOpenToAllTeams()
+    public function isOpenToAllTeams(): bool
     {
         return $this->openToAllTeams;
     }
 
-    /**
-     * Add team
-     *
-     * @param \App\Entity\Team $team
-     *
-     * @return Contest
-     */
-    public function addTeam(\App\Entity\Team $team)
+    public function addTeam(Team $team): Contest
     {
         $this->teams[] = $team;
-
         return $this;
     }
 
-    /**
-     * Remove team
-     *
-     * @param \App\Entity\Team $team
-     */
-    public function removeTeam(\App\Entity\Team $team)
+    public function removeTeam(Team $team)
     {
         $this->teams->removeElement($team);
     }
 
-    /**
-     * Get teams
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getTeams()
+    public function getTeams(): Collection
     {
         return $this->teams;
     }
 
-    /**
-     * Add problem
-     *
-     * @param ContestProblem $problem
-     *
-     * @return Contest
-     */
-    public function addProblem(ContestProblem $problem)
+    public function addProblem(ContestProblem $problem): Contest
     {
         $this->problems[] = $problem;
-
         return $this;
     }
 
-    /**
-     * Remove problem
-     *
-     * @param ContestProblem $problem
-     */
     public function removeProblem(ContestProblem $problem)
     {
         $this->problems->removeElement($problem);
     }
 
-    /**
-     * Get problems
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getProblems()
+    public function getProblems(): Collection
     {
         return $this->problems;
     }
 
-    /**
-     * Add clarification
-     *
-     * @param \App\Entity\Clarification $clarification
-     *
-     * @return Contest
-     */
-    public function addClarification(\App\Entity\Clarification $clarification)
+    public function addClarification(Clarification $clarification): Contest
     {
         $this->clarifications[] = $clarification;
-
         return $this;
     }
 
-    /**
-     * Remove clarification
-     *
-     * @param \App\Entity\Clarification $clarification
-     */
-    public function removeClarification(\App\Entity\Clarification $clarification)
+    public function removeClarification(Clarification $clarification)
     {
         $this->clarifications->removeElement($clarification);
     }
 
-    /**
-     * Get clarifications
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getClarifications()
+    public function getClarifications(): Collection
     {
         return $this->clarifications;
     }
 
-    /**
-     * Add submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Contest
-     */
-    public function addSubmission(\App\Entity\Submission $submission)
+    public function addSubmission(Submission $submission): Contest
     {
         $this->submissions[] = $submission;
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param \App\Entity\Submission $submission
-     */
-    public function removeSubmission(\App\Entity\Submission $submission)
+    public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Add internalError
-     *
-     * @param \App\Entity\InternalError $internalError
-     *
-     * @return Contest
-     */
-    public function addInternalError(\App\Entity\InternalError $internalError)
+    public function addInternalError(InternalError $internalError): Contest
     {
         $this->internal_errors[] = $internalError;
-
         return $this;
     }
 
-    /**
-     * Remove internalError
-     *
-     * @param \App\Entity\InternalError $internalError
-     */
-    public function removeInternalError(\App\Entity\InternalError $internalError)
+    public function removeInternalError(InternalError $internalError)
     {
         $this->internal_errors->removeElement($internalError);
     }
 
-    /**
-     * Get internalErrors
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getInternalErrors()
+    public function getInternalErrors(): Collection
     {
         return $this->internal_errors;
     }
 
     /**
-     * Get duration for this contest
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\Type("string")
      */
-    public function getDuration()
+    public function getDuration(): string
     {
         return Utils::relTime($this->getEndtime() - $this->starttime);
     }
 
     /**
-     * Get scoreboard freeze duration for this contest
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\Type("string")
      */
-    public function getScoreboardFreezeDuration()
+    public function getScoreboardFreezeDuration(): ?string
     {
         if (!empty($this->getFreezetime())) {
             return Utils::relTime($this->getEndtime() - $this->getFreezetime());
@@ -1145,7 +759,7 @@ class Contest extends BaseApiEntity
     /**
      * Returns true iff the contest is already and still active, and not disabled.
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->getEnabled() &&
             $this->getPublic() &&
@@ -1196,45 +810,22 @@ class Contest extends BaseApiEntity
         }
     }
 
-    /**
-     * Add removedInterval
-     *
-     * @param RemovedInterval $removedInterval
-     *
-     * @return Contest
-     */
-    public function addRemovedInterval(RemovedInterval $removedInterval)
+    public function addRemovedInterval(RemovedInterval $removedInterval): Contest
     {
         $this->removedIntervals->add($removedInterval);
-
         return $this;
     }
 
-    /**
-     * Remove removedInterval
-     *
-     * @param RemovedInterval $removedInterval
-     */
     public function removeRemovedInterval(RemovedInterval $removedInterval)
     {
         $this->removedIntervals->removeElement($removedInterval);
     }
 
-    /**
-     * Get removedIntervals
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getRemovedIntervals()
+    public function getRemovedIntervals(): Collection
     {
         return $this->removedIntervals;
     }
 
-    /**
-     * Get the contest time for a given wall time
-     * @param float $wallTime
-     * @return float
-     */
     public function getContestTime(float $wallTime): float
     {
         $contestTime = Utils::difftime($wallTime, (float)$this->getStarttime(false));
@@ -1251,11 +842,7 @@ class Contest extends BaseApiEntity
         return $contestTime;
     }
 
-    /**
-     * Get the data to display in the jury interface for the given contest
-     * @return array
-     */
-    public function getJuryTimeData(): array
+    public function getDataForJuryInterface(): array
     {
         $now         = Utils::now();
         $times       = ['activate', 'start', 'freeze', 'end', 'unfreeze', 'finalize', 'deactivate'];
@@ -1342,11 +929,7 @@ class Contest extends BaseApiEntity
         return $result;
     }
 
-    /**
-     * Get the state for this contest
-     * @return array
-     */
-    public function getState()
+    public function getState(): ?array
     {
         $time_or_null             = function ($time, $extra_cond = true) {
             if (!$extra_cond || $time === null || Utils::now() < $time) {
@@ -1373,20 +956,12 @@ class Contest extends BaseApiEntity
         return $result;
     }
 
-    /**
-     * Get the number of remaining minutes for this contest
-     * @return int
-     */
     public function getMinutesRemaining(): int
     {
         return (int)floor(($this->getEndtime() - $this->getFreezetime()) / 60);
     }
 
-    /**
-     * Get the freeze data for this contest
-     * @return FreezeData
-     */
-    public function getFreezeData()
+    public function getFreezeData(): FreezeData
     {
         return new FreezeData($this);
     }
@@ -1398,12 +973,11 @@ class Contest extends BaseApiEntity
     public function updateTimes()
     {
         // Update the start times, as this will update all other fields
-        $this->setStarttime(strtotime($this->getStarttimeString()));
+        $this->setStarttime((float)strtotime($this->getStarttimeString()));
         $this->setStarttimeString($this->getStarttimeString());
     }
 
     /**
-     * @param ExecutionContextInterface $context
      * @Assert\Callback()
      */
     public function validate(ExecutionContextInterface $context)
@@ -1494,7 +1068,6 @@ class Contest extends BaseApiEntity
 
     /**
      * Return whether a (wall clock) time falls within the contest.
-     * @return bool
      */
     public function isTimeInContest(float $time): bool
     {
@@ -1502,11 +1075,7 @@ class Contest extends BaseApiEntity
                Utils::difftime((float)$this->getEndtime(), $time) > 0;
     }
 
-    /**
-     * Get a countdown string for this contest to display in the UI
-     * @return string
-     */
-    public function getCountdown(): string
+    public function getCountdownString(): string
     {
         $now = Utils::now();
         if (Utils::difftime((float)$this->getActivatetime(),$now) <= 0) {

--- a/webapp/src/Entity/ContestProblem.php
+++ b/webapp/src/Entity/ContestProblem.php
@@ -141,7 +141,7 @@ class ContestProblem
         return $this;
     }
 
-    public function getShortname(): string
+    public function getShortname(): ?string
     {
         return $this->shortname;
     }

--- a/webapp/src/Entity/ContestProblem.php
+++ b/webapp/src/Entity/ContestProblem.php
@@ -218,7 +218,7 @@ class ContestProblem
         return $this;
     }
 
-    public function getProblem(): Problem
+    public function getProblem(): ?Problem
     {
         return $this->problem;
     }

--- a/webapp/src/Entity/ContestProblem.php
+++ b/webapp/src/Entity/ContestProblem.php
@@ -11,7 +11,8 @@ use JMS\Serializer\Annotation as Serializer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Many-to-Many mapping of contests and problems
+ * Many-to-Many mapping of contests and problems.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="contestproblem",
@@ -124,266 +125,126 @@ class ContestProblem
         $this->submissions = new ArrayCollection();
     }
 
-    /**
-     * Get cid
-     *
-     * @return integer
-     */
-    public function getCid()
+    public function getCid(): int
     {
         return $this->getContest()->getCid();
     }
 
-    /**
-     * Get probid
-     *
-     * @return integer
-     */
-    public function getProbid()
+    public function getProbid(): int
     {
         return $this->getProblem()->getProbid();
     }
 
-    /**
-     * Set shortname
-     *
-     * @param string $shortname
-     *
-     * @return ContestProblem
-     */
-    public function setShortname($shortname)
+    public function setShortname(string $shortname): ContestProblem
     {
         $this->shortname = $shortname;
-
         return $this;
     }
 
-    /**
-     * Get shortname
-     *
-     * @return string
-     */
-    public function getShortname()
+    public function getShortname(): string
     {
         return $this->shortname;
     }
 
-    /**
-     * Set points
-     *
-     * @param integer $points
-     *
-     * @return ContestProblem
-     */
-    public function setPoints($points)
+    public function setPoints(int $points): ContestProblem
     {
         $this->points = $points;
-
         return $this;
     }
 
-    /**
-     * Get points
-     *
-     * @return integer
-     */
-    public function getPoints()
+    public function getPoints(): int
     {
         return $this->points;
     }
 
-    /**
-     * Set allowSubmit
-     *
-     * @param boolean $allowSubmit
-     *
-     * @return ContestProblem
-     */
-    public function setAllowSubmit($allowSubmit)
+    public function setAllowSubmit(bool $allowSubmit): ContestProblem
     {
         $this->allowSubmit = $allowSubmit;
-
         return $this;
     }
 
-    /**
-     * Get allowSubmit
-     *
-     * @return boolean
-     */
-    public function getAllowSubmit()
+    public function getAllowSubmit(): bool
     {
         return $this->allowSubmit;
     }
 
-    /**
-     * Set allowJudge
-     *
-     * @param boolean $allowJudge
-     *
-     * @return ContestProblem
-     */
-    public function setAllowJudge($allowJudge)
+    public function setAllowJudge(bool $allowJudge): ContestProblem
     {
         $this->allowJudge = $allowJudge;
-
         return $this;
     }
 
-    /**
-     * Get allowJudge
-     *
-     * @return boolean
-     */
-    public function getAllowJudge()
+    public function getAllowJudge(): bool
     {
         return $this->allowJudge;
     }
 
-    /**
-     * Set color
-     *
-     * @param string $color
-     *
-     * @return ContestProblem
-     */
-    public function setColor($color)
+    public function setColor(string $color): ContestProblem
     {
         $this->color = $color;
-
         return $this;
     }
 
-    /**
-     * Get color
-     *
-     * @return string
-     */
-    public function getColor()
+    public function getColor(): ?string
     {
         return $this->color;
     }
 
-    /**
-     * Set lazyEvalResults
-     *
-     * @param boolean $lazyEvalResults
-     *
-     * @return ContestProblem
-     */
-    public function setLazyEvalResults($lazyEvalResults)
+    public function setLazyEvalResults(bool $lazyEvalResults): ContestProblem
     {
         $this->lazyEvalResults = $lazyEvalResults;
-
         return $this;
     }
 
-    /**
-     * Get lazyEvalResults
-     *
-     * @return boolean
-     */
-    public function getLazyEvalResults()
+    public function getLazyEvalResults(): ?bool
     {
         return $this->lazyEvalResults;
     }
 
-    /**
-     * Set contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return ContestProblem
-     */
-    public function setContest(\App\Entity\Contest $contest = null)
+    public function setContest(?Contest $contest = null): ContestProblem
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return \App\Entity\Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set problem
-     *
-     * @param \App\Entity\Problem $problem
-     *
-     * @return ContestProblem
-     */
-    public function setProblem(\App\Entity\Problem $problem = null)
+    public function setProblem(?Problem $problem = null): ContestProblem
     {
         $this->problem = $problem;
-
         return $this;
     }
 
-    /**
-     * Get problem
-     *
-     * @return \App\Entity\Problem
-     */
-    public function getProblem()
+    public function getProblem(): Problem
     {
         return $this->problem;
     }
 
-    /**
-     * Add submission
-     *
-     * @param Submission $submission
-     *
-     * @return ContestProblem
-     */
-    public function addSubmission(Submission $submission)
+    public function addSubmission(Submission $submission): ContestProblem
     {
         $this->submissions->add($submission);
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param Submission $submission
-     */
     public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalId()
+    public function getExternalId(): string
     {
         return $this->getProblem()->getExternalid();
     }
 
     /**
-     * Get the API ID for this entity
-     * @param EventLogService        $eventLogService
-     * @param EntityManagerInterface $entityManager
      * @return mixed
      * @throws Exception
      */

--- a/webapp/src/Entity/Event.php
+++ b/webapp/src/Entity/Event.php
@@ -5,7 +5,7 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Log of all events during a contest
+ * Log of all events during a contest.
  *
  * @ORM\Table(
  *     name="event",
@@ -77,143 +77,73 @@ class Event
      */
     private $contest;
 
-    /**
-     * Set eventid
-     *
-     * @param integer $eventid
-     *
-     * @return Event
-     */
-    public function setEventid($eventid)
+    public function setEventid(int $eventid): Event
     {
         $this->eventid = $eventid;
-
         return $this;
     }
 
-    /**
-     * Get eventid
-     *
-     * @return integer
-     */
-    public function getEventid()
+    public function getEventid(): int
     {
         return $this->eventid;
     }
 
-    /**
-     * Set eventtime
-     *
-     * @param double $eventtime
-     *
-     * @return Event
-     */
-    public function setEventtime($eventtime)
+    /** @param string|float $eventtime */
+    public function setEventtime($eventtime): Event
     {
         $this->eventtime = $eventtime;
-
         return $this;
     }
 
-    /**
-     * Get eventtime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getEventtime()
     {
         return $this->eventtime;
     }
 
-    /**
-     * Set endpointtype
-     *
-     * @param string $endpointtype
-     *
-     * @return Event
-     */
-    public function setEndpointtype($endpointtype)
+    public function setEndpointtype(string $endpointtype): Event
     {
         $this->endpointtype = $endpointtype;
-
         return $this;
     }
 
-    /**
-     * Get endpointtype
-     *
-     * @return string
-     */
-    public function getEndpointtype()
+    public function getEndpointtype(): string
     {
         return $this->endpointtype;
     }
 
-    /**
-     * Set endpointid
-     *
-     * @param string $endpointid
-     *
-     * @return Event
-     */
-    public function setEndpointid($endpointid)
+    public function setEndpointid(string $endpointid): Event
     {
         $this->endpointid = $endpointid;
-
         return $this;
     }
 
-    /**
-     * Get endpointid
-     *
-     * @return string
-     */
-    public function getEndpointid()
+    public function getEndpointid(): string
     {
         return $this->endpointid;
     }
 
-    /**
-     * Set action
-     *
-     * @param string $action
-     *
-     * @return Event
-     */
-    public function setAction($action)
+    public function setAction(string $action): Event
     {
         $this->action = $action;
-
         return $this;
     }
 
-    /**
-     * Get action
-     *
-     * @return string
-     */
-    public function getAction()
+    public function getAction(): string
     {
         return $this->action;
     }
 
     /**
-     * Set content
-     *
      * @param mixed $content
-     *
-     * @return Event
      */
-    public function setContent($content)
+    public function setContent($content): Event
     {
         $this->content = $content;
-
         return $this;
     }
 
     /**
-     * Get content
-     *
      * @return mixed
      */
     public function getContent()
@@ -221,24 +151,13 @@ class Event
         return $this->content;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest|null $contest
-     * @return Event
-     */
-    public function setContest($contest)
+    public function setContest(?Contest $contest): Event
     {
         $this->contest = $contest;
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest|null
-     */
-    public function getContest()
+    public function getContest(): ?Contest
     {
         return $this->contest;
     }

--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -8,7 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Compile, compare, and run script executable bundles
+ * Compile, compare, and run script executable bundles.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="executable",
@@ -66,14 +67,11 @@ class Executable
      */
     private $problems_run;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->languages = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->languages        = new ArrayCollection();
         $this->problems_compare = new ArrayCollection();
-        $this->problems_run = new ArrayCollection();
+        $this->problems_run     = new ArrayCollection();
     }
 
     public function setExecid(string $execid): Executable

--- a/webapp/src/Entity/ExecutableFile.php
+++ b/webapp/src/Entity/ExecutableFile.php
@@ -5,7 +5,8 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Files associated to an executable
+ * Files associated to an executable.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="executable_file",
@@ -106,7 +107,7 @@ class ExecutableFile
         return $this;
     }
 
-    public function getImmutableExecutable()
+    public function getImmutableExecutable(): ImmutableExecutable
     {
         return $this->immutableExecutable;
     }
@@ -117,7 +118,7 @@ class ExecutableFile
         return $this;
     }
 
-    public function getFileContent()
+    public function getFileContent(): string
     {
         return $this->fileContent;
     }

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -8,7 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Judgement in external system
+ * Judgement in external system.
+ *
  * @ORM\Table(
  *     name="external_judgement",
  *     options={"comment":"Judgement in external system"},
@@ -132,303 +133,147 @@ class ExternalJudgement
      */
     private $external_runs;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->external_runs = new ArrayCollection();
     }
 
-    /**
-     * Get extjudgementid
-     *
-     * @return int
-     */
-    public function getExtjudgementid()
+    public function getExtjudgementid(): int
     {
         return $this->extjudgementid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return ExternalJudgement
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): ExternalJudgement
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set result
-     *
-     * @param string|null $result
-     *
-     * @return ExternalJudgement
-     */
-    public function setResult($result)
+    public function setResult(?string $result): ExternalJudgement
     {
         $this->result = $result;
-
         return $this;
     }
 
-    /**
-     * Get result
-     *
-     * @return string|null
-     */
-    public function getResult()
+    public function getResult(): ?string
     {
         return $this->result;
     }
 
-    /**
-     * Set verified status of the result / difference
-     *
-     * @param boolean $verified
-     *
-     * @return ExternalJudgement
-     */
-    public function setVerified($verified)
+    public function setVerified(bool $verified): ExternalJudgement
     {
         $this->verified = $verified;
-
         return $this;
     }
 
-    /**
-     * Get verified status of the result / difference
-     *
-     * @return boolean
-     */
-    public function getVerified()
+    public function getVerified(): bool
     {
         return $this->verified;
     }
 
-    /**
-     * Set jury member who verified this judgement
-     *
-     * @param string $juryMember
-     *
-     * @return ExternalJudgement
-     */
-    public function setJuryMember($juryMember)
+    public function setJuryMember(string $juryMember): ExternalJudgement
     {
         $this->jury_member = $juryMember;
-
         return $this;
     }
 
-    /**
-     * Get jury member who verified this judgement
-     *
-     * @return string
-     */
-    public function getJuryMember()
+    public function getJuryMember(): string
     {
         return $this->jury_member;
     }
 
-    /**
-     * Set verify comment
-     *
-     * @param string $verifyComment
-     *
-     * @return ExternalJudgement
-     */
-    public function setVerifyComment($verifyComment)
+    public function setVerifyComment(string $verifyComment): ExternalJudgement
     {
         $this->verify_comment = $verifyComment;
-
         return $this;
     }
 
-    /**
-     * Get verifyComment
-     *
-     * @return string
-     */
-    public function getVerifyComment()
+    public function getVerifyComment(): string
     {
         return $this->verify_comment;
     }
 
-    /**
-     * Set starttime
-     *
-     * @param double $starttime
-     *
-     * @return ExternalJudgement
-     */
-    public function setStarttime($starttime)
+    /** @param string|float $starttime */
+    public function setStarttime($starttime): ExternalJudgement
     {
         $this->starttime = $starttime;
-
         return $this;
     }
 
-    /**
-     * Get starttime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getStarttime()
     {
         return $this->starttime;
     }
 
-    /**
-     * Set endtime
-     *
-     * @param double $endtime
-     *
-     * @return ExternalJudgement
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): ExternalJudgement
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
-    /**
-     * Set valid
-     *
-     * @param boolean $valid
-     *
-     * @return ExternalJudgement
-     */
-    public function setValid($valid)
+    public function setValid(bool $valid): ExternalJudgement
     {
         $this->valid = $valid;
-
         return $this;
     }
 
-    /**
-     * Get valid
-     *
-     * @return boolean
-     */
-    public function getValid()
+    public function getValid(): bool
     {
         return $this->valid;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest $contest
-     *
-     * @return ExternalJudgement
-     */
-    public function setContest(Contest $contest = null)
+    public function setContest(?Contest $contest = null): ExternalJudgement
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest
-     */
-    public function getContest()
+   public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set submission
-     *
-     * @param Submission $submission
-     *
-     * @return ExternalJudgement
-     */
-    public function setSubmission(Submission $submission)
+    public function setSubmission(Submission $submission): ExternalJudgement
     {
         $this->submission = $submission;
-
         return $this;
     }
 
-    /**
-     * Get submission
-     *
-     * @return Submission
-     */
-    public function getSubmission()
+    public function getSubmission(): Submission
     {
         return $this->submission;
     }
 
-    /**
-     * Add externalRun
-     *
-     * @param ExternalRun $externalRun
-     *
-     * @return ExternalJudgement
-     */
-    public function addExternalRun(ExternalRun $externalRun)
+    public function addExternalRun(ExternalRun $externalRun): ExternalJudgement
     {
         $this->external_runs[] = $externalRun;
-
         return $this;
     }
 
-    /**
-     * Remove externalRun
-     *
-     * @param ExternalRun $externalRun
-     */
     public function removeExternalRun(ExternalRun $externalRun)
     {
         $this->external_runs->removeElement($externalRun);
     }
 
-    /**
-     * Get externalRuns
-     *
-     * @return Collection
-     */
-    public function getExternalRuns()
+    public function getExternalRuns(): Collection
     {
         return $this->external_runs;
     }
 
-    /**
-     * Get the max runtime for this external judgement
-     * @return float
-     */
-    public function getMaxRuntime()
+    public function getMaxRuntime(): float
     {
         $max = 0;
         foreach ($this->external_runs as $run) {
@@ -437,11 +282,7 @@ class ExternalJudgement
         return $max;
     }
 
-    /**
-     * Get the sum runtime for this external judgement
-     * @return float
-     */
-    public function getSumRuntime()
+    public function getSumRuntime(): float
     {
         $sum = 0;
         foreach ($this->external_runs as $run) {

--- a/webapp/src/Entity/ExternalRelationshipEntityInterface.php
+++ b/webapp/src/Entity/ExternalRelationshipEntityInterface.php
@@ -6,7 +6,8 @@ namespace App\Entity;
  * Interface ExternalRelationshipEntityInterface
  *
  * For entities implementing this interface, the SetExternalIdVisitor class will replace ID's
- * with external ID's for related entities if applicable
+ * with external ID's for related entities if applicable.
+ *
  * @package App\Controller\API
  */
 interface ExternalRelationshipEntityInterface
@@ -15,8 +16,7 @@ interface ExternalRelationshipEntityInterface
      * Get the entities to check for external ID's while serializing.
      *
      * This method should return an array with as keys the JSON field names and as values the actual entity
-     * objects that the SetExternalIdVisitor should check for applicable external ID's
-     * @return array
+     * objects that the SetExternalIdVisitor should check for applicable external ID's.
      */
     public function getExternalRelationships(): array;
 }

--- a/webapp/src/Entity/ExternalRun.php
+++ b/webapp/src/Entity/ExternalRun.php
@@ -5,7 +5,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Run in external system
+ * Run in external system.
+ *
  * @ORM\Table(
  *     name="external_run",
  *     options={"comment":"Run in external system"},
@@ -89,180 +90,86 @@ class ExternalRun
      */
     private $contest;
 
-    /**
-     * Get extrunid
-     *
-     * @return int
-     */
-    public function getExtrunid()
+    public function getExtrunid(): int
     {
         return $this->extrunid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return ExternalRun
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): ExternalRun
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set result
-     *
-     * @param string $result
-     *
-     * @return ExternalRun
-     */
-    public function setResult($result)
+    public function setResult(string $result): ExternalRun
     {
         $this->result = $result;
-
         return $this;
     }
 
-    /**
-     * Get result
-     *
-     * @return string
-     */
-    public function getResult()
+    public function getResult(): string
     {
         return $this->result;
     }
 
-    /**
-     * Set endtime
-     *
-     * @param double $endtime
-     *
-     * @return ExternalRun
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): ExternalRun
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return double
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
-    /**
-     * Set runtime
-     *
-     * @param double $runtime
-     *
-     * @return ExternalRun
-     */
-    public function setRuntime($runtime)
+    public function setRuntime(float $runtime): ExternalRun
     {
         $this->runtime = $runtime;
-
         return $this;
     }
 
-    /**
-     * Get runtime
-     *
-     * @return double
-     */
-    public function getRuntime()
+    public function getRuntime(): float
     {
         return $this->runtime;
     }
 
-    /**
-     * Set externalJudgement
-     *
-     * @param ExternalJudgement $externalJudgement
-     *
-     * @return ExternalRun
-     */
-    public function setExternalJudgement(ExternalJudgement $externalJudgement)
+    public function setExternalJudgement(ExternalJudgement $externalJudgement): ExternalRun
     {
         $this->external_judgement = $externalJudgement;
-
         return $this;
     }
 
-    /**
-     * Get externalJudgement
-     *
-     * @return ExternalJudgement
-     */
-    public function getExternalJudgement()
+    public function getExternalJudgement(): ExternalJudgement
     {
         return $this->external_judgement;
     }
 
-    /**
-     * Set testcase
-     *
-     * @param Testcase $testcase
-     *
-     * @return ExternalRun
-     */
-    public function setTestcase(Testcase $testcase)
+    public function setTestcase(Testcase $testcase): ExternalRun
     {
         $this->testcase = $testcase;
-
         return $this;
     }
 
-    /**
-     * Get testcase
-     *
-     * @return Testcase
-     */
-    public function getTestcase()
+    public function getTestcase(): Testcase
     {
         return $this->testcase;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest $contest
-     *
-     * @return ExternalRun
-     */
-    public function setContest(Contest $contest = null)
+    public function setContest(?Contest $contest = null): ExternalRun
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }

--- a/webapp/src/Entity/ImmutableExecutable.php
+++ b/webapp/src/Entity/ImmutableExecutable.php
@@ -9,6 +9,7 @@ use JMS\Serializer\Annotation as Serializer;
 
 /**
  * Immutable wrapper for a collection of files for executable bundles.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="immutable_executable",

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -5,7 +5,8 @@ use App\Doctrine\DBAL\Types\InternalErrorStatusType;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Log of judgehost internal errors
+ * Log of judgehost internal errors.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="internal_error",
@@ -79,195 +80,92 @@ class InternalError
      */
     private $judging;
 
-
-    /**
-     * Set errorid
-     *
-     * @param integer $errorid
-     *
-     * @return InternalError
-     */
-    public function setErrorid($errorid)
+    public function setErrorid(int $errorid): InternalError
     {
         $this->errorid = $errorid;
-
         return $this;
     }
 
-    /**
-     * Get errorid
-     *
-     * @return integer
-     */
-    public function getErrorid()
+    public function getErrorid(): int
     {
         return $this->errorid;
     }
 
-    /**
-     * Set description
-     *
-     * @param string $description
-     *
-     * @return InternalError
-     */
-    public function setDescription($description)
+    public function setDescription(string $description): InternalError
     {
         $this->description = $description;
-
         return $this;
     }
 
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * Set judgehostlog
-     *
-     * @param string $judgehostlog
-     *
-     * @return InternalError
-     */
-    public function setJudgehostlog($judgehostlog)
+    public function setJudgehostlog(string $judgehostlog): InternalError
     {
         $this->judgehostlog = $judgehostlog;
-
         return $this;
     }
 
-    /**
-     * Get judgehostlog
-     *
-     * @return string
-     */
-    public function getJudgehostlog()
+    public function getJudgehostlog(): string
     {
         return $this->judgehostlog;
     }
 
-    /**
-     * Set time
-     *
-     * @param string $time
-     *
-     * @return InternalError
-     */
-    public function setTime($time)
+    /** @param string|float $time */
+    public function setTime($time): InternalError
     {
         $this->time = $time;
-
         return $this;
     }
 
-    /**
-     * Get time
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getTime()
     {
         return $this->time;
     }
 
-    /**
-     * Set disabled
-     *
-     * @param array $disabled
-     *
-     * @return InternalError
-     */
-    public function setDisabled($disabled)
+    public function setDisabled(array $disabled): InternalError
     {
         $this->disabled = $disabled;
-
         return $this;
     }
 
-    /**
-     * Get disabled
-     *
-     * @return array
-     */
-    public function getDisabled()
+    public function getDisabled(): array
     {
         return $this->disabled;
     }
 
-    /**
-     * Set status
-     *
-     * @param string $status
-     *
-     * @return InternalError
-     */
-    public function setStatus($status)
+    public function setStatus(string $status): InternalError
     {
         $this->status = $status;
-
         return $this;
     }
 
-    /**
-     * Get status
-     *
-     * @return string
-     */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->status;
     }
 
-    /**
-     * Set contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return InternalError
-     */
-    public function setContest(\App\Entity\Contest $contest = null)
+    public function setContest(?Contest $contest = null): InternalError
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return \App\Entity\Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set judging
-     *
-     * @param \App\Entity\Judging $judging
-     *
-     * @return InternalError
-     */
-    public function setJudging(\App\Entity\Judging $judging = null)
+    public function setJudging(?Judging $judging = null): InternalError
     {
         $this->judging = $judging;
-
         return $this;
     }
 
-    /**
-     * Get judging
-     *
-     * @return \App\Entity\Judging
-     */
-    public function getJudging()
+    public function getJudging(): Judging
     {
         return $this->judging;
     }

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -8,7 +8,8 @@ use JMS\Serializer\Annotation as Serializer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Hostnames of the autojudgers
+ * Hostnames of the autojudgers.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judgehost",
@@ -34,7 +35,6 @@ class Judgehost
      */
     private $active = true;
 
-
     /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="polltime",
@@ -51,146 +51,75 @@ class Judgehost
      */
     private $restriction;
 
-
     /**
      * @ORM\OneToMany(targetEntity="Judging", mappedBy="judgehost")
      * @Serializer\Exclude()
      */
     private $judgings;
 
-    /**
-     * Set hostname
-     *
-     * @param string $hostname
-     *
-     * @return Judgehost
-     */
-    public function setHostname($hostname)
-    {
-        $this->hostname = $hostname;
-
-        return $this;
-    }
-
-    /**
-     * Get hostname
-     *
-     * @return string
-     */
-    public function getHostname()
-    {
-        return $this->hostname;
-    }
-
-    /**
-     * Set active
-     *
-     * @param boolean $active
-     *
-     * @return Judgehost
-     */
-    public function setActive($active)
-    {
-        $this->active = $active;
-
-        return $this;
-    }
-
-    /**
-     * Get active
-     *
-     * @return boolean
-     */
-    public function getActive()
-    {
-        return $this->active;
-    }
-
-    /**
-     * Set polltime
-     *
-     * @param string $polltime
-     *
-     * @return Judgehost
-     */
-    public function setPolltime($polltime)
-    {
-        $this->polltime = $polltime;
-
-        return $this;
-    }
-
-    /**
-     * Get polltime
-     *
-     * @return string
-     */
-    public function getPolltime()
-    {
-        return $this->polltime;
-    }
-
-    /**
-     * Set restriction
-     *
-     * @param JudgehostRestriction|null $restriction
-     *
-     * @return Judgehost
-     */
-    public function setRestriction(JudgehostRestriction $restriction = null)
-    {
-        $this->restriction = $restriction;
-
-        return $this;
-    }
-
-    /**
-     * Get restriction
-     *
-     * @return JudgehostRestriction
-     */
-    public function getRestriction()
-    {
-        return $this->restriction;
-    }
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->judgings = new ArrayCollection();
     }
 
-    /**
-     * Add judging
-     *
-     * @param Judging $judging
-     *
-     * @return Judgehost
-     */
-    public function addJudging(Judging $judging)
+    public function setHostname(string $hostname): Judgehost
     {
-        $this->judgings[] = $judging;
-
+        $this->hostname = $hostname;
         return $this;
     }
 
-    /**
-     * Remove judging
-     *
-     * @param Judging $judging
-     */
+    public function getHostname(): string
+    {
+        return $this->hostname;
+    }
+
+    public function setActive(bool $active): Judgehost
+    {
+        $this->active = $active;
+        return $this;
+    }
+
+    public function getActive(): bool
+    {
+        return $this->active;
+    }
+
+    /** @param string|float $polltime */
+    public function setPolltime($polltime): Judgehost
+    {
+        $this->polltime = $polltime;
+        return $this;
+    }
+
+    /** @return string|float */
+    public function getPolltime()
+    {
+        return $this->polltime;
+    }
+
+    public function setRestriction(?JudgehostRestriction $restriction = null): Judgehost
+    {
+        $this->restriction = $restriction;
+        return $this;
+    }
+
+    public function getRestriction(): JudgehostRestriction
+    {
+        return $this->restriction;
+    }
+
+    public function addJudging(Judging $judging): Judgehost
+    {
+        $this->judgings[] = $judging;
+        return $this;
+    }
+
     public function removeJudging(Judging $judging)
     {
         $this->judgings->removeElement($judging);
     }
 
-    /**
-     * Get judgings
-     *
-     * @return Collection
-     */
-    public function getJudgings()
+    public function getJudgings(): Collection
     {
         return $this->judgings;
     }

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -103,7 +103,7 @@ class Judgehost
         return $this;
     }
 
-    public function getRestriction(): JudgehostRestriction
+    public function getRestriction(): ?JudgehostRestriction
     {
         return $this->restriction;
     }

--- a/webapp/src/Entity/JudgehostRestriction.php
+++ b/webapp/src/Entity/JudgehostRestriction.php
@@ -6,7 +6,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Hostnames of the autojudgers
+ * Restrictions to be applied to judgehosts, e.g. to certain problems or languages.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judgehost_restriction",
@@ -42,182 +43,94 @@ class JudgehostRestriction
      */
     private $judgehosts;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->judgehosts = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->judgehosts = new ArrayCollection();
     }
 
-    /**
-     * Get restrictionid
-     *
-     * @return integer
-     */
-    public function getRestrictionid()
+    public function getRestrictionid(): int
     {
         return $this->restrictionid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return JudgehostRestriction
-     */
-    public function setName($name)
+    public function setName(string $name): JudgehostRestriction
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set restrictions
-     *
-     * @param array $restrictions
-     *
-     * @return JudgehostRestriction
-     */
-    public function setRestrictions($restrictions)
+    public function setRestrictions(array $restrictions): JudgehostRestriction
     {
         $this->restrictions = $restrictions;
-
         return $this;
     }
 
-    /**
-     * Get restrictions
-     *
-     * @return array
-     */
-    public function getRestrictions()
+    public function getRestrictions(): array
     {
         return $this->restrictions;
     }
 
-    /**
-     * Set restriction contests
-     * @param int[] $contests
-     * @return $this
-     */
-    public function setContests(array $contests)
+    public function setContests(array $contests): JudgehostRestriction
     {
         $this->restrictions['contest'] = $contests;
         return $this;
     }
 
-    /**
-     * Get restriction contests
-     * @return int[]
-     */
-    public function getContests()
+    public function getContests(): array
     {
         return $this->restrictions['contest'] ?? [];
     }
 
-    /**
-     * Set restriction problems
-     * @param int[] $problems
-     * @return $this
-     */
-    public function setProblems(array $problems)
+    public function setProblems(array $problems): JudgehostRestriction
     {
         $this->restrictions['problem'] = $problems;
         return $this;
     }
 
-    /**
-     * Get restriction problems
-     * @return int[]
-     */
-    public function getProblems()
+    public function getProblems(): array
     {
         return $this->restrictions['problem'] ?? [];
     }
 
-    /**
-     * Set restriction languages
-     * @param string[] $languages
-     * @return $this
-     */
-    public function setLanguages(array $languages)
+    public function setLanguages(array $languages): JudgehostRestriction
     {
         $this->restrictions['language'] = $languages;
         return $this;
     }
 
-    /**
-     * Get restriction languages
-     * @return string[]
-     */
-    public function getLanguages()
+    public function getLanguages(): array
     {
         return $this->restrictions['language'] ?? [];
     }
 
-    /**
-     * Set restriction rejudge own
-     * @param bool $rejudgeOwn
-     * @return $this
-     */
-    public function setRejudgeOwn(bool $rejudgeOwn)
+    public function setRejudgeOwn(bool $rejudgeOwn): JudgehostRestriction
     {
         $this->restrictions['rejudge_own'] = $rejudgeOwn;
         return $this;
     }
 
-    /**
-     * Get restriction rejudge own
-     * @return bool
-     */
-    public function getRejudgeOwn()
+    public function getRejudgeOwn(): bool
     {
         return $this->restrictions['rejudge_own'] ?? true;
     }
 
-    /**
-     * Add judgehost
-     *
-     * @param \App\Entity\Judgehost $judgehost
-     *
-     * @return JudgehostRestriction
-     */
-    public function addJudgehost(\App\Entity\Judgehost $judgehost)
+    public function addJudgehost(Judgehost $judgehost): JudgehostRestriction
     {
         $this->judgehosts[] = $judgehost;
-
         return $this;
     }
 
-    /**
-     * Remove judgehost
-     *
-     * @param \App\Entity\Judgehost $judgehost
-     */
-    public function removeJudgehost(\App\Entity\Judgehost $judgehost)
+    public function removeJudgehost(Judgehost $judgehost)
     {
         $this->judgehosts->removeElement($judgehost);
     }
 
-    /**
-     * Get judgehosts
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getJudgehosts()
+    public function getJudgehosts(): Collection
     {
         return $this->judgehosts;
     }

--- a/webapp/src/Entity/JudgehostRestriction.php
+++ b/webapp/src/Entity/JudgehostRestriction.php
@@ -59,7 +59,7 @@ class JudgehostRestriction
         return $this;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -8,7 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Result of judging a submission
+ * Result of judging a submission.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judging",
@@ -23,7 +24,6 @@ use JMS\Serializer\Annotation as Serializer;
  */
 class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterface
 {
-    // constants for results
     const RESULT_CORRECT = 'correct';
     const RESULT_COMPILER_ERROR = 'compiler-error';
 
@@ -158,7 +158,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     private $rejudging;
 
     /**
-     * rejudgings have one parent judging
+     * Rejudgings have one parent judging.
      * @ORM\ManyToOne(targetEntity="Judging")
      * @ORM\JoinColumn(name="prevjudgingid", referencedColumnName="judgingid", onDelete="SET NULL")
      * @Serializer\Exclude()
@@ -171,11 +171,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
      */
     private $runs;
 
-    /**
-     * Get the max runtime for this judging
-     * @return float
-     */
-    public function getMaxRuntime()
+    public function getMaxRuntime(): float
     {
         $max = 0;
         foreach ($this->runs as $run) {
@@ -184,11 +180,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
         return $max;
     }
 
-    /**
-     * Get the sum runtime for this judging
-     * @return float
-     */
-    public function getSumRuntime()
+    public function getSumRuntime(): float
     {
         $sum = 0;
         foreach ($this->runs as $run) {
@@ -197,253 +189,142 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
         return $sum;
     }
 
-    /**
-     * Get judgingid
-     *
-     * @return integer
-     */
-    public function getJudgingid()
+    public function getJudgingid(): int
     {
         return $this->judgingid;
     }
 
-    /**
-     * Set starttime
-     *
-     * @param string $starttime
-     *
-     * @return Judging
-     */
-    public function setStarttime($starttime)
+    /** @param string|float $starttime */
+    public function setStarttime($starttime): Judging
     {
         $this->starttime = $starttime;
-
         return $this;
     }
 
-    /**
-     * Get starttime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getStarttime()
     {
         return $this->starttime;
     }
 
     /**
-     * Get the absolute start time for this judging
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("start_time")
      * @Serializer\Type("string")
      */
-    public function getAbsoluteStartTime()
+    public function getAbsoluteStartTime(): string
     {
         return Utils::absTime($this->getStarttime());
     }
 
     /**
-     * Get the relative start time for this judging
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("start_contest_time")
      * @Serializer\Type("string")
      */
-    public function getRelativeStartTime()
+    public function getRelativeStartTime(): string
     {
         return Utils::relTime($this->getStarttime() - $this->getContest()->getStarttime());
     }
 
-    /**
-     * Set endtime
-     *
-     * @param string $endtime
-     *
-     * @return Judging
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): Judging
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
     /**
-     * Get the absolute end time for this judging
-     *
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("end_time")
      * @Serializer\Type("string")
      */
-    public function getAbsoluteEndTime()
+    public function getAbsoluteEndTime(): ?string
     {
         return $this->getEndtime() ? Utils::absTime($this->getEndtime()) : null;
     }
 
     /**
-     * Get the relative end time for this judging
-     *
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("end_contest_time")
      * @Serializer\Type("string")
      */
-    public function getRelativeEndTime()
+    public function getRelativeEndTime(): ?string
     {
         return $this->getEndtime() ? Utils::relTime($this->getEndtime() - $this->getContest()->getStarttime()) : null;
     }
 
-    /**
-     * Set result
-     *
-     * @param string $result
-     *
-     * @return Judging
-     */
-    public function setResult($result)
+    public function setResult(string $result): Judging
     {
         $this->result = $result;
-
         return $this;
     }
 
-    /**
-     * Get result
-     *
-     * @return string
-     */
-    public function getResult()
+    public function getResult(): ?string
     {
         return $this->result;
     }
 
-    /**
-     * Set verified
-     *
-     * @param boolean $verified
-     *
-     * @return Judging
-     */
-    public function setVerified($verified)
+    public function setVerified(bool $verified): Judging
     {
         $this->verified = $verified;
-
         return $this;
     }
 
-    /**
-     * Get verified
-     *
-     * @return boolean
-     */
-    public function getVerified()
+    public function getVerified(): bool
     {
         return $this->verified;
     }
 
-    /**
-     * Set juryMember
-     *
-     * @param string $juryMember
-     *
-     * @return Judging
-     */
-    public function setJuryMember($juryMember)
+    public function setJuryMember(string $juryMember): Judging
     {
         $this->jury_member = $juryMember;
-
         return $this;
     }
 
-    /**
-     * Get juryMember
-     *
-     * @return string
-     */
-    public function getJuryMember()
+    public function getJuryMember(): ?string
     {
         return $this->jury_member;
     }
 
-    /**
-     * Set verifyComment
-     *
-     * @param string $verifyComment
-     *
-     * @return Judging
-     */
-    public function setVerifyComment($verifyComment)
+    public function setVerifyComment(string $verifyComment): Judging
     {
         $this->verify_comment = $verifyComment;
-
         return $this;
     }
 
-    /**
-     * Get verifyComment
-     *
-     * @return string
-     */
-    public function getVerifyComment()
+    public function getVerifyComment(): ?string
     {
         return $this->verify_comment;
     }
 
-    /**
-     * Set valid
-     *
-     * @param boolean $valid
-     *
-     * @return Judging
-     */
-    public function setValid($valid)
+    public function setValid(bool $valid): Judging
     {
         $this->valid = $valid;
-
         return $this;
     }
 
-    /**
-     * Get valid
-     *
-     * @return boolean
-     */
-    public function getValid()
+    public function getValid(): bool
     {
         return $this->valid;
     }
 
     /**
-     * Set outputCompile
-     *
      * @param resource|string $outputCompile
-     *
-     * @return Judging
      */
-    public function setOutputCompile($outputCompile)
+    public function setOutputCompile($outputCompile): Judging
     {
         $this->output_compile = $outputCompile;
-
         return $this;
     }
 
     /**
-     * Get outputCompile
-     *
      * @return resource|string|null
      */
     public function getOutputCompile(bool $asString = false)
@@ -457,165 +338,83 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
         return $this->output_compile;
     }
 
-    /**
-     * Set seen
-     *
-     * @param boolean $seen
-     *
-     * @return Judging
-     */
-    public function setSeen($seen)
+    public function setSeen(bool $seen): Judging
     {
         $this->seen = $seen;
-
         return $this;
     }
 
-    /**
-     * Get seen
-     *
-     * @return boolean
-     */
-    public function getSeen()
+    public function getSeen(): bool
     {
         return $this->seen;
     }
 
-    /**
-     * Set submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Judging
-     */
-    public function setSubmission(\App\Entity\Submission $submission = null)
+    public function setSubmission(?Submission $submission = null): Judging
     {
         $this->submission = $submission;
-
         return $this;
     }
 
-    /**
-     * Get submission
-     *
-     * @return \App\Entity\Submission
-     */
-    public function getSubmission()
+    public function getSubmission(): Submission
     {
         return $this->submission;
     }
 
     /**
-     * @return int
      * @Serializer\VirtualProperty
      * @Serializer\SerializedName("submission_id")
      * @Serializer\Type("string")
      */
-    public function getSubmissionId()
+    public function getSubmissionId(): int
     {
         return $this->getSubmission()->getSubmitid();
     }
 
-    /**
-     * Set contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return Judging
-     */
-    public function setContest(\App\Entity\Contest $contest = null)
+    public function setContest(?Contest $contest = null): Judging
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return \App\Entity\Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set rejudging
-     *
-     * @param \App\Entity\Rejudging $rejudging
-     *
-     * @return Judging
-     */
-    public function setRejudging(\App\Entity\Rejudging $rejudging = null)
+    public function setRejudging(?Rejudging $rejudging = null): Judging
     {
         $this->rejudging = $rejudging;
-
         return $this;
     }
 
-    /**
-     * Get rejudging
-     *
-     * @return \App\Entity\Rejudging
-     */
-    public function getRejudging()
+    public function getRejudging(): ?Rejudging
     {
         return $this->rejudging;
     }
 
-    /**
-     * Set originalJudging
-     *
-     * @param \App\Entity\Judging $originalJudging
-     *
-     * @return Judging
-     */
-    public function setOriginalJudging(\App\Entity\Judging $originalJudging = null)
+    public function setOriginalJudging(?Judging $originalJudging = null): Judging
     {
         $this->original_judging = $originalJudging;
-
         return $this;
     }
 
-    /**
-     * Get originalJudging
-     *
-     * @return \App\Entity\Judging
-     */
-    public function getOriginalJudging()
+    public function getOriginalJudging(): ?Judging
     {
         return $this->original_judging;
     }
 
-    /**
-     * Set judgehost
-     *
-     * @param \App\Entity\Judgehost $judgehost
-     *
-     * @return Judging
-     */
-    public function setJudgehost(\App\Entity\Judgehost $judgehost = null)
+    public function setJudgehost(?Judgehost $judgehost = null): Judging
     {
         $this->judgehost = $judgehost;
-
         return $this;
     }
 
-    /**
-     * Get judgehost
-     *
-     * @return \App\Entity\Judgehost
-     */
-    public function getJudgehost()
+    public function getJudgehost(): Judgehost
     {
         return $this->judgehost;
     }
 
     /**
-     * Get judgehost name
-     *
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\Expose(if="context.getAttribute('domjudge_service').checkrole('jury')")
      * @Serializer\SerializedName("judgehost")
@@ -625,44 +424,23 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
         return $this->getJudgehost() ? $this->getJudgehost()->getHostname() : null;
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->runs = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->runs = new ArrayCollection();
     }
 
-    /**
-     * Add run
-     *
-     * @param \App\Entity\JudgingRun $run
-     *
-     * @return Judging
-     */
-    public function addRun(\App\Entity\JudgingRun $run)
+    public function addRun(JudgingRun $run): Judging
     {
         $this->runs[] = $run;
-
         return $this;
     }
 
-    /**
-     * Remove run
-     *
-     * @param \App\Entity\JudgingRun $run
-     */
-    public function removeRun(\App\Entity\JudgingRun $run)
+    public function removeRun(JudgingRun $run)
     {
         $this->runs->removeElement($run);
     }
 
-    /**
-     * Get runs
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getRuns()
+    public function getRuns(): Collection
     {
         return $this->runs;
     }
@@ -671,8 +449,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
      * Get the entities to check for external ID's while serializing.
      *
      * This method should return an array with as keys the JSON field names and as values the actual entity
-     * objects that the SetExternalIdVisitor should check for applicable external ID's
-     * @return array
+     * objects that the SetExternalIdVisitor should check for applicable external ID's.
      */
     public function getExternalRelationships(): array
     {
@@ -680,12 +457,11 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     }
 
     /**
-     * Check whether this judging is for an aborted judging
-     * @return bool
+     * Check whether this judging is for an aborted judging.
      */
-    public function isAborted()
+    public function isAborted(): bool
     {
-        // This logic has been copied from putSubmissions()
+        // This logic has been copied from putSubmissions().
         return $this->getEndtime() === null && !$this->getValid() &&
             (!$this->getRejudging() || !$this->getRejudging()->getValid());
     }
@@ -693,9 +469,8 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     /**
      * Check whether this judging is still busy while the final result is already known,
      * e.g. with non-lazy evaluation.
-     * @return bool
      */
-    public function isStillBusy()
+    public function isStillBusy(): bool
     {
         return !empty($this->getResult()) && empty($this->getEndtime()) && !$this->isAborted();
     }

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Annotation as Serializer;
 
 /**
  * Result of a testcase run.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judging_run",
@@ -22,7 +23,6 @@ use JMS\Serializer\Annotation as Serializer;
  */
 class JudgingRun extends BaseApiEntity
 {
-
     /**
      * @var int
      *
@@ -136,133 +136,78 @@ class JudgingRun extends BaseApiEntity
         return $this;
     }
 
-    /**
-     * Set runresult
-     *
-     * @param string $runresult
-     *
-     * @return JudgingRun
-     */
-    public function setRunresult($runresult)
+    public function setRunresult(string $runresult): JudgingRun
     {
         $this->runresult = $runresult;
-
         return $this;
     }
 
-    /**
-     * Get runresult
-     *
-     * @return string
-     */
-    public function getRunresult()
+    public function getRunresult(): string
     {
         return $this->runresult;
     }
 
-    /**
-     * Set runtime
-     *
-     * @param float $runtime
-     *
-     * @return JudgingRun
-     */
-    public function setRuntime($runtime)
+    public function setRuntime(float $runtime): JudgingRun
     {
         $this->runtime = $runtime;
-
         return $this;
     }
 
     /**
-     * Get runtime
-     *
-     * @return float
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("run_time")
      * @Serializer\Type("float")
      */
-    public function getRuntime()
+    public function getRuntime(): float
     {
         return Utils::roundedFloat($this->runtime);
     }
 
-    /**
-     * Set endtime
-     *
-     * @param float $endtime
-     *
-     * @return JudgingRun
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): JudgingRun
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return float
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
     /**
-     * Get the absolute end time for this run
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("time")
      * @Serializer\Type("string")
      */
-    public function getAbsoluteEndTime()
+    public function getAbsoluteEndTime(): string
     {
         return Utils::absTime($this->getEndtime());
     }
 
     /**
-     * Get the relative end time for this run
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("contest_time")
      * @Serializer\Type("string")
      */
-    public function getRelativeEndTime()
+    public function getRelativeEndTime(): string
     {
         return Utils::relTime($this->getEndtime() - $this->getJudging()->getContest()->getStarttime());
     }
 
-    /**
-     * Set judging
-     *
-     * @param \App\Entity\Judging $judging
-     *
-     * @return JudgingRun
-     */
-    public function setJudging(\App\Entity\Judging $judging = null)
+    public function setJudging(?Judging $judging = null): JudgingRun
     {
         $this->judging = $judging;
-
         return $this;
     }
 
-    /**
-     * Get judging
-     *
-     * @return \App\Entity\Judging
-     */
-    public function getJudging()
+    public function getJudging(): Judging
     {
         return $this->judging;
     }
 
     /**
-     * @return int
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("judgement_id")
      * @Serializer\Type("string")
@@ -272,50 +217,28 @@ class JudgingRun extends BaseApiEntity
         return $this->getJudging()->getJudgingid();
     }
 
-    /**
-     * Set testcase
-     *
-     * @param \App\Entity\Testcase $testcase
-     *
-     * @return JudgingRun
-     */
-    public function setTestcase(\App\Entity\Testcase $testcase = null)
+    public function setTestcase(?Testcase $testcase = null): JudgingRun
     {
         $this->testcase = $testcase;
-
         return $this;
     }
 
-    /**
-     * Get testcase
-     *
-     * @return \App\Entity\Testcase
-     */
-    public function getTestcase()
+    public function getTestcase(): Testcase
     {
         return $this->testcase;
     }
 
     /**
-     * Get testcase rank
-     * @return int
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("ordinal")
      * @Serializer\Type("int")
      */
-    public function getTestcaseRank()
+    public function getTestcaseRank(): int
     {
         return $this->getTestcase()->getRank();
     }
 
-    /**
-     * Set output
-     *
-     * @param JudgingRunOutput $output
-     *
-     * @return JudgingRun
-     */
-    public function setOutput(JudgingRunOutput $output)
+    public function setOutput(JudgingRunOutput $output): JudgingRun
     {
         $this->output->clear();
         $this->output->add($output);
@@ -324,12 +247,7 @@ class JudgingRun extends BaseApiEntity
         return $this;
     }
 
-    /**
-     * Get output
-     *
-     * @return JudgingRunOutput
-     */
-    public function getOutput()
+    public function getOutput(): ?JudgingRunOutput
     {
         return $this->output->first() ?: null;
     }

--- a/webapp/src/Entity/JudgingRunOutput.php
+++ b/webapp/src/Entity/JudgingRunOutput.php
@@ -5,7 +5,7 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Output of a judging run
+ * Output of a judging run.
  *
  * @ORM\Entity
  * @ORM\Table(
@@ -67,125 +67,62 @@ class JudgingRunOutput
      */
     private $metadata;
 
-    /**
-     * @param JudgingRun $run
-     *
-     * @return JudgingRunOutput
-     */
-    public function setRun(JudgingRun $run)
+    public function setRun(JudgingRun $run): JudgingRunOutput
     {
         $this->run = $run;
-
         return $this;
     }
 
-    /**
-     * Get run
-     *
-     * @return JudgingRun
-     */
     public function getRun(): JudgingRun
     {
         return $this->run;
     }
 
-    /**
-     * Set outputRun
-     *
-     * @param string $outputRun
-     *
-     * @return JudgingRunOutput
-     */
-    public function setOutputRun($outputRun)
+    public function setOutputRun($outputRun): JudgingRunOutput
     {
         $this->output_run = $outputRun;
-
         return $this;
     }
 
-    /**
-     * Get outputRun
-     *
-     * @return string
-     */
-    public function getOutputRun()
+    public function getOutputRun(): string
     {
         return $this->output_run;
     }
 
-    /**
-     * Set outputDiff
-     *
-     * @param string $outputDiff
-     *
-     * @return JudgingRunOutput
-     */
-    public function setOutputDiff($outputDiff)
+    public function setOutputDiff(string $outputDiff): JudgingRunOutput
     {
         $this->output_diff = $outputDiff;
-
         return $this;
     }
 
-    /**
-     * Get outputDiff
-     *
-     * @return string
-     */
-    public function getOutputDiff()
+    public function getOutputDiff(): string
     {
         return $this->output_diff;
     }
 
-    /**
-     * Set outputError
-     *
-     * @param string $outputError
-     *
-     * @return JudgingRunOutput
-     */
-    public function setOutputError($outputError)
+    public function setOutputError(string $outputError): JudgingRunOutput
     {
         $this->output_error = $outputError;
-
         return $this;
     }
 
-    /**
-     * Get outputError
-     *
-     * @return string
-     */
-    public function getOutputError()
+    public function getOutputError(): string
     {
         return $this->output_error;
     }
 
-    /**
-     * Set outputSystem
-     *
-     * @param string $outputSystem
-     *
-     * @return JudgingRunOutput
-     */
-    public function setOutputSystem($outputSystem)
+    public function setOutputSystem(string $outputSystem): JudgingRunOutput
     {
         $this->output_system = $outputSystem;
-
         return $this;
     }
 
-    /**
-     * Get outputSystem
-     *
-     * @return string
-     */
-    public function getOutputSystem()
+    public function getOutputSystem(): string
     {
         return $this->output_system;
     }
 
-    public function getMetadata()
+    public function getMetadata(): string
     {
         return $this->metadata;
     }
@@ -193,7 +130,6 @@ class JudgingRunOutput
     public function setMetadata($metadata): self
     {
         $this->metadata = $metadata;
-
         return $this;
     }
 }

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -152,7 +152,7 @@ class Language extends BaseApiEntity
         return $this;
     }
 
-    public function getExternalid(): string
+    public function getExternalid(): ?string
     {
         return $this->externalid;
     }

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -10,7 +10,8 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Programming languages in which teams can submit solutions
+ * Programming languages in which teams can submit solutions.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="language",
@@ -24,7 +25,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Language extends BaseApiEntity
 {
-
     /**
      * @var string
      * @ORM\Id
@@ -135,316 +135,149 @@ class Language extends BaseApiEntity
      */
     private $submissions;
 
-    /**
-     * Set langid
-     *
-     * @param string $langid
-     *
-     * @return Language
-     */
-    public function setLangid($langid)
+    public function setLangid(string $langid): Language
     {
         $this->langid = $langid;
-
         return $this;
     }
 
-    /**
-     * Get langid
-     *
-     * @return string
-     */
-    public function getLangid()
+    public function getLangid(): string
     {
         return $this->langid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string externalid
-     *
-     * @return Language
-     */
-    public function setExternalid(string $externalid)
+    public function setExternalid(string $externalid): Language
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return Language
-     */
-    public function setName($name)
+    public function setName(string $name): Language
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set extensions
-     *
-     * @param string[] $extensions
-     *
-     * @return Language
-     */
-    public function setExtensions(array $extensions)
+    public function setExtensions(array $extensions): Language
     {
         $this->extensions = $extensions;
-
         return $this;
     }
 
-    /**
-     * Get extensions
-     *
-     * @return string[]
-     */
-    public function getExtensions()
+    public function getExtensions(): array
     {
         return $this->extensions;
     }
 
-    /**
-     * Set filterCompilerFiles
-     *
-     * @param bool $filterCompilerFiles
-     *
-     * @return Language
-     */
-    public function setFilterCompilerFiles(bool $filterCompilerFiles)
+    public function setFilterCompilerFiles(bool $filterCompilerFiles): Language
     {
         $this->filterCompilerFiles = $filterCompilerFiles;
-
         return $this;
     }
 
-    /**
-     * Get filterCompilerFiles
-     *
-     * @return bool
-     */
-    public function getFilterCompilerFiles()
+    public function getFilterCompilerFiles(): bool
     {
         return $this->filterCompilerFiles;
     }
 
-    /**
-     * Set allowSubmit
-     *
-     * @param boolean $allowSubmit
-     *
-     * @return Language
-     */
-    public function setAllowSubmit($allowSubmit)
+    public function setAllowSubmit(bool $allowSubmit): Language
     {
         $this->allowSubmit = $allowSubmit;
-
         return $this;
     }
 
-    /**
-     * Get allowSubmit
-     *
-     * @return boolean
-     */
-    public function getAllowSubmit()
+    public function getAllowSubmit(): bool
     {
         return $this->allowSubmit;
     }
 
-    /**
-     * Set allowJudge
-     *
-     * @param boolean $allowJudge
-     *
-     * @return Language
-     */
-    public function setAllowJudge($allowJudge)
+    public function setAllowJudge(bool $allowJudge): Language
     {
         $this->allowJudge = $allowJudge;
-
         return $this;
     }
 
-    /**
-     * Get allowJudge
-     *
-     * @return boolean
-     */
-    public function getAllowJudge()
+    public function getAllowJudge(): bool
     {
         return $this->allowJudge;
     }
 
-    /**
-     * Set timeFactor
-     *
-     * @param float $timeFactor
-     *
-     * @return Language
-     */
-    public function setTimeFactor($timeFactor)
+    public function setTimeFactor(float $timeFactor): Language
     {
         $this->timeFactor = $timeFactor;
-
         return $this;
     }
 
-    /**
-     * Get timeFactor
-     *
-     * @return float
-     */
-    public function getTimeFactor()
+    public function getTimeFactor(): float
     {
         return $this->timeFactor;
     }
 
-    /**
-     * Set requireEntryPoint
-     *
-     * @param boolean $requireEntryPoint
-     *
-     * @return Language
-     */
-    public function setRequireEntryPoint($requireEntryPoint)
+    public function setRequireEntryPoint(bool $requireEntryPoint): Language
     {
         $this->require_entry_point = $requireEntryPoint;
-
         return $this;
     }
 
-    /**
-     * Get requireEntryPoint
-     *
-     * @return boolean
-     */
-    public function getRequireEntryPoint()
+    public function getRequireEntryPoint(): bool
     {
         return $this->require_entry_point;
     }
 
-    /**
-     * Set entryPointDescription
-     *
-     * @param string $entryPointDescription
-     *
-     * @return Language
-     */
-    public function setEntryPointDescription($entryPointDescription)
+    public function setEntryPointDescription(string $entryPointDescription): Language
     {
         $this->entry_point_description = $entryPointDescription;
-
         return $this;
     }
 
-    /**
-     * Get entryPointDescription
-     *
-     * @return string
-     */
-    public function getEntryPointDescription()
+    public function getEntryPointDescription(): string
     {
         return $this->entry_point_description;
     }
 
-    /**
-     * Set compileExecutable
-     *
-     * @param \App\Entity\Executable $compileExecutable
-     *
-     * @return Language
-     */
-    public function setCompileExecutable(\App\Entity\Executable $compileExecutable = null)
+    public function setCompileExecutable(?Executable $compileExecutable = null): Language
     {
         $this->compile_executable = $compileExecutable;
-
         return $this;
     }
 
-    /**
-     * Get compileExecutable
-     *
-     * @return \App\Entity\Executable
-     */
-    public function getCompileExecutable()
+    public function getCompileExecutable(): Executable
     {
         return $this->compile_executable;
     }
-    /**
-     * Constructor
-     */
+
     public function __construct()
     {
-        $this->submissions = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->submissions = new ArrayCollection();
     }
 
-    /**
-     * Add submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Language
-     */
-    public function addSubmission(\App\Entity\Submission $submission)
+    public function addSubmission(Submission $submission): Language
     {
         $this->submissions[] = $submission;
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param \App\Entity\Submission $submission
-     */
-    public function removeSubmission(\App\Entity\Submission $submission)
+    public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Get the language for the ACE editor for this language
-     * @return string
-     */
-    public function getAceLanguage()
+    public function getAceLanguage(): string
     {
         switch ($this->getLangid()) {
             case 'c':

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -141,7 +141,7 @@ class Language extends BaseApiEntity
         return $this;
     }
 
-    public function getLangid(): string
+    public function getLangid(): ?string
     {
         return $this->langid;
     }
@@ -240,7 +240,7 @@ class Language extends BaseApiEntity
         return $this;
     }
 
-    public function getEntryPointDescription(): string
+    public function getEntryPointDescription(): ?string
     {
         return $this->entry_point_description;
     }

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -12,7 +12,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Stores testcases per problem
+ * Stores testcases per problem.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="problem",
@@ -27,7 +28,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Problem extends BaseApiEntity
 {
-
     /**
      * @var int
      *
@@ -176,233 +176,119 @@ class Problem extends BaseApiEntity
      */
     private $testcases;
 
-    /**
-     * Set probid
-     *
-     * @param integer $probId
-     *
-     * @return Problem
-     */
-    public function setProbid($probid)
+    public function setProbid(int $probid): Problem
     {
         $this->probid = $probid;
-
         return $this;
     }
 
-    /**
-     * Get probid
-     *
-     * @return integer
-     */
-    public function getProbid()
+    public function getProbid(): int
     {
         return $this->probid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return Problem
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): Problem
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return Problem
-     */
-    public function setName($name)
+    public function setName(string $name): Problem
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set timelimit
-     *
-     * @param float $timelimit
-     *
-     * @return Problem
-     */
-    public function setTimelimit($timelimit)
+    public function setTimelimit(float $timelimit): Problem
     {
         $this->timelimit = $timelimit;
-
         return $this;
     }
 
     /**
-     * Get timelimit
-     *
-     * @return float
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("time_limit")
      * @Serializer\Type("float")
      */
-    public function getTimelimit()
+    public function getTimelimit(): float
     {
         return Utils::roundedFloat($this->timelimit);
     }
 
-    /**
-     * Set memlimit
-     *
-     * @param integer $memlimit
-     *
-     * @return Problem
-     */
-    public function setMemlimit($memlimit)
+    public function setMemlimit(int $memlimit): Problem
     {
         $this->memlimit = $memlimit;
-
         return $this;
     }
 
-    /**
-     * Get memlimit
-     *
-     * @return integer
-     */
-    public function getMemlimit()
+    public function getMemlimit(): ?int
     {
         return $this->memlimit;
     }
 
-    /**
-     * Set outputlimit
-     *
-     * @param integer $outputlimit
-     *
-     * @return Problem
-     */
-    public function setOutputlimit($outputlimit)
+    public function setOutputlimit(int $outputlimit): Problem
     {
         $this->outputlimit = $outputlimit;
-
         return $this;
     }
 
-    /**
-     * Get outputlimit
-     *
-     * @return integer
-     */
-    public function getOutputlimit()
+    public function getOutputlimit(): ?int
     {
         return $this->outputlimit;
     }
 
-    /**
-     * Set specialCompareArgs
-     *
-     * @param string $specialCompareArgs
-     *
-     * @return Problem
-     */
-    public function setSpecialCompareArgs($specialCompareArgs)
+    public function setSpecialCompareArgs(string $specialCompareArgs): Problem
     {
         $this->special_compare_args = $specialCompareArgs;
-
         return $this;
     }
 
-    /**
-     * Get specialCompareArgs
-     *
-     * @return string
-     */
-    public function getSpecialCompareArgs()
+    public function getSpecialCompareArgs(): ?string
     {
         return $this->special_compare_args;
     }
 
-    /**
-     * Set combinedRunCompare
-     *
-     * @param boolean $combinedRunCompare
-     *
-     * @return Problem
-     */
-    public function setCombinedRunCompare($combinedRunCompare)
+    public function setCombinedRunCompare(bool $combinedRunCompare): Problem
     {
         $this->combined_run_compare = $combinedRunCompare;
-
         return $this;
     }
 
-    /**
-     * Get combinedRunCompare
-     *
-     * @return boolean
-     */
-    public function getCombinedRunCompare()
+    public function getCombinedRunCompare(): bool
     {
         return $this->combined_run_compare;
     }
 
     /**
-     * Set problemtext
-     *
      * @param resource|string $problemtext
-     *
-     * @return Problem
      */
-    public function setProblemtext($problemtext)
+    public function setProblemtext($problemtext): Problem
     {
         $this->problemtext = $problemtext;
-
         return $this;
     }
 
-    /**
-     * @param UploadedFile|null $problemtextFile
-     * @return Problem
-     */
-    public function setProblemtextFile($problemtextFile)
+    public function setProblemtextFile(?UploadedFile $problemtextFile): Problem
     {
         $this->problemtextFile = $problemtextFile;
-        // Clear the problem text to make sure the entity is modified
+
+        // Clear the problem text to make sure the entity is modified.
         $this->problemtext = '';
 
         return $this;
     }
 
-    /**
-     * @param bool $clearProblemtext
-     * @return Problem
-     */
-    public function setClearProblemtext(bool $clearProblemtext)
+    public function setClearProblemtext(bool $clearProblemtext): Problem
     {
         $this->clearProblemtext = $clearProblemtext;
         $this->problemtext = null;
@@ -411,8 +297,6 @@ class Problem extends BaseApiEntity
     }
 
     /**
-     * Get problemtext
-     *
      * @return resource|string
      */
     public function getProblemtext()
@@ -420,167 +304,85 @@ class Problem extends BaseApiEntity
         return $this->problemtext;
     }
 
-    /**
-     * @return UploadedFile|null
-     */
-    public function getProblemtextFile()
+    public function getProblemtextFile(): ?UploadedFile
     {
         return $this->problemtextFile;
     }
 
-    /**
-     * @return bool
-     */
     public function isClearProblemtext(): bool
     {
         return $this->clearProblemtext;
     }
 
-    /**
-     * Set problemtextType
-     *
-     * @param string $problemtextType
-     *
-     * @return Problem
-     */
-    public function setProblemtextType($problemtextType)
+    public function setProblemtextType(?string $problemtextType): Problem
     {
         $this->problemtext_type = $problemtextType;
-
         return $this;
     }
 
-    /**
-     * Get problemtextType
-     *
-     * @return string
-     */
-    public function getProblemtextType()
+    public function getProblemtextType(): string
     {
         return $this->problemtext_type;
     }
 
-    /**
-     * Set compareExecutable
-     *
-     * @param \App\Entity\Executable $compareExecutable
-     *
-     * @return Problem
-     */
-    public function setCompareExecutable(\App\Entity\Executable $compareExecutable = null)
+    public function setCompareExecutable(?Executable $compareExecutable = null): Problem
     {
         $this->compare_executable = $compareExecutable;
-
         return $this;
     }
 
-    /**
-     * Get compareExecutable
-     *
-     * @return \App\Entity\Executable
-     */
-    public function getCompareExecutable()
+    public function getCompareExecutable(): ?Executable
     {
         return $this->compare_executable;
     }
 
-    /**
-     * Set runExecutable
-     *
-     * @param \App\Entity\Executable $runExecutable
-     *
-     * @return Problem
-     */
-    public function setRunExecutable(\App\Entity\Executable $runExecutable = null)
+    public function setRunExecutable(?Executable $runExecutable = null): Problem
     {
         $this->run_executable = $runExecutable;
-
         return $this;
     }
 
-    /**
-     * Get runExecutable
-     *
-     * @return \App\Entity\Executable
-     */
-    public function getRunExecutable()
+    public function getRunExecutable(): ?Executable
     {
         return $this->run_executable;
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->testcases = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->submissions = new ArrayCollection();
-        $this->clarifications = new ArrayCollection();
+        $this->testcases        = new ArrayCollection();
+        $this->submissions      = new ArrayCollection();
+        $this->clarifications   = new ArrayCollection();
         $this->contest_problems = new ArrayCollection();
     }
 
-    /**
-     * Add testcase
-     *
-     * @param \App\Entity\Testcase $testcase
-     *
-     * @return Problem
-     */
-    public function addTestcase(\App\Entity\Testcase $testcase)
+    public function addTestcase(Testcase $testcase): Problem
     {
         $this->testcases[] = $testcase;
-
         return $this;
     }
 
-    /**
-     * Remove testcase
-     *
-     * @param \App\Entity\Testcase $testcase
-     */
-    public function removeTestcase(\App\Entity\Testcase $testcase)
+    public function removeTestcase(Testcase $testcase)
     {
         $this->testcases->removeElement($testcase);
     }
 
-    /**
-     * Get testcases
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getTestcases()
+    public function getTestcases(): Collection
     {
         return $this->testcases;
     }
 
-    /**
-     * Add contestProblem
-     *
-     * @param \App\Entity\ContestProblem $contestProblem
-     *
-     * @return Problem
-     */
-    public function addContestProblem(\App\Entity\ContestProblem $contestProblem)
+    public function addContestProblem(ContestProblem $contestProblem): Problem
     {
         $this->contest_problems[] = $contestProblem;
-
         return $this;
     }
 
-    /**
-     * Remove contestProblem
-     *
-     * @param \App\Entity\ContestProblem $contestProblem
-     */
-    public function removeContestProblem(
-        \App\Entity\ContestProblem $contestProblem)
+    public function removeContestProblem(ContestProblem $contestProblem)
     {
         $this->contest_problems->removeElement($contestProblem);
     }
 
     /**
-     * Get contestProblems
-     *
      * @return \Doctrine\Common\Collections\Collection|ContestProblem[]
      */
     public function getContestProblems()
@@ -588,70 +390,34 @@ class Problem extends BaseApiEntity
         return $this->contest_problems;
     }
 
-    /**
-     * Add submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Problem
-     */
-    public function addSubmission(\App\Entity\Submission $submission)
+    public function addSubmission(Submission $submission): Problem
     {
         $this->submissions[] = $submission;
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param \App\Entity\Submission $submission
-     */
-    public function removeSubmission(\App\Entity\Submission $submission)
+    public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Add clarification
-     *
-     * @param \App\Entity\Clarification $clarification
-     *
-     * @return Problem
-     */
-    public function addClarification(\App\Entity\Clarification $clarification)
+    public function addClarification(Clarification $clarification): Problem
     {
         $this->clarifications[] = $clarification;
-
         return $this;
     }
 
-    /**
-     * Remove clarification
-     *
-     * @param \App\Entity\Clarification $clarification
-     */
-    public function removeClarification(\App\Entity\Clarification $clarification)
+    public function removeClarification(Clarification $clarification)
     {
         $this->clarifications->removeElement($clarification);
     }
 
-    /**
-     * Get clarifications
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getClarifications()
+    public function getClarifications(): Collection
     {
         return $this->clarifications;
     }

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -204,7 +204,7 @@ class Problem extends BaseApiEntity
         return $this;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -182,7 +182,7 @@ class Problem extends BaseApiEntity
         return $this;
     }
 
-    public function getProbid(): int
+    public function getProbid(): ?int
     {
         return $this->probid;
     }
@@ -193,7 +193,7 @@ class Problem extends BaseApiEntity
         return $this;
     }
 
-    public function getExternalid(): string
+    public function getExternalid(): ?string
     {
         return $this->externalid;
     }

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -320,7 +320,7 @@ class Problem extends BaseApiEntity
         return $this;
     }
 
-    public function getProblemtextType(): string
+    public function getProblemtextType(): ?string
     {
         return $this->problemtext_type;
     }

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -4,7 +4,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Scoreboard cache rank
+ * Scoreboard cache rank.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="rankcache",
@@ -73,146 +74,68 @@ class RankCache
      */
     private $team;
 
-    /**
-     * Set pointsRestricted
-     *
-     * @param integer $pointsRestricted
-     *
-     * @return RankCache
-     */
-    public function setPointsRestricted($pointsRestricted)
+    public function setPointsRestricted(int $pointsRestricted): RankCache
     {
         $this->points_restricted = $pointsRestricted;
-
         return $this;
     }
 
-    /**
-     * Get pointsRestricted
-     *
-     * @return integer
-     */
-    public function getPointsRestricted()
+    public function getPointsRestricted(): int
     {
         return $this->points_restricted;
     }
 
-    /**
-     * Set totaltimeRestricted
-     *
-     * @param integer $totaltimeRestricted
-     *
-     * @return RankCache
-     */
-    public function setTotaltimeRestricted($totaltimeRestricted)
+    public function setTotaltimeRestricted(int $totaltimeRestricted): RankCache
     {
         $this->totaltime_restricted = $totaltimeRestricted;
-
         return $this;
     }
 
-    /**
-     * Get totaltimeRestricted
-     *
-     * @return integer
-     */
-    public function getTotaltimeRestricted()
+    public function getTotaltimeRestricted(): int
     {
         return $this->totaltime_restricted;
     }
 
-    /**
-     * Set pointsPublic
-     *
-     * @param integer $pointsPublic
-     *
-     * @return RankCache
-     */
-    public function setPointsPublic($pointsPublic)
+    public function setPointsPublic(int $pointsPublic): RankCache
     {
         $this->points_public = $pointsPublic;
-
         return $this;
     }
 
-    /**
-     * Get pointsPublic
-     *
-     * @return integer
-     */
-    public function getPointsPublic()
+    public function getPointsPublic(): int
     {
         return $this->points_public;
     }
 
-    /**
-     * Set totaltimePublic
-     *
-     * @param integer $totaltimePublic
-     *
-     * @return RankCache
-     */
-    public function setTotaltimePublic($totaltimePublic)
+    public function setTotaltimePublic(int $totaltimePublic): RankCache
     {
         $this->totaltime_public = $totaltimePublic;
-
         return $this;
     }
 
-    /**
-     * Get totaltimePublic
-     *
-     * @return integer
-     */
-    public function getTotaltimePublic()
+    public function getTotaltimePublic(): int
     {
         return $this->totaltime_public;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest $contest
-     *
-     * @return RankCache
-     */
-    public function setContest(Contest $contest = null)
+    public function setContest(?Contest $contest = null): RankCache
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set team
-     *
-     * @param Team $team
-     *
-     * @return RankCache
-     */
-    public function setTeam(Team $team = null)
+    public function setTeam(?Team $team = null): RankCache
     {
         $this->team = $team;
-
         return $this;
     }
 
-    /**
-     * Get team
-     *
-     * @return Team
-     */
-    public function getTeam()
+    public function getTeam(): Team
     {
         return $this->team;
     }

--- a/webapp/src/Entity/Rejudging.php
+++ b/webapp/src/Entity/Rejudging.php
@@ -7,7 +7,8 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Rejudge group
+ * Rejudge group.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="rejudging",
@@ -65,27 +66,27 @@ class Rejudging
     private $valid = true;
 
     /**
-     * Who started the rejudging
+     * Who started the rejudging.
      * @ORM\ManyToOne(targetEntity="User")
      * @ORM\JoinColumn(name="userid_start", referencedColumnName="userid", onDelete="SET NULL")
      */
     private $start_user;
 
     /**
-     * Who finished the rejudging
+     * Who finished the rejudging.
      * @ORM\ManyToOne(targetEntity="User")
      * @ORM\JoinColumn(name="userid_finish", referencedColumnName="userid", onDelete="SET NULL")
      */
     private $finish_user;
 
     /**
-     * One rejudging has many judgings
+     * One rejudging has many judgings.
      * @ORM\OneToMany(targetEntity="Judging", mappedBy="rejudging")
      */
     private $judgings;
 
     /**
-     * One rejudging has many submissions
+     * One rejudging has many submissions.
      * @ORM\OneToMany(targetEntity="App\Entity\Submission", mappedBy="rejudging")
      */
     private $submissions;
@@ -116,305 +117,148 @@ class Rejudging
      */
     private $repeatedRejudging;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->judgings = new ArrayCollection();
+        $this->judgings    = new ArrayCollection();
         $this->submissions = new ArrayCollection();
     }
 
-    /**
-     * Get rejudgingid
-     *
-     * @return integer
-     */
-    public function getRejudgingid()
+    public function getRejudgingid(): int
     {
         return $this->rejudgingid;
     }
 
-    /**
-     * Set starttime
-     *
-     * @param string $starttime
-     *
-     * @return Rejudging
-     */
-    public function setStarttime($starttime)
+    /** @param string|float $starttime */
+    public function setStarttime($starttime): Rejudging
     {
         $this->starttime = $starttime;
-
         return $this;
     }
 
-    /**
-     * Get starttime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getStarttime()
     {
         return $this->starttime;
     }
 
-    /**
-     * Set endtime
-     *
-     * @param string $endtime
-     *
-     * @return Rejudging
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): Rejudging
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
-    /**
-     * Set reason
-     *
-     * @param string $reason
-     *
-     * @return Rejudging
-     */
-    public function setReason($reason)
+    public function setReason(string $reason): Rejudging
     {
         $this->reason = $reason;
-
         return $this;
     }
 
-    /**
-     * Get reason
-     *
-     * @return string
-     */
-    public function getReason()
+    public function getReason(): string
     {
         return $this->reason;
     }
 
-    /**
-     * Set valid
-     *
-     * @param boolean $valid
-     *
-     * @return Rejudging
-     */
-    public function setValid($valid)
+    public function setValid(bool $valid): Rejudging
     {
         $this->valid = $valid;
-
         return $this;
     }
 
-    /**
-     * Get valid
-     *
-     * @return boolean
-     */
-    public function getValid()
+    public function getValid(): bool
     {
         return $this->valid;
     }
 
-    /**
-     * Set startUser
-     *
-     * @param \App\Entity\User $startUser
-     *
-     * @return Rejudging
-     */
-    public function setStartUser(\App\Entity\User $startUser = null)
+    public function setStartUser(?User $startUser = null): Rejudging
     {
         $this->start_user = $startUser;
-
         return $this;
     }
 
-    /**
-     * Get startUser
-     *
-     * @return \App\Entity\User
-     */
-    public function getStartUser()
+    public function getStartUser(): ?User
     {
         return $this->start_user;
     }
 
-    /**
-     * Set finishUser
-     *
-     * @param \App\Entity\User $finishUser
-     *
-     * @return Rejudging
-     */
-    public function setFinishUser(\App\Entity\User $finishUser = null)
+    public function setFinishUser(?User $finishUser = null): Rejudging
     {
         $this->finish_user = $finishUser;
-
         return $this;
     }
 
-    /**
-     * Get finishUser
-     *
-     * @return \App\Entity\User
-     */
-    public function getFinishUser()
+    public function getFinishUser(): ?User
     {
         return $this->finish_user;
     }
 
-    /**
-     * Add judging
-     *
-     * @param \App\Entity\Judging $judging
-     *
-     * @return Rejudging
-     */
-    public function addJudging(\App\Entity\Judging $judging)
+    public function addJudging(Judging $judging): Rejudging
     {
         $this->judgings[] = $judging;
-
         return $this;
     }
 
-    /**
-     * Remove judging
-     *
-     * @param \App\Entity\Judging $judging
-     */
-    public function removeJudging(\App\Entity\Judging $judging)
+    public function removeJudging(Judging $judging)
     {
         $this->judgings->removeElement($judging);
     }
 
-    /**
-     * Get judgings
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getJudgings()
+    public function getJudgings(): Collection
     {
         return $this->judgings;
     }
 
-    /**
-     * Add submission
-     *
-     * @param Submission $submission
-     *
-     * @return Rejudging
-     */
-    public function addSubmission(Submission $submission)
+    public function addSubmission(Submission $submission): Rejudging
     {
         $this->submissions[] = $submission;
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param Submission $submission
-     */
     public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Set auto_apply
-     *
-     * @param boolean $autoApply
-     *
-     * @return Rejudging
-     */
-    public function setAutoApply(bool $autoApply)
+    public function setAutoApply(bool $autoApply): Rejudging
     {
         $this->autoApply = $autoApply;
-
         return $this;
     }
 
-    /**
-     * Get auto_apply
-     *
-     * @return boolean
-     */
-    public function getAutoApply()
+    public function getAutoApply(): bool
     {
         return $this->autoApply;
     }
 
-    /**
-     * Set repeat
-     *
-     * @param int $repeat
-     *
-     * @return Rejudging
-     */
-    public function setRepeat(int $repeat)
+    public function setRepeat(int $repeat): Rejudging
     {
         $this->repeat = $repeat;
-
         return $this;
     }
 
-    /**
-     * Get repeat
-     *
-     * @return int
-     */
-    public function getRepeat()
+    public function getRepeat(): ?int
     {
         return $this->repeat;
     }
 
-    /**
-     * Set repeated rejudging
-     *
-     * @param Rejudging|null $repeatedRejudging
-     *
-     * @return Rejudging
-     */
-    public function setRepeatedRejudging(?Rejudging $repeatedRejudging)
+    public function setRepeatedRejudging(?Rejudging $repeatedRejudging): Rejudging
     {
         $this->repeatedRejudging = $repeatedRejudging;
-
         return $this;
     }
 
-    /**
-     * Get repeated rejudging
-     *
-     * @return Rejudging|null
-     */
-    public function getRepeatedRejudging()
+    public function getRepeatedRejudging(): ?Rejudging
     {
         return $this->repeatedRejudging;
     }

--- a/webapp/src/Entity/RemovedInterval.php
+++ b/webapp/src/Entity/RemovedInterval.php
@@ -9,7 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
- * Time intervals removed from the contest for scoring
+ * Time intervals removed from the contest for scoring.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="removed_interval",
@@ -68,73 +69,41 @@ class RemovedInterval
      */
     private $contest;
 
-    /**
-     * Get intervalid
-     *
-     * @return integer
-     */
-    public function getIntervalid()
+    public function getIntervalid(): int
     {
         return $this->intervalid;
     }
 
-    /**
-     * Set starttime
-     *
-     * @param string $starttime
-     *
-     * @return RemovedInterval
-     */
-    public function setStarttime($starttime)
+    /** @param string|float $starttime */
+    public function setStarttime($starttime): RemovedInterval
     {
         $this->starttime = $starttime;
-
         return $this;
     }
 
-    /**
-     * Get starttime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getStarttime()
     {
         return $this->starttime;
     }
 
-    /**
-     * Set endtime
-     *
-     * @param string $endtime
-     *
-     * @return RemovedInterval
-     */
-    public function setEndtime($endtime)
+    /** @param string|float $endtime */
+    public function setEndtime($endtime): RemovedInterval
     {
         $this->endtime = $endtime;
-
         return $this;
     }
 
-    /**
-     * Get endtime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getEndtime()
     {
         return $this->endtime;
     }
 
     /**
-     * Set starttimeString
-     *
-     * @param string $starttimeString
-     *
-     * @return RemovedInterval
      * @throws \Exception
      */
-    public function setStarttimeString($starttimeString)
+    public function setStarttimeString(string $starttimeString): RemovedInterval
     {
         $this->starttimeString = $starttimeString;
         $date                  = new \DateTime($starttimeString);
@@ -143,25 +112,15 @@ class RemovedInterval
         return $this;
     }
 
-    /**
-     * Get starttimeString
-     *
-     * @return string
-     */
-    public function getStarttimeString()
+    public function getStarttimeString(): ?string
     {
         return $this->starttimeString;
     }
 
     /**
-     * Set endtimeString
-     *
-     * @param string $endtimeString
-     *
-     * @return RemovedInterval
      * @throws \Exception
      */
-    public function setEndtimeString($endtimeString)
+    public function setEndtimeString(string $endtimeString): RemovedInterval
     {
         $this->endtimeString = $endtimeString;
         $date                = new \DateTime($endtimeString);
@@ -170,42 +129,23 @@ class RemovedInterval
         return $this;
     }
 
-    /**
-     * Get endtimeString
-     *
-     * @return string
-     */
-    public function getEndtimeString()
+    public function getEndtimeString(): ?string
     {
         return $this->endtimeString;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest $contest
-     *
-     * @return RemovedInterval
-     */
-    public function setContest(Contest $contest = null)
+    public function setContest(?Contest $contest = null): RemovedInterval
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
     /**
-     * @param ExecutionContextInterface $context
      * @Assert\Callback()
      */
     public function validate(ExecutionContextInterface $context)

--- a/webapp/src/Entity/Role.php
+++ b/webapp/src/Entity/Role.php
@@ -6,7 +6,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Possible user roles
+ * Possible user roles.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="role",
@@ -41,111 +42,60 @@ class Role
      */
     private $users;
 
-    public function getRole()
+    public function getRole(): string
     {
         return "ROLE_" . strtoupper($this->dj_role);
     }
 
-    /**
-     * Get roleid
-     *
-     * @return integer
-     */
-    public function getRoleid()
+    public function getRoleid(): int
     {
         return $this->roleid;
     }
 
-    /**
-     * Set description
-     *
-     * @param string $description
-     *
-     * @return Role
-     */
-    public function setDescription($description)
+    public function setDescription(string $description): Role
     {
         $this->description = $description;
-
         return $this;
     }
 
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-    * Set djRole
-    *
-    * @param string $djRole
-    *
-    * @return Role
-    */
-    public function setDjRole($djRole)
+    public function setDjRole(string $djRole): Role
     {
         $this->dj_role = $djRole;
-
         return $this;
     }
 
-    /**
-    * Get djRole
-    *
-    * @return string
-    */
-    public function getDjRole()
+    public function getDjRole(): string
     {
         return $this->dj_role;
     }
-    /**
-     * Constructor
-     */
+
     public function __construct()
     {
-        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->users = new ArrayCollection();
     }
 
-    /**
-     * Add user
-     *
-     * @param \App\Entity\User $user
-     *
-     * @return Role
-     */
-    public function addUser(\App\Entity\User $user)
+    public function addUser(User $user): Role
     {
         $this->users[] = $user;
-
         return $this;
     }
 
-    /**
-     * Remove user
-     *
-     * @param \App\Entity\User $user
-     */
-    public function removeUser(\App\Entity\User $user)
+    public function removeUser(User $user)
     {
         $this->users->removeElement($user);
     }
 
-    /**
-     * Get users
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getUsers()
+    public function getUsers(): Collection
     {
         return $this->users;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getRole() . ": " . $this->getDescription();
     }

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -4,7 +4,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Scoreboard cache
+ * Scoreboard cache.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="scorecache",
@@ -127,329 +128,158 @@ class ScoreCache
      */
     private $problem;
 
-    /**
-     * Set submissionsRestricted
-     *
-     * @param integer $submissionsRestricted
-     *
-     * @return ScoreCache
-     */
-    public function setSubmissionsRestricted($submissionsRestricted)
+    public function setSubmissionsRestricted(int $submissionsRestricted): ScoreCache
     {
         $this->submissions_restricted = $submissionsRestricted;
-
         return $this;
     }
 
-    /**
-     * Get submissionsRestricted
-     *
-     * @return integer
-     */
-    public function getSubmissionsRestricted()
+    public function getSubmissionsRestricted(): int
     {
         return $this->submissions_restricted;
     }
 
-    /**
-     * Set pendingRestricted
-     *
-     * @param integer $pendingRestricted
-     *
-     * @return ScoreCache
-     */
-    public function setPendingRestricted($pendingRestricted)
+    public function setPendingRestricted(int $pendingRestricted): ScoreCache
     {
         $this->pending_restricted = $pendingRestricted;
-
         return $this;
     }
 
-    /**
-     * Get pendingRestricted
-     *
-     * @return integer
-     */
-    public function getPendingRestricted()
+    public function getPendingRestricted(): int
     {
         return $this->pending_restricted;
     }
 
-    /**
-     * Set isCorrectRestricted
-     *
-     * @param boolean $isCorrectRestricted
-     *
-     * @return ScoreCache
-     */
-    public function setIsCorrectRestricted($isCorrectRestricted)
+    public function setIsCorrectRestricted(bool $isCorrectRestricted): ScoreCache
     {
         $this->is_correct_restricted = $isCorrectRestricted;
-
         return $this;
     }
 
-    /**
-     * Get isCorrectRestricted
-     *
-     * @return boolean
-     */
-    public function getIsCorrectRestricted()
+    public function getIsCorrectRestricted(): bool
     {
         return $this->is_correct_restricted;
     }
 
-    /**
-     * Set solvetimeRestricted
-     *
-     * @param double $solvetimeRestricted
-     *
-     * @return ScoreCache
-     */
-    public function setSolvetimeRestricted($solvetimeRestricted)
+    /** @param string|float $solvetimeRestricted */
+    public function setSolvetimeRestricted($solvetimeRestricted): ScoreCache
     {
         $this->solvetime_restricted = $solvetimeRestricted;
-
         return $this;
     }
 
-    /**
-     * Get solvetimeRestricted
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getSolvetimeRestricted()
     {
         return $this->solvetime_restricted;
     }
 
-    /**
-     * Set submissionsPublic
-     *
-     * @param integer $submissionsPublic
-     *
-     * @return ScoreCache
-     */
-    public function setSubmissionsPublic($submissionsPublic)
+    public function setSubmissionsPublic(int $submissionsPublic): ScoreCache
     {
         $this->submissions_public = $submissionsPublic;
-
         return $this;
     }
 
-    /**
-     * Get submissionsPublic
-     *
-     * @return integer
-     */
-    public function getSubmissionsPublic()
+    public function getSubmissionsPublic(): int
     {
         return $this->submissions_public;
     }
 
-    /**
-     * Set pendingPublic
-     *
-     * @param integer $pendingPublic
-     *
-     * @return ScoreCache
-     */
-    public function setPendingPublic($pendingPublic)
+    public function setPendingPublic(int $pendingPublic): ScoreCache
     {
         $this->pending_public = $pendingPublic;
-
         return $this;
     }
 
-    /**
-     * Get pendingPublic
-     *
-     * @return integer
-     */
-    public function getPendingPublic()
+    public function getPendingPublic(): int
     {
         return $this->pending_public;
     }
 
-    /**
-     * Set isCorrectPublic
-     *
-     * @param boolean $isCorrectPublic
-     *
-     * @return ScoreCache
-     */
-    public function setIsCorrectPublic($isCorrectPublic)
+    public function setIsCorrectPublic(bool $isCorrectPublic): ScoreCache
     {
         $this->is_correct_public = $isCorrectPublic;
-
         return $this;
     }
 
-    /**
-     * Get isCorrectPublic
-     *
-     * @return boolean
-     */
-    public function getIsCorrectPublic()
+    public function getIsCorrectPublic(): bool
     {
         return $this->is_correct_public;
     }
 
-    /**
-     * Set solvetimePublic
-     *
-     * @param double $solvetimePublic
-     *
-     * @return ScoreCache
-     */
-    public function setSolvetimePublic($solvetimePublic)
+    /** @param string|float $solvetimePublic */
+    public function setSolvetimePublic($solvetimePublic): ScoreCache
     {
         $this->solvetime_public = $solvetimePublic;
-
         return $this;
     }
 
-    /**
-     * Get solvetimePublic
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getSolvetimePublic()
     {
         return $this->solvetime_public;
     }
 
-    /**
-     * Set isFirstToSolve
-     *
-     * @param boolean $isFirstToSolve
-     *
-     * @return ScoreCache
-     */
-    public function setIsFirstToSolve(bool $isFirstToSolve)
+    public function setIsFirstToSolve(bool $isFirstToSolve): ScoreCache
     {
         $this->is_first_to_solve = $isFirstToSolve;
-
         return $this;
     }
 
-    /**
-     * Get isFirstToSolve
-     *
-     * @return boolean
-     */
     public function getIsFirstToSolve() : bool
     {
         return $this->is_first_to_solve;
     }
 
-    /**
-     * Set contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return ScoreCache
-     */
-    public function setContest(\App\Entity\Contest $contest = null)
+    public function setContest(?Contest $contest = null): ScoreCache
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return \App\Entity\Contest
-     */
-    public function getContest()
+    public function getContest(): ScoreCache
     {
         return $this->contest;
     }
 
-    /**
-     * Set team
-     *
-     * @param \App\Entity\Team $team
-     *
-     * @return ScoreCache
-     */
-    public function setTeam(\App\Entity\Team $team = null)
+    public function setTeam(?Team $team = null): ScoreCache
     {
         $this->team = $team;
-
         return $this;
     }
 
-    /**
-     * Get team
-     *
-     * @return \App\Entity\Team
-     */
-    public function getTeam()
+    public function getTeam(): Team
     {
         return $this->team;
     }
 
-    /**
-     * Set problem
-     *
-     * @param \App\Entity\Problem $problem
-     *
-     * @return ScoreCache
-     */
-    public function setProblem(\App\Entity\Problem $problem = null)
+    public function setProblem(?Problem $problem = null): ScoreCache
     {
         $this->problem = $problem;
-
         return $this;
     }
 
-    /**
-     * Get problem
-     *
-     * @return \App\Entity\Problem
-     */
-    public function getProblem()
+    public function getProblem(): Problem
     {
         return $this->problem;
     }
 
-    /**
-     * Get the number of public or restricted submissions based on the parameter
-     * @param bool $restricted
-     * @return int
-     */
     public function getSubmissions(bool $restricted): int
     {
         return $restricted ? $this->getSubmissionsRestricted() : $this->getSubmissionsPublic();
     }
 
-    /**
-     * Get the number of public or restricted pending submissions based on the parameter
-     * @param bool $restricted
-     * @return int
-     */
     public function getPending(bool $restricted): int
     {
         return $restricted ? $this->getPendingRestricted() : $this->getPendingPublic();
     }
 
-    /**
-     * Get the public or restricted solve time based on the parameter
-     * @param bool $restricted
-     * @return float|string
-     */
+    /** @return string|float */
     public function getSolveTime(bool $restricted)
     {
         return $restricted ? $this->getSolvetimeRestricted() : $this->getSolvetimePublic();
     }
 
-    /**
-     * Get whether the problem is publicly or restrictedly correct based on the parameter
-     * @param bool $restricted
-     * @return bool
-     */
     public function getIsCorrect(bool $restricted): bool
     {
         return $restricted ? $this->getIsCorrectRestricted() : $this->getIsCorrectPublic();

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -10,7 +10,8 @@ use JMS\Serializer\Annotation as Serializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
- * All incoming submissions
+ * All incoming submissions.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="submission",
@@ -187,12 +188,12 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     private $resubmissions;
 
     /**
-     * @var string Holds the old result in the case this submission is displayed in a rejudging table
+     * @var string Holds the old result in the case this submission is displayed in a rejudging table.
      * @Serializer\Exclude()
      */
     private $old_result;
 
-    public function getResult()
+    public function getResult(): ?string
     {
         foreach ($this->judgings as $j) {
             if ($j->getValid()) {
@@ -202,476 +203,248 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         return null;
     }
 
-    /**
-     * Get submitid
-     *
-     * @return integer
-     */
-    public function getSubmitid()
+    public function getSubmitid(): int
     {
         return $this->submitid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return Submission
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(?string $externalid): Submission
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): ?string
     {
         return $this->externalid;
     }
 
     /**
-     * Get the language ID
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("language_id")
      * @Serializer\Type("string")
      */
-    public function getLanguageId()
+    public function getLanguageId(): string
     {
         return $this->getLanguage()->getExternalid();
     }
 
-    /**
-     * Set submittime
-     *
-     * @param string $submittime
-     *
-     * @return Submission
-     */
-    public function setSubmittime($submittime)
+    /** @param string|float $submittime */
+    public function setSubmittime($submittime): Submission
     {
         $this->submittime = $submittime;
-
         return $this;
     }
 
-    /**
-     * Get submittime
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getSubmittime()
     {
         return $this->submittime;
     }
 
     /**
-     * Get the absolute submit time for this submission
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("time")
      * @Serializer\Type("string")
      */
-    public function getAbsoluteSubmitTime()
+    public function getAbsoluteSubmitTime(): string
     {
         return Utils::absTime($this->getSubmittime());
     }
 
     /**
-     * Get the relative submit time for this submission
-     *
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("contest_time")
      * @Serializer\Type("string")
      */
-    public function getRelativeSubmitTime()
+    public function getRelativeSubmitTime(): string
     {
         return Utils::relTime($this->getContest()->getContestTime((float)$this->getSubmittime()));
     }
 
-    /**
-     * Set judgehost
-     *
-     * @param Judgehost|null $judgehost
-     *
-     * @return Submission
-     */
-    public function setJudgehost($judgehost)
+    public function setJudgehost(?Judgehost $judgehost): Submission
     {
         $this->judgehost = $judgehost;
-
         return $this;
     }
 
-    /**
-     * Get judgehost
-     *
-     * @return Judgehost|null
-     */
-    public function getJudgehost()
+    public function getJudgehost(): ?Judgehost
     {
         return $this->judgehost;
     }
 
-    /**
-     * Set valid
-     *
-     * @param boolean $valid
-     *
-     * @return Submission
-     */
-    public function setValid($valid)
+    public function setValid(bool $valid): Submission
     {
         $this->valid = $valid;
-
         return $this;
     }
 
-    /**
-     * Get valid
-     *
-     * @return boolean
-     */
-    public function getValid()
+    public function getValid(): bool
     {
         return $this->valid;
     }
 
-    /**
-     * Set expectedResults
-     *
-     * @param array $expectedResults
-     *
-     * @return Submission
-     */
-    public function setExpectedResults($expectedResults)
+    public function setExpectedResults(array $expectedResults): Submission
     {
         $this->expected_results = $expectedResults;
-
         return $this;
     }
 
-    /**
-     * Get expectedResults
-     *
-     * @return array
-     */
-    public function getExpectedResults()
+    public function getExpectedResults(): array
     {
         return $this->expected_results;
     }
 
-    /**
-     * Set entry_point
-     *
-     * @param string $entryPoint
-     *
-     * @return Submission
-     */
-    public function setEntryPoint($entryPoint)
+    public function setEntryPoint(?string $entryPoint): Submission
     {
         $this->entry_point = $entryPoint;
-
         return $this;
     }
 
-    /**
-     * Get entry_point
-     *
-     * @return string
-     */
-    public function getEntryPoint()
+    public function getEntryPoint(): ?string
     {
         return $this->entry_point;
     }
 
-    /**
-     * Set team
-     *
-     * @param \App\Entity\Team $team
-     *
-     * @return Submission
-     */
-    public function setTeam(\App\Entity\Team $team = null)
+    public function setTeam(?Team $team = null): Submission
     {
         $this->team = $team;
-
         return $this;
     }
 
-    /**
-     * Get team
-     *
-     * @return \App\Entity\Team
-     */
-    public function getTeam()
+    public function getTeam(): Team
     {
         return $this->team;
     }
 
     /**
-     * Get the team ID
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("team_id")
      * @Serializer\Type("string")
      */
-    public function getTeamId()
+    public function getTeamId(): int
     {
         return $this->getTeam()->getTeamid();
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->judgings            = new ArrayCollection();
         $this->files               = new ArrayCollection();
         $this->resubmissions       = new ArrayCollection();
         $this->external_judgements = new ArrayCollection();
-        $this->balloons = new ArrayCollection();
+        $this->balloons            = new ArrayCollection();
     }
 
-    /**
-     * Add judging
-     *
-     * @param Judging $judging
-     *
-     * @return Submission
-     */
-    public function addJudging(Judging $judging)
+    public function addJudging(Judging $judging): Submission
     {
         $this->judgings[] = $judging;
-
         return $this;
     }
 
-    /**
-     * Remove judging
-     *
-     * @param Judging $judging
-     */
     public function removeJudging(Judging $judging)
     {
         $this->judgings->removeElement($judging);
     }
 
-    /**
-     * Get judgings
-     *
-     * @return Collection
-     */
-    public function getJudgings()
+    public function getJudgings(): Collection
     {
         return $this->judgings;
     }
 
-    /**
-     * Set language
-     *
-     * @param Language $language
-     *
-     * @return Submission
-     */
-    public function setLanguage(Language $language = null)
+    public function setLanguage(?Language $language = null): Submission
     {
         $this->language = $language;
-
         return $this;
     }
 
-    /**
-     * Get language
-     *
-     * @return Language
-     */
-    public function getLanguage()
+    public function getLanguage(): Language
     {
         return $this->language;
     }
 
-    /**
-     * Add file
-     *
-     * @param SubmissionFile $file
-     *
-     * @return Submission
-     */
-    public function addFile(SubmissionFile $file)
+    public function addFile(SubmissionFile $file): Submission
     {
         $this->files->add($file);
-
         return $this;
     }
 
-    /**
-     * Remove file
-     *
-     * @param SubmissionFile $file
-     */
     public function removeFile(SubmissionFile $file)
     {
         $this->files->removeElement($file);
     }
 
-    /**
-     * Get files
-     *
-     * @return Collection
-     */
-    public function getFiles()
+    public function getFiles(): Collection
     {
         return $this->files;
     }
 
-    /**
-     * Add balloon
-     *
-     * @param Balloon $balloon
-     *
-     * @return Submission
-     */
-    public function addBalloon(Balloon $balloon)
+    public function addBalloon(Balloon $balloon): Submission
     {
         $this->balloons[] = $balloon;
-
         return $this;
     }
 
-    /**
-     * Remove balloon
-     *
-     * @param Balloon $balloon
-     */
     public function removeBalloon(Balloon $balloon)
     {
         $this->balloons->removeElement($balloon);
     }
 
-    /**
-     * Get balloons
-     *
-     * @return Collection
-     */
-    public function getBalloons()
+    public function getBalloons(): Collection
     {
         return $this->balloons;
     }
 
-    /**
-     * Set contest
-     *
-     * @param Contest $contest
-     *
-     * @return Submission
-     */
-    public function setContest(Contest $contest = null)
+    public function setContest(?Contest $contest = null): Submission
     {
         $this->contest = $contest;
-
         return $this;
     }
 
-    /**
-     * Get contest
-     *
-     * @return Contest
-     */
-    public function getContest()
+    public function getContest(): Contest
     {
         return $this->contest;
     }
 
-    /**
-     * Set problem
-     *
-     * @param Problem $problem
-     *
-     * @return Submission
-     */
-    public function setProblem(Problem $problem = null)
+    public function setProblem(?Problem $problem = null): Submission
     {
         $this->problem = $problem;
-
         return $this;
     }
 
-    /**
-     * Get problem
-     *
-     * @return Problem
-     */
-    public function getProblem()
+    public function getProblem(): Problem
     {
         return $this->problem;
     }
 
     /**
-     * Get the problem ID
-     * @return string
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("problem_id")
      * @Serializer\Type("string")
      */
-    public function getProblemId()
+    public function getProblemId(): int
     {
         return $this->getProblem()->getProbid();
     }
 
-    /**
-     * Set contest problem
-     *
-     * @param ContestProblem $contestProblem
-     *
-     * @return Submission
-     */
-    public function setContestProblem(ContestProblem $contestProblem = null)
+    public function setContestProblem(?ContestProblem $contestProblem = null): Submission
     {
         $this->contest_problem = $contestProblem;
-
         return $this;
     }
 
-    /**
-     * Get contest problem
-     *
-     * @return ContestProblem
-     */
-    public function getContestProblem()
+    public function getContestProblem(): ContestProblem
     {
         return $this->contest_problem;
     }
 
-    /**
-     * Set rejudging
-     *
-     * @param Rejudging $rejudging
-     *
-     * @return Submission
-     */
-    public function setRejudging(Rejudging $rejudging = null)
+    public function setRejudging(?Rejudging $rejudging = null): Submission
     {
         $this->rejudging = $rejudging;
-
         return $this;
     }
 
-    /**
-     * Get rejudging
-     *
-     * @return Rejudging
-     */
-    public function getRejudging()
+    public function getRejudging(): ?Rejudging
     {
         return $this->rejudging;
     }
@@ -680,94 +453,57 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
      * Get the entities to check for external ID's while serializing.
      *
      * This method should return an array with as keys the JSON field names and as values the actual entity
-     * objects that the SetExternalIdVisitor should check for applicable external ID's
-     * @return array
+     * objects that the SetExternalIdVisitor should check for applicable external ID's.
      */
     public function getExternalRelationships(): array
     {
         return [
             'language_id' => $this->getLanguage(),
-            'problem_id' => $this->getProblem(),
-            'team_id' => $this->getTeam(),
+            'problem_id'  => $this->getProblem(),
+            'team_id'     => $this->getTeam(),
         ];
     }
 
-    /**
-     * Return whether this submission is after the freeze
-     * @return bool
-     */
     public function isAfterFreeze(): bool
     {
         return $this->getContest()->getFreezetime() !== null && (float)$this->getSubmittime() >= (float)$this->getContest()->getFreezetime();
     }
 
-    /**
-     * @return string
-     */
     public function getOldResult(): string
     {
         return $this->old_result;
     }
 
-    /**
-     * @param string $old_result
-     * @return Submission
-     */
     public function setOldResult(string $old_result): Submission
     {
         $this->old_result = $old_result;
         return $this;
     }
 
-    /**
-     * Get original submission
-     * @return Submission|null
-     */
-    public function getOriginalSubmission()
+    public function getOriginalSubmission(): ?Submission
     {
         return $this->originalSubmission;
     }
 
-    /**
-     * Set original submission
-     * @param Submission|null $originalSubmission
-     * @return Submission
-     */
-    public function setOriginalSubmission($originalSubmission): Submission
+    public function setOriginalSubmission(?Submission $originalSubmission): Submission
     {
         $this->originalSubmission = $originalSubmission;
         return $this;
     }
 
-    /**
-     * Add resubmission
-     *
-     * @param Submission $submission
-     * @return Submission
-     */
-    public function addResubmission(Submission $submission)
+    public function addResubmission(Submission $submission): Submission
     {
         $this->resubmissions->add($submission);
-
         return $this;
     }
 
-    /**
-     * Remove resubmission
-     *
-     * @param Submission $submission
-     * @return Submission
-     */
-    public function removeResubmission(Submission $submission)
+    public function removeResubmission(Submission $submission): Submission
     {
         $this->resubmissions->removeElement($submission);
-
         return $this;
     }
 
     /**
-     * Get resubmissions
-     *
      * @return Collection|Submission[]
      */
     public function getResubmissions()
@@ -775,13 +511,9 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         return $this->resubmissions;
     }
 
-    /**
-     * Check whether this submission is for an aborted judging
-     * @return bool
-     */
-    public function isAborted()
+    public function isAborted(): bool
     {
-        // This logic has been copied from putSubmissions()
+        // This logic has been copied from putSubmissions().
         /** @var Judging|null $judging */
         $judging = $this->getJudgings()->first();
         if (!$judging) {
@@ -795,9 +527,8 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     /**
      * Check whether this submission is still busy while the final result is already known,
      * e.g. with non-lazy evaluation.
-     * @return bool
      */
-    public function isStillBusy()
+    public function isStillBusy(): bool
     {
         /** @var Judging|null $judging */
         $judging = $this->getJudgings()->first();
@@ -808,36 +539,18 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         return !empty($judging->getResult()) && empty($judging->getEndtime()) && !$this->isAborted();
     }
 
-    /**
-     * Add externalJudgement
-     *
-     * @param ExternalJudgement $externalJudgement
-     *
-     * @return Submission
-     */
-    public function addExternalJudgement(ExternalJudgement $externalJudgement)
+    public function addExternalJudgement(ExternalJudgement $externalJudgement): Submission
     {
         $this->external_judgements[] = $externalJudgement;
-
         return $this;
     }
 
-    /**
-     * Remove externalJudgement
-     *
-     * @param ExternalJudgement $externalJudgement
-     */
     public function removeExternalJudgement(ExternalJudgement $externalJudgement)
     {
         $this->external_judgements->removeElement($externalJudgement);
     }
 
-    /**
-     * Get externalJudgements
-     *
-     * @return Collection
-     */
-    public function getExternalJudgements()
+    public function getExternalJudgements(): Collection
     {
         return $this->external_judgements;
     }

--- a/webapp/src/Entity/SubmissionFile.php
+++ b/webapp/src/Entity/SubmissionFile.php
@@ -5,7 +5,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Files associated to a submission
+ * Files associated to a submission.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="submission_file",
@@ -56,108 +57,51 @@ class SubmissionFile
      */
     private $sourcecode;
 
-    /**
-     * Get submitfileid
-     *
-     * @return integer
-     */
-    public function getSubmitfileid()
+    public function getSubmitfileid(): int
     {
         return $this->submitfileid;
     }
 
-    /**
-     * Set filename
-     *
-     * @param string $filename
-     *
-     * @return SubmissionFile
-     */
-    public function setFilename($filename)
+    public function setFilename(string $filename): SubmissionFile
     {
         $this->filename = $filename;
-
         return $this;
     }
 
-    /**
-     * Get filename
-     *
-     * @return string
-     */
-    public function getFilename()
+    public function getFilename(): string
     {
         return $this->filename;
     }
 
-    /**
-     * Set rank
-     *
-     * @param integer $rank
-     *
-     * @return SubmissionFile
-     */
-    public function setRank($rank)
+    public function setRank(int $rank): SubmissionFile
     {
         $this->ranknumber = $rank;
-
         return $this;
     }
 
-    /**
-     * Get rank
-     *
-     * @return integer
-     */
-    public function getRank()
+    public function getRank(): int
     {
         return $this->ranknumber;
     }
 
-    /**
-     * Set submission
-     *
-     * @param Submission $submission
-     *
-     * @return SubmissionFile
-     */
-    public function setSubmission(Submission $submission = null)
+    public function setSubmission(?Submission $submission = null): SubmissionFile
     {
         $this->submission = $submission;
-
         return $this;
     }
 
-    /**
-     * Get submission
-     *
-     * @return Submission
-     */
-    public function getSubmission()
+    public function getSubmission(): Submission
     {
         return $this->submission;
     }
 
-    /**
-     * Set sourcecode
-     *
-     * @param string $sourcecode
-     *
-     * @return SubmissionFile
-     */
-    public function setSourcecode($sourcecode)
+    public function setSourcecode(string $sourcecode): SubmissionFile
     {
         $this->sourcecode = $sourcecode;
-
         return $this;
     }
 
-    /**
-     * Get sourcecode
-     *
-     * @return string
-     */
-    public function getSourcecode()
+    public function getSourcecode(): string
     {
         return $this->sourcecode;
     }

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -10,7 +11,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
- * All teams participating in the contest
+ * All teams participating in the contest.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team",
@@ -172,301 +174,149 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
      */
     private $unread_clarifications;
 
-    /**
-     * Set teamid
-     *
-     * @param int $teamid
-     *
-     * @return Team
-     */
-    public function setTeamid($teamid)
+    public function setTeamid(int $teamid): Team
     {
         $this->teamid = $teamid;
-
         return $this;
     }
 
-    /**
-     * Get teamid
-     *
-     * @return integer
-     */
-    public function getTeamid()
+   public function getTeamid(): int
     {
         return $this->teamid;
     }
 
-    /**
-     * Set icpcid
-     *
-     * @param string $icpcid
-     *
-     * @return Team
-     */
-    public function setIcpcid($icpcid)
+    public function setIcpcid(string $icpcid): Team
     {
         $this->icpcid = $icpcid;
 
         return $this;
     }
 
-    /**
-     * Get icpcid
-     *
-     * @return string
-     */
-    public function getIcpcid()
+    public function getIcpcid(): ?string
     {
         return $this->icpcid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return Team
-     */
-    public function setName($name)
+    public function setName(string $name): Team
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+   public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set display name
-     * @param string|null $display_name
-     *
-     * @return $this
-     */
     public function setDisplayName(?string $display_name): self
     {
         $this->display_name = $display_name;
-
         return $this;
     }
 
-    /**
-     * Get display name
-     * @return string|null
-     */
     public function getDisplayName(): ?string
     {
         return $this->display_name;
     }
 
-    /**
-     * Get the effective name of this team
-     * @return string
-     */
     public function getEffectiveName(): string
     {
         return $this->getDisplayName() ?? $this->getName();
     }
 
-    /**
-     * Set enabled
-     *
-     * @param boolean $enabled
-     *
-     * @return Team
-     */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): Team
     {
         $this->enabled = $enabled;
-
         return $this;
     }
 
-    /**
-     * Get enabled
-     *
-     * @return boolean
-     */
-    public function getEnabled()
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    /**
-     * Set members
-     *
-     * @param string $members
-     *
-     * @return Team
-     */
-    public function setMembers($members)
+    public function setMembers(string $members): Team
     {
         $this->members = $members;
-
         return $this;
     }
 
-    /**
-     * Get members
-     *
-     * @return string
-     */
-    public function getMembers()
+    public function getMembers(): ?string
     {
         return $this->members;
     }
 
-    /**
-     * Set room
-     *
-     * @param string $room
-     *
-     * @return Team
-     */
-    public function setRoom($room)
+    public function setRoom(string $room): Team
     {
         $this->room = $room;
-
         return $this;
     }
 
-    /**
-     * Get room
-     *
-     * @return string
-     */
-    public function getRoom()
+    public function getRoom(): ?string
     {
         return $this->room;
     }
 
-    /**
-     * Set comments
-     *
-     * @param string $comments
-     *
-     * @return Team
-     */
-    public function setComments($comments)
+    public function setComments(string $comments): Team
     {
         $this->comments = $comments;
-
         return $this;
     }
 
-    /**
-     * Get comments
-     *
-     * @return string
-     */
-    public function getComments()
+    public function getComments(): ?string
     {
         return $this->comments;
     }
 
-    /**
-     * Set judgingLastStarted
-     *
-     * @param string $judgingLastStarted
-     *
-     * @return Team
-     */
-    public function setJudgingLastStarted($judgingLastStarted)
+    /** @param string|float $judgingLastStarted */
+    public function setJudgingLastStarted($judgingLastStarted): Team
     {
         $this->judging_last_started = $judgingLastStarted;
-
         return $this;
     }
 
-    /**
-     * Get judgingLastStarted
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getJudgingLastStarted()
     {
         return $this->judging_last_started;
     }
 
-    /**
-     * Set penalty
-     *
-     * @param integer $penalty
-     *
-     * @return Team
-     */
-    public function setPenalty($penalty)
+    public function setPenalty(int $penalty): Team
     {
         $this->penalty = $penalty;
-
         return $this;
     }
 
     /**
-     * Set whether to add a user for this team. Will not be stored, but is used in validation
-     *
-     * @param bool $addUserForTeam
+     * Set whether to add a user for this team. Will not be stored, but is used in validation.
      */
     public function setAddUserForTeam(bool $addUserForTeam)
     {
         $this->addUserForTeam = $addUserForTeam;
     }
 
-    /**
-     * Get penalty
-     *
-     * @return integer
-     */
-    public function getPenalty()
+    public function getPenalty(): int
     {
         return $this->penalty;
     }
 
-    /**
-     * Whether to add a user for this team. Will not be stored, but is used in validation
-     *
-     * @return bool
-     */
     public function getAddUserForTeam(): bool
     {
         return $this->addUserForTeam;
     }
 
-    /**
-     * Set affiliation
-     *
-     * @param \App\Entity\TeamAffiliation $affiliation
-     *
-     * @return Team
-     */
-    public function setAffiliation(\App\Entity\TeamAffiliation $affiliation = null)
+    public function setAffiliation(TeamAffiliation $affiliation = null): Team
     {
         $this->affiliation = $affiliation;
-
         return $this;
     }
 
-    /**
-     * Get affiliation
-     *
-     * @return \App\Entity\TeamAffiliation
-     */
-    public function getAffiliation()
+    public function getAffiliation(): ?TeamAffiliation
     {
         return $this->affiliation;
     }
 
     /**
-     * Get affiliation ID
-     *
-     * @return int|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("organization_id")
      * @Serializer\Type("string")
@@ -476,260 +326,126 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
         return $this->getAffiliation() ? $this->getAffiliation()->getAffilid() : null;
     }
 
-    /**
-     * Set category
-     *
-     * @param \App\Entity\TeamCategory $category
-     *
-     * @return Team
-     */
-    public function setCategory(\App\Entity\TeamCategory $category = null)
+    public function setCategory(?TeamCategory $category = null): Team
     {
         $this->category = $category;
-
         return $this;
     }
 
-    /**
-     * Get category
-     *
-     * @return \App\Entity\TeamCategory
-     */
-    public function getCategory()
+    public function getCategory(): TeamCategory
     {
         return $this->category;
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->contests = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->submissions = new ArrayCollection();
-        $this->sent_clarifications = new ArrayCollection();
+        $this->contests                = new ArrayCollection();
+        $this->users                   = new ArrayCollection();
+        $this->submissions             = new ArrayCollection();
+        $this->sent_clarifications     = new ArrayCollection();
         $this->received_clarifications = new ArrayCollection();
-        $this->unread_clarifications = new ArrayCollection();
+        $this->unread_clarifications   = new ArrayCollection();
     }
 
-    /**
-     * Add contest
-     *
-     * @param \App\Entity\Contest $contest
-     *
-     * @return Team
-     */
-    public function addContest(\App\Entity\Contest $contest)
+    public function addContest(Contest $contest): Team
     {
         $this->contests[] = $contest;
-
         $contest->addTeam($this);
-
         return $this;
     }
 
-    /**
-     * Remove contest
-     *
-     * @param \App\Entity\Contest $contest
-     */
-    public function removeContest(\App\Entity\Contest $contest)
+    public function removeContest(Contest $contest)
     {
         $this->contests->removeElement($contest);
-
         $contest->removeTeam($this);
     }
 
-    /**
-     * Get contests
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getContests()
+    public function getContests(): Collection
     {
         return $this->contests;
     }
 
-    /**
-     * Add user
-     *
-     * @param \App\Entity\User $user
-     *
-     * @return Team
-     */
-    public function addUser(\App\Entity\User $user)
+    public function addUser(User $user): Team
     {
         $this->users[] = $user;
-
         return $this;
     }
 
-    /**
-     * Remove user
-     *
-     * @param \App\Entity\User $user
-     */
-    public function removeUser(\App\Entity\User $user)
+    public function removeUser(User $user)
     {
         $this->users->removeElement($user);
     }
 
-    /**
-     * Get users
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getUsers()
+    public function getUsers(): Collection
     {
         return $this->users;
     }
 
-    /**
-     * Add submission
-     *
-     * @param \App\Entity\Submission $submission
-     *
-     * @return Team
-     */
-    public function addSubmission(\App\Entity\Submission $submission)
+    public function addSubmission(Submission $submission): Team
     {
         $this->submissions[] = $submission;
-
         return $this;
     }
 
-    /**
-     * Remove submission
-     *
-     * @param \App\Entity\Submission $submission
-     */
-    public function removeSubmission(\App\Entity\Submission $submission)
+    public function removeSubmission(Submission $submission)
     {
         $this->submissions->removeElement($submission);
     }
 
-    /**
-     * Get submissions
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }
 
-    /**
-     * Add sentClarification
-     *
-     * @param \App\Entity\Clarification $sentClarification
-     *
-     * @return Team
-     */
-    public function addSentClarification(
-        \App\Entity\Clarification $sentClarification)
+    public function addSentClarification(Clarification $sentClarification): Team
     {
         $this->sent_clarifications[] = $sentClarification;
-
         return $this;
     }
 
-    /**
-     * Remove sentClarification
-     *
-     * @param \App\Entity\Clarification $sentClarification
-     */
-    public function removeSentClarification(
-        \App\Entity\Clarification $sentClarification)
+    public function removeSentClarification(Clarification $sentClarification)
     {
         $this->sent_clarifications->removeElement($sentClarification);
     }
 
-    /**
-     * Get sentClarifications
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getSentClarifications()
+    public function getSentClarifications(): Collection
     {
         return $this->sent_clarifications;
     }
 
-    /**
-     * Add receivedClarification
-     *
-     * @param \App\Entity\Clarification $receivedClarification
-     *
-     * @return Team
-     */
-    public function addReceivedClarification(
-        \App\Entity\Clarification $receivedClarification)
+    public function addReceivedClarification(Clarification $receivedClarification): Team
     {
         $this->received_clarifications[] = $receivedClarification;
-
         return $this;
     }
 
-    /**
-     * Remove receivedClarification
-     *
-     * @param \App\Entity\Clarification $receivedClarification
-     */
-    public function removeReceivedClarification(
-        \App\Entity\Clarification $receivedClarification)
+    public function removeReceivedClarification(Clarification $receivedClarification)
     {
         $this->received_clarifications->removeElement($receivedClarification);
     }
 
-    /**
-     * Get receivedClarifications
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getReceivedClarifications()
+    public function getReceivedClarifications(): Collection
     {
         return $this->received_clarifications;
     }
 
-    /**
-     * Add unreadClarification
-     *
-     * @param \App\Entity\Clarification $unreadClarification
-     *
-     * @return Team
-     */
-    public function addUnreadClarification(
-        \App\Entity\Clarification $unreadClarification)
+    public function addUnreadClarification(Clarification $unreadClarification): Team
     {
         $this->unread_clarifications[] = $unreadClarification;
-
         return $this;
     }
 
-    /**
-     * Remove unreadClarification
-     *
-     * @param \App\Entity\Clarification $unreadClarification
-     */
-    public function removeUnreadClarification(
-        \App\Entity\Clarification $unreadClarification)
+    public function removeUnreadClarification(Clarification $unreadClarification)
     {
         $this->unread_clarifications->removeElement($unreadClarification);
     }
 
-    /**
-     * Get unreadClarifications
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getUnreadClarifications()
+    public function getUnreadClarifications(): Collection
     {
         return $this->unread_clarifications;
     }
 
     /**
-     * Get the group ID's for this team
-     * @return string[]
      * @Serializer\VirtualProperty()
      * @Serializer\Type("array<string>")
      */
@@ -739,37 +455,28 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     }
 
     /**
-     * Get the affiliation name of this team
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("affiliation")
      * @Serializer\Type("string")
      * @Serializer\Groups({"Nonstrict"})
      */
-    public function getAffiliationName()
+    public function getAffiliationName(): ?string
     {
         return $this->getAffiliation() ? $this->getAffiliation()->getName() : null;
     }
 
     /**
-     * Get the nationality of this team
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\Type("string")
      * @Serializer\Groups({"Nonstrict"})
      * @Serializer\Expose(if="context.getAttribute('config_service').get('show_flags')")
      */
-    public function getNationality()
+    public function getNationality() : ?string
     {
         return $this->getAffiliation() ? $this->getAffiliation()->getCountry() : null;
     }
 
-    /**
-     * Return whether this team can view the given clarification
-     * @param Clarification $clarification
-     * @return bool
-     */
-    public function canViewClarification(Clarification $clarification)
+    public function canViewClarification(Clarification $clarification): bool
     {
         return (($clarification->getSender() && $clarification->getSender()->getTeamid() === $this->getTeamid()) ||
             ($clarification->getRecipient() && $clarification->getRecipient()->getTeamid() === $this->getTeamid()) ||
@@ -785,7 +492,6 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
     }
 
     /**
-     * @param ExecutionContextInterface $context
      * @Assert\Callback()
      */
     public function validate(ExecutionContextInterface $context)
@@ -805,13 +511,6 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
         }
     }
 
-    /**
-     * Check if this team belongs to the given contest
-     *
-     * @param Contest $contest
-     *
-     * @return bool
-     */
     public function inContest(Contest $contest): bool
     {
         return $contest->isOpenToAllTeams() ||

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -180,7 +180,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface
         return $this;
     }
 
-   public function getTeamid(): int
+   public function getTeamid(): ?int
     {
         return $this->teamid;
     }

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -141,7 +141,7 @@ class TeamAffiliation extends BaseApiEntity
         return $this;
     }
 
-   public function getName(): string
+   public function getName(): ?string
     {
         return $this->name;
     }

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -10,7 +10,8 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
 /**
- * Affilitations for teams (e.g.: university, company)
+ * Affilitations for teams (e.g.: university, company).
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team_affiliation",
@@ -95,189 +96,90 @@ class TeamAffiliation extends BaseApiEntity
      */
     private $teams;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->teams = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->teams = new ArrayCollection();
     }
 
-    /**
-     * Set affilid
-     *
-     * @param integer affilid
-     *
-     * @return TeamAffiliation
-     */
-    public function setAffilid($affilid)
+    public function setAffilid(int $affilid): TeamAffiliation
     {
         $this->affilid = $affilid;
-
         return $this;
     }
 
 
-    /**
-     * Get affilid
-     *
-     * @return integer
-     */
-    public function getAffilid()
+    public function getAffilid(): int
     {
         return $this->affilid;
     }
 
-    /**
-     * Set externalid
-     *
-     * @param string $externalid
-     *
-     * @return TeamAffiliation
-     */
-    public function setExternalid($externalid)
+    public function setExternalid(string $externalid): TeamAffiliation
     {
         $this->externalid = $externalid;
-
         return $this;
     }
 
-    /**
-     * Get externalid
-     *
-     * @return string
-     */
-    public function getExternalid()
+    public function getExternalid(): string
     {
         return $this->externalid;
     }
 
-    /**
-     * Set shortname
-     *
-     * @param string $shortname
-     *
-     * @return TeamAffiliation
-     */
-    public function setShortname($shortname)
+    public function setShortname(string $shortname): TeamAffiliation
     {
         $this->shortname = $shortname;
-
         return $this;
     }
 
-    /**
-     * Get shortname
-     *
-     * @return string
-     */
-    public function getShortname()
+    public function getShortname(): string
     {
         return $this->shortname;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return TeamAffiliation
-     */
-    public function setName($name)
+    public function setName(string $name): TeamAffiliation
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+   public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set country
-     *
-     * @param string $country
-     *
-     * @return TeamAffiliation
-     */
-    public function setCountry($country)
+    public function setCountry(string $country): TeamAffiliation
     {
         $this->country = $country;
-
         return $this;
     }
 
-    /**
-     * Get country
-     *
-     * @return string
-     */
-    public function getCountry()
+    public function getCountry(): string
     {
         return $this->country;
     }
 
-    /**
-     * Set comments
-     *
-     * @param string $comments
-     *
-     * @return TeamAffiliation
-     */
-    public function setComments($comments)
+    public function setComments(string $comments): TeamAffiliation
     {
         $this->comments = $comments;
-
         return $this;
     }
 
-    /**
-     * Get comments
-     *
-     * @return string
-     */
-    public function getComments()
+    public function getComments(): ?string
     {
         return $this->comments;
     }
 
-    /**
-     * Add team
-     *
-     * @param \App\Entity\Team $team
-     *
-     * @return TeamAffiliation
-     */
-    public function addTeam(\App\Entity\Team $team)
+    public function addTeam(Team $team): TeamAffiliation
     {
         $this->teams[] = $team;
-
         return $this;
     }
 
-    /**
-     * Remove team
-     *
-     * @param \App\Entity\Team $team
-     */
-    public function removeTeam(\App\Entity\Team $team)
+    public function removeTeam(Team $team)
     {
         $this->teams->removeElement($team);
     }
 
-    /**
-     * Get teams
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getTeams()
+    public function getTeams(): Collection
     {
         return $this->teams;
     }

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -130,7 +130,7 @@ class TeamAffiliation extends BaseApiEntity
         return $this;
     }
 
-    public function getShortname(): string
+    public function getShortname(): ?string
     {
         return $this->shortname;
     }
@@ -152,7 +152,7 @@ class TeamAffiliation extends BaseApiEntity
         return $this;
     }
 
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->country;
     }

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -8,7 +8,8 @@ use JMS\Serializer\Annotation as Serializer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Categories for teams (e.g.: participants, observers, ...)
+ * Categories for teams (e.g.: participants, observers, ...).
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team_category",
@@ -98,196 +99,95 @@ class TeamCategory extends BaseApiEntity
      */
     private $contests;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->teams = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->teams    = new ArrayCollection();
         $this->contests = new ArrayCollection();
     }
 
-    /**
-    * To String
-    */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set categoryid
-     *
-     * @param int $categoryid
-     *
-     * @return TeamCategory
-     */
-    public function setCategoryid(int $categoryid)
+    public function setCategoryid(int $categoryid): TeamCategory
     {
         $this->categoryid = $categoryid;
         return $this;
     }
 
-    /**
-     * Get categoryid
-     *
-     * @return integer
-     */
-    public function getCategoryid()
+    public function getCategoryid(): int
     {
         return $this->categoryid;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return TeamCategory
-     */
-    public function setName($name)
+    public function setName(string $name): TeamCategory
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set sortorder
-     *
-     * @param integer $sortorder
-     *
-     * @return TeamCategory
-     */
-    public function setSortorder($sortorder)
+    public function setSortorder(int $sortorder): TeamCategory
     {
         $this->sortorder = $sortorder;
-
         return $this;
     }
 
-    /**
-     * Get sortorder
-     *
-     * @return integer
-     */
-    public function getSortorder()
+    public function getSortorder(): int
     {
         return $this->sortorder;
     }
 
-    /**
-     * Set color
-     *
-     * @param string $color
-     *
-     * @return TeamCategory
-     */
-    public function setColor($color)
+    public function setColor(string $color): TeamCategory
     {
         $this->color = $color;
-
         return $this;
     }
 
-    /**
-     * Get color
-     *
-     * @return string
-     */
-    public function getColor()
+    public function getColor(): ?string
     {
         return $this->color;
     }
 
-    /**
-     * Set visible
-     *
-     * @param boolean $visible
-     *
-     * @return TeamCategory
-     */
-    public function setVisible($visible)
+    public function setVisible(bool $visible): TeamCategory
     {
         $this->visible = $visible;
-
         return $this;
     }
 
-    /**
-     * Get visible
-     *
-     * @return boolean
-     */
-    public function getVisible()
+    public function getVisible(): bool
     {
         return $this->visible;
     }
 
-    /**
-     * Set allowSelfRegistration
-     *
-     * @param boolean $allowSelfRegistration
-     *
-     * @return TeamCategory
-     */
-    public function setAllowSelfRegistration($allowSelfRegistration)
+    public function setAllowSelfRegistration(bool $allowSelfRegistration): TeamCategory
     {
         $this->allow_self_registration = $allowSelfRegistration;
-
         return $this;
     }
 
-    /**
-     * Get allowSelfRegistration
-     *
-     * @return boolean
-     */
-    public function getAllowSelfRegistration()
+    public function getAllowSelfRegistration(): bool
     {
         return $this->allow_self_registration;
     }
 
-    /**
-     * Add team
-     *
-     * @param \App\Entity\Team $team
-     *
-     * @return TeamCategory
-     */
-    public function addTeam(\App\Entity\Team $team)
+    public function addTeam(Team $team): TeamCategory
     {
         $this->teams[] = $team;
-
         return $this;
     }
 
-    /**
-     * Remove team
-     *
-     * @param \App\Entity\Team $team
-     */
-    public function removeTeam(\App\Entity\Team $team)
+    public function removeTeam(Team $team)
     {
         $this->teams->removeElement($team);
     }
 
-    /**
-     * Get teams
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getTeams()
+    public function getTeams(): Collection
     {
         return $this->teams;
     }
@@ -320,13 +220,6 @@ class TeamCategory extends BaseApiEntity
         return $this;
     }
 
-    /**
-     * Check if this team category belongs to the given contest
-     *
-     * @param Contest $contest
-     *
-     * @return bool
-     */
     public function inContest(Contest $contest): bool
     {
         return $contest->isOpenToAllTeams() || $this->getContests()->contains($contest);

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -127,7 +127,7 @@ class TeamCategory extends BaseApiEntity
         return $this;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -7,7 +7,8 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
- * Stores testcases per problem
+ * Stores testcases per problem.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="testcase",
@@ -20,7 +21,6 @@ use JMS\Serializer\Annotation as Serializer;
  */
 class Testcase
 {
-
     /**
      * @var int
      *
@@ -136,115 +136,61 @@ class Testcase
      */
     private $problem;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
-        $this->judging_runs = new ArrayCollection();
+        $this->judging_runs  = new ArrayCollection();
         $this->external_runs = new ArrayCollection();
-        $this->content = new ArrayCollection();
+        $this->content       = new ArrayCollection();
     }
 
-    /**
-     * Get testcaseid
-     *
-     * @return integer
-     */
-    public function getTestcaseid()
+    public function getTestcaseid(): int
     {
         return $this->testcaseid;
     }
 
-    /**
-     * Set md5sumInput
-     *
-     * @param string $md5sumInput
-     *
-     * @return Testcase
-     */
-    public function setMd5sumInput($md5sumInput)
+    public function setMd5sumInput(string $md5sumInput): Testcase
     {
         $this->md5sum_input = $md5sumInput;
-
         return $this;
     }
 
-    /**
-     * Get md5sumInput
-     *
-     * @return string
-     */
-    public function getMd5sumInput()
+    public function getMd5sumInput(): string
     {
         return $this->md5sum_input;
     }
 
-    /**
-     * Set md5sumOutput
-     *
-     * @param string $md5sumOutput
-     *
-     * @return Testcase
-     */
-    public function setMd5sumOutput($md5sumOutput)
+    public function setMd5sumOutput(string $md5sumOutput): Testcase
     {
         $this->md5sum_output = $md5sumOutput;
-
         return $this;
     }
 
-    /**
-     * Get md5sumOutput
-     *
-     * @return string
-     */
-    public function getMd5sumOutput()
+    public function getMd5sumOutput(): string
     {
         return $this->md5sum_output;
     }
 
-    /**
-     * Set rank
-     *
-     * @param integer $ranknumber
-     *
-     * @return Testcase
-     */
-    public function setRank($rank)
+    public function setRank(int $rank): Testcase
     {
         $this->ranknumber = $rank;
-
         return $this;
     }
 
-    /**
-     * Get rank
-     *
-     * @return integer
-     */
-    public function getRank()
+    public function getRank(): int
     {
         return $this->ranknumber;
     }
 
     /**
-     * Set description
-     *
      * @param resource|string $description
-     *
-     * @return Testcase
      */
-    public function setDescription($description)
+    public function setDescription($description): Testcase
     {
         $this->description = $description;
-
         return $this;
     }
 
     /**
-     * Get description
-     *
      * @return resource|string|null
      */
     public function getDescription(bool $asString = false)
@@ -258,132 +204,62 @@ class Testcase
         return $this->description;
     }
 
-    /**
-     * Set original input filename
-     *
-     * @param string $origInputFilename
-     *
-     * @return Testcase
-     */
-    public function setOrigInputFilename($origInputFilename)
+    public function setOrigInputFilename(string $origInputFilename): Testcase
     {
         $this->orig_input_filename = $origInputFilename;
-
         return $this;
     }
 
-    /**
-     * Get original input filename
-     *
-     * @return string
-     */
-    public function getOrigInputFilename()
+    public function getOrigInputFilename(): ?string
     {
         return $this->orig_input_filename;
     }
 
-    /**
-     * Set imageType
-     *
-     * @param string $imageType
-     *
-     * @return Testcase
-     */
-    public function setImageType($imageType)
+    public function setImageType(string $imageType): Testcase
     {
         $this->image_type = $imageType;
-
         return $this;
     }
 
-    /**
-     * Get imageType
-     *
-     * @return string
-     */
-    public function getImageType()
+    public function getImageType(): string
     {
         return $this->image_type;
     }
 
-    /**
-     * Set sample
-     *
-     * @param boolean $sample
-     *
-     * @return Testcase
-     */
-    public function setSample($sample)
+    public function setSample(bool $sample): Testcase
     {
         $this->sample = $sample;
-
         return $this;
     }
 
-    /**
-     * Set deleted
-     *
-     * @param boolean $deleted
-     *
-     * @return Testcase
-     */
-    public function setDeleted(bool $deleted)
+    public function setDeleted(bool $deleted): Testcase
     {
         $this->deleted = $deleted;
-
         return $this;
     }
 
-    /**
-     * Get sample
-     *
-     * @return boolean
-     */
-    public function getSample()
+    public function getSample(): bool
     {
         return $this->sample;
     }
 
-    /**
-     * Get deleted
-     *
-     * @return boolean
-     */
-    public function getDeleted()
+    public function getDeleted(): bool
     {
         return $this->deleted;
     }
 
-    /**
-     * Add judgingRun
-     *
-     * @param \App\Entity\JudgingRun $judgingRun
-     *
-     * @return Testcase
-     */
-    public function addJudgingRun(\App\Entity\JudgingRun $judgingRun)
+    public function addJudgingRun(JudgingRun $judgingRun): Testcase
     {
         $this->judging_runs[] = $judgingRun;
-
         return $this;
     }
 
-    /**
-     * Remove judgingRun
-     *
-     * @param \App\Entity\JudgingRun $judgingRun
-     */
-    public function removeJudgingRun(\App\Entity\JudgingRun $judgingRun)
+    public function removeJudgingRun(JudgingRun $judgingRun): Testcase
     {
         $this->judging_runs->removeElement($judgingRun);
     }
 
-    /**
-     * Get judgingRuns
-     *
-     * @return Collection
-     */
-    public function getJudgingRuns()
+    public function getJudgingRuns(): Collection
     {
         return $this->judging_runs;
     }
@@ -391,11 +267,9 @@ class Testcase
     /**
      * Gets the first judging run for this testcase.
      *
-     * This is useful when this testcase is joined to a single run to get code completion in Twig templates
-     *
-     * @return JudgingRun|null
+     * This is useful when this testcase is joined to a single run to get code completion in Twig templates.
      */
-    public function getFirstJudgingRun()
+    public function getFirstJudgingRun(): ?JudgingRun
     {
         return $this->judging_runs->first() ?: null;
     }
@@ -403,23 +277,14 @@ class Testcase
     /**
      * Gets the first external run for this testcase.
      *
-     * This is useful when this testcase is joined to a single external run to get code completion in Twig templates
-     *
-     * @return ExternalRun|null
+     * This is useful when this testcase is joined to a single external run to get code completion in Twig templates.
      */
-    public function getFirstExternalRun()
+    public function getFirstExternalRun(): ?ExternalRun
     {
         return $this->external_runs->first() ?: null;
     }
 
-    /**
-     * Set content
-     *
-     * @param TestcaseContent $content
-     *
-     * @return Testcase
-     */
-    public function setContent(?TestcaseContent $content)
+    public function setContent(?TestcaseContent $content): Testcase
     {
         $this->content->clear();
         $this->content->add($content);
@@ -428,70 +293,34 @@ class Testcase
         return $this;
     }
 
-    /**
-     * Get content
-     *
-     * @return TestcaseContent
-     */
     public function getContent(): ?TestcaseContent
     {
         return $this->content->first() ?: null;
     }
 
-    /**
-     * Set problem
-     *
-     * @param \App\Entity\Problem $problem
-     *
-     * @return Testcase
-     */
-    public function setProblem(\App\Entity\Problem $problem = null)
+    public function setProblem(?Problem $problem = null): Testcase
     {
         $this->problem = $problem;
-
         return $this;
     }
 
-    /**
-     * Get problem
-     *
-     * @return \App\Entity\Problem
-     */
-    public function getProblem()
+    public function getProblem(): Problem
     {
         return $this->problem;
     }
 
-    /**
-     * Add externalRun
-     *
-     * @param ExternalRun $externalRun
-     *
-     * @return Testcase
-     */
-    public function addExternalRun(ExternalRun $externalRun)
+    public function addExternalRun(ExternalRun $externalRun): Testcase
     {
         $this->external_runs[] = $externalRun;
-
         return $this;
     }
 
-    /**
-     * Remove externalRun
-     *
-     * @param ExternalRun $externalRun
-     */
     public function removeExternalRun(ExternalRun $externalRun)
     {
         $this->external_runs->removeElement($externalRun);
     }
 
-    /**
-     * Get externalRuns
-     *
-     * @return Collection
-     */
-    public function getExternalRuns()
+    public function getExternalRuns(): Collection
     {
         return $this->external_runs;
     }

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -221,7 +221,7 @@ class Testcase
         return $this;
     }
 
-    public function getImageType(): string
+    public function getImageType(): ?string
     {
         return $this->image_type;
     }

--- a/webapp/src/Entity/TestcaseContent.php
+++ b/webapp/src/Entity/TestcaseContent.php
@@ -5,7 +5,7 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Contents of a testcase
+ * Contents of a testcase.
  *
  * @ORM\Entity
  * @ORM\Table(
@@ -77,120 +77,57 @@ class TestcaseContent
         return $this;
     }
 
-    /**
-     * @param Testcase $testcase
-     *
-     * @return TestcaseContent
-     */
-    public function setTestcase(Testcase $testcase)
+    public function setTestcase(Testcase $testcase): TestcaseContent
     {
         $this->testcase = $testcase;
-
         return $this;
     }
 
-    /**
-     * Get testcase
-     *
-     * @return Testcase
-     */
-    public function getTestcase(): Testcase
+   public function getTestcase(): Testcase
     {
         return $this->testcase;
     }
 
-    /**
-     * Set input
-     *
-     * @param string $input
-     *
-     * @return TestcaseContent
-     */
-    public function setInput($input)
+    public function setInput(string $input): TestcaseContent
     {
         $this->input = $input;
-
         return $this;
     }
 
-    /**
-     * Get input
-     *
-     * @return string
-     */
-    public function getInput()
+    public function getInput(): string
     {
         return $this->input;
     }
 
-    /**
-     * Set output
-     *
-     * @param string $output
-     *
-     * @return TestcaseContent
-     */
-    public function setOutput($output)
+    public function setOutput(string $output): TestcaseContent
     {
         $this->output = $output;
-
         return $this;
     }
 
-    /**
-     * Get output
-     *
-     * @return string
-     */
-    public function getOutput()
+    public function getOutput(): string
     {
         return $this->output;
     }
 
-    /**
-     * Set image
-     *
-     * @param string $image
-     *
-     * @return TestcaseContent
-     */
-    public function setImage($image)
+    public function setImage(string $image): TestcaseContent
     {
         $this->image = $image;
-
         return $this;
     }
 
-    /**
-     * Get image
-     *
-     * @return string
-     */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->image;
     }
 
-    /**
-     * Set imageThumb
-     *
-     * @param string $imageThumb
-     *
-     * @return TestcaseContent
-     */
-    public function setImageThumb($imageThumb)
+    public function setImageThumb(string $imageThumb): TestcaseContent
     {
         $this->image_thumb = $imageThumb;
-
         return $this;
     }
 
-    /**
-     * Get imageThumb
-     *
-     * @return string
-     */
-    public function getImageThumb()
+    public function getImageThumb(): string
     {
         return $this->image_thumb;
     }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -169,7 +169,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
         ) = unserialize($serialized);
     }
 
-    public function getUserid(): int
+    public function getUserid(): ?int
     {
         return $this->userid;
     }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -14,7 +14,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Users that have access to DOMjudge
+ * Users that have access to DOMjudge.
+ *
  * @ORM\Entity()
  * @ORM\Table(
  *     name="user",
@@ -140,8 +141,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
      */
     private $user_roles;
 
-
-    public function getSalt()
+    public function getSalt(): ?string
     {
         return null;
     }
@@ -159,6 +159,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
             $this->password,
         ));
     }
+
     public function unserialize($serialized)
     {
         list(
@@ -168,365 +169,194 @@ class User implements UserInterface, EquatableInterface, \Serializable
         ) = unserialize($serialized);
     }
 
-    /**
-     * Get userid
-     *
-     * @return integer
-     */
-    public function getUserid()
+    public function getUserid(): int
     {
         return $this->userid;
     }
 
-    /**
-     * Set username
-     *
-     * @param string $username
-     *
-     * @return User
-     */
-    public function setUsername($username)
+    public function setUsername(string $username): User
     {
         $this->username = $username;
-
         return $this;
     }
 
-    /**
-     * Get username
-     *
-     * @return string
-     */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
 
-    /**
-     * Set name
-     *
-     * @param string $name
-     *
-     * @return User
-     */
-    public function setName($name)
+    public function setName(string $name): User
     {
         $this->name = $name;
-
         return $this;
     }
 
-    /**
-     * Get name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set email
-     *
-     * @param string $email
-     *
-     * @return User
-     */
-    public function setEmail($email)
+    public function setEmail(string $email): User
     {
         $this->email = $email;
-
         return $this;
     }
 
-    /**
-     * Get email
-     *
-     * @return string
-     */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    /**
-     * Set lastLogin
-     *
-     * @param string $lastLogin
-     *
-     * @return User
-     */
-    public function setLastLogin($lastLogin)
+    /** @param string|float $lastLogin */
+    public function setLastLogin($lastLogin): User
     {
         $this->last_login = $lastLogin;
-
         return $this;
     }
 
-    /**
-     * Get lastLogin
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getLastLogin()
     {
         return $this->last_login;
     }
 
     /**
-     * Get the last login time for this user as a DateTime object
-     *
-     * @return DateTime|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("last_login_time")
      * @Serializer\Type("DateTime")
      * @throws Exception
      */
-    public function getLastLoginObject()
+    public function getLastLoginAsDateTime(): ?DateTime
     {
         return $this->getLastLogin() ? new DateTime(Utils::absTime($this->getLastLogin())) : null;
     }
 
-    /**
-     * Set firstLogin
-     *
-     * @param $firstLogin
-     * @return User
-     */
-    public function setFirstLogin($firstLogin)
+    /** @param string|float $firstLogin */
+    public function setFirstLogin($firstLogin): User
     {
         $this->first_login = $firstLogin;
-
         return $this;
     }
 
-    /**
-     * Get firstLogin
-     *
-     * @return string
-     */
+    /** @return string|float */
     public function getFirstLogin()
     {
         return $this->first_login;
     }
 
     /**
-     * Get the first login time for this user as a DateTime object
-     *
-     * @return DateTime|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("first_login_time")
      * @Serializer\Type("DateTime")
      * @throws Exception
      */
-    public function getFirstLoginObject()
+    public function getFirstLoginAsDateTime(): ?DateTime
     {
         return $this->getFirstLogin() ? new DateTime(Utils::absTime($this->getFirstLogin())) : null;
     }
 
-    /**
-     * Set lastIpAddress
-     *
-     * @param string $lastIpAddress
-     *
-     * @return User
-     */
-    public function setLastIpAddress($lastIpAddress)
+    public function setLastIpAddress(string $lastIpAddress): User
     {
         $this->last_ip_address = $lastIpAddress;
-
         return $this;
     }
 
-    /**
-     * Get lastIpAddress
-     *
-     * @return string
-     */
-    public function getLastIpAddress()
+    public function getLastIpAddress(): ?string
     {
         return $this->last_ip_address;
     }
 
-    /**
-     * Set password
-     *
-     * @param string $password
-     *
-     * @return User
-     */
-    public function setPassword($password)
+    public function setPassword(string $password): User
     {
         $this->password = $password;
-
         return $this;
     }
 
-    /**
-     * Set the plain password, used to create the encoded password
-     * @param string|null $plainPassword
-     *
-     * @return User
-     */
-    public function setPlainPassword($plainPassword): User
+    public function setPlainPassword(?string $plainPassword): User
     {
         $this->plainPassword = $plainPassword;
-        // Make sure we let Doctrine know the password changed when we set a plain password by modifying the field
+        // Make sure we let Doctrine know the password changed when we set a plain password by modifying the field.
         $this->password      = $this->password === null ? '' : null;
         return $this;
     }
 
-    /**
-     * Get password
-     *
-     * @return string
-     */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * Get the plain password, used to create the encoded password
-     *
-     * @return string|null
-     */
-    public function getPlainPassword()
+    public function getPlainPassword(): ?string
     {
         return $this->plainPassword;
     }
 
-    /**
-     * Set ipaddress
-     *
-     * @param string $ipAddress
-     *
-     * @return User
-     */
-    public function setIpAddress($ipAddress)
+    public function setIpAddress(string $ipAddress): User
     {
         $this->ipAddress = $ipAddress;
-
         return $this;
     }
 
-    /**
-     * Get ipaddress
-     *
-     * @return string
-     */
-    public function getIpAddress()
+    public function getIpAddress(): ?string
     {
         return $this->ipAddress;
     }
 
-    /**
-     * Set enabled
-     *
-     * @param boolean $enabled
-     *
-     * @return User
-     */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): User
     {
         $this->enabled = $enabled;
-
         return $this;
     }
 
-    /**
-     * Get enabled
-     *
-     * @return boolean
-     */
-    public function getEnabled()
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    /**
-     * Set team
-     *
-     * @param Team $team
-     *
-     * @return User
-     */
-    public function setTeam(Team $team = null)
+    public function setTeam(?Team $team = null): User
     {
         $this->team = $team;
-
         return $this;
     }
 
-    /**
-     * Get team
-     *
-     * @return Team
-     */
-    public function getTeam()
+    public function getTeam(): ?Team
     {
         return $this->team;
     }
 
     /**
-     * Get the team name of this user
-     * @return string|null
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("team")
      * @Serializer\Type("string")
      * @Serializer\Groups({"Nonstrict"})
      */
-    public function getTeamName()
+    public function getTeamName(): ?Team
     {
         return $this->getTeam() ? $this->getTeam()->getEffectiveName() : null;
     }
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->user_roles = new ArrayCollection();
     }
 
-    /**
-     * Add role
-     *
-     * @param Role $role
-     *
-     * @return User
-     */
-    public function addUserRole(Role $role)
+    public function addUserRole(Role $role): User
     {
         $this->user_roles[] = $role;
-
         return $this;
     }
 
-    /**
-     * Remove role
-     *
-     * @param Role $role
-     */
     public function removeUserRole(Role $role)
     {
         $this->user_roles->removeElement($role);
     }
 
-    /**
-     * Get roles
-     *
-     * @return Role[]
-     */
-    public function getUserRoles()
+    public function getUserRoles(): array
     {
         return $this->user_roles->toArray();
     }
 
     /**
      * Get the roles of this user as an array of strings
-     * @return string[]
      * @Serializer\VirtualProperty()
      * @Serializer\SerializedName("roles")
      * @Serializer\Type("array<string>")
@@ -557,7 +387,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function isEqualTo(UserInterface $user)
+    public function isEqualTo(UserInterface $user): bool
     {
         if (!$user instanceof self) {
             return false;

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -280,7 +280,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
         return $this;
     }
 
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -463,13 +463,17 @@ class DOMJudgeService
             $user = $this->getUser() ? $this->getUser()->getUsername() : null;
         }
 
+        if (gettype($cid) == 'string') {
+            $cid = (int) $cid;
+        }
+
         $auditLog = new AuditLog();
         $auditLog
             ->setLogtime(Utils::now())
             ->setCid($cid)
             ->setUser($user)
             ->setDatatype($datatype)
-            ->setDataid($dataid)
+            ->setDataid((string)$dataid)
             ->setAction($action)
             ->setExtrainfo($extraInfo);
 

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -455,7 +455,7 @@ class EventLogService implements ContainerAwareInterface
                     ->setEventtime($now)
                     ->setContest($contest)
                     ->setEndpointtype($type)
-                    ->setEndpointid($ids[$idx])
+                    ->setEndpointid((string)$ids[$idx])
                     ->setAction($action)
                     ->setContent($jsonElement);
                 $this->em->persist($event);

--- a/webapp/templates/jury/contests.html.twig
+++ b/webapp/templates/jury/contests.html.twig
@@ -31,7 +31,7 @@
                             {% endif %}
                             <table class="table table-hover">
                                 <tbody>
-                                {% for type, data in contest.juryTimeData %}
+                                {% for type, data in contest.dataForJuryInterface %}
                                     <tr>
                                         <td class="{{ data.class|default('') }}">
                                             {% if data.icon is defined %}

--- a/webapp/templates/partials/menu_countdown.html.twig
+++ b/webapp/templates/partials/menu_countdown.html.twig
@@ -7,7 +7,7 @@
         {%- if contest is null -%}
           no contest
         {%- else -%}
-            {{ contest.countdown }}
+            {{ contest.countdownString }}
         {%- endif -%}
     </span>
 </div>


### PR DESCRIPTION
Mostly remove useless comments, e.g. for a method called `setFoo` we
don't need a comment "Sets foo".

Set proper type hints whereever possible.

No functional changes intended.