### PR TITLE
remove redundant access check in scoreboard API

### DIFF
--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -125,12 +125,8 @@ class ScoreboardController extends AbstractRestController
         }
 
         /** @var Contest $contest */
-        $contest         = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
-        $inactiveAllowed = $this->isGranted('ROLE_API_READER');
-        $accessAllowed   = ($inactiveAllowed && $contest->getEnabled()) || (!$inactiveAllowed && $contest->isActive());
-        if (!$accessAllowed) {
-            throw new AccessDeniedHttpException();
-        }
+        // also checks access of user to the contest via getContestQueryBuilder() from superclass
+        $contest = $this->em->getRepository(Contest::class)->find($this->getContestId($request));
 
         // Get the event for this scoreboard
         // TODO: add support for after_event_id

--- a/webapp/src/DataFixtures/Test/ExtendDemoPracticeSessionTimeFixture.php
+++ b/webapp/src/DataFixtures/Test/ExtendDemoPracticeSessionTimeFixture.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use DateTime;
+use Doctrine\Persistence\ObjectManager;
+
+class ExtendDemoPracticeSessionTimeFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager)
+    {
+        // Make sure the demo practice contest is still running
+        /** @var Contest $demoPracticeContest */
+        $demoPracticeContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demoprac']);
+        $demoPracticeContest
+            ->setEndtimeString((new DateTime('+1 day'))->format('Y-m-d H:i:s'))
+            ->setDeactivatetimeString((new DateTime('+2 days'))->format('Y-m-d H:i:s'));
+
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/SampleEventsFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleEventsFixture.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\Event;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleEventsFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager)
+    {
+        $contests = $manager->getRepository(Contest::class)->findAll();
+        foreach ($contests as $contest) {
+            $event = (new Event())
+                ->setContest($contest)
+                ->setEndpointid((string)$contest->getCid())
+                ->setEndpointtype('contest')
+                ->setAction('create')
+                ->setEventtime(Utils::now())
+                // Note: we do not care about the actual contents, as long as we have some event
+                ->setContent([]);
+
+            $manager->persist($event);
+        }
+        $manager->flush();
+    }
+}

--- a/webapp/tests/Unit/Controller/API/ScoreboardControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ScoreboardControllerTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+use App\DataFixtures\Test\ExtendDemoPracticeSessionTimeFixture;
+use App\DataFixtures\Test\RemoveTeamFromDemoUserFixture;
+use App\DataFixtures\Test\SampleEventsFixture;
+use Generator;
+
+class ScoreboardControllerTest extends BaseTest
+{
+    protected static $fixtures = [ExtendDemoPracticeSessionTimeFixture::class, SampleEventsFixture::class];
+
+    /**
+     * Test that the given user has the correct access to the scoreboard for the given contest
+     *
+     * @dataProvider provideScoreboardAccess
+     */
+    public function testScoreboardAccess(?string $user, int $contestId, bool $removeTeamFromDemoUser, bool $expectedAllowedAccess): void
+    {
+        if ($removeTeamFromDemoUser) {
+            $this->loadFixture(RemoveTeamFromDemoUserFixture::class);
+        }
+        $url = "/contests/$contestId/scoreboard";
+        $scoreboard = $this->verifyApiJsonResponse('GET', $url, $expectedAllowedAccess ? 200 : 404, $user);
+        self::assertNotEmpty($scoreboard);
+    }
+
+    public function provideScoreboardAccess(): Generator
+    {
+        // Contest 2 is a public contest, everyone should have access
+        yield [null, 2, false, true];
+        yield ['demo', 2, false, true];
+        yield ['demo', 2, true, true];
+        yield ['admin', 2, false, true];
+
+        // Contest 1 is not public, but the team demo belongs to has access
+        yield [null, 1, false, false];
+        yield ['demo', 1, false, true];
+        yield ['demo', 1, true, false]; // If we remove the team from the demo user, it should not be able to access the contest anymore
+        yield ['admin', 1, false, true];
+    }
+}


### PR DESCRIPTION
fixes #1106.

The removed checks are done implicitly by calling `getContestId()`.

I don't know enough about domjudge to add a specific test for this, though :(