### PR TITLE
Remove shell escape chars as they are passed different to tail

### DIFF
--- a/lib/lib.error.php
+++ b/lib/lib.error.php
@@ -64,7 +64,11 @@ function logmsg(int $msglevel, string $string)
             fflush(STDLOG);
         }
         if (defined('SYSLOG')) {
-            syslog($msglevel, $string . "\n");
+            // Remove the ANSI escape characters,
+            // When logging direct to the terminal the checkmark should be green, this
+            // does not work in log so remove this specific control char.
+            // This removes both the start and the reset of the color.
+            syslog($msglevel, preg_replace('# ?\\x1b\[[0-9];?[0-9]*m#', '', $string) . "\n");
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14887731/117503472-49478d00-af81-11eb-97b2-17d9d2b6c1ab.png)

The running man is without these and looks fine, also included a copy of the line when the escape chars are removed.

I'm not sure if the running man should be escaped (and that the escape itself should also be fixed) or if this is in general a good solution. It works in my terminal but I'm not sure if this is correct.