### PR TITLE
Support contest award configuration and rendering on scoreboard

### DIFF
--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -24,74 +25,86 @@ class ContestType extends AbstractExternalIdEntityType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->addExternalIdField($builder, Contest::class);
-        $builder->add('shortname', TextType::class, [
-            'help' => 'Contest name as shown in the top right.'
-        ]);
-        $builder->add('name', TextType::class, [
-            'help' => 'Contest name in full as shown on the scoreboard.'
-        ]);
+        $builder->add('shortname', TextType::class);
+        $builder->add('name', TextType::class);
         $builder->add('activatetimeString', TextType::class, [
             'label' => 'Activate time',
-            'help' => 'Time when the contest becomes visible for teams. Must be in the past to enable submission of jury submissions.',
         ]);
         $builder->add('starttimeString', TextType::class, [
             'label' => 'Start time',
-            'help' => 'Absolute time when the contest starts.',
         ]);
         $builder->add('starttimeEnabled', ChoiceType::class, [
-            'label' => 'Start time countdown enabled',
+            'label' => 'Start time enabled',
             'expanded' => true,
             'choices' => [
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Disable to delay the contest start and stop the countdown. Enable again after setting a new start time.',
         ]);
         $builder->add('freezetimeString', TextType::class, [
             'label' => 'Scoreboard freeze time',
             'required' => false,
-            'help' => 'Time when the freeze starts: the results of submissions made after this time are not revealed until the scoreboard unfreeze time below has passed.',
         ]);
         $builder->add('endtimeString', TextType::class, [
             'label' => 'End time',
-            'help' => 'Time when the contest ends. Submissions made after this time will be accepted and judged but shown (to teams and public) as \'too-late\' and not counted towards the score.',
         ]);
         $builder->add('unfreezetimeString', TextType::class, [
             'label' => 'Scoreboard unfreeze time',
             'required' => false,
-            'help' => 'Time when the final scoreboard is revealed. Usually this is a few hours after the contest ends and the award ceremony is over.',
         ]);
         $builder->add('deactivatetimeString', TextType::class, [
             'label' => 'Deactivate time',
             'required' => false,
-            'help' => 'Time when the contest and scoreboard are hidden again. Usually a few hours/days after the contest ends.',
         ]);
         $builder->add('processBalloons', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Record balloons',
             'choices' => [
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
+        ]);
+        $builder->add('processAwards', ChoiceType::class, [
+            'expanded' => true,
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+        ]);
+        $builder->add('awardsCategories', EntityType::class, [
+            'required' => false,
+            'class' => TeamCategory::class,
+            'multiple' => true,
+            'choice_label' => function (TeamCategory $category) {
+                return $category->getName();
+            },
+        ]);
+        $builder->add('goldAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'leave empty for default',
+        ]);
+        $builder->add('silverAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'leave empty for default',
+        ]);
+        $builder->add('bronzeAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'leave empty for default',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Enable public scoreboard',
+            'label' => 'Contest visible on public scoreboard',
             'choices' => [
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'When the public scoreboard is enabled, everyone can see it without logging in. When disabled, only logged in users/teams can see the scoreboard.',
         ]);
         $builder->add('openToAllTeams', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Open contest to all teams',
+            'label' => 'Contest open to all teams',
             'choices' => [
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'When enabled, any logged in team is part of the contest. When disabled, only the teams/categories listed below are part of the contest.',
         ]);
         $builder->add('teams', EntityType::class, [
             'required' => false,
@@ -100,7 +113,6 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (Team $team) {
                 return sprintf('%s (t%d)', $team->getEffectiveName(), $team->getTeamid());
             },
-            'help' => 'List of teams participating in the contest, in case it is not open to all teams.',
         ]);
         $builder->add('teamCategories', EntityType::class, [
             'required' => false,
@@ -109,16 +121,13 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (TeamCategory $category) {
                 return $category->getName();
             },
-            'help' => 'List of team categories participating in the contest, in case it is not open to all teams.',
         ]);
         $builder->add('enabled', ChoiceType::class, [
             'expanded' => true,
-            'label' => 'Enable contest',
             'choices' => [
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'When disabled, the contest is hidden from teams (even when active) and judging is disabled. Disabling is a quick way to remove access to it without changing any other settings.',
         ]);
         $builder->add('problems', CollectionType::class, [
             'entry_type' => ContestProblemType::class,

--- a/webapp/src/Migrations/Version20210611141202.php
+++ b/webapp/src/Migrations/Version20210611141202.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210611141202 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE contestteamcategoryforawards (cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\', categoryid INT UNSIGNED NOT NULL COMMENT \'Team category ID\', INDEX IDX_40B1F5544B30D9C4 (cid), INDEX IDX_40B1F5549B32FD3 (categoryid), PRIMARY KEY(cid, categoryid)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE contestteamcategoryforawards ADD CONSTRAINT FK_40B1F5544B30D9C4 FOREIGN KEY (cid) REFERENCES contest (cid) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE contestteamcategoryforawards ADD CONSTRAINT FK_40B1F5549B32FD3 FOREIGN KEY (categoryid) REFERENCES team_category (categoryid) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE contest ADD process_awards TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Are there awards for this contest?\', ADD gold_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of gold medals\', ADD silver_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of silver medals\', ADD bronze_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of bronze medals\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE contestteamcategoryforawards');
+        $this->addSql('ALTER TABLE contest DROP process_awards, DROP gold_awards, DROP silver_awards, DROP bronze_awards');
+    }
+}

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -12,19 +12,19 @@
 
     <h1>Contest {{ contest.name }}</h1>
 
-    {% if contest.isActive %}
+    {% if isActive %}
         <div class="alert alert-success">
-            This contest is currently active.
+            This is an active contest
         </div>
     {% endif %}
     {% if not contest.enabled %}
         <div class="alert alert-danger">
-            This contest is disabled.
+            This contest is disabled
         </div>
     {% endif %}
     {% if contest.finalizetime is not empty %}
         <div class="alert alert-info">
-            This contest is final.
+            This contest is final
         </div>
     {% endif %}
 
@@ -51,21 +51,13 @@
                 </tr>
                 <tr>
                     <th>Activate time</th>
-                    <td>
-                        {{ contest.activatetimeString }}
-                        {% if contest.isActive %}
-                            <i class="fas fa-check"></i>
-                        {% endif %}
-                    </td>
+                    <td>{{ contest.activatetimeString }}</td>
                 </tr>
                 <tr>
                     <th>Start time</th>
                     <td>
                         {% if contest.starttimeEnabled %}
                             {{ contest.starttimeString }}
-                            {% if contest.state.started %}
-                                <i class="fas fa-check"></i>
-                            {% endif %}
                         {% else %}
                             <span class="ignore">{{ contest.starttimeString }}</span> <em>delayed</em>
                         {% endif %}
@@ -73,30 +65,15 @@
                 </tr>
                 <tr>
                     <th>Scoreboard freeze</th>
-                    <td>
-                        {{ contest.freezetimeString|default('-') }}
-                        {% if contest.state.frozen %}
-                            <i class="fas fa-check"></i>
-                        {% endif %}
-                    </td>
+                    <td>{{ contest.freezetimeString|default('-') }}</td>
                 </tr>
                 <tr>
                     <th>End time</th>
-                    <td>
-                        {{ contest.endtimeString }}
-                        {% if contest.state.ended %}
-                            <i class="fas fa-check"></i>
-                        {% endif %}
-                    </td>
+                    <td>{{ contest.endtimeString }}</td>
                 </tr>
                 <tr>
                     <th>Scoreboard unfreeze</th>
-                    <td>
-                        {{ contest.unfreezetimeString|default('-') }}
-                        {% if contest.state.thawed %}
-                            <i class="fas fa-check"></i>
-                        {% endif %}
-                    </td>
+                    <td>{{ contest.unfreezetimeString|default('-') }}</td>
                 </tr>
                 <tr>
                     <th>Deactivate time</th>
@@ -105,6 +82,24 @@
                 <tr>
                     <th>Process balloons</th>
                     <td>{{ contest.processBalloons | printYesNo }}</td>
+                </tr>
+                <tr>
+                    <th>Process awards</th>
+                    <td>{{ contest.processAwards | printYesNo }}</td>
+                </tr>
+                <tr>
+                    <th>Awards</th>
+                    <td>
+                        {% if contest.processAwards %}
+                            <a>{{ contest.goldAwards|default('-') }} Gold Medal</a>
+                            </br>
+                            <a>{{ contest.silverAwards|default('-') }} Silver Medal</a>
+                            </br>
+                            <a>{{ contest.bronzeAwards|default('-') }} Bronze Medal</a>
+                        {% else %}
+                            <em>none</em>
+                        {% endif %}
+                    </td>
                 </tr>
                 <tr>
                     <th>Publicly visible</th>
@@ -233,9 +228,6 @@
                     if (confirm('Really delete interval?')) {
                         var $form = $('<form method="post" />');
                         $form.attr('action', $(this).data('submit-url'));
-                        // Some browsers require the form to be present in the DOM,
-                        // so append it to the body
-                        $(document.body).append($form);
                         $form.submit();
                     }
                     return false;
@@ -313,13 +305,12 @@
         {%- if is_granted('ROLE_ADMIN') -%}
             {{ button(path('jury_contest_edit', {'contestId': contest.cid}), 'Edit', 'primary', 'edit') }}
             {{ button(path('jury_contest_delete', {'contestId': contest.cid}), 'Delete', 'danger', 'trash-alt', true) }}
-            {% if contest.finalizetime %}
-                {{ button(path('jury_contest_finalize', {'contestId': contest.cid}), 'Update finalization', 'secondary', 'lock') }}
-            {% else %}
-                {{ button(path('jury_contest_finalize', {'contestId': contest.cid}), 'Finalize this contest', 'secondary', 'lock') }}
-            {% endif %}
         {% endif %}
-        {{ button(path('jury_contest_prefetch', {'contestId': contest.cid}), 'Heat up judgehosts with contest data', 'secondary', 'download') }}
+        {% if contest.finalizetime %}
+            {{ button(path('jury_contest_finalize', {'contestId': contest.cid}), 'Update finalization', 'secondary', 'lock') }}
+        {% else %}
+            {{ button(path('jury_contest_finalize', {'contestId': contest.cid}), 'Finalize this contest', 'secondary', 'lock') }}
+        {% endif %}
         {% include 'jury/partials/rejudge_form.html.twig' with {table: 'contest', id: contest.cid, buttonClass: 'btn-secondary'} %}
     </p>
 

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -18,6 +18,13 @@
         {{ form_row(form.unfreezetimeString) }}
         {{ form_row(form.deactivatetimeString) }}
         {{ form_row(form.processBalloons) }}
+        {{ form_row(form.processAwards) }}
+        <div data-awards-field>
+            {{ form_row(form.awardsCategories) }}
+            {{ form_row(form.goldAwards) }}
+            {{ form_row(form.silverAwards) }}
+            {{ form_row(form.bronzeAwards) }}
+        </div>
         {{ form_row(form.public) }}
         {{ form_row(form.openToAllTeams) }}
         <div data-teams-field>
@@ -26,17 +33,16 @@
         </div>
         {{ form_row(form.enabled) }}
     </div>
-    <div class="col-lg-6">
-        <h5>Specification of contest times</h5>
-        <div>Each of the contest times can be specified as absolute time or relative
-        to the start time (except for start time itself). Use up to 6 subsecond
+    <div class="col-lg-4">
+        <b>Specification of contest times:</b><br/>
+        Each of the contest times can be specified as absolute time or relative<br/>
+        to the start time (except for start time itself). Use up to 6 subsecond<br/>
         decimals and a timezone from the
         <a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
-            time zone database</a>.</div>
-        <div class="mt-3"><table>
-        <tr><td>Absolute time format:</td><td><kbd>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</kbd></td></tr>
-        <tr><td>Relative time format:</td><td><kbd>±[HHH]H:MM[:SS[.uuuuuu]]</kbd></td></tr>
-        </table></div>
+            time zone database
+        </a>.<br/><br/>
+        Absolute time format: <b><tt>YYYY-MM-DD HH:MM:SS[.uuuuuu] timezone</tt></b><br/>
+        Relative time format: <b><tt>±[HHH]H:MM[:SS[.uuuuuu]]</tt></b><br/>
     </div>
 </div>
 <table class="table table-sm table-striped">
@@ -118,7 +124,7 @@
 
 <script>
     function bindColor() {
-        jscolor.install();
+        jscolor.bind();
     }
 
     $(function () {
@@ -132,5 +138,16 @@
 
         $('#contest_openToAllTeams_1, #contest_openToAllTeams_0').on('change', showHideTeams);
         showHideTeams();
+
+        function showHideAwards() {
+            if ($('#contest_processAwards_0').is(':checked')) {
+                $('[data-awards-field]').show();
+            } else {
+                $('[data-awards-field]').hide();
+            }
+        }
+
+        $('#contest_processAwards_1, #contest_processAwards_0').on('change', showHideAwards);
+        showHideAwards();
     })
 </script>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -18,6 +18,11 @@
 {% set hasDifferentCategoryColors = scoreboard.categoryColors(limitToTeamIds) %}
 {% set scores = scoreboard.scores | filter(score => limitToTeams is null or score.team.teamid in limitToTeamIds) %}
 {% set problems = scoreboard.problems %}
+{% set processAwards = contest.processAwards %}
+{% set awardsCategories = contest.awardsCategories %}
+{% set goldAwards = contest.goldAwards %}
+{% set silverAwards = contest.silverAwards %}
+{% set bronzeAwards = contest.bronzeAwards %}
 
 {% if maxWidth > 0 %}
     <style>
@@ -114,6 +119,21 @@
             {% set previousTeam = null %}
         {% endif %}
 
+        {# process awards color #}
+        {% set awardColor = '' %}
+        {% if showLegends and processAwards and score.team.category.name in awardsCategories %}
+            {% if goldAwards > 0 %}
+                {% set awardColor = ' gold-medal' %}
+                {% set goldAwards = goldAwards - 1 %}
+            {% elseif silverAwards > 0 %}
+                {% set awardColor = ' silver-medal' %}
+                {% set silverAwards = silverAwards - 1 %}
+            {% elseif bronzeAwards > 0 %}
+                {% set awardColor = ' bronze-medal' %}
+                {% set bronzeAwards = bronzeAwards - 1 %}
+            {% endif %}
+        {% endif %}
+
         {# check whether this is us, otherwise use category colour #}
         {% if myTeamId is defined and myTeamId == score.team.teamid %}
             {% set classes = classes | merge(['scorethisisme']) %}
@@ -122,7 +142,7 @@
             {% set color = score.team.category.color %}
         {% endif %}
         <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}">
-            <td class="scorepl">
+            <td class="scorepl{{awardColor}}">
                 {# Only print rank when score is different from the previous team #}
                 {% if not displayRank %}
                     ?
@@ -137,13 +157,18 @@
                     {% if score.team.affiliation %}
                         {% set link = null %}
                         {% if jury %}
-                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
+                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affilid}) %}
                         {% endif %}
                         <a {% if link %}href="{{ link }}"{% endif %}>
                             {% if score.team.affiliation.country %}
