### PR TITLE
Allow to hide judgehosts that haven't checked in in a while.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -186,12 +186,14 @@ class JudgehostController extends AbstractFOSRestController
             ->getQuery()
             ->getOneOrNullResult();
 
-        if (!$judgehost) {
+        if ($judgehost) {
+            $judgehost->setHidden(false);
+        } else {
             $judgehost = new Judgehost();
             $judgehost->setHostname($hostname);
             $this->em->persist($judgehost);
-            $this->em->flush();
         }
+        $this->em->flush();
 
         // If there are any unfinished judgings in the queue in my name, they will not be finished.
         // Give them back.

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -671,7 +671,10 @@ class ContestController extends BaseController
         if ($contest === null) {
            throw new BadRequestHttpException("Contest with cid=$contestId not found.");
         }
-        $judgehosts = $this->em->getRepository(Judgehost::class)->findBy(['active' => true]);
+        $judgehosts = $this->em->getRepository(Judgehost::class)->findBy([
+            'active' => true,
+            'hidden' => false,
+        ]);
         $cnt = 0;
         foreach ($judgehosts as $judgehost) {
             /** @var Judgehost $judgehost */

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -57,6 +57,15 @@ class Judgehost
      */
     private $judgings;
 
+    /**
+     * @var boolean
+     * @ORM\Column(type="boolean", name="hidden",
+     *     options={"comment"="Should this host be hidden in the overview?",
+     *              "default"="0"},
+     *     nullable=false)
+     */
+    private $hidden = false;
+
     public function __construct()
     {
         $this->judgings = new ArrayCollection();
@@ -122,5 +131,16 @@ class Judgehost
     public function getJudgings(): Collection
     {
         return $this->judgings;
+    }
+
+    public function setHidden(bool $hidden): Judgehost
+    {
+        $this->hidden = $hidden;
+        return $this;
+    }
+
+    public function getHidden(): bool
+    {
+        return $this->hidden;
     }
 }

--- a/webapp/src/Form/Type/JudgehostType.php
+++ b/webapp/src/Form/Type/JudgehostType.php
@@ -24,6 +24,12 @@ class JudgehostType extends AbstractType
                 'no' => false,
             ],
         ]);
+        $builder->add('hidden', ChoiceType::class, [
+            'choices' => [
+                'yes' => true,
+                'no' => false,
+            ],
+        ]);
         $builder->add('restriction', EntityType::class, [
             'class' => JudgehostRestriction::class,
             'choice_label' => 'name',

--- a/webapp/src/Migrations/Version20210404065113.php
+++ b/webapp/src/Migrations/Version20210404065113.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210404065113 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add new hidden field to judgehost entity.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judgehost ADD hidden TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Should this host be hidden in the overview?\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judgehost DROP hidden');
+    }
+}

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -373,6 +373,7 @@ class DOMJudgeService
                 ->select('j.hostname', 'j.polltime')
                 ->from(Judgehost::class, 'j')
                 ->andWhere('j.active = 1')
+                ->andWhere('j.hidden = 0')
                 ->andWhere('j.polltime < :i')
                 ->setParameter('i', time() - $this->config->get('judgehost_critical'))
                 ->getQuery()->getResult();

--- a/webapp/templates/jury/judgehost.html.twig
+++ b/webapp/templates/jury/judgehost.html.twig
@@ -12,6 +12,10 @@
 
     <h1>Judgehost {{ judgehost.hostname | printHost }}</h1>
 
+    {% if judgehost.hidden %}
+        <div class="alert alert-warning">This judgehost is currently hidden.</div>
+    {% endif %}
+
     <div class="row">
         <div class="col-lg-4">
             <table class="table table-sm table-striped">

--- a/webapp/templates/jury/judgehosts.html.twig
+++ b/webapp/templates/jury/judgehosts.html.twig
@@ -31,8 +31,17 @@
                     Stop all judgehosts
                 </button>
             </form>
+            {% if not all_checked_in_recently %}
+                <form action="{{ path('jury_judgehost_autohide') }}" method="post" class="d-inline">
+                    <button type="submit" name="cmd-autohide" class="btn btn-warning">
+                        <i class="fas fa-trash"></i>
+                        Auto-hide judgehosts
+                    </button>
+                </form>
+            {% endif %}
             <div class="d-inline">
-                {{ button(path('jury_judgehost_edit'), 'Edit judgehosts', 'secondary', 'edit') }}
+                {{ button(path('jury_judgehost_edit', {'include_hidden': false}), 'Edit visible judgehosts', 'secondary', 'edit') }}
+                {{ button(path('jury_judgehost_edit'), 'Edit all judgehosts', 'secondary', 'edit') }}
             </div>
         </div>
 

--- a/webapp/templates/jury/partials/judgehosts_form.html.twig
+++ b/webapp/templates/jury/partials/judgehosts_form.html.twig
@@ -5,6 +5,7 @@
     <tr>
         <th>{{ form_label(form.judgehosts.vars.prototype.hostname) }}</th>
         <th>{{ form_label(form.judgehosts.vars.prototype.active) }}</th>
+        <th>{{ form_label(form.judgehosts.vars.prototype.hidden) }}</th>
         <th>{{ form_label(form.judgehosts.vars.prototype.restriction) }}</th>
     </tr>
     </thead>
@@ -17,6 +18,10 @@
             <td style="width: 10%">
                 {{ form_widget(judgehost.active) }}
                 {{ form_errors(judgehost.active) }}
+            </td>
+            <td style="width: 10%">
+                {{ form_widget(judgehost.hidden) }}
+                {{ form_errors(judgehost.hidden) }}
             </td>
             <td>
                 {{ form_widget(judgehost.restriction) }}


### PR DESCRIPTION
You can do this manually on individual judgehosts, but the main purpose
is to do this once after switching to a different set of judgehosts.

Fixes #857.