### PR TITLE
Add button to request remaining runs.

### DIFF
--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -129,6 +129,17 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     private $seen = false;
 
     /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="judge_completely",
+     *     options={"comment"="Explicitly requested to be judged completely.",
+     *              "default"="0"},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $judgeCompletely = false;
+
+
+    /**
      * @ORM\ManyToOne(targetEntity="Contest")
      * @ORM\JoinColumn(name="cid", referencedColumnName="cid", onDelete="CASCADE")
      * @Serializer\Exclude()
@@ -351,6 +362,17 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     public function getSeen(): bool
     {
         return $this->seen;
+    }
+
+    public function setJudgeCompletely(bool $judgeCompletely): Judging
+    {
+        $this->judgeCompletely = $judgeCompletely;
+        return $this;
+    }
+
+    public function getJudgeCompletely(): bool
+    {
+        return $this->judgeCompletely;
     }
 
     public function setSubmission(?Submission $submission = null): Judging

--- a/webapp/src/Migrations/Version20210402100155.php
+++ b/webapp/src/Migrations/Version20210402100155.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210402100155 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add boolean to indicate whether this judging was explicitly requested.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judging ADD judge_completely TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Explicitly requested to be judged completely.\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judging DROP judge_completely');
+    }
+}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -384,6 +384,12 @@
                                 {% set judgingDone = selectedJudging.endtime is not empty %}
                             {% endif %}
                             {{ runs | displayTestcaseResults(judgingDone) }}
+                            {% if selectedJudging is not null and not selectedJudging.judgeCompletely and runsOutstanding %}
+                                <form action="{{ path('jury_submission_request_remaining', {'judgingId': selectedJudging.judgingid}) }}" method="post"
+                                      style="display: inline; ">
+                                    <input type="submit" class="btn btn-outline-secondary btn-sm" value="judge remaining" />
+                                </form>
+                            {% endif %}
                         </td>
                     </tr>
                     {% if lastJudging is not null %}


### PR DESCRIPTION
Use-case: The contest administrator enables lazy judging because of
limited resources, but the jury wants for particular
submissions/judgings the results of all testcases.

The judgetasks got downgraded in priority already when the final verdict
was determined, so we don't have to do that explicitly here.

Fixes #162.