### PR TITLE
Organization, team and contest images in API

### DIFF
--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -49,6 +49,31 @@ nelmio_api_doc:
                     description: The specified resource was not found
                 Unauthorized:
                     description: Unauthorized
+                ImageList:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            href:
+                                type: string
+                            mime:
+                                type: string
+                            width:
+                                type: integer
+                            height:
+                                type: integer
+                Banner:
+                    properties:
+                        banner:
+                            $ref: "#/components/schemas/ImageList"
+                Logo:
+                    properties:
+                        logo:
+                            $ref: "#/components/schemas/ImageList"
+                Photo:
+                    properties:
+                        photo:
+                            $ref: "#/components/schemas/ImageList"
                 ContestProblem:
                     properties:
                         id:
@@ -80,6 +105,8 @@ nelmio_api_doc:
                         type: object
                         properties:
                             href:
+                                type: string
+                            mime:
                                 type: string
                 SourceCodeList:
                     type: array

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -180,8 +180,13 @@ class ContestController extends AbstractRestController
             throw new NotFoundHttpException('Contest banner not found');
         }
 
-        $response = new BinaryFileResponse($banner);
+        $response = new BinaryFileResponse($banner, 200, [], true, null, true);
         $response->headers->set('Content-Type', 'image/png');
+
+        if ($response->isNotModified($request)) {
+            $response->send();
+        }
+
         return $response;
     }
 

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -177,7 +177,7 @@ class ContestController extends AbstractRestController
         $banner = sprintf('%s/public/images/banner.png', $this->dj->getDomjudgeWebappDir());
 
         if (!file_exists($banner)) {
-            throw new NotFoundHttpException('contest banner not found');
+            throw new NotFoundHttpException('Contest banner not found');
         }
 
         $response = new BinaryFileResponse($banner);

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -180,14 +180,7 @@ class ContestController extends AbstractRestController
             throw new NotFoundHttpException('Contest banner not found');
         }
 
