### PR TITLE
Report visual changes also when not on a PR branch

### DIFF
--- a/gitlab/visualcompare.sh
+++ b/gitlab/visualcompare.sh
@@ -37,11 +37,6 @@ do
     fi
 done
 
-if ! grep "^pr-" <<< $CI_COMMIT_BRANCH; then
-    # We're not on a PR, so we dont push results to the GitHub discussion
-    exit 0
-fi
-
 CHANGE=0
 for dir in $failingchanges $predictedchanges
 do

--- a/gitlab/visualcompare.sh
+++ b/gitlab/visualcompare.sh
@@ -9,6 +9,13 @@ predictedchanges="predictedchanges"
 
 mkdir -p {$failingchanges,$predictedchanges}
 
+if grep "^pr-" <<< $CI_COMMIT_BRANCH; then
+    GITHUB_PR=`cut -d '/' -f1 <<< ${CI_COMMIT_BRANCH##pr-}`
+else
+    GITHUB_PR=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/domjudge/domjudge/commits/$CI_COMMIT_SHA/pulls | awk '/"number": /{print $2}'`
+    GITHUB_PR=${GITHUB_PR%,}
+fi
+
 for file in `ls screenshotspr`
 do
     PR=screenshotspr/$file
@@ -22,7 +29,6 @@ do
     if [ $RET -ne 0 ]; then
         REMOVE=".html-ff.png"
         if grep "^pr-" <<< $CI_COMMIT_BRANCH; then
-            GITHUB_PR=`cut -d '/' -f1 <<< ${CI_COMMIT_BRANCH##pr-}`
             ENDPOINT=${file/$REMOVE}
             WANTED=`python3 gitlab/visualgithubprdiscussion.py $ENDPOINT $GITHUB_PR`
             if [ $WANTED = "wanted" ]; then


### PR DESCRIPTION
This might sometimes break rerun pipeline in gitlab, but as this happens
less frequent I think this is better. Also when rerunning a pipeline one
is probably interested in other results.