### PR TITLE
include packaging release pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ include:
   - template: Dependency-Scanning.gitlab-ci.yml
   - template: SAST.gitlab-ci.yml
   - template: License-Scanning.gitlab-ci.yml
+  - remote: https://raw.githubusercontent.com/DOMjudge/domjudge-packaging/main/.DOMjudge-release.yml
 
 .retry_config: &retry_job
   retry:


### PR DESCRIPTION
This pipeline is used to trigger a new release on the domjudge.org
server.

I propose the following actions (based on suggestions..):
- Gitlab curls <endpoint>wsgi (I will probably use python..)
- The server builds the tar.gz is built and signed
- We trigger a pipeline in domjudge-packaging (https://docs.gitlab.com/ee/ci/triggers/#triggering-a-pipeline)
   - This can test the build tar.gz,
   - This can build the dockers
   - This could build the debs
   - This could build the live-image
- The server could than also download the debs from gitlabci (You could possibly also feed a random temp string so when it has this string in the filename you can trust that the debs were built on a pipeline triggered by the server)
- Do the website update step (future PR probably)
- Trigger a slack message that the email can be send.

The reason that I prefer to do as much as possible on gitlab is that the logging in my opinion is easier to follow, but I'm also fine with doing more on the webserver.