-        $response = new BinaryFileResponse($banner, 200, [], true, null, true);
-        $response->headers->set('Content-Type', 'image/png');
-
-        if ($response->isNotModified($request)) {
-            $response->send();
-        }
-
-        return $response;
+        return static::sendBinaryFileResponse($request, $banner, 'image/png');
     }
 
     /**

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -18,7 +18,6 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
 use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -325,14 +324,7 @@ class GeneralInfoController extends AbstractFOSRestController
             throw new NotFoundHttpException("country flag for $alpha3code of size $size not found");
         }
 
-        $response = new BinaryFileResponse($flagFile, 200, [], true, null, true);
-        $response->headers->set('Content-Type', 'image/svg+xml');
-
-        if ($response->isNotModified($request)) {
-            $response->send();
-        }
-
-        return $response;
+        return AbstractRestController::sendBinaryFileResponse($request, $flagFile, 'image/svg+xml');
     }
 
     /**

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -110,8 +110,13 @@ class OrganizationController extends AbstractRestController
             throw new NotFoundHttpException('Affiliation logo not found');
         }
 
-        $response = new BinaryFileResponse($affiliationLogo);
+        $response = new BinaryFileResponse($affiliationLogo, 200, [], true, null, true);
         $response->headers->set('Content-Type', 'image/png');
+
+        if ($response->isNotModified($request)) {
+            $response->send();
+        }
+
         return $response;
     }
 

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -107,7 +107,7 @@ class OrganizationController extends AbstractRestController
         $affiliationLogo = $this->dj->assetPath($id, 'affiliation', true);
 
         if (!file_exists($affiliationLogo)) {
-            throw new NotFoundHttpException('affiliation logo not found');
+            throw new NotFoundHttpException('Affiliation logo not found');
         }
 
         $response = new BinaryFileResponse($affiliationLogo);

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -12,8 +12,6 @@ use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -110,14 +108,7 @@ class OrganizationController extends AbstractRestController
             throw new NotFoundHttpException('Affiliation logo not found');
         }
 
-        $response = new BinaryFileResponse($affiliationLogo, 200, [], true, null, true);
-        $response->headers->set('Content-Type', 'image/png');
-
-        if ($response->isNotModified($request)) {
-            $response->send();
-        }
-
-        return $response;
+        return static::sendBinaryFileResponse($request, $affiliationLogo, 'image/png');
     }
 
     /**

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -118,7 +118,7 @@ class TeamController extends AbstractRestController
         $teamPhoto = $this->dj->assetPath($id, 'team', true);
 
         if (!file_exists($teamPhoto)) {
-            throw new NotFoundHttpException('team photo not found');
+            throw new NotFoundHttpException('Team photo not found');
         }
 
         $response = new BinaryFileResponse($teamPhoto);

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -121,14 +121,7 @@ class TeamController extends AbstractRestController
             throw new NotFoundHttpException('Team photo not found');
         }
 
-        $response = new BinaryFileResponse($teamPhoto, 200, [], true, null, true);
-        $response->headers->set('Content-Type', 'image/jpeg');
-
-        if ($response->isNotModified($request)) {
-            $response->send();
-        }
-
-        return $response;
+        return static::sendBinaryFileResponse($request, $teamPhoto, 'image/jpeg');
     }
 
     /**

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -121,8 +121,13 @@ class TeamController extends AbstractRestController
             throw new NotFoundHttpException('Team photo not found');
         }
 
-        $response = new BinaryFileResponse($teamPhoto);
+        $response = new BinaryFileResponse($teamPhoto, 200, [], true, null, true);
         $response->headers->set('Content-Type', 'image/jpeg');
+
+        if ($response->isNotModified($request)) {
+            $response->send();
+        }
+
         return $response;
     }
 

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -12,10 +12,11 @@ use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @Rest\Route("/contests/{cid}/teams")
@@ -34,7 +35,12 @@ class TeamController extends AbstractRestController
      *     description="Returns all the teams for this contest",
      *     @OA\JsonContent(
      *         type="array",
-     *         @OA\Items(ref=@Model(type=Team::class))
+     *         @OA\Items(
+     *             allOf={
+     *                 @OA\Schema(ref=@Model(type=Team::class)),
+     *                 @OA\Schema(ref="#/components/schemas/Photo")
+     *             }
+     *         )
      *     )
      * )
      * @OA\Parameter(ref="#/components/parameters/idlist")
@@ -71,7 +77,12 @@ class TeamController extends AbstractRestController
      * @OA\Response(
      *     response="200",
      *     description="Returns the given team for this contest",
-     *     @Model(type=Team::class)
+     *     @OA\JsonContent(
+     *         allOf={
+     *             @OA\Schema(ref=@Model(type=Team::class)),
+     *             @OA\Schema(ref="#/components/schemas/Photo")
+     *         }
+     *     )
      * )
      * @OA\Parameter(ref="#/components/parameters/id")
      * @OA\Parameter(ref="#/components/parameters/strict")
@@ -79,6 +90,40 @@ class TeamController extends AbstractRestController
     public function singleAction(Request $request, string $id) : Response
     {
         return parent::performSingleAction($request, $id);
+    }
+
+    /**
+     * Get the photo for the given team
+     * @Rest\Get("/{id}/photo.jpg", name="team_photo")
+     * @OA\Response(
+     *     response="200",
+     *     description="Returns the given team photo in JPG format",
+     *     @OA\MediaType(mediaType="image/jpeg")
+     * )
+     * @OA\Parameter(ref="#/components/parameters/id")
+     */
+    public function photoAction(Request $request, string $id): Response
+    {
+        /** @var Team $team */
+        $team = $this->getQueryBuilder($request)
+            ->andWhere(sprintf('%s = :id', $this->getIdField()))
+            ->setParameter(':id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($team === null) {
+            throw new NotFoundHttpException(sprintf('Object with ID \'%s\' not found', $id));
+        }
+
+        $teamPhoto = $this->dj->assetPath($id, 'team', true);
+
+        if (!file_exists($teamPhoto)) {
+            throw new NotFoundHttpException('team photo not found');
+        }
+
+        $response = new BinaryFileResponse($teamPhoto);
+        $response->headers->set('Content-Type', 'image/jpeg');
+        return $response;
     }
 
     /**

--- a/webapp/src/Serializer/ContestVisitor.php
+++ b/webapp/src/Serializer/ContestVisitor.php
@@ -5,6 +5,8 @@ namespace App\Serializer;
 use App\Entity\Contest;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
+use Exception;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
@@ -23,13 +25,38 @@ class ContestVisitor implements EventSubscriberInterface
     protected $config;
 
     /**
+     * @var DOMJudgeService
+     */
+    protected $dj;
+
+    /**
+     * @var EventLogService
+     */
+    protected $eventLogService;
+
+    /**
+     * @var bool
+     */
+    protected $bannerExists;
+
+    /**
      * ContestVisitor constructor.
      *
      * @param ConfigurationService $config
+     * @param DOMJudgeService      $dj
+     * @param EventLogService      $eventLogService
+     * @param bool                 $bannerExists
      */
