### PR TITLE
Implement CCS specs submission upload (icpc/ccs-specs#14).

### DIFF
--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -133,6 +133,9 @@ cd /tmp
 git clone --depth=1 https://github.com/Kattis/problemtools.git
 cd problemtools/examples
 mv hello hello_kattis
+# Remove 2 submissions that will not pass validation. The first is because it is
+# a Python 2 submission. The latter has a judgement type we do not understand.
+rm different/submissions/accepted/different_py2.py different/submissions/slow_accepted/different_slow.py
 for i in hello_kattis different guess; do
 	(
 		cd "$i"

--- a/submit/submit.cc
+++ b/submit/submit.cc
@@ -964,11 +964,11 @@ bool doAPIsubmit()
 		        reader.getFormattedErrorMessages().c_str());
 	}
 
-	if ( !root.isInt() ) {
+	if ( !root.isString() ) {
 		error(0,"REST API returned unexpected JSON data");
 	}
 
-	logmsg(LOG_NOTICE,"Submission received, id = s%i", root.asInt());
+	logmsg(LOG_NOTICE,"Submission received, id = s%s", root.asCString());
 
 	return true;
 }

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -118,7 +118,7 @@ class SubmissionController extends AbstractRestController
      * Add a submission to this contest
      * @Rest\Post("")
      * @OA\Post()
-     * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role or be an admin to add a submission")
+     * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a submission")
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -357,15 +357,15 @@ class SubmissionController extends AbstractRestController
             // CCS spec format, files are a ZIP, get them and transform them into a file object
             $filesList = $request->request->get('files');
             if (!is_array($filesList) || count($filesList) !== 1 || !isset($filesList[0]['data'])) {
-                throw new BadRequestHttpException("The 'files' attribute should be an array with a single item, containing an object with a base64 encoded data field");
+                throw new BadRequestHttpException("The 'files' attribute must be an array with a single item, containing an object with a base64 encoded data field");
             }
 
             if (isset($filesList[0]['mime']) && $filesList[0]['mime'] !== 'application/zip') {
-                throw new BadRequestHttpException("The 'files[0].mime' attribute should be application/zip if provided");
+                throw new BadRequestHttpException("The 'files[0].mime' attribute must be application/zip if provided");
             }
 
             $data        = $filesList[0]['data'];
-            $decodedData = base64_decode($data);
+            $decodedData = base64_decode($data, true);
             if ($decodedData === false) {
                 throw new BadRequestHttpException("The 'files[0].data' attribute is not base64 encoded");
             }

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -359,6 +359,11 @@ class SubmissionController extends AbstractRestController
             if (!is_array($filesList) || count($filesList) !== 1 || !isset($filesList[0]['data'])) {
                 throw new BadRequestHttpException("The 'files' attribute should be an array with a single item, containing an object with a base64 encoded data field");
             }
+
+            if (isset($filesList[0]['mime']) && $filesList[0]['mime'] !== 'application/zip') {
+                throw new BadRequestHttpException("The 'files[0].mime' attribute should be application/zip if provided");
+            }
+
             $data        = $filesList[0]['data'];
             $decodedData = base64_decode($data);
             if ($decodedData === false) {

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -53,6 +53,8 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
      *     options={"comment"="Specifies ID of submission if imported from external CCS, e.g. Kattis",
      *              "collation"="utf8mb4_bin"},
      *     nullable=true)
+     * @Serializer\Groups({"Nonstrict"})
+     * @Serializer\SerializedName("external_id")
      */
     protected $externalid;
 

--- a/webapp/src/Serializer/SetExternalIdVisitor.php
+++ b/webapp/src/Serializer/SetExternalIdVisitor.php
@@ -3,6 +3,7 @@
 namespace App\Serializer;
 
 use App\Entity\ExternalRelationshipEntityInterface;
+use App\Entity\Submission;
 use App\Service\EventLogService;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
@@ -65,6 +66,15 @@ class SetExternalIdVisitor implements EventSubscriberInterface
                     );
                     $visitor->visitProperty($property, $object->{$method}());
                 }
+            } elseif ($object instanceof Submission && $object->getExternalid() !== null) {
+                // Special case for submissions: they can have an external ID even if when running in
+                // full local mode, because one can use the API to upload a submission with an external ID
+                $property = new StaticPropertyMetadata(
+                    get_class($object),
+                    'id',
+                    null
+                );
+                $visitor->visitProperty($property, $object->getExternalid());
             }
         } catch (\BadMethodCallException $e) {
             // Ignore these exceptions, as this means this is not an entity or it is not configured
@@ -83,6 +93,15 @@ class SetExternalIdVisitor implements EventSubscriberInterface
                             );
                             $visitor->visitProperty($property, $entity->{$method}());
                         }
