### PR TITLE
Only admin role should be able to upload executables

### DIFF
--- a/webapp/templates/jury/executable_add.html.twig
+++ b/webapp/templates/jury/executable_add.html.twig
@@ -1,0 +1,20 @@
+{% extends "jury/base.html.twig" %}
+{% import "jury/jury_macros.twig" as macros %}
+
+{% block title %}Add executable - {{ parent() }}{% endblock %}
+
+{% block extrahead %}
+    {{ parent() }}
+    {{ macros.select2_extrahead() }}
+    {{ macros.jscolor_extrahead() }}
+{% endblock %}
+
+{% block content %}
+
+    <h1>Add executable</h1>
+
+    {% include 'jury/partials/executable_form.html.twig' %}
+
+    {{ macros.collection_scripts() }}
+
+{% endblock %}

--- a/webapp/templates/jury/executables.html.twig
+++ b/webapp/templates/jury/executables.html.twig
@@ -14,14 +14,10 @@
 
     {{ macros.table(executables, table_fields, num_actions) }}
 
-    {%- if is_granted('ROLE_ADMIN') %}
-
-        <h3>Upload new executable</h3>
-        <div class="row">
-            <div class="col-lg-4">
-                {{ form(form) }}
-            </div>
-        </div>
-    {%- endif %}
+    {% if is_granted('ROLE_ADMIN') %}
+        <p>
+            {{ button(path('jury_executable_add'), 'Add new executable', 'primary', 'plus') }}
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/webapp/templates/jury/partials/executable_form.html.twig
+++ b/webapp/templates/jury/partials/executable_form.html.twig
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-lg-4">
+        {{ form(form) }}
+    </div>
+</div>

--- a/webapp/tests/Controller/Jury/ExecutableControllerTest.php
+++ b/webapp/tests/Controller/Jury/ExecutableControllerTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\Jury;
+
+use App\Tests\BaseTest;
+use Generator;
+
+class ExecutableControllerTest extends BaseTest
+{
+    protected static $roles = ['admin'];
+
+    /**
+     * @param String $role
+     * @param String $url
+     * @param int $statusCode
+     * @param String $HTTPMethod
+     * @dataProvider provideRoleAccessData
+     */
+    public function testHTTPAccessForRole(string $role, string $url, int $statusCode, string $HTTPMethod)
+    {
+        static::$roles = [$role];
+        // Optionally use the setupUser
+        $this->logOut();
+        $this->logIn();
+        $this->verifyPageResponse($HTTPMethod, $url, $statusCode);
+    }
+
+    /**
+     * Data provider used to test role access. Each item contains:
+     * - the base role the user has
+     * - the endpoint to check
+     * - expected statusCode for this role
+     * - the method to try (GET, POST)
+     */
+    public function provideRoleAccessData() : Generator
+    {
+        foreach (['GET', 'POST', 'HEAD'] as $HTTP)
+        {
+            foreach (['admin', 'jury'] as $role) {
+                yield [$role, '/jury/executables', 200, $HTTP];
+            }
+            foreach (['team', 'jury'] as $role) {
+                yield [$role, '/jury/executables/add', 403, $HTTP];
+            }
+            yield ['team', '/jury/executables', 403, $HTTP];
+            yield ['admin', '/jury/executables/add', 200, $HTTP];
+        }
+    }
+}


### PR DESCRIPTION
Move executable upload to /add page

Minor:
Reformatted PHPcode
Added return types
Removed redundant type annotations
Removed not used imports

PHPstorm also reports on:
https://github.com/mvr320/domjudge/blob/858b03f0427c49f9fd03f7db292a022aa27c6cc5/webapp/src/Controller/Jury/ExecutableController.php#L199

Where DOMJudge has 2 functions, which only has 1 argument and 1 which has 2, I'm not sure if its suggestion is correct.
Followed PHPstorm suggestions on imports