-    public function __construct(ConfigurationService $config)
-    {
+    public function __construct(
+        ConfigurationService $config,
+        DOMJudgeService $dj,
+        EventLogService $eventLogService,
+        bool $bannerExists
+    ) {
         $this->config = $config;
+        $this->dj = $dj;
+        $this->eventLogService = $eventLogService;
+        $this->bannerExists = $bannerExists;
     }
 
     /**
@@ -39,8 +66,8 @@ class ContestVisitor implements EventSubscriberInterface
     {
         return [
             [
-                'event' => Events::POST_SERIALIZE,
-                'class' => Contest::class,
+                'event'  => Events::POST_SERIALIZE,
+                'class'  => Contest::class,
                 'format' => 'json',
                 'method' => 'onPostSerialize'
             ],
@@ -49,17 +76,38 @@ class ContestVisitor implements EventSubscriberInterface
 
     /**
      * @param ObjectEvent $event
-     * @throws \Exception
+     *
+     * @throws Exception
      */
     public function onPostSerialize(ObjectEvent $event)
     {
         /** @var JsonSerializationVisitor $visitor */
-        $visitor  = $event->getVisitor();
+        $visitor = $event->getVisitor();
+        /** @var Contest $contest */
+        $contest = $event->getObject();
+
         $property = new StaticPropertyMetadata(
             Contest::class,
             'penalty_time',
             null
         );
         $visitor->visitProperty($property, (int)$this->config->get('penalty_time'));
+
+        if ($this->bannerExists) {
+            $idField = sprintf('get%s', ucfirst($this->eventLogService->externalIdFieldForEntity(Contest::class) ?? 'cid'));
+            $id = call_user_func([$contest, $idField]);
+
+            $banner = sprintf('%s/public/images/banner.png', $this->dj->getDomjudgeWebappDir());
+
+            $imageSize = getimagesize($banner);
+
+            $route = $this->dj->apiRelativeUrl('v4_contest_banner', ['id' => $id]);
+            $property = new StaticPropertyMetadata(
+                Contest::class,
+                'banner',
+                null
+            );
+            $visitor->visitProperty($property, [['href' => $route, 'mime' => 'image/png', 'width' => $imageSize[0], 'height' => $imageSize[1]]]);
+        }
     }
 }

--- a/webapp/src/Serializer/TeamAffiliationVisitor.php
+++ b/webapp/src/Serializer/TeamAffiliationVisitor.php
@@ -3,6 +3,7 @@
 namespace App\Serializer;
 
 use App\Entity\TeamAffiliation;
+use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Exception;
@@ -21,6 +22,11 @@ class TeamAffiliationVisitor implements EventSubscriberInterface
     protected $dj;
 
     /**
+     * @var ConfigurationService
+     */
+    protected $config;
+
+    /**
      * @var EventLogService
      */
     protected $eventLogService;
@@ -32,10 +38,12 @@ class TeamAffiliationVisitor implements EventSubscriberInterface
 
     public function __construct(
         DOMJudgeService $dj,
+        ConfigurationService $config,
         EventLogService $eventLogService,
         RequestStack $requestStack
     ) {
         $this->dj = $dj;
+        $this->config = $config;
         $this->eventLogService = $eventLogService;
         $this->requestStack = $requestStack;
     }
@@ -68,7 +76,7 @@ class TeamAffiliationVisitor implements EventSubscriberInterface
         $id = call_user_func([$affiliation, $idField]);
 
         // Country flag