-                                <img loading="lazy" class="countryflag"
-                                     src="{{ asset('images/countries/' ~ score.team.affiliation.country ~ '.png') }}" alt="{{ alpha3_countries[score.team.affiliation.country] }}"
-                                     title="{{ alpha3_countries[score.team.affiliation.country] }}">
+                                {% set countryFlag = 'images/countries/' ~ score.team.affiliation.country ~ '.png' %}
+                                {% if countryFlag | assetExists %}
+                                    <img loading="lazy" class="countryflag"
+                                         src="{{ asset(countryFlag) }}" alt="{{ alpha3_countries[score.team.affiliation.country] }}"
+                                         title="{{ alpha3_countries[score.team.affiliation.country] }}">
+                                {% else %}
+                                    {{ alpha3_countries[score.team.affiliation.country] }}
+                                {% endif %}
                             {% endif %}
                         </a>
                     {% endif %}
@@ -154,15 +179,15 @@
                     {% if score.team.affiliation %}
                         {% set link = null %}
                         {% if jury %}
-                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
+                            {% set link = path('jury_team_affiliation', {'affilId': score.team.affilid}) %}
                         {% endif %}
                         <a {% if link %}href="{{ link }}"{% endif %}>
                             {% set affiliationId = score.team.affiliation.affilid %}
                             {% if showExternalId(score.team.affiliation) %}
                                 {% set affiliationId = score.team.affiliation.externalid %}
                             {% endif %}
