### PR TITLE
Only update direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 0
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
See:
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#versioning-strategy
for all choices