-        if ($affiliation->getCountry()) {
+        if ($this->config->get('show_flags') && $affiliation->getCountry()) {
             $countryFlags = [];
             // Mapping from API URL size to viewbox size of SVG's
             $countryFlagSizes = [

--- a/webapp/src/Serializer/TeamAffiliationVisitor.php
+++ b/webapp/src/Serializer/TeamAffiliationVisitor.php
@@ -3,36 +3,44 @@
 namespace App\Serializer;
 
 use App\Entity\TeamAffiliation;
-use App\Service\ConfigurationService;
+use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
+use Exception;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class TeamAffiliationVisitor implements EventSubscriberInterface
 {
     /**
-     * @var ConfigurationService
+     * @var DOMJudgeService
      */
-    protected $config;
+    protected $dj;
 
     /**
-     * @var RouterInterface
+     * @var EventLogService
      */
-    protected $router;
+    protected $eventLogService;
 
-    public function __construct(ConfigurationService $config, RouterInterface $router)
-    {
-        $this->config = $config;
-        $this->router = $router;
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    public function __construct(
+        DOMJudgeService $dj,
+        EventLogService $eventLogService,
+        RequestStack $requestStack
+    ) {
+        $this->dj = $dj;
+        $this->eventLogService = $eventLogService;
+        $this->requestStack = $requestStack;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [
@@ -47,48 +55,64 @@ class TeamAffiliationVisitor implements EventSubscriberInterface
     /**
      * @param ObjectEvent $event
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function onPostSerialize(ObjectEvent $event)
     {
-        if (!$this->config->get('show_flags')) {
-            return;
-        }
-
-        /** @var TeamAffiliation $affiliation */
-        $affiliation = $event->getObject();
-        if (!$affiliation->getCountry()) {
-            return;
-        }
-
-        $apiRootRoute = $this->router->generate('v4_api_root');
-        $offset = substr($apiRootRoute, -1) === '/' ? 0 : 1;
-        $countryFlags = [];
-        // Mapping from API URL size to viewbox size of SVG's
-        $countryFlagSizes = [
-            '4x3' => [640, 480],
-            '1x1' => [512, 512],
-        ];
-        foreach ($countryFlagSizes as $size => $viewBoxSize) {
-            $countryFlagRoute = $this->router->generate(
-                'v4_app_api_generalinfo_countryflag', ['countryCode' => $affiliation->getCountry(), 'size' => $size]
-            );
-            $relativeCountryFlagRoute = substr($countryFlagRoute, strlen($apiRootRoute) + $offset);
-            $countryFlags[] = [
-                'href'   => $relativeCountryFlagRoute,
-                'mime'   => 'image/svg+xml',
-                'width'  => $viewBoxSize[0],
-                'height' => $viewBoxSize[1],
-            ];
-        }
-
         /** @var JsonSerializationVisitor $visitor */
         $visitor = $event->getVisitor();
-        $property = new StaticPropertyMetadata(
-            TeamAffiliation::class,
-            'country_flag',
-            null
-        );
-        $visitor->visitProperty($property, $countryFlags);
+        /** @var TeamAffiliation $affiliation */
+        $affiliation = $event->getObject();
+
+        $idField = sprintf('get%s', ucfirst($this->eventLogService->externalIdFieldForEntity(TeamAffiliation::class) ?? 'affilid'));
+        $id = call_user_func([$affiliation, $idField]);
+
+        // Country flag
+        if ($affiliation->getCountry()) {
+            $countryFlags = [];
+            // Mapping from API URL size to viewbox size of SVG's
+            $countryFlagSizes = [
+                '4x3' => [640, 480],
+                '1x1' => [512, 512],
+            ];
+
+            foreach ($countryFlagSizes as $size => $viewBoxSize) {
+                $route = $this->dj->apiRelativeUrl(
+                    'v4_app_api_generalinfo_countryflag', ['countryCode' => $affiliation->getCountry(), 'size' => $size]
+                );
+                $countryFlags[] = [
+                    'href'   => $route,
+                    'mime'   => 'image/svg+xml',
+                    'width'  => $viewBoxSize[0],
+                    'height' => $viewBoxSize[1],
+                ];
+            }
+
+            $property = new StaticPropertyMetadata(
+                TeamAffiliation::class,
+                'country_flag',
+                null
+            );
+            $visitor->visitProperty($property, $countryFlags);
+        }
+
+        // Affiliation logo
+        if ($affiliationLogo = $this->dj->assetPath((string)$id, 'affiliation', true)) {
+            $imageSize = getimagesize($affiliationLogo);
+
+            $route = $this->dj->apiRelativeUrl(
+                'v4_organization_logo',
+                [
+                    'cid' => $this->requestStack->getCurrentRequest()->attributes->get('cid'),
+                    'id'  => $id,
+                ]
+            );
+            $property = new StaticPropertyMetadata(
+                TeamAffiliation::class,
+                'logo',
+                null
+            );
+            $visitor->visitProperty($property, [['href' => $route, 'mime' => 'image/png', 'width' => $imageSize[0], 'height' => $imageSize[1]]]);
+        }
     }
 }

--- a/webapp/src/Serializer/TeamVisitor.php
+++ b/webapp/src/Serializer/TeamVisitor.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace App\Serializer;
+
+use App\Entity\Team;
+use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
+use Exception;
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TeamVisitor implements EventSubscriberInterface
+{
+    /**
+     * @var DOMJudgeService
+     */
+    protected $dj;
+
+    /**
+     * @var EventLogService
+     */
+    protected $eventLogService;
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    public function __construct(
+        DOMJudgeService $dj,
+        EventLogService $eventLogService,
+        RequestStack $requestStack
+    ) {
+        $this->dj = $dj;
+        $this->eventLogService = $eventLogService;
+        $this->requestStack = $requestStack;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            [
+                'event'  => Events::POST_SERIALIZE,
+                'class'  => Team::class,
+                'format' => 'json',
+                'method' => 'onPostSerialize'
+            ],
+        ];
+    }
+
+    /**
+     * @param ObjectEvent $event
+     *
+     * @throws Exception
+     */
+    public function onPostSerialize(ObjectEvent $event)
+    {
+        /** @var JsonSerializationVisitor $visitor */
+        $visitor = $event->getVisitor();
+        /** @var Team $team */
+        $team = $event->getObject();
+
+        // Check if the asset actually exists
+        if (!($teamPhoto = $this->dj->assetPath((string)$team->getTeamid(), 'team', true))) {
+            return;
+        }
+
+        $imageSize = getimagesize($teamPhoto);
+
+        $idField = sprintf('get%s', ucfirst($this->eventLogService->externalIdFieldForEntity(Team::class) ?? 'teamid'));
+
+        $route = $this->dj->apiRelativeUrl(
+            'v4_team_photo',
+            [
+                'cid' => $this->requestStack->getCurrentRequest()->attributes->get('cid'),
+                'id'  => call_user_func([$team, $idField]),
+            ]
+        );
+        $property = new StaticPropertyMetadata(
+            Team::class,
+            'photo',
+            null
+        );
+        $visitor->visitProperty($property, [['href' => $route, 'mime' => 'image/jpeg', 'width' => $imageSize[0], 'height' => $imageSize[1]]]);
+    }
+}

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -42,6 +42,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -83,6 +84,11 @@ class DOMJudgeService
     protected $config;
 
     /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
      * @var Executable|null
      */
     protected $defaultCompareExecutable = null;
@@ -112,6 +118,7 @@ class DOMJudgeService
      * @param TokenStorageInterface         $tokenStorage
      * @param HttpKernelInterface           $httpKernel
      * @param ConfigurationService          $config
+     * @param RouterInterface               $router
      */
     public function __construct(
         EntityManagerInterface $em,
@@ -121,7 +128,8 @@ class DOMJudgeService
         AuthorizationCheckerInterface $authorizationChecker,
         TokenStorageInterface $tokenStorage,
         HttpKernelInterface $httpKernel,
-        ConfigurationService $config
+        ConfigurationService $config,
+        RouterInterface $router
     ) {
         $this->em                   = $em;
         $this->logger               = $logger;
@@ -131,6 +139,7 @@ class DOMJudgeService
         $this->tokenStorage         = $tokenStorage;
         $this->httpKernel           = $httpKernel;
         $this->config               = $config;
+        $this->router               = $router;
     }
 
     /**
@@ -1254,5 +1263,16 @@ class DOMJudgeService
         }
 
         return $ret;
+    }
+
+    /**
+     * Get the URL to a route relative to the API root
+     */
+    public function apiRelativeUrl(string $route, array $params = []): string
+    {
+        $route = $this->router->generate($route, $params);
+        $apiRootRoute = $this->router->generate('v4_api_root');
+        $offset = substr($apiRootRoute, -1) === '/' ? 0 : 1;
+        return substr($route, strlen($apiRootRoute) + $offset);
     }
 }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -98,6 +98,16 @@ class DOMJudgeService
      */
     protected $defaultRunExecutable = null;
 
+    /**
+     * @var array
+     */
+    protected $affiliationLogos;
+
+    /**
+     * @var array
+     */
+    protected $teamImages;
+
     const DATA_SOURCE_LOCAL = 0;
     const DATA_SOURCE_CONFIGURATION_EXTERNAL = 1;
     const DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL = 2;
@@ -119,6 +129,8 @@ class DOMJudgeService
      * @param HttpKernelInterface           $httpKernel
      * @param ConfigurationService          $config
      * @param RouterInterface               $router
+     * @param array                         $affiliationLogos
+     * @param array                         $teamImages
      */
     public function __construct(
         EntityManagerInterface $em,
@@ -129,7 +141,9 @@ class DOMJudgeService
         TokenStorageInterface $tokenStorage,
         HttpKernelInterface $httpKernel,
         ConfigurationService $config,
-        RouterInterface $router
+        RouterInterface $router,
+        array $affiliationLogos,
+        array $teamImages
     ) {
         $this->em                   = $em;
         $this->logger               = $logger;
@@ -140,6 +154,8 @@ class DOMJudgeService
         $this->httpKernel           = $httpKernel;
         $this->config               = $config;
         $this->router               = $router;
+        $this->affiliationLogos     = $affiliationLogos;
+        $this->teamImages           = $teamImages;
     }
 
     /**
@@ -1274,5 +1290,39 @@ class DOMJudgeService
         $apiRootRoute = $this->router->generate('v4_api_root');
         $offset = substr($apiRootRoute, -1) === '/' ? 0 : 1;
         return substr($route, strlen($apiRootRoute) + $offset);
+    }
+
+    /**
+     * Get the path of an asset if it exists
+     *
+     * @param string $name
+     * @param string $type
+     * @param bool $fullPath If true, get the full path. If false, get the webserver relative path
+     *
+     * @return string|null
+     */
+    public function assetPath(string $name, string $type, bool $fullPath = false): ?string
+    {
+        $prefix = $fullPath ? ($this->getDomjudgeWebappDir() . '/public/') : '';
+        switch ($type) {
+            case 'affiliation':
+                $extension = 'png';
+                $var = $this->affiliationLogos;
+                $dir = 'images/affiliations';
+                break;
+            case 'team':
+                $extension = 'jpg';
+                $var = $this->teamImages;
+                $dir = 'images/teams';
+                break;
+        }
+
+        if (isset($extension)) {
+            if (in_array($name . '.' . $extension, $var)) {
+                return sprintf('%s%s/%s.%s', $prefix, $dir, $name, $extension);
+            }
+        }
+
+        return null;
     }
 }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -78,16 +78,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     protected $customJsFiles;
 
     /**
-     * @var array
-     */
-    protected $affiliationLogos;
-
-    /**
-     * @var array
-     */
-    protected $teamImages;
-
-    /**
      * @var bool
      */
     protected $bannerExists;
@@ -105,8 +95,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      * @param string                        $projectDir
      * @param array                         $customCssFiles
      * @param array                         $customJsFiles
-     * @param array                         $affiliationLogos
-     * @param array                         $teamImages
      * @param bool                          $bannerExists
      */
     public function __construct(
@@ -120,8 +108,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         string $projectDir,
         array $customCssFiles,
         array $customJsFiles,
-        array $affiliationLogos,
-        array $teamImages,
         bool $bannerExists
     ) {
         $this->dj                   = $dj;
@@ -134,8 +120,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         $this->projectDir           = $projectDir;
         $this->customCssFiles       = $customCssFiles;
         $this->customJsFiles        = $customJsFiles;
-        $this->affiliationLogos     = $affiliationLogos;
-        $this->teamImages           = $teamImages;
         $this->bannerExists         = $bannerExists;
     }
 
@@ -175,7 +159,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('codeEditor', [$this, 'codeEditor'], ['is_safe' => ['html']]),
             new TwigFilter('showDiff', [$this, 'showDiff'], ['is_safe' => ['html']]),
             new TwigFilter('printContestStart', [$this, 'printContestStart']),
-            new TwigFilter('assetPath', [$this, 'assetPath']),
+            new TwigFilter('assetPath', [$this->dj, 'assetPath']),
             new TwigFilter('printTimeRelative', [$this, 'printTimeRelative']),
             new TwigFilter('scoreTime', [$this, 'scoreTime']),
             new TwigFilter('statusClass', [$this, 'statusClass']),
@@ -931,38 +915,6 @@ JS;
             $res .= "on " . $this->printtime($contest->getStarttime(), '%a %d %b %Y %T %Z');
         }
         return $res;
-    }
-
-    /**
-     * Get the path of an asset if it exists
-     *
-     * @param string $name
-     * @param string $type
-     *
-     * @return string|null
-     */
-    public function assetPath(string $name, string $type): ?string
-    {
-        switch ($type) {
-            case 'affiliation':
-                $extension = 'png';
-                $var = $this->affiliationLogos;
-                $dir = 'images/affiliations';
-                break;
-            case 'team':
-                $extension = 'jpg';
-                $var = $this->teamImages;
-                $dir = 'images/teams';
-                break;
-        }
-
-        if (isset($extension)) {
-            if (in_array($name . '.' . $extension, $var)) {
-                return sprintf('%s/%s.%s', $dir, $name, $extension);
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/BaseTest.php
+++ b/webapp/tests/Unit/Controller/API/BaseTest.php
@@ -162,7 +162,7 @@ abstract class BaseTest extends BaseBaseTest
             static::assertEquals($expectedObjectId, $object['id']);
             foreach ($expectedObject as $key => $value) {
                 // null values can also be absent
-                static::assertEquals($value, $object[$key] ?? null);
+                static::assertEquals($value, $object[$key] ?? null, $key . ' has correct value');
             }
         }
 
@@ -308,7 +308,7 @@ abstract class BaseTest extends BaseBaseTest
 
         foreach ($expectedProperties as $key => $value) {
             // null values can also be absent
-            static::assertEquals($value, $object[$key] ?? null);
+            static::assertEquals($value, $object[$key] ?? null, $key . ' has correct value');
         }
     }
 

--- a/webapp/tests/Unit/Controller/API/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class ContestControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'contests';
+
+    protected $expectedObjects = [
+        '2' => [
+            'formal_name'                => 'Demo contest',
+            'penalty_time'               => 20,
+            'start_time'                 => '2020-01-01T11:00:00+00:00',
+            'end_time'                   => '2023-01-01T16:00:00+00:00',
+            'duration'                   => '26309:00:00.000',
+            'scoreboard_freeze_duration' => '1:00:00.000',
+            'id'                         => '2',
+            'external_id'                => 'demo',
+            'name'                       => 'Demo contest',
+            'shortname'                  => 'demo',
+            'banner'           => [
+                [
+                    'href'   => 'contests/2/banner.png',
+                    'mime'   => 'image/png',
+                    'width'  => 181,
+                    'height' => 101
+                ]
+            ]
+        ],
+    ];
+
+    protected $expectedAbsent = ['4242', 'nonexistent'];
+
+    /**
+     * @var string
+     */
+    protected $banner;
+
+    protected function setUp(): void
+    {
+        // Make sure we have a contest banner by copying an existing file
+        $fileToCopy = __DIR__ . '/../../../../public/js/hv.png';
+        $imagesDir = __DIR__ . '/../../../../public/images/';
+        $this->banner = $imagesDir . 'banner.png';
+        copy($fileToCopy, $this->banner);
+
+        // Make sure we remove the test container, since we need to rebuild it for the images to work
+        $this->removeTestContainer();
+
+        parent::setUp();
+
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove the image again
+        unlink($this->banner);
+        $this->removeTestContainer();
+    }
+}

