### PR TITLE
Transaction unit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
 		"twig/twig": "^2.11"
 	},
 	"require-dev": {
+		"dama/doctrine-test-bundle": "^6.5",
 		"symfony/debug-bundle": "4.4.*",
 		"symfony/maker-bundle": "^1.13",
 		"symfony/phpunit-bridge": "^4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0b8190d9f9bd07a6dbc3089d317d2a0",
+    "content-hash": "96ccb5d313ff920adb011b379f1fa3c4",
     "packages": [
         {
             "name": "angel-vladov/select2-theme-bootstrap4",
@@ -10722,6 +10722,69 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "a43f79239f446bb85ffa34e799878156a43b590b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/a43f79239f446bb85ffa34e799878156a43b590b",
+                "reference": "a43f79239f446bb85ffa34e799878156a43b590b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.9.3 || ^3.0",
+                "doctrine/doctrine-bundle": "^1.11 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.1"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "symfony/phpunit-bridge": "^5.1",
+                "symfony/process": "^3.4 || ^4.4 || ^5.1",
+                "symfony/yaml": "^3.4 || ^4.4 || ^5.1"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src/DAMA/DoctrineTestBundle"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v6.5.0"
+            },
+            "time": "2020-12-12T16:34:54+00:00"
+        },
         {
             "name": "nikic/php-parser",
             "version": "v4.9.1",

--- a/symfony.lock
+++ b/symfony.lock
@@ -8,6 +8,18 @@
     "composer/package-versions-deprecated": {
         "version": "1.11.99.1"
     },
+    "dama/doctrine-test-bundle": {
+        "version": "4.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "master",
+            "version": "4.0",
+            "ref": "56eaa387b5e48ebcc7c95a893b47dfa1ad51449c"
+        },
+        "files": [
+            "webapp/config/packages/test/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "datatables/datatables": {
         "version": "1.10.19"
     },

--- a/webapp/config/bundles.php
+++ b/webapp/config/bundles.php
@@ -16,4 +16,5 @@ return [
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/webapp/phpunit.xml.dist
+++ b/webapp/phpunit.xml.dist
@@ -32,4 +32,8 @@
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
+
+    <extensions>
+        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+    </extensions>
 </phpunit>

--- a/webapp/tests/BaseTest.php
+++ b/webapp/tests/BaseTest.php
@@ -188,7 +188,8 @@ abstract class BaseTest extends WebTestCase
         string $configKey,
         $configValue,
         callable $callback
-    ) {
+    ) : void
+    {
         $config   = self::$container->get(ConfigurationService::class);
         $eventLog = self::$container->get(EventLogService::class);
         $dj       = self::$container->get(DOMJudgeService::class);
@@ -201,15 +202,6 @@ abstract class BaseTest extends WebTestCase
 
         // Call the callback
         call_user_func($callback);
-
-        // Reset the changes by removing it from the database
-        $em         = self::$container->get(EntityManagerInterface::class);
-        $configItem = $em->getRepository(Configuration::class)->findOneBy(['name' => $configKey]);
-        $em->remove($configItem);
-        $em->flush();
-
-        // Call saveChanges with an empty array to clear any pending config
-        $config->saveChanges([], $eventLog, $dj);
     }
 
     /**

--- a/webapp/tests/Controller/ControllerRolesTest.php
+++ b/webapp/tests/Controller/ControllerRolesTest.php
@@ -39,7 +39,8 @@ class ControllerRolesTest extends BaseTest
      **/
     protected function urlExcluded(string $url)
     {
-        return ($url[0] == '#' ||                                          // Links to local page
+        return ($url === '' ||                                                 // Empty URL
+            $url[0] == '#' ||                                          // Links to local page
             strpos($url, 'http') !== false ||                        // External links
             substr($url, 0, 4) == '/doc' ||                     // Documentation is not setup
             substr($url, 0, 4) == '/api' ||                     // API is not functional in framework

--- a/webapp/tests/Controller/Jury/UserControllerTest.php
+++ b/webapp/tests/Controller/Jury/UserControllerTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\Jury;
+
+use App\Entity\User;
+use App\Tests\BaseTest;
+
+class UserControllerTest extends BaseTest
+{
+    protected static $roles     = ['admin'];
+    protected static $baseUrl   = '/jury/users';
+    protected static $getIDFunc = 'getUserid';
+
+    public function testDeleteEntity () : void
+    {
+        $this->logOut();
+        $this->logIn();
+        $this->verifyPageResponse('GET', static::$baseUrl, 200);
+        // Find a CID we can delete
+        $em = self::$container->get('doctrine')->getManager();
+        $ent = $em->getRepository(User::class)->findOneBy(['username' => 'dummy']);
+        self::assertSelectorExists('i[class*=fa-trash-alt]');
+        self::assertSelectorExists('body:contains("dummy")');
+        $this->verifyPageResponse('GET', static::$baseUrl.'/'.$ent->{static::$getIDFunc}().'/delete', 200);
+        $this->client->submitForm('Delete', []);
+        self::assertSelectorNotExists('body:contains("dummy")');
+    }
+}


### PR DESCRIPTION
This should reset the database transaction after each unit test. The advantage of this is that unit tests and their ordering cannot break the state for other unit tests, some changes were needed as apparently some of these race conditions existed. The test for the Jury UserController should work but can also be removed as its a subset of the code of another PR.

Before:
Time: 1.84 minutes, Memory: 117.00 MB

After:
Time: 1.29 minutes, Memory: 88.50 MB