-                            {% set affiliationImage = affiliationId | assetPath('affiliation') %}
-                            {% if affiliationImage %}
+                            {% set affiliationImage = 'images/affiliations/' ~ affiliationId ~ '.png' %}
+                            {% if affiliationImage | assetExists %}
                                 <img loading="lazy" class="affiliation-logo"
                                      src="{{ asset(affiliationImage) }}" alt="{{ score.team.affiliation.name }}"
                                      title="{{ score.team.affiliation.name }}">
@@ -339,6 +364,27 @@
             </tbody>
         </table>
     {% endif %}
+
+    {% if processAwards %}
+        <table class="scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+            <thead>
+            <tr>
+                <th scope="col">Awards</th>
+            </tr>
+            </thead>
+            <tbody>
+                <tr class="gold-medal">
+                    <td>Gold Medal</td>
+                </tr>
+                <tr class="silver-medal">
+                    <td>Silver Medal</td>
+                </tr>
+                <tr class="bronze-medal">
+                    <td>Bronze Medal</td>
+                </tr>
+            </tbody>
+        </table>
+    {% endif %}
 {% endif %}
 
 <style>
@@ -358,6 +404,16 @@
                 {{ cMax }} 96%);
         }
     {% endfor %}
+
+    .gold-medal {
+        background-color: #EEC710
+    }
+    .silver-medal {
+        background-color: #AAA
+    }
+    .bronze-medal {
+        background-color: #C08E55
+    }
 </style>
 <script>
     document.querySelectorAll(".forceWidth:not(.toolong)").forEach(el => {


### PR DESCRIPTION
Feature for #1102.

Changes:
- Add award attributes for contest: these attributes could be configured in jury's contest add/edit page.
    -  `process_awards`: Is to process awards for this contest
    -  `contest_team_category_for_awards`: Only teams belonging to these categories can be awarded
    - `gold_awards`: number of gold medals for awards
    - `silver_awards`: number of silver medals for awards
    -  `bronze_awards`: number of bronze medals for awards
- Render awards' color on scoreboard if `process_awards=True`

Here are some Pictures for these feature:
- Awards in scoreboard
![2](https://user-images.githubusercontent.com/29372915/121727445-7f4ad480-cb1e-11eb-829e-f38ad3b75103.png)
![1](https://user-images.githubusercontent.com/29372915/121727437-7bb74d80-cb1e-11eb-963a-57ba2c69b1fb.png)
- Configuration in jury pages
![5](https://user-images.githubusercontent.com/29372915/121727524-9c7fa300-cb1e-11eb-94b4-0d198fe0c888.png)
![4](https://user-images.githubusercontent.com/29372915/121727460-840f8880-cb1e-11eb-9d1b-46af67465a92.png)
![6](https://user-images.githubusercontent.com/29372915/121727527-9e496680-cb1e-11eb-885a-b8b003fa8f00.png)
![3](https://user-images.githubusercontent.com/29372915/121727454-8245c500-cb1e-11eb-8991-16c84ee89d71.png)


