### PR TITLE
Get security PRs for stable release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 0
     versioning-strategy: lockfile-only
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    versioning-strategy: lockfile-only
+    target-branch: "7.3"


### PR DESCRIPTION
If this is possible depends on if upstream is still patching these versions.