--- a/webapp/tests/Unit/Controller/API/GroupControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GroupControllerTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class GroupControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'groups';
+
+    protected $expectedObjects = [
+        '2' => [
+            'hidden'    => false,
+            'icpc_id'   => '2',
+            'id'        => '2',
+            'name'      => 'Self-Registered',
+            'sortorder' => 8,
+            'color'     => '#33cc44'
+        ],
+        '3' => [
+            'hidden'    => false,
+            'icpc_id'   => '3',
+            'id'        => '3',
+            'name'      => 'Participants',
+            'sortorder' => 0,
+            'color'     => null
+        ],
+        '4' => [
+            'hidden'    => false,
+            'icpc_id'   => '4',
+            'id'        => '4',
+            'name'      => 'Observers',
+            'sortorder' => 1,
+            'color'     => '#ffcc33'
+        ]
+    ];
+
+    // We test explicitly for groups 1 and 5 here, which are hidden groups and
+    // should not be returned for non-admin users
+    protected $expectedAbsent = ['4242', 'nonexistent', '1', '5'];
+}

--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -13,6 +13,8 @@ class OrganizationControllerTest extends BaseTest
     protected $expectedObjects = [
         '1'                                      => [
             'icpc_id'      => '1',
+            'shortname'    => 'UU',
+            'id'           => '1',
             'name'         => 'UU',
             'formal_name'  => 'Utrecht University',
             'country'      => 'NLD',
@@ -30,6 +32,14 @@ class OrganizationControllerTest extends BaseTest
                     'height' => 512,
                 ],
             ],
