### PR TITLE
Allow .env.local to override variables so that we can set DATABASE_URL with the correct MySQL version.

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -71,6 +71,24 @@ maintainer-install`` when the file did not exist before.
 For more details see
 `https://symfony.com/doc/current/configuration/dot-env-changes.html`.
 
+The ``webapp/.env.local`` file can also be used to overwrite the database
+version. This is needed to automatically generate migrations based on the
+current database compared to the models. To set the correct version, add a line
+to ``webapp/.env.local`` with the following contents::
+
+  DATABASE_URL=mysql://<user>:<password>@<host>:<port>/<database>?serverVersion=<version>
+
+Replace the following:
+
+* ``<user>`` with the database user.
+* ``<password>`` with the database password.
+* ``<host>`` with the database host.
+* ``<port>`` with the database port, probably 3306.
+* ``<version>`` with the server version. For MySQL use the server version
+  like ``5.7.0``. For MariaDB use something like ``mariadb-10.5.9``.
+
+Everything except ``<version>`` can be found in ``etc/dbpasswords.secret``.
+
 The file ``webapp/.env.test`` (and ``webapp/.env.test.local`` if it
 exists) are loaded when you run the unit tests. You can thus place any
 test-specific settings in there.

--- a/webapp/config/bootstrap.php
+++ b/webapp/config/bootstrap.php
@@ -48,6 +48,14 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
             $dotenv->load($p);
         }
     }
+
+    // In case we are running in dev mode, allow .env.local to override variables.
+    // This is useful to override the DATABASE_URL from load_db_secrets.php to contain
+    // the proper serverVersion, which is needed for automatically creating migrations.
+    $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null;
+    if ($env === 'dev' && file_exists($p = "$path.local")) {
+        $dotenv->overload($p);
+    }
 }
 
 $_SERVER += $_ENV;

--- a/webapp/src/Entity/ExecutableFile.php
+++ b/webapp/src/Entity/ExecutableFile.php
@@ -14,7 +14,7 @@ use JMS\Serializer\Annotation as Serializer;
  *     indexes={@ORM\Index(name="immutable_execid", columns={"immutable_execid"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="rankindex", columns={"immutable_execid", "ranknumber"}),
- *         @ORM\UniqueConstraint(name="filename", columns={"immutable_execid", "filename"}, options={"lengths": {NULL, "190"}})
+ *         @ORM\UniqueConstraint(name="filename", columns={"immutable_execid", "filename"}, options={"lengths": {NULL, 190}})
  *     })
  */
 class ExecutableFile


### PR DESCRIPTION
So as noted running `webapp/bin/console doctrine:migrations:diff` gave a huge diff when you had a database that was not MySQL 5.7.0, because we specify that version in `load_db_secrets.php`.

Since it seems this server version string is only useful for creating migrations, which is only useful for people developing on DOMjudge, it seemed logical to make the `.env.local` (which we already use to run in `APP_ENV=dev` mode) to override the database string. With this change you can add something like this to your `.env.local`:

```bash
DATABASE_URL=mysql://domjudge:domjudge@mariadb:3306/domjudge?serverVersion=mariadb-10.5.9
```

Assuming you are running MariaDB 10.5.7. This makes the migration diff work again.

Also made a small fix in an index specification, since it would result in a diff every time.