### PR TITLE
Exclude Migrations/Command from coverage

### DIFF
--- a/webapp/phpunit.xml.dist
+++ b/webapp/phpunit.xml.dist
@@ -29,6 +29,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src/Migrations</directory>
+            </exclude>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
Migrations is write once code so doesn't benefit from coverage.
For commands the database ends up in a lock with the current DB
structure for what I tested.