+            'logo'         => [
+                [
+                    'href'   => 'contests/2/organizations/1/logo.png',
+                    'mime'   => 'image/png',
+                    'width'  => 510,
+                    'height' => 1123
+                ]
+            ]
         ],
         SampleAffilicationsFixture::class . ':0' => [
             'name'         => 'FAU',
@@ -90,6 +100,32 @@ class OrganizationControllerTest extends BaseTest
             $expectedProperties['country_flag'] = null;
         }
         parent::testSingle($id, $expectedProperties);
+    }
+
+    /**
+     * @var string
+     */
+    protected $organizationLogo;
+
+    protected function setUp(): void
+    {
+        // Make sure we have an organization logo for organization 1 by copying an existing file
+        $fileToCopy = __DIR__ . '/../../../../public/doc/logos/DOMjudgelogo.png';
+        $organizationLogosDir = __DIR__ . '/../../../../public/images/affiliations/';
+        $this->organizationLogo = $organizationLogosDir . '1.png';
+        copy($fileToCopy, $this->organizationLogo);
+
+        // Make sure we remove the test container, since we need to rebuild it for the images to work
+        $this->removeTestContainer();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove the image again
+        unlink($this->organizationLogo);
+        $this->removeTestContainer();
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -36,8 +36,8 @@ class OrganizationControllerTest extends BaseTest
                 [
                     'href'   => 'contests/2/organizations/1/logo.png',
                     'mime'   => 'image/png',
-                    'width'  => 510,
-                    'height' => 1123
+                    'width'  => 181,
+                    'height' => 101
                 ]
             ]
         ],
