### PR TITLE
ICPC uses pypy3 for python3

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -133,7 +133,7 @@ if [ "$DISTRO" = 'Debian' ]; then
 INCLUDEDEBS="ca-certificates"
 
 # Packages to install after upgrade (space separated):
-INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy pypy3 python3 locales"
+INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy3 locales"
 # For C# support add: mono-runtime libmono-system2.0-cil
 # However running mono within chroot still gives errors...
 


### PR DESCRIPTION
I think python2 was now also removed in the webinterface, so installing it makes little sense.