### PR TITLE
Stop dependabot proposing non security changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
See docs at: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#open-pull-requests-limit

I'm not sure if security updates for PHP do work though as I think this was discussed earlier that dependabot was enabled but never gave security update proposals.