### PR TITLE
Sort rejudgings on relevant status

### DIFF
--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -102,18 +102,18 @@ class RejudgingController extends BaseController
             ->getQuery()->getResult();
 
         $table_fields = [
-            'rejudgingid' => [
-                'title' => 'ID',
-                'sort' => true,
-                'default_sort' => true,
-                'default_sort_order' => 'desc'
-            ],
+            'rejudgingid' => ['title' => 'ID', 'sort' => true],
             'reason' => ['title' => 'reason', 'sort' => true],
             'startuser' => ['title' => 'startuser', 'sort' => true],
             'finishuser' => ['title' => 'finishuser', 'sort' => true],
             'starttime' => ['title' => 'starttime', 'sort' => true],
             'endtime' => ['title' => 'finishtime', 'sort' => true],
-            'status' => ['title' => 'status', 'sort' => true],
+            'status' => [
+                'title' => 'status',
+                'sort' => true,
+                'default_sort' => true,
+                'default_sort_order' => 'asc'
+            ],
         ];
 
         $timeFormat       = (string)$this->config->get('time_format');
@@ -143,16 +143,20 @@ class RejudgingController extends BaseController
 
             if ($rejudging->getEndtime() !== null) {
                 $status = $rejudging->getValid() ? 'applied' : 'canceled';
+                $sort_order = 2;
             } elseif ($todo > 0) {
                 $perc   = (int)(100 * ((double)$done / (double)($done + $todo)));
                 $status = sprintf("%d%% done", $perc);
+                $sort_order = 0;
             } else {
                 $status = 'ready';
+                $sort_order = 1;
             }
 
-            $rejudgingdata['starttime']['value'] = Utils::printtime($rejudging->getStarttime(), $timeFormat);
-            $rejudgingdata['endtime']['value']   = Utils::printtime($rejudging->getEndtime(), $timeFormat);
-            $rejudgingdata['status']['value']    = $status;
+            $rejudgingdata['starttime']['value']  = Utils::printtime($rejudging->getStarttime(), $timeFormat);
+            $rejudgingdata['endtime']['value']    = Utils::printtime($rejudging->getEndtime(), $timeFormat);
+            $rejudgingdata['status']['value']     = $status;
+            $rejudgingdata['status']['sortvalue'] = $sort_order;
 
             if ($rejudging->getEndtime() !== null) {
                 $class = 'disabled';
@@ -166,6 +170,7 @@ class RejudgingController extends BaseController
                 'actions' => [],
                 'link' => $this->generateUrl('jury_rejudging', ['rejudgingId' => $rejudging->getRejudgingid()]),
                 'cssclass' => $class,
+                'sort' => $sort_order,
             ];
         }
 

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Jury;
 
 use App\Controller\BaseController;
 use App\Entity\Contest;
+use App\Entity\ContestProblem;
 use App\Entity\Judgehost;
 use App\Entity\JudgeTask;
 use App\Entity\Judging;
@@ -97,8 +98,6 @@ class RejudgingController extends BaseController
         $rejudgings = $this->em->createQueryBuilder()
             ->select('r')
             ->from(Rejudging::class, 'r')
-            ->leftJoin('r.start_user', 's')
-            ->leftJoin('r.finish_user', 'f')
             ->orderBy('r.rejudgingid', 'DESC')
             ->getQuery()->getResult();
 

--- a/webapp/src/DataFixtures/Test/RejudgingStatesFixture.php
+++ b/webapp/src/DataFixtures/Test/RejudgingStatesFixture.php
@@ -5,19 +5,22 @@ namespace App\DataFixtures\Test;
 use App\Entity\Contest;
 use App\Entity\Judging;
 use App\Entity\Rejudging;
+use App\Entity\Submission;
 use App\Entity\User;
 use App\Utils\Utils;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 
