### PR TITLE
Add direct download button on team page (if allowed).

### DIFF
--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -165,6 +165,7 @@ class MiscController extends BaseController
             $data['clarifications']        = $clarifications;
             $data['clarificationRequests'] = $clarificationRequests;
             $data['categories']            = $this->config->get('clar_categories');
+            $data['allowDownload']         = (bool)$this->config->get('allow_team_submission_download');
         }
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -11,6 +11,9 @@
             <th scope="col">problem</th>
             <th scope="col">lang</th>
             <th scope="col">result</th>
+            {% if allowDownload %}
+                <th scope="col"></th>
+            {% endif %}
         </tr>
         </thead>
         <tbody>
@@ -56,6 +59,13 @@
                         {%- endif %}
                     </a>
                 </td>
+        {% if allowDownload %}
+                <td>
+                    <a class="btn btn-light" href="{{ path('team_submission_download', {'submitId': submission.submitid}) }}">
+                        <i class="fa fa-download"></i>
+                    </a>
+                </td>
+        {% endif %}
             </tr>
         {%- endfor %}
         </tbody>


### PR DESCRIPTION
The modal submission page is only available after it is judged (and
potentially verified if verification is required) but teams may want to
download it even earlier (and without leaving the main page).