+                    } elseif ($entity && $entity instanceof Submission && $entity->getExternalid() !== null) {
+                        // Special case for submissions: they can have an external ID even if when running in
+                        // full local mode, because one can use the API to upload a submission with an external ID
+                        $property = new StaticPropertyMetadata(
+                            get_class($entity),
+                            $field,
+                            null
+                        );
+                        $visitor->visitProperty($property, $entity->getExternalid());
                     }
                 } catch (\BadMethodCallException $e) {
                     // Ignore these exceptions, as this means this is not an entity or it is not configured

--- a/webapp/src/Serializer/SubmissionVisitor.php
+++ b/webapp/src/Serializer/SubmissionVisitor.php
@@ -88,7 +88,7 @@ class SubmissionVisitor implements EventSubscriberInterface
                 'v4_submission_files',
                 [
                     'cid' => $submission->getContest()->getApiId($this->eventLogService),
-                    'id'  => $submission->getApiId($this->eventLogService)
+                    'id'  => $submission->getExternalid() ?? $submission->getSubmitid(),
                 ]
             );
             $apiRootRoute       = $this->router->generate('v4_api_root');

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
@@ -687,7 +688,7 @@ class DOMJudgeService
         $zip = new ZipArchive();
         $res = $zip->open($filename, ZIPARCHIVE::CHECKCONS);
         if ($res === ZIPARCHIVE::ER_NOZIP || $res === ZIPARCHIVE::ER_INCONS) {
-            throw new ServiceUnavailableHttpException(null, 'No valid zip archive given');
+            throw new BadRequestHttpException('No valid zip archive given');
         } elseif ($res === ZIPARCHIVE::ER_MEMORY) {
             throw new ServiceUnavailableHttpException(null, 'Not enough memory to extract zip archive');
         } elseif ($res !== true) {

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -3,6 +3,7 @@ namespace App\Utils;
 
 use DateTime;
 use Doctrine\Inflector\InflectorFactory;
+use Exception;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -460,6 +461,8 @@ class Utils
      * optional fractional part). The original time string should be in one of
      * the formats understood by DateTime (e.g. an ISO 8601 date and time with
      * fractional seconds). Throws an exception if $time cannot be parsed.
+     *
+     * @throws Exception
      */
     public static function toEpochFloat(string $time) : float
     {

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -86,7 +86,12 @@
                     </td>
                 {% endif %}
                 <td class="{{ tdExtraClass }}">
-                    <a href="{{ link }}">s{{ submission.submitid }}</a>
+                    <a href="{{ link }}">
+                        s{{ submission.submitid }}
+                        {% if submission.externalid %}
+                            ({{ submission.externalid }})
+                        {% endif %}
+                    </a>
                 </td>
                 {%- if showContest %}
                     <td class="{{ tdExtraClass }}"><a href="{{ link }}">c{{ submission.contest.cid }}</a></td>

--- a/webapp/tests/Controller/API/BaseTest.php
+++ b/webapp/tests/Controller/API/BaseTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\API;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class BaseTest extends WebTestCase
+{
+    /** @var KernelBrowser */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        // Reset the kernel to make sure we have a clean slate
+        self::ensureKernelShutdown();
+
+        // Create a client to communicate with the application
+        $this->client = self::createClient();
+    }
+
+    /**
+     * Verify the given API URL produces the given status code and return the body as JSON
+     *
+     * @param string      $method   The HTTP method to use
+     * @param string      $apiUri   The API URL to use. Will be prefixed with /api
+     * @param int         $status   The status code to expect
+     * @param string|null $user     The username to use. Currently only admin and dummy are supported
+     * @param mixed       $jsonData The JSON data to set as a body, if any
+     * @param array       $files    The files to upload, if any
+     *
+     * @return mixed The returned JSON data
+     */
+    protected function verifyApiJsonResponse(
+        string $method,
+        string $apiUri,
+        int $status,
+        ?string $user = null,
+        $jsonData = null,
+        array $files = []
+    ) {
+        $server = ['CONTENT_TYPE' => 'application/json'];
+        // The API doesn't use cookie based logins, so we need to set a username/password.
+        // For the admin, we can get it from initial_admin_password.secret and for the dummy user we know it's 'dummy'
+        if ($user === 'admin') {
+            $adminPasswordFile       = sprintf(
+                '%s/%s',
+                static::$container->getParameter('domjudge.etcdir'),
+                'initial_admin_password.secret'
+            );
+            $server['PHP_AUTH_USER'] = 'admin';
+            $server['PHP_AUTH_PW']   = trim(file_get_contents($adminPasswordFile));
+        } elseif ($user === 'dummy') {
+            // Team user
+            $server['PHP_AUTH_USER'] = 'dummy';
+            $server['PHP_AUTH_PW']   = 'dummy';
+        }
+        $this->client->request($method, '/api' . $apiUri, [], $files, $server, $jsonData ? json_encode($jsonData) : null);
+        $response = $this->client->getResponse();
+        $message  = var_export($response, true);
+        self::assertEquals($status, $response->getStatusCode(), $message);
+        return json_decode($response->getContent(), true);
+    }
+}