@@ -110,7 +110,7 @@ class OrganizationControllerTest extends BaseTest
     protected function setUp(): void
     {
         // Make sure we have an organization logo for organization 1 by copying an existing file
-        $fileToCopy = __DIR__ . '/../../../../public/doc/logos/DOMjudgelogo.png';
+        $fileToCopy = __DIR__ . '/../../../../public/js/hv.png';
         $organizationLogosDir = __DIR__ . '/../../../../public/images/affiliations/';
         $this->organizationLogo = $organizationLogosDir . '1.png';
         copy($fileToCopy, $this->organizationLogo);

--- a/webapp/tests/Unit/Controller/API/TeamControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/TeamControllerTest.php
@@ -16,9 +16,42 @@ class TeamControllerTest extends BaseTest
             'icpc_id'         => 'exteam',
             'name'            => 'Example teamname',
             'display_name'    => null,
-            'members'         => null
+            'members'         => null,
+            'photo'           => [
+                [
+                    'href'   => 'contests/2/teams/2/photo.jpg',
+                    'mime'   => 'image/jpeg',
+                    'width'  => 320,
+                    'height' => 200
+                ]
+            ]
         ],
     ];
 
     protected $expectedAbsent = ['4242', 'nonexistent'];
+
+    /**
+     * @var string
+     */
+    protected $teamPhoto;
+
+    protected function setUp(): void
+    {
+        // Make sure we have a team photo for team 2 by copying an existing file
+        $teamPhotosDir = __DIR__ . '/../../../../public/images/teams/';
+        $this->teamPhoto = $teamPhotosDir . '2.jpg';
+        copy($teamPhotosDir . 'domjudge.jpg', $this->teamPhoto);
+
+        // Make sure we remove the test container, since we need to rebuild it for the images to work
+        $this->removeTestContainer();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove the image again
+        unlink($this->teamPhoto);
+        $this->removeTestContainer();
+    }
 }

