### PR TITLE
Show nice interactive output for teams. Fixes #925.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -219,7 +219,7 @@ function rest_encode_file(string $file, $sizelimit = true) : string
     } else {
         error("Invalid argument sizelimit = '$sizelimit' specified.");
     }
-    return urlencode(base64_encode(dj_file_get_contents($file, $maxsize)));
+    return base64_encode(dj_file_get_contents($file, $maxsize));
 }
 
 $waittime = 5;
@@ -970,7 +970,7 @@ function compile(array $judgeTask, string $workdir, string $workdirpath, array $
 
     // pop the compilation result back into the judging table
     $args = 'compile_success=' . $compile_success .
-        '&output_compile=' . rest_encode_file($workdir . '/compile.out', $output_storage_limit);
+        '&output_compile=' . urlencode(rest_encode_file($workdir . '/compile.out', $output_storage_limit));
     if (isset($metadata['entry_point'])) {
         $args .= '&entry_point=' . urlencode($metadata['entry_point']);
     }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -698,7 +698,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         return $return;
     }
 
-    public function interactiveLog(string $log) {
+    public function interactiveLog(string $log, bool $forTeam = false) {
         $truncated = '/\[output display truncated after \d* B\]$/';
         $matches = array();
         $truncation = "";
@@ -706,7 +706,11 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $truncation = $matches[0];
             $log = preg_replace($truncated, "", $log);
         }
-        $header = "<table><tr><th>time</th><th>validator</th><th>submission<th></tr>\n";
+        if ($forTeam) {
+            $header = "<table><tr><th>jury</th><th>your submission<th></tr>\n";
+        } else {
+            $header = "<table><tr><th>time</th><th>validator</th><th>submission<th></tr>\n";
+        }
         $body = "";
         $idx = 0;
         while ($idx < strlen($log)) {
@@ -732,7 +736,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $idx += $len + 4;
             $team = $is_validator ? '<td/>' : $content;
             $validator = $is_validator ? $content : '<td/>';
-            $body .= "<tr><td>$time</td>"
+            $body .= "<tr>" . ($forTeam ? "" : "<td>$time</td>")
                 . $validator
                 . $team
                 . "</tr>\n";

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -98,28 +98,37 @@
                             </div>
                         </div>
 
-                        <h6 class="mt-3">Program output</h6>
-                        {% if run.output_run is not empty %}
-                            <pre class="output_text">
+                        {% if judging.submission.problem.combinedRunCompare %}
+                            <h6 class="mt-3">Jury/Submission interaction</h6>
+                            {% if run.output_run is empty %}
+                                <p class="nodata">There was no interaction log.</p>
+                            {% else %}
+                                {{ run.output_run | interactiveLog(true) }}
+                            {% endif %}
+                        {% else %}
+                            <h6 class="mt-3">Program output</h6>
+                            {% if run.output_run is not empty %}
+                                <pre class="output_text">
 {{ run.output_run }}</pre>
-                        {% else %}
-                            <p class="nodata">There was no program output.</p>
-                        {% endif %}
+                            {% else %}
+                                <p class="nodata">There was no program output.</p>
+                            {% endif %}
 
-                        <h6 class="mt-3">Diff output</h6>
-                        {% if run.output_diff is not empty %}
-                            <pre class="output_text">
+                            <h6 class="mt-3">Diff output</h6>
+                            {% if run.output_diff is not empty %}
+                                <pre class="output_text">
 {{ run.output_diff }}</pre>
-                        {% else %}
-                            <p class="nodata">There was no diff output.</p>
-                        {% endif %}
+                            {% else %}
+                                <p class="nodata">There was no diff output.</p>
+                            {% endif %}
 
-                        <h6 class="mt-3">Error output (info/debug/errors)</h6>
-                        {% if run.output_error is not empty %}
-                            <pre class="output_text">
+                            <h6 class="mt-3">Error output (info/debug/errors)</h6>
+                            {% if run.output_error is not empty %}
+                                <pre class="output_text">
 {{ run.output_error }}</pre>
-                        {% else %}
-                            <p class="nodata">There was no stderr output.</p>
+                            {% else %}
+                                <p class="nodata">There was no stderr output.</p>
+                            {% endif %}
                         {% endif %}
                     {% endif %}
                 {% endfor %}


### PR DESCRIPTION
Output for team:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/550145/104482264-05420e00-55c7-11eb-873a-1d17e418ada0.png">

Also fixes an issue in the judgedaemon where we pass `$new_judging_run` as an array to `CURLOPT_POSTFIELDS` and `urlencode` the array values, which should not be done since cURL does that for us; thus it gave garbled data.