### PR TITLE
Make language API conform to new API spec. Fixes #1031.

### DIFF
--- a/submit/submit.cc
+++ b/submit/submit.cc
@@ -162,7 +162,7 @@ contest mycontest;
 /* Languages */
 struct language {
 	string id, name;
-	bool require_entry_point;
+	bool entry_point_required;
 	vector<string> extensions;
 };
 vector<language> languages;
@@ -187,7 +187,6 @@ int main(int argc, char **argv)
 	struct stat fstats;
 	string filebase, fileext;
 	time_t fileage;
-	string require_entry_point;
 
 	progname = argv[0];
 	stdlog = NULL;
@@ -387,7 +386,7 @@ lang_found:
 	if ( baseurl.empty()       ) usage2(0,"no url specified");
 
 	/* Guess entry point if not already specified. */
-	if ( entry_point==NULL && mylanguage.require_entry_point ) {
+	if ( entry_point==NULL && mylanguage.entry_point_required ) {
 		if ( mylanguage.name == "Java" ) {
 			entry_point = strdup(filebase.c_str());
 		} else if ( mylanguage.name == "Kotlin" ) {
@@ -399,7 +398,7 @@ lang_found:
 		}
 	}
 
-	if ( entry_point==NULL && mylanguage.require_entry_point ) {
+	if ( entry_point==NULL && mylanguage.entry_point_required ) {
 		error(0, "Entry point required but not specified nor detected.");
 	}
 
@@ -799,7 +798,7 @@ bool readlanguages()
 
 		lang.id   = res[i]["id"].asString();
 		lang.name = res[i]["name"].asString();
-		lang.require_entry_point = res[i]["require_entry_point"].asBool();
+		lang.entry_point_required = res[i]["entry_point_required"].asBool();
 		if ( lang.id=="" ||
 		     !(exts = res[i]["extensions"]) ||
 		     !exts.isArray() || exts.size()==0 ) {

--- a/webapp/src/DataFixtures/Test/EnableJavaEntrypointFixture.php
+++ b/webapp/src/DataFixtures/Test/EnableJavaEntrypointFixture.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Language;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class EnableJavaEntrypointFixture extends Fixture
+{
+    public function load(ObjectManager $manager)
+    {
+        $java = $manager->getRepository(Language::class)->find('java');
+        $java->setRequireEntryPoint(true);
+        $manager->flush();
+    }
+}

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -58,7 +58,6 @@ class Language extends BaseApiEntity
      * @ORM\Column(type="json", length=4294967295, name="extensions",
      *     options={"comment"="List of recognized extensions (JSON encoded)"},
      *     nullable=true)
-     * @Serializer\Groups({"Nonstrict"})
      * @Serializer\Type("array<string>")
      * @Assert\NotBlank()
      */
@@ -109,7 +108,7 @@ class Language extends BaseApiEntity
      * @ORM\Column(type="boolean", name="require_entry_point",
      *     options={"comment"="Whether submissions require a code entry point to be specified.","default":"0"},
      *     nullable=false)
-     * @Serializer\Groups({"Nonstrict"})
+     * @Serializer\SerializedName("entry_point_required")
      */
     private $require_entry_point = false;
 
@@ -118,7 +117,7 @@ class Language extends BaseApiEntity
      * @ORM\Column(type="string", name="entry_point_description",
      *     options={"comment"="The description used in the UI for the entry point field."},
      *     nullable=true)
-     * @Serializer\Groups({"Nonstrict"})
+     * @Serializer\SerializedName("entry_point_name")
      */
     private $entry_point_description = null;
 

--- a/webapp/tests/Controller/API/LanguageControllerTest.php
+++ b/webapp/tests/Controller/API/LanguageControllerTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Controller\API;
+
+use App\DataFixtures\Test\EnableJavaEntrypointFixture;
+
+class LanguageControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'languages';
+
+    protected $expectedObjects = [
+        'cpp'  => [
+            'id'                   => 'cpp',
+            'name'                 => 'C++',
+            'entry_point_required' => false,
+            'entry_point_name'     => null,
+            'extensions'           => ['cpp', 'cc', 'cxx', 'c++'],
+        ],
+        'java' => [
+            'id'                   => 'java',
+            'name'                 => 'Java',
+            'entry_point_required' => true,
+            'entry_point_name'     => 'Main class',
+            'extensions'           => ['java'],
+        ],
+    ];
+
+    // Kotlin has allow_submit=false by default, so we don't expect it.
+    protected $expectedAbsent = ['kotlin', 'nonexistent'];
+
+    protected static $fixtures = [
+        EnableJavaEntrypointFixture::class,
+    ];
+}


### PR DESCRIPTION
I propose to drop the old field names, since they were out of spec anyway. Also modified the submit client to use the new field name.