### PR TITLE
WSL2 currently has the cgroup support

### DIFF
--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -14,6 +14,7 @@ System requirements
 ```````````````````
 * The operating system is Linux or another Unix variant. DOMjudge has mostly
   been tested with Debian and Ubuntu, but should work on other environments.
+  Using WSL2 should work but is is not extensively tested.
 * It is probably necessary that you have root access to be able to install
   the necessary components, but it's not required for actually running the
   DOMserver.

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -14,6 +14,7 @@ System requirements
 
 * The operating system is a Linux variant. DOMjudge has mostly
   been tested with Debian and Ubuntu, but should work on other environments.
+  Using WSL2 should work but is is not extensively tested.
 * It is necessary that you have root access.
 * A TCP/IP network which connects the DOMserver and the judgehosts.
   The machines only need HTTP(S) access to the DOMserver.

--- a/doc/manual/overview.rst
+++ b/doc/manual/overview.rst
@@ -91,7 +91,7 @@ machines.
 
   The judgehost requires Linux cgroup support for memory and swap accounting.
   Platforms that do not provide this support (some virtualization environments,
-  for example WSL 1 / 2) will not work with the judgehost.
+  for example WSL 1) will not work with the judgehost.
 
 Copyright and licencing
 -----------------------


### PR DESCRIPTION
Tested both with a custom build WSL distro, an installation in the
current ubuntu 20.04 WSL and running the docker containers (which use
WSL2 when enabled).

Both via the documented installation instructions of 7.3.3 and the the
maintainer install as used in the ansible WF scripts.

No extra tweaking on the OS was needed apart from how to enable WSL (which the internet can better explain than the wiki can)