### PR TITLE
Contest page does not break on Language without compile script.

### DIFF
--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -493,7 +493,11 @@ class CheckConfigService
             $languageerrors[$langid] = $errors;
 
             $morelanguageerrors[$langid] = '';
-            if ($compile = $language->getCompileExecutable()->getExecid()) {
+            $compileExecutable = $language->getCompileExecutable();
+            if (null === $compileExecutable) {
+                $result = 'E';
+                $morelanguageerrors[$langid] .= sprintf("No compile script found for %s\n", $langid);
+            } elseif ($compile = $language->getCompileExecutable()->getExecid()) {
                $exec = $this->em->getRepository(Executable::class)->findOneBy(['execid' => $compile]);
                if (!$exec) {
                    $result = 'E';


### PR DESCRIPTION
Currently its possible to upload a language without a compile script. On
itself this might be a problem, but as the config page is the place to
report these problems it should not assume a Language to be correct.