### PR TITLE
Language fix

### DIFF
--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -51,7 +51,7 @@ class Language extends BaseApiEntity
      * @Serializer\Groups({"Default", "Nonstrict"})
      * @Assert\NotBlank()
      */
-    private $name;
+    private $name = '';
 
     /**
      * @var string[]
@@ -62,7 +62,7 @@ class Language extends BaseApiEntity
      * @Serializer\Type("array<string>")
      * @Assert\NotBlank()
      */
-    private $extensions;
+    private $extensions = [];
 
     /**
      * @var bool
@@ -251,7 +251,7 @@ class Language extends BaseApiEntity
         return $this;
     }
 
-    public function getCompileExecutable(): Executable
+    public function getCompileExecutable(): ?Executable
     {
         return $this->compile_executable;
     }


### PR DESCRIPTION
@nickygerritsen @meisterT this fixes the problem that http://localhost:12345/jury/languages/add works again, but I'm not sure if these variables should indeed be empty.

As the problem is already there on the Add page, where Language is an empty object the problem will not be here, but I'm not sure if somewhere else there is an assumption that a Language always has correct values.