### PR TITLE
Allow dots (.) in external identifiers. Fixes #1030.

### DIFF
--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -333,6 +333,10 @@ class SubmissionController extends AbstractRestController
 
         if ($submissionId = $request->request->get('id')) {
             if ($this->isGranted('ROLE_API_WRITER')) {
+                if (preg_match(DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX, $submissionId) !== 1) {
+                    throw new BadRequestHttpException(sprintf("ID %s is not valid", $submissionId));
+                }
+
                 // Check if we already have a submission with this ID
                 $existingSubmission = $this->em->createQueryBuilder()
                     ->from(Submission::class, 's')

--- a/webapp/src/Entity/ImmutableExecutable.php
+++ b/webapp/src/Entity/ImmutableExecutable.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 namespace App\Entity;
 
-use App\Validator\Constraints\Identifier;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;

--- a/webapp/src/Form/Type/AbstractExternalIdEntityType.php
+++ b/webapp/src/Form/Type/AbstractExternalIdEntityType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form\Type;
 
+use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -47,8 +48,8 @@ class AbstractExternalIdEntityType extends AbstractType
                 'constraints' => [
                     new Regex(
                         [
-                            'pattern' => '/^[a-zA-Z0-9_-]+$/i',
-                            'message' => 'Only letters, numbers, dashes and underscores are allowed',
+                            'pattern' => DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX,
+                            'message' => 'Only letters, numbers, dashes, underscores and dots are allowed',
                         ]
                     ),
                     new NotBlank(),

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -96,6 +96,11 @@ class DOMJudgeService
     const DATA_SOURCE_CONFIGURATION_EXTERNAL = 1;
     const DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL = 2;
 
+    // Regex external identifiers must adhere to. Note that we are not checking whether it
+    // does not start with a dot or dash or ends with a dot. We could but it would make the
+    // regex way more complicated and would also complicate the logic in ImportExportService::importContestYaml
+    const EXTERNAL_IDENTIFIER_REGEX = '/^[a-zA-Z0-9_.-]+$/';
+
     /**
      * DOMJudgeService constructor.
      *

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -152,8 +152,7 @@ class ImportExportService
             return false;
         }
 
-        $identifierChars = '[a-zA-Z0-9_-]';
-        $invalid_regex   = '/[^' . substr($identifierChars, 1) . '/';
+        $invalid_regex = str_replace(['/^[', '+$/'], ['/[^', '/'], DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX);
 
         if (is_string($data['start-time'])) {
             $starttime = date_create_from_format(DateTime::ISO8601, $data['start-time']) ?:

--- a/webapp/src/Validator/Constraints/Identifier.php
+++ b/webapp/src/Validator/Constraints/Identifier.php
@@ -9,5 +9,5 @@ use Symfony\Component\Validator\Constraint;
  */
 class Identifier extends Constraint
 {
-    public $message = 'Only alphanumeric characters and _- are allowed';
+    public $message = 'Only alphanumeric characters and ._- are allowed';
 }

--- a/webapp/src/Validator/Constraints/IdentifierValidator.php
+++ b/webapp/src/Validator/Constraints/IdentifierValidator.php
@@ -2,6 +2,7 @@
 
 namespace App\Validator\Constraints;
 
+use App\Service\DOMJudgeService;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -25,7 +26,7 @@ class IdentifierValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, 'string');
         }
 
-        if (preg_match('/^[a-z0-9_-]+$/i', $value) !== 1) {
+        if (preg_match(DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX, $value) !== 1) {
             $this->context->buildViolation($constraint->message)->addViolation();
         }
     }

--- a/webapp/tests/Controller/API/SubmissionControllerTest.php
+++ b/webapp/tests/Controller/API/SubmissionControllerTest.php
@@ -135,6 +135,16 @@ class SubmissionControllerTest extends BaseTest
         yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 1], "No files specified."];
         yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 3], "Team 3 not found or not enabled"];
         yield ['admin', ['problem_id' => 1, 'language' => 'cpp', 'team_id' => 1, 'time' => 'this is not a time'], "Can not parse time this is not a time"];
+        yield [
+            'admin',
+            [
+                'problem_id'  => 1,
+                'language_id' => 'cpp',
+                'team_id'     => 1,
+                'id'          => '$this is not valid$',
+            ],
+            'ID $this is not valid$ is not valid',
+        ];
     }
 
     /**


### PR DESCRIPTION
As the comment states we do not check if the identifiers do not start or end with invalid characters.
If someone has an idea to easily do this and still allow the check in `ImportExportService::importContestYaml` to be easy, I am all ears. This is the regex I had to check for beginning/end, very ugly:

```
/^(([a-zA-Z0-9_][a-zA-Z0-9_.-]*[a-zA-Z0-9-])|[a-zA-Z0-9])$/
```