--- a/webapp/tests/Controller/API/SubmissionControllerTest.php
+++ b/webapp/tests/Controller/API/SubmissionControllerTest.php
@@ -1,0 +1,384 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\API;
+
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\SubmissionFile;
+use App\Service\DOMJudgeService;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use ZipArchive;
+
+class SubmissionControllerTest extends BaseTest
+{
+    /**
+     * Test that a non logged in user can not add a submission
+     */
+    public function testAddSubmissionNoAccess()
+    {
+        $this->verifyApiJsonResponse('POST', '/contests/2/submissions', 401);
+    }
+
+    /**
+     * Test that if not all data is supplied, the correct message is returned
+     *
+     * @dataProvider provideAddMissingData
+     */
+    public function testAddMissingData(string $user, array $dataToSend, string $expectedMessage)
+    {
+        $data = $this->verifyApiJsonResponse('POST', '/contests/2/submissions', 400, $user, $dataToSend);
+        static::assertEquals($expectedMessage, $data['message']);
+    }
+
+    public function provideAddMissingData(): Generator
+    {
+        yield ['dummy', [], "One of the arguments 'problem', 'problem_id' is mandatory"];
+        yield ['dummy', ['problem' => 1], "One of the arguments 'language', 'language_id' is mandatory"];
+        yield ['dummy', ['problem_id' => 1], "One of the arguments 'language', 'language_id' is mandatory"];
+        yield ['dummy', ['problem_id' => 4, 'language' => 'cpp'], "Problem 4 not found or not submittable"];
+        yield ['dummy', ['problem_id' => 1, 'language' => 'cpp'], "No files specified."];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'cpp'], "No files specified."];
+        yield ['dummy', ['problem_id' => 1, 'language' => 'abc'], "Language abc not found or not submittable"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'abc'], "Language abc not found or not submittable"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'abc'], "Language abc not found or not submittable"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'cpp', 'team_id' => 1], "Can not submit for a different team"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'cpp', 'id' => '123'], "A team can not assign id"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'cpp', 'time' => '2021-01-01T00:00:00'], "A team can not assign time"];
+        yield ['dummy', ['problem_id' => 1, 'language_id' => 'cpp', 'files' => []], "The 'files' attribute must be an array with a single item, containing an object with a base64 encoded data field"];
+        yield [
+            'dummy',
+            ['problem_id' => 1, 'language_id' => 'cpp', 'files' => 'this is not an array'],
+            "The 'files' attribute must be an array with a single item, containing an object with a base64 encoded data field"
+        ];
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'files'       => [
+                    // More than one item
+                    ['data' => 'aaa'],
+                    ['data' => 'aaa'],
+                ],
+            ],
+            "The 'files' attribute must be an array with a single item, containing an object with a base64 encoded data field"
+        ];
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'files'       => [
+                    // Not valid base64
+                    ['data' => '*&(^&*(^(&*(&*^'],
+                ],
+            ],
+            "The 'files[0].data' attribute is not base64 encoded"
+        ];
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'files'       => [
+                    // Valid base64, but not a ZIP file
+                    ['data' => 'aaa'],
+                ],
+            ],
+            "No valid zip archive given"
+        ];
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'files'       => [
+                    ['data' => 'aaa', 'mime' => 'wrong'],
+                ],
+            ],
+            "The 'files[0].mime' attribute must be application/zip if provided"
+        ];
+        yield ['admin', ['problem_id' => 1, 'language' => 'cpp'], "User does not belong to a team"];
+        yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 1], "No files specified."];
+        yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 3], "Team 3 not found or not enabled"];
+        yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 1, 'time' => 'this is not a time'], "Can not parse time this is not a time"];
+    }
+
+    /**
+     * Test that when submitting for a language that requires an entry point but not supplying an error is returned
+     */
+    public function testMissingEntryPoint()
+    {
+        // First, enable Kotlin as a language
+        $em = self::$container->get(EntityManagerInterface::class);
+        /** @var Language $kotlin */
+        $kotlin = $em->getRepository(Language::class)->find('kt');
+        $kotlin->setAllowSubmit(true);
+        $em->flush();
+
+        $data = $this->verifyApiJsonResponse('POST', '/contests/2/submissions', 400, 'dummy', ['problem_id' => 1, 'language' => 'kotlin']);
+
+        static::assertEquals('Main class required, but not specified.', $data['message']);
+    }
+
+    /**
+     * Test that adding submissions works as expected
+     *
+     * @dataProvider provideAddSuccess
+     */
+    public function testAddSuccess(
+        string $user,
+        array $dataToSend,
+        ?array $zipFiles,
+        array $filesToSend,
+        bool $idIsExternal,
+        int $expectedProblemId,
+        int $expectedTeamId,
+        string $expectedLanguageId,
+        ?string $expectedSubmissionExternalId, // If known
+        ?string $expectedTime, // If known
+        array $expectedFiles,
+        ?string $expectedEntryPoint = null
+    ) {
+        // First, enable Kotlin as a language as this is the only language with an entrypoint
+        $em = self::$container->get(EntityManagerInterface::class);
+        /** @var Language $kotlin */
+        $kotlin = $em->getRepository(Language::class)->find('kt');
+        $kotlin->setAllowSubmit(true);
+        $em->flush();
+
+        if ($zipFiles !== null) {
+            if (!isset($dataToSend['files'])) {
+                $dataToSend['files'] = [];
+            }
+            if (!isset($dataToSend['files'][0])) {
+                $dataToSend['files'][0] = [];
+            }
+            $dataToSend['files'][0]['data'] = $this->base64ZipWithFiles($zipFiles);
+        }
+        $submissionId = $this->verifyApiJsonResponse('POST', '/contests/2/submissions', 200, $user, $dataToSend, $filesToSend);
+        static::assertIsString($submissionId);
+
+        // Now load the submission
+        $submissionRepository = static::$container->get(EntityManagerInterface::class)->getRepository(Submission::class);
+        if ($idIsExternal) {
+            /** @var Submission $submission */
+            $submission = $submissionRepository->findOneBy(['externalid' => $submissionId]);
+        } else {
+            $submission = $submissionRepository->find($submissionId);
+        }
+
+        static::assertInstanceOf(Submission::class, $submission);
+        static::assertEquals($expectedProblemId, $submission->getProblem()->getProbid(), 'Wrong problem ID');
+        static::assertEquals($expectedTeamId, $submission->getTeam()->getTeamid(), 'Wrong team ID');
+        static::assertEquals($expectedLanguageId, $submission->getLanguage()->getLangid(), 'Wrong language ID');
+        if ($expectedSubmissionExternalId) {
+            static::assertEquals($expectedSubmissionExternalId, $submission->getExternalid(), 'Wrong external submission ID');
+        }
+        if ($expectedTime) {
+            static::assertEquals($expectedTime, $submission->getAbsoluteSubmitTime());
+        }
+        static::assertEquals($expectedEntryPoint, $submission->getEntryPoint());
+        $submissionFiles = [];
+        /** @var SubmissionFile $file */
+        foreach ($submission->getFiles() as $file) {
+            $submissionFiles[$file->getFilename()] = $file->getSourcecode();
+        }
+        static::assertEquals($expectedFiles, $submissionFiles, 'Wrong files');
+    }
+
+    public function provideAddSuccess(): Generator
+    {
+        // Submit a single file as a file upload
+        yield [
+            'dummy',
+            [
+                'problem'  => 1,
+                'language' => 'cpp',
+            ],
+            null,
+            ['code' => new UploadedFile(__FILE__, 'somefile.cpp')],
+            false,
+            1,
+            2,
+            'cpp',
+            null,
+            null,
+            ['somefile.cpp' => file_get_contents(__FILE__)],
+        ];
+        // Submit multiple files as a file upload
+        yield [
+            'dummy',
+            [
+                'problem'  => 1,
+                'language' => 'cpp',
+            ],
+            null,
+            [
+                'code' => [
+                    new UploadedFile(__FILE__, 'somefile.cpp'),
+                    new UploadedFile(__DIR__ . '/BaseTest.php', 'another.cpp'),
+                ],
+            ],
+            false,
+            1,
+            2,
+            'cpp',
+            null,
+            null,
+            [
+                'somefile.cpp' => file_get_contents(__FILE__),
+                'another.cpp'  => file_get_contents(__DIR__ . '/BaseTest.php'),
+            ],
+        ];
+        // Submit with an entrypoint
+        yield [
+            'dummy',
+            [
+                'problem'     => 1,
+                'language'    => 'kotlin',
+                'entry_point' => 'SomeFileKt',
+            ],
+            null,
+            [
+                'code' => [
+                    new UploadedFile(__FILE__, 'somefile.kt'),
+                ],
+            ],
+            false,
+            1,
+            2,
+            'kt',
+            null,
+            null,
+            ['somefile.kt' => file_get_contents(__FILE__)],
+            'SomeFileKt',
+        ];
+        // Submit a single file in CLICS format
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+            ],
+            ['main.cpp' => '// No content'],
+            [],
+            false,
+            1,
+            2,
+            'cpp',
+            null,
+            null,
+            ['main.cpp' => '// No content'],
+        ];
+        // Submit multiple files in CLICS format, also provide mime
+        yield [
+            'dummy',
+            [
+                'problem_id'  => 2,
+                'language_id' => 'java',
+                'files'       => [
+                    ['mime' => 'application/zip'],
+                ],
+            ],
+            [
+                'main.java'    => 'Some java file',
+                'another.java' => 'A second java file',
+            ],
+            [],
+            false,
+            2,
+            2,
+            'java',
+            null,
+            null,
+            [
+                'main.java'    => 'Some java file',
+                'another.java' => 'A second java file',
+            ],
+        ];
+        // Submit as admin under a different team ID
+        yield [
+            'admin',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'team_id'     => 1,
+            ],
+            ['main.cpp' => '// No content'],
+            [],
+            false,
+            1,
+            1,
+            'cpp',
+            null,
+            null,
+            ['main.cpp' => '// No content'],
+        ];
+        // Submit as admin and specify the submission ID
+        yield [
+            'admin',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'team_id'     => 1,
+                'id'          => 'myextid123',
+            ],
+            ['main.cpp' => '// No content'],
+            [],
+            true,
+            1,
+            1,
+            'cpp',
+            'myextid123',
+            null,
+            ['main.cpp' => '// No content'],
+        ];
+        // Submit as admin and specify time
+        yield [
+            'admin',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'team_id'     => 1,
+                'time'        => '2020-01-01T12:34:56',
+            ],
+            ['main.cpp' => '// No content'],
+            [],
+            false,
+            1,
+            1,
+            'cpp',
+            null,
+            '2020-01-01T12:34:56.000+00:00',
+            ['main.cpp' => '// No content'],
+        ];
+    }
+
+    /**
+     * Get a base64 encoded ZIP with the files as contents.
+     *
+     * Note: this method can not be called inside a data provider, since it uses the container
+     *
+     * @param array $files Mapping from filename to contents
+     *
+     * @return string The base64 encoded ZIP file
+     */
+    protected function base64ZipWithFiles(array $files): string
+    {
+        $zip          = new ZipArchive();
+        $tempFilename = tempnam(static::$container->get(DOMJudgeService::class)->getDomjudgeTmpDir(), "api-submissions-test-");
+
+        $zip->open($tempFilename, ZipArchive::OVERWRITE);
+        foreach ($files as $file => $content) {
+            $zip->addFromString($file, $content);
+        }
+        $zip->close();
+
+        $zipContent = file_get_contents($tempFilename);
+        unlink($tempFilename);
+        return base64_encode($zipContent);
+    }
+}


### PR DESCRIPTION
This implements the changes described in icpc/ccs-specs#14.

Since the spec is not officially merged yet I will leave this as a draft for now.

Some open questions:
* Should we internally switch to using `problem_id` and `language_id` in the submit client as well? Since we are doing a new major release this could be a breaking change. Other option would be to still allow both options for now but switch in the submit client, then later drop the old option. In that case I propose to not *document* the old fields. Leaving the `code` argument makes sense, since I think using the base64-encoded ZIP format the CCS specs use internally is not a good idea.
* For now I made a distinction between form and JSON body types. The primary reason is that in a form in SwaggerUI you can not have nested objects, which means you can not do the `files[0].data` thingy there. Browsers and HTTPie do support it, so maybe we should merge the two? If we still have both the fields with and without `_id` this does make the spec a little messy, since we can not set `required=` to anything in that case.
* There is no check whether files are in the root of the ZIP and filenames are valid but the submission service checks this already, so I don't think we need anything for this.
* It has no tests (yet). Probably best to do this together with the tests for the old/`code` behavior.