--- a/webapp/tests/Unit/Controller/API/TeamControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/TeamControllerTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class TeamControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'teams';
+
+    protected $expectedObjects = [
+        '2' => [
+            'organization_id' => '1',
+            'group_ids'       => ['3'],
+            'affiliation'     => 'Utrecht University',
+            'nationality'     => 'NLD',
+            'id'              => '2',
+            'icpc_id'         => 'exteam',
+            'name'            => 'Example teamname',
+            'display_name'    => null,
+            'members'         => null
+        ],
+    ];
+
+    protected $expectedAbsent = ['4242', 'nonexistent'];
+}


### PR DESCRIPTION
The API spec allows us to expose team photos, organization logos and the contest banner in the API. This PR adds this.

This is useful for example if you want to use the ICPC Resolver directly with DOMjudge without a CDS in between, since these images should then appear in the Resolver.

The `apiRelativeUrl` method in `DOMJudgeService` can later also be used for #1038 to have a bit less duplicate code.

Note that the tests, controllers and visitors all have a bit of duplicated code, but they are a bit too different for me to think of an easy way to unify them. Differences:
* Team always uses teamid for the filename, while organization uses the ID as exposed in the API. Contest always uses banner.png, no per contest file.
* Team and organization both need the contest AND entity ID in the API URL, while contest only needs the contest ID (but named `id` and not `cid`).
* Since contest uses a single file, we can not use the current `assetPath` method, although we could easily extend that one.

I think that if we try to unify these three we get so many if statements, it will not be that readable anymore. But thoughts are of course welcome.