### PR TITLE
Dont inherit $roles of other Unit tests

### DIFF
--- a/webapp/tests/BaseTest.php
+++ b/webapp/tests/BaseTest.php
@@ -32,7 +32,7 @@ abstract class BaseTest extends WebTestCase
     protected $client;
 
     /** @var string[] */
-    protected static $roles = [];
+    protected $roles = [];
 
     /** @var ORMExecutor */
     protected $fixtureExecutor;
@@ -53,7 +53,7 @@ abstract class BaseTest extends WebTestCase
         $this->client = self::createClient();
 
         // Log in if we have any roles
-        if (!empty(static::$roles)) {
+        if (!empty($this->roles)) {
             $this->logIn();
         }
 
@@ -132,7 +132,7 @@ abstract class BaseTest extends WebTestCase
     }
 
     /**
-     * Log in a user with the roles defined in static::$roles.
+     * Log in a user with the roles defined in $roles.
      *
      * Note that this will change the roles of the user in the database, so if
      * you assume specific roles on a user, make sure to set them using setupUser().
@@ -169,7 +169,7 @@ abstract class BaseTest extends WebTestCase
     }
 
     /**
-     * Set up the demo user with the roles given in static::$roles
+     * Set up the demo user with the roles given in $roles
      */
     protected function setupUser(): User
     {
@@ -181,7 +181,7 @@ abstract class BaseTest extends WebTestCase
             $user->removeUserRole($role);
         }
         // Now add the roles
