### PR TITLE
Speed up rejudgings and show progress while creating, canceling and finishing them.

### DIFF
--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -213,9 +213,7 @@ class JuryMiscController extends BaseController
                 ob_flush();
                 flush();
             };
-            $response         = new StreamedResponse();
-            $response->headers->set('X-Accel-Buffering', 'no');
-            $response->setCallback(function () use ($contests, $progressReporter, $scoreboardService) {
+            return $this->streamResponse(function () use ($contests, $progressReporter, $scoreboardService) {
                 $timeStart = microtime(true);
 
                 foreach ($contests as $contest) {
@@ -227,7 +225,6 @@ class JuryMiscController extends BaseController
                 $progressReporter(sprintf('<p>Scoreboard cache refresh completed in %.2lf seconds.</p>',
                                           $timeEnd - $timeStart));
             });
-            return $response;
         }
 
         return $this->render('jury/refresh_cache.html.twig', [
@@ -350,7 +347,7 @@ class JuryMiscController extends BaseController
      */
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId): Response
     {
-        if ($this->isLocalReferrer($router, $request)) {
+        if ($this->isLocalReferer($router, $request)) {
             $response = new RedirectResponse($request->headers->get('referer'));
         } else {
             $response = $this->redirectToRoute('jury_index');

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -142,7 +142,7 @@ class PublicController extends BaseController
      */
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId): Response
     {
-        if ($this->isLocalReferrer($router, $request)) {
+        if ($this->isLocalReferer($router, $request)) {
             $response = new RedirectResponse($request->headers->get('referer'));
         } else {
             $response = $this->redirectToRoute('public_index');

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -173,7 +173,7 @@ class MiscController extends BaseController
      */
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId) : Response
     {
-        if ($this->isLocalReferrer($router, $request)) {
+        if ($this->isLocalReferer($router, $request)) {
             $response = new RedirectResponse($request->headers->get('referer'));
         } else {
             $response = $this->redirectToRoute('team_index');

--- a/webapp/templates/jury/rejudging_add.html.twig
+++ b/webapp/templates/jury/rejudging_add.html.twig
@@ -1,41 +1,40 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
-{% block title %}{{ action | capitalize }} rejudging r{{ rejudging.rejudgingid }} - {{ parent() }}{% endblock %}
-
 {% block extrahead %}
     {{ parent() }}
-    {{ macros.table_extrahead() }}
     {{ macros.select2_extrahead() }}
 {% endblock %}
 
+{% block title %}Creating rejudging - {{ parent() }}{% endblock %}
+
 {% block content %}
 
-    <h1>{{ action | capitalize }} rejudging r{{ rejudging.rejudgingid }}</h1>
+    <h1>Creating rejudging...</h1>
 
-    <div class="alert alert-info">
-        {% if action == "apply" %}
-        <p>Applying rejudge may take some time, please be patient.</p>
-        {% endif %}
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="alert alert-info">
+                Creating rejudging. This might take a while...
 
-        <div class="progress mt-2 mb-2">
-            <div id="finish-progress"
-                 class="progress-bar progress-bar-animated progress-bar-striped" style="width: 0%;">
-                0%
+                <div class="progress mt-2 mb-2">
+                    <div id="rejudge-progress"
+                         class="progress-bar progress-bar-animated progress-bar-striped" style="width: 0%;">
+                        0%
+                    </div>
+                </div>
+                <div id="rejudge-log"></div>
             </div>
         </div>
-        <div id="finish-log"></div>
-        <div class="mt-4" id="finish-message"></div>
     </div>
 
 {% endblock %}
 
 {% block extrafooter %}
     <script>
-        $(function() {
-            var $progress = $('#finish-progress');
-            var $log = $('#finish-log');
-            var $message = $('#finish-message');
+        $(function () {
+            var $progress = $('#rejudge-progress');
+            var $log = $('#rejudge-log');
 
             var consume = function(responseReader) {
                 return responseReader.read().then(function(result) {
@@ -49,8 +48,8 @@
                         .attr('style', 'width: ' + data.progress + '%;')
                         .text(data.progress + '%');
 
-                    if (data.message) {
-                        $message.html(data.message);
+                    if (data.redirect) {
+                        window.location = data.redirect;
                         return;
                     }
 
@@ -59,11 +58,13 @@
                     return consume(responseReader);
                 });
             };
-            fetch('{{ path('jury_rejudging_finish', {rejudgingId: rejudging.rejudgingid, action: action}) }}', {
-                method: 'GET',
+            fetch('{{ url }}', {
+                method: 'POST',
                 headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
                     'X-Requested-With': 'XMLHttpRequest'
-                }
+                },
+                body: '{{ data | raw }}'
             }).then(function(response) {
                 return consume(response.body.getReader());
             });

--- a/webapp/templates/jury/rejudging_form.html.twig
+++ b/webapp/templates/jury/rejudging_form.html.twig
@@ -32,6 +32,7 @@
                 data[$contests.attr('name')] = $contests.val();
                 data[$problems.attr('name')] = $problems.val();
                 data[$teams.attr('name')] = $teams.val();
+                data['refresh_form'] = true;
                 $.ajax({
                     url: $form.attr('action'),
                     type: $form.attr('method'),


### PR DESCRIPTION
The speedup is handled by doing mass SQL inserts.

Since it still takes a while to create big rejudgings, we now show a progress bar to indicate how far along the progress is. We also set a timeout of 0 when creating rejudgings, allowing it to finish.
I tried to minimize the duplicated code and fixes some typo's along the way.

Gif of it in action:
![Screen Recording 2021-03-28 at 15 34 58](https://user-images.githubusercontent.com/550145/112762587-aa825500-9000-11eb-8047-7599ee1c4892.gif)

