### PR TITLE
Double check to prevent $properties being null in problem importing

### DIFF
--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -127,7 +127,7 @@ class ImportProblemService
 
         // Double check to prevent $properties being null, which may throw at
         // array_key_exists saying parameter 2 "array expected, null given".
-        if ($propertiesString !== false && $properties === null) {
+        if ($propertiesString !== false && $properties === false) {
             $properties   = [];
             $messages[]   = "The given <code>domjudge-problem.ini</code> is invalid, ignoring.";
         }

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -125,6 +125,12 @@ class ImportProblemService
         $propertiesString = $zip->getFromName($propertiesFile);
         $properties       = $propertiesString === false ? [] : parse_ini_string($propertiesString);
 
+        // Double check to prevent $properties being null, which may throw at
+        // array_key_exists saying parameter 2 "array expected, null given".
+        if ($propertiesString !== false && $properties === null) {
+            $properties   = []; 
+        }
+
         // Only preserve valid keys:
         $problemProperties        = array_intersect_key($properties, array_flip($iniKeysProblem));
         $contestProblemProperties = array_intersect_key($properties, array_flip($iniKeysContestProblem));

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -123,13 +123,15 @@ class ImportProblemService
 
         // Read problem properties
         $propertiesString = $zip->getFromName($propertiesFile);
-        $properties       = $propertiesString === false ? [] : parse_ini_string($propertiesString);
+        $properties = [];
 
-        // Double check to prevent $properties being null, which may throw at
-        // array_key_exists saying parameter 2 "array expected, null given".
-        if ($propertiesString !== false && $properties === false) {
-            $properties   = [];
-            $messages[]   = "The given <code>domjudge-problem.ini</code> is invalid, ignoring.";
+        if ($propertiesString !== false) {
+            $tryParseProperties = parse_ini_string($propertiesString);
+            if (is_array($tryParseProperties)) {
+                $properties = $tryParseProperties;
+            } else {
+                $messages[] = "The given <code>domjudge-problem.ini</code> is invalid, ignoring.";
+            }
         }
 
         // Only preserve valid keys:

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -128,7 +128,8 @@ class ImportProblemService
         // Double check to prevent $properties being null, which may throw at
         // array_key_exists saying parameter 2 "array expected, null given".
         if ($propertiesString !== false && $properties === null) {
-            $properties   = []; 
+            $properties   = [];
+            $messages[]   = "The given <code>domjudge-problem.ini</code> is invalid, ignoring.";
         }
 
         // Only preserve valid keys:


### PR DESCRIPTION
Double check to prevent $properties being null.

If we upload an archive with `domjudge-problem.ini` like

```
name = True Friends
timelimit = 1.0
```

without the quotation marks, the token `True` will be parsed as boolean. Then the `Friends` will be treated as an invalid token, after which the parse_ini_string function gives a warning and returns null. So that `$problemProperties` will be null.

![image](https://user-images.githubusercontent.com/10959348/120068069-63bce400-c0b1-11eb-9c3b-a786d3e6fc60.png)

When checking external id, `array_key_exists` would say parameter 2 "array expected, null given".