-        foreach (static::$roles as $role) {
+        foreach ($this->roles as $role) {
             $user->addUserRole($em->getRepository(Role::class)->findOneBy(['dj_role' => $role]));
         }
         $em->flush();

--- a/webapp/tests/Controller/ControllerRolesTest.php
+++ b/webapp/tests/Controller/ControllerRolesTest.php
@@ -103,7 +103,7 @@ class ControllerRolesTest extends BaseTest
      */
     protected function getPagesRoles(array $roleBaseURL, array $roles, bool $allPages) : array
     {
-        static::$roles = $roles;
+        $this->roles = $roles;
         $this->logOut();
         $this->logIn();
         $urlsFoundPerRole = [];
@@ -128,7 +128,7 @@ class ControllerRolesTest extends BaseTest
     protected function verifyAccess(array $combinations, array $roleURLs) : void
     {
         foreach ($combinations as $static_roles) {
-            static::$roles = $static_roles;
+            $this->roles = $static_roles;
             $this->logOut();
             $this->logIn();
             foreach ($roleURLs as $url) {
@@ -149,7 +149,7 @@ class ControllerRolesTest extends BaseTest
      */
     public function testRoleAccess(string $roleBaseURL, array $baseRoles, array $optionalRoles, bool $allPages) : void
     {
-        static::$roles = $baseRoles;
+        $this->roles = $baseRoles;
         $this->logOut();
         $this->logIn();
         $urlsToCheck = $this->crawlPageGetLinks($roleBaseURL, 200);
@@ -175,7 +175,7 @@ class ControllerRolesTest extends BaseTest
     {
         $urlsToCheck        = $this->getPagesRoles([$roleBaseURL], $roles, $allPages);
         $urlsToCheckOther   = $this->getPagesRoles($roleOthersBaseURL, $rolesOther, $allPages);
-        static::$roles = $roles;
+        $this->roles = $roles;
         $this->logOut();
         $this->logIn();
         foreach (array_diff($urlsToCheckOther, $urlsToCheck) as $url) {

--- a/webapp/tests/Controller/Jury/BalloonControllerTest.php
+++ b/webapp/tests/Controller/Jury/BalloonControllerTest.php
@@ -6,7 +6,7 @@ use App\Tests\BaseTest;
 
 class BalloonControllerTest extends BaseTest
 {
-    protected static $roles = ['jury'];
+    protected $roles = ['jury'];
 
     /**
      * Test that jury role can access balloons page.

--- a/webapp/tests/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Controller/Jury/ClarificationControllerTest.php
@@ -6,7 +6,7 @@ use App\Tests\BaseTest;
 
 class ClarificationControllerTest extends BaseTest
 {
-    protected static $roles = ['jury'];
+    protected $roles = ['jury'];
 
     /**
      * Test that the jury clarifications page contains the correct information

--- a/webapp/tests/Controller/Jury/ConfigControllerTest.php
+++ b/webapp/tests/Controller/Jury/ConfigControllerTest.php
@@ -6,7 +6,7 @@ use App\Tests\BaseTest;
 
 class ConfigControllerTest extends BaseTest
 {
-    protected static $roles = ['admin'];
+    protected $roles = ['admin'];
 
     /**
      * Test that configcheck page completes.

--- a/webapp/tests/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Controller/Jury/ImportExportControllerTest.php
@@ -7,7 +7,7 @@ use Generator;
 
 class ImportExportControllerTest extends BaseTest
 {
-    protected static $roles = ['admin'];
+    protected $roles = ['admin'];
 
     /**
      * Test that the basic building blocks of the index page are there.

--- a/webapp/tests/Controller/Jury/JuryControllerTest.php
+++ b/webapp/tests/Controller/Jury/JuryControllerTest.php
@@ -16,7 +16,7 @@ use Generator;
  */
 abstract class JuryControllerTest extends BaseTest
 {
-    protected static $roles             = ['admin'];
+    protected        $roles             = ['admin'];
     protected        $addButton         = '';
     protected static $rolesView         = ['admin','jury'];
     protected static $rolesDisallowed   = ['team'];
@@ -64,7 +64,7 @@ abstract class JuryControllerTest extends BaseTest
         array $elements,
         string $standardEntry
     ): void {
-        static::$roles = [$role];
+        $this->roles = [$role];
         // Alternative: $this->setupUser();
         $this->logOut();
         $this->logIn();
@@ -86,7 +86,7 @@ abstract class JuryControllerTest extends BaseTest
      */
     public function testHTTPAccessForRole(string $role, string $url, int $statusCode, string $HTTPMethod): void
     {
-        static::$roles = [$role];
+        $this->roles = [$role];
         // Optionally use the setupUser
         $this->logOut();
         $this->logIn();
@@ -147,7 +147,7 @@ abstract class JuryControllerTest extends BaseTest
      */
     public function testCheckAddEntityJury(): void
     {
-        static::$roles = ['jury'];
+        $this->roles = ['jury'];
         $this->logOut();
         $this->logIn();
         $this->verifyPageResponse('GET', static::$baseUrl, 200);
@@ -163,7 +163,7 @@ abstract class JuryControllerTest extends BaseTest
      */
     public function testDeleteEntity(string $identifier, string $entityShortName): void
     {
-        static::$roles = ['admin'];
+        $this->roles = ['admin'];
         $this->logOut();
         $this->logIn();
         $this->verifyPageResponse('GET', static::$baseUrl, 200);

--- a/webapp/tests/Controller/Jury/JuryMiscControllerTest.php
+++ b/webapp/tests/Controller/Jury/JuryMiscControllerTest.php
@@ -6,7 +6,7 @@ use App\Tests\BaseTest;
 
 class JuryMiscControllerTest extends BaseTest
 {
-    protected static $roles = ['jury'];
+    protected $roles = ['jury'];
 
     /**
      * Test that if no user is logged in the user gets redirected to the login page

--- a/webapp/tests/Controller/Jury/PrintControllerTest.php
+++ b/webapp/tests/Controller/Jury/PrintControllerTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class PrintControllerTest extends BaseTest
 {
-    protected static $roles = ['jury'];
+    protected $roles = ['jury'];
 
     protected const PRINT_COMMAND = 'echo [language] && /bin/cat [file]';
 

--- a/webapp/tests/Controller/Jury/RejudgingControllerTest.php
+++ b/webapp/tests/Controller/Jury/RejudgingControllerTest.php
@@ -8,13 +8,14 @@ use Generator;
 
 class RejudgingControllerTest extends BaseTest
 {
+    protected $roles = ['admin'];
+
     /**
      * @dataProvider provideRoles
      */
     public function testStartPage(array $roles, int $http): void
     {
-        $oldRoles = static::$roles;
-        static::$roles = $roles;
+        $this->roles = $roles;
         $this->logOut();
         $this->logIn();
         $this->verifyPageResponse('GET', '/jury/rejudgings', $http);
@@ -23,8 +24,6 @@ class RejudgingControllerTest extends BaseTest
                 self::assertSelectorExists('body:contains("'.$element.'")');
             }
         }
-        // TODO: static::$roles is not always reset between tests
-        static::$roles = $oldRoles;
     }
 
     /**
@@ -43,8 +42,7 @@ class RejudgingControllerTest extends BaseTest
 
     public function testCorrectSorting() : void
     {
-        $oldRoles = static::$roles;
-        static::$roles = ['admin'];
+        $this->roles = ['admin'];
         $this->logOut();
         $this->logIn();
         $this->loadFixture(RejudgingStatesFixture::class);
@@ -54,7 +52,5 @@ class RejudgingControllerTest extends BaseTest
         {
             self::assertSelectorExists('tr:nth-child('.($index+1).'):contains("'.$reason.'")');
         }
-        // TODO: static::$roles is not always reset between tests
-        static::$roles = $oldRoles;
     }
 }

--- a/webapp/tests/Controller/Jury/SubmissionControllerTest.php
+++ b/webapp/tests/Controller/Jury/SubmissionControllerTest.php
@@ -8,7 +8,7 @@ use Generator;
 
 class SubmissionControllerTest extends BaseTest
 {
-    protected static $roles = ['jury'];
+    protected $roles = ['jury'];
     protected static $baseURL = '/jury/submissions';
 
     /**

--- a/webapp/tests/Controller/Team/ClarificationControllerTest.php
+++ b/webapp/tests/Controller/Team/ClarificationControllerTest.php
@@ -6,7 +6,7 @@ use App\Tests\BaseTest;
 
 class ClarificationControllerTest extends BaseTest
 {
-    protected static $roles = ['team'];
+    protected $roles = ['team'];
 
     public function testClarificationRequest() : void
     {

--- a/webapp/tests/Controller/Team/MiscControllerTest.php
+++ b/webapp/tests/Controller/Team/MiscControllerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class MiscControllerTest extends BaseTest
 {
-    protected static $roles = ['team'];
+    protected $roles = ['team'];
 
     private const PRINT_COMMAND = 'echo [language] && /bin/cat [file]';
 

--- a/webapp/tests/Controller/Team/ProblemControllerTest.php
+++ b/webapp/tests/Controller/Team/ProblemControllerTest.php
@@ -10,7 +10,7 @@ use Generator;
 
 class ProblemControllerTest extends BaseTest
 {
-    protected static $roles = ['team'];
+    protected $roles = ['team'];
 
     /**
      * Test that the problem index page shows the correct information


### PR DESCRIPTION
The static roles leaked different values to other tests. Due to this
there was a difference when using the standard value or explicit setting
this in the test. This difference was shown when you either only run 1
test or run everything where this can either succeed or fail based on
the values of other tests.

@nickygerritsen I'm not sure if this is the correct explanation (or even the correct fix) but this works on my side.