-class RejudgingStatesFixture extends Fixture
+class RejudgingStatesFixture extends AbstractTestDataFixture
 {
     public function rejudgingStages(): array
     {
         $rejudgingStages = [
-            ['Unit',NULL],
-            ['Finished',True],
-            ['Canceled',False],
+            ['Unit',NULL,0],
+            ['0Percent_1',NULL,1],
+            ['0Percent_2',NULL,2],
+            ['Finished',True,0],
+            ['Canceled',False,0],
         ];
 
         return $rejudgingStages;
@@ -25,12 +28,15 @@ class RejudgingStatesFixture extends Fixture
 
     public function load(ObjectManager $manager)
     {
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
         /** @var User $user */
         $user = $manager->getRepository(User::class)->findOneBy(['username' => 'admin']);
         foreach ($this->rejudgingStages() as $index => $rejudgingStage) {
             $rejudging = (new Rejudging())
                 ->setStarttime(Utils::toEpochFloat('2019-01-01 07:07:07'))
                 ->setStartUser($user)
+                ->setAutoApply(False)
                 ->setReason($rejudgingStage[0]);
             if ($rejudgingStage[1] !== NULL) {
                 $rejudging->setValid($rejudgingStage[1]);
@@ -39,6 +45,19 @@ class RejudgingStatesFixture extends Fixture
             }
             $manager->persist($rejudging);
             $manager->flush();
+            for ($x = 0; $x < $rejudgingStage[2]; $x++) {
+                $submission = (new Submission())
+                    ->setSubmittime(Utils::toEpochFloat('2018-01-02 07:07:07'))
+                    ->setRejudging($rejudging);
+                $judging = (new Judging())
+                    ->setContest($contest)
+                    ->setSubmission($submission)
+                    ->setValid(False)
+                    ->setRejudging($rejudging);
+                $manager->persist($judging);
+                $manager->persist($submission);
+                $manager->flush();
+            }
         }
     }
 }

--- a/webapp/src/DataFixtures/Test/RejudgingStatesFixture.php
+++ b/webapp/src/DataFixtures/Test/RejudgingStatesFixture.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\Judging;
+use App\Entity\Rejudging;
+use App\Entity\User;
+use App\Utils\Utils;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class RejudgingStatesFixture extends Fixture
+{
+    public function rejudgingStages(): array
+    {
+        $rejudgingStages = [
+            ['Unit',NULL],
+            ['Finished',True],
+            ['Canceled',False],
+        ];
+
+        return $rejudgingStages;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        /** @var User $user */
+        $user = $manager->getRepository(User::class)->findOneBy(['username' => 'admin']);
+        foreach ($this->rejudgingStages() as $index => $rejudgingStage) {
+            $rejudging = (new Rejudging())
+                ->setStarttime(Utils::toEpochFloat('2019-01-01 07:07:07'))
+                ->setStartUser($user)
+                ->setReason($rejudgingStage[0]);
+            if ($rejudgingStage[1] !== NULL) {
+                $rejudging->setValid($rejudgingStage[1]);
+                $rejudging->setEndtime(Utils::toEpochFloat('2019-01-02 07:07:07'))
+                    ->setFinishUser($user);
+            }
+            $manager->persist($rejudging);
+            $manager->flush();
+        }
+    }
+}

--- a/webapp/tests/Controller/Jury/RejudgingControllerTest.php
+++ b/webapp/tests/Controller/Jury/RejudgingControllerTest.php
@@ -43,7 +43,6 @@ class RejudgingControllerTest extends BaseTest
 
     public function testCorrectSorting() : void
     {
-        self::assertEquals("yes","yes");
         $oldRoles = static::$roles;
         static::$roles = ['admin'];
         $this->logOut();
@@ -51,7 +50,7 @@ class RejudgingControllerTest extends BaseTest
         $this->loadFixture(RejudgingStatesFixture::class);
         $this->verifyPageResponse('GET', '/jury/rejudgings', 200);
         // The sorting is done in JS (and cannot be tested), this is the inverse ordering of the Fixture
-        foreach(['Canceled','Finished','Unit'] as $index=>$reason)
+        foreach(['Canceled','Finished','0Percent_2','0Percent_1','Unit'] as $index=>$reason)
         {
             self::assertSelectorExists('tr:nth-child('.($index+1).'):contains("'.$reason.'")');
         }

--- a/webapp/tests/Controller/Jury/RejudgingControllerTest.php
+++ b/webapp/tests/Controller/Jury/RejudgingControllerTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\Jury;
+
+use App\DataFixtures\Test\RejudgingStatesFixture;
+use App\Tests\BaseTest;
+use Generator;
+
+class RejudgingControllerTest extends BaseTest
+{
+    /**
+     * @dataProvider provideRoles
+     */
+    public function testStartPage(array $roles, int $http): void
+    {
+        $oldRoles = static::$roles;
+        static::$roles = $roles;
+        $this->logOut();
+        $this->logIn();
+        $this->verifyPageResponse('GET', '/jury/rejudgings', $http);
+        if($http===200) {
+            foreach(['No rejudgings defined',' Add new rejudging','Rejudgings'] as $element) {
+                self::assertSelectorExists('body:contains("'.$element.'")');
+            }
+        }
+        // TODO: static::$roles is not always reset between tests
+        static::$roles = $oldRoles;
+    }
+
+    /**
+     * Provide the HTTP access code for the DOMjudge role
+     */
+    public function provideRoles(): Generator
+    {
+        yield [[],302];
+        foreach(['team','balloon','clarification_rw'] as $role) {
+            yield [[$role],403];
+        }
+        foreach(['jury','admin'] as $role) {
+            yield [[$role],200];
+        }
+    }
+
+    public function testCorrectSorting() : void
+    {
+        self::assertEquals("yes","yes");
+        $oldRoles = static::$roles;
+        static::$roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+        $this->loadFixture(RejudgingStatesFixture::class);
+        $this->verifyPageResponse('GET', '/jury/rejudgings', 200);
+        // The sorting is done in JS (and cannot be tested), this is the inverse ordering of the Fixture
+        foreach(['Canceled','Finished','Unit'] as $index=>$reason)
+        {
+            self::assertSelectorExists('tr:nth-child('.($index+1).'):contains("'.$reason.'")');
+        }
+        // TODO: static::$roles is not always reset between tests
+        static::$roles = $oldRoles;
+    }
+}


### PR DESCRIPTION
We now prefer:
x% done > ready > cancelled+applied

![image](https://user-images.githubusercontent.com/14887731/112755465-1ce33d00-8fe1-11eb-81c6-f408e470f852.png)

I assume that sorting on the ids is not relevant here (and would only delay the page) as you can do this in the UI.