### PR TITLE
Support contest award configuration and rendering on scoreboard

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -260,6 +260,10 @@ img.affiliation-logo {
 .score_pending   { background: #6666FF; }
 .score_incorrect { background: #e87272; }
 
+.gold-award   { background-color: #EEC710 }
+.silver-award { background-color: #AAA }
+.bronze-award { background-color: #C08E55 }
+
 #scoresolv,#scoretotal { width: 2.5em; }
 .scorenc,.scorett,.scorepl { text-align: center; width: 2ex; }
 .scorenc { font-weight: bold; }

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -173,7 +173,7 @@ class Contest extends BaseApiEntity
     /**
      * @var boolean|null
      * @ORM\Column(type="boolean", name="process_awards",
-     *     options={"comment"="Are there awards for this contest?","default"=0},
+     *     options={"comment"="Whether to process awards for this contest","default"=0},
      *     nullable=false)
      * @Serializer\Exclude()
      */
@@ -187,12 +187,12 @@ class Contest extends BaseApiEntity
      *               )
      * @Serializer\Exclude()
      */
-    private $awardsCategories;
+    private $awards_categories;
 
     /**
      * @var int|null
      * @ORM\Column(type="smallint", length=3, name="gold_awards",
-     *     options={"comment"="Number of gold medals","unsigned"="true","default"=0},
+     *     options={"comment"="Number of gold awards","unsigned"="true","default"=0},
      *     nullable=false)
      * @Serializer\Exclude()
      */
@@ -201,7 +201,7 @@ class Contest extends BaseApiEntity
     /**
      * @var int|null
      * @ORM\Column(type="smallint", length=3, name="silver_awards",
-     *     options={"comment"="Number of silver medals","unsigned"="true","default"=0},
+     *     options={"comment"="Number of silver awards","unsigned"="true","default"=0},
      *     nullable=false)
      * @Serializer\Exclude()
      */
@@ -210,7 +210,7 @@ class Contest extends BaseApiEntity
     /**
      * @var int|null
      * @ORM\Column(type="smallint", length=3, name="bronze_awards",
-     *     options={"comment"="Number of bronze medals","unsigned"="true","default"=0},
+     *     options={"comment"="Number of bronze awards","unsigned"="true","default"=0},
      *     nullable=false)
      * @Serializer\Exclude()
      */
@@ -387,7 +387,7 @@ class Contest extends BaseApiEntity
         $this->submissions      = new ArrayCollection();
         $this->internal_errors  = new ArrayCollection();
         $this->team_categories  = new ArrayCollection();
-        $this->awardsCategories = new ArrayCollection();
+        $this->awards_categories = new ArrayCollection();
     }
 
     public function getCid(): int
@@ -688,10 +688,9 @@ class Contest extends BaseApiEntity
      *
      * @return Contest
      */
-    public function setProcessAwards($processAwards)
+    public function setProcessAwards(bool $processAwards): Contest
     {
         $this->processAwards = $processAwards;
-
         return $this;
     }
 
@@ -700,7 +699,7 @@ class Contest extends BaseApiEntity
      *
      * @return boolean
      */
-    public function getProcessAwards()
+    public function getProcessAwards(): bool
     {
         return $this->processAwards;
     }
@@ -710,22 +709,22 @@ class Contest extends BaseApiEntity
      */
     public function getAwardsCategories(): Collection
     {
-        return $this->awardsCategories;
+        return $this->awards_categories;
     }
 
-    public function addAwardsCategories(TeamCategory $awardsCategory): self
+    public function addAwardsCategories(TeamCategory $awardsCategory): Contest
     {
-        if (!$this->awardsCategories->contains($awardsCategory)) {
-            $this->awardsCategories[] = $awardsCategory;
+        if (!$this->awards_categories->contains($awardsCategory)) {
+            $this->awards_categories[] = $awardsCategory;
         }
 
         return $this;
     }
 
-    public function removeAwardsCategories(TeamCategory $awardsCategory): self
+    public function removeAwardsCategories(TeamCategory $awardsCategory): Contest
     {
-        if ($this->awardsCategories->contains($awardsCategory)) {
-            $this->awardsCategories->removeElement($awardsCategory);
+        if ($this->awards_categories->contains($awardsCategory)) {
+            $this->awards_categories->removeElement($awardsCategory);
         }
 
         return $this;
@@ -738,10 +737,9 @@ class Contest extends BaseApiEntity
      *
      * @return Contest
      */
-    public function setGoldAwards($goldAwards)
+    public function setGoldAwards(int $goldAwards): Contest
     {
         $this->goldAwards = $goldAwards;
-
         return $this;
     }
 
@@ -750,7 +748,7 @@ class Contest extends BaseApiEntity
      *
      * @return integer
      */
-    public function getGoldAwards()
+    public function getGoldAwards(): int
     {
         return $this->goldAwards;
     }
@@ -762,10 +760,9 @@ class Contest extends BaseApiEntity
      *
      * @return Contest
      */
-    public function setSilverAwards($silverAwards)
+    public function setSilverAwards(int $silverAwards): Contest
     {
         $this->silverAwards = $silverAwards;
-
         return $this;
     }
 
@@ -774,7 +771,7 @@ class Contest extends BaseApiEntity
      *
      * @return integer
      */
-    public function getSilverAwards()
+    public function getSilverAwards(): int
     {
         return $this->silverAwards;
     }
@@ -786,10 +783,9 @@ class Contest extends BaseApiEntity
      *
      * @return Contest
      */
-    public function setBronzeAwards($bronzeAwards)
+    public function setBronzeAwards(int $bronzeAwards): Contest
     {
         $this->bronzeAwards = $bronzeAwards;
-
         return $this;
     }
 

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -171,6 +171,52 @@ class Contest extends BaseApiEntity
     private $b = 0;
 
     /**
+     * @var boolean|null
+     * @ORM\Column(type="boolean", name="process_awards",
+     *     options={"comment"="Are there awards for this contest?","default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $processAwards = false;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\TeamCategory", inversedBy="contests")
+     * @ORM\JoinTable(name="contestteamcategoryforawards",
+     *                joinColumns={@ORM\JoinColumn(name="cid", referencedColumnName="cid", onDelete="CASCADE")},
+     *                inverseJoinColumns={@ORM\JoinColumn(name="categoryid", referencedColumnName="categoryid", onDelete="CASCADE")}
+     *               )
+     * @Serializer\Exclude()
+     */
+    private $awardsCategories;
+
+    /**
+     * @var int|null
+     * @ORM\Column(type="smallint", length=3, name="gold_awards",
+     *     options={"comment"="Number of gold medals","unsigned"="true","default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $goldAwards = 0;
+
+    /**
+     * @var int|null
+     * @ORM\Column(type="smallint", length=3, name="silver_awards",
+     *     options={"comment"="Number of silver medals","unsigned"="true","default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $silverAwards = 0;
+
+    /**
+     * @var int|null
+     * @ORM\Column(type="smallint", length=3, name="bronze_awards",
+     *     options={"comment"="Number of bronze medals","unsigned"="true","default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private $bronzeAwards = 0;
+
+    /**
      * @var double
      * @ORM\Column(type="decimal", precision=32, scale=9, name="deactivatetime",
      *     options={"comment"="Time contest becomes invisible in team/public views",
@@ -341,6 +387,7 @@ class Contest extends BaseApiEntity
         $this->submissions      = new ArrayCollection();
         $this->internal_errors  = new ArrayCollection();
         $this->team_categories  = new ArrayCollection();
+        $this->awardsCategories = new ArrayCollection();
     }
 
     public function getCid(): int
@@ -632,6 +679,128 @@ class Contest extends BaseApiEntity
     public function getProcessBalloons(): bool
     {
         return $this->processBalloons;
+    }
+
+    /**
+     * Set processAwards
+     *
+     * @param boolean $processAwards
+     *
+     * @return Contest
+     */
+    public function setProcessAwards($processAwards)
+    {
+        $this->processAwards = $processAwards;
+
+        return $this;
+    }
+
+    /**
+     * Get processAwards
+     *
+     * @return boolean
+     */
+    public function getProcessAwards()
+    {
+        return $this->processAwards;
+    }
+
+    /**
+     * @return Collection|TeamCategory[]
+     */
+    public function getAwardsCategories(): Collection
+    {
+        return $this->awardsCategories;
+    }
+
+    public function addAwardsCategories(TeamCategory $awardsCategory): self
+    {
+        if (!$this->awardsCategories->contains($awardsCategory)) {
+            $this->awardsCategories[] = $awardsCategory;
+        }
+
+        return $this;
+    }
+
+    public function removeAwardsCategories(TeamCategory $awardsCategory): self
+    {
+        if ($this->awardsCategories->contains($awardsCategory)) {
+            $this->awardsCategories->removeElement($awardsCategory);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set goldAwards
+     *
+     * @param integer $goldAwards
+     *
+     * @return Contest
+     */
+    public function setGoldAwards($goldAwards)
+    {
+        $this->goldAwards = $goldAwards;
+
+        return $this;
+    }
+
+    /**
+     * Get goldAwards
+     *
+     * @return integer
+     */
+    public function getGoldAwards()
+    {
+        return $this->goldAwards;
+    }
+
+    /**
+     * Set silverAwards
+     *
+     * @param integer $silverAwards
+     *
+     * @return Contest
+     */
+    public function setSilverAwards($silverAwards)
+    {
+        $this->silverAwards = $silverAwards;
+
+        return $this;
+    }
+
+    /**
+     * Get silverAwards
+     *
+     * @return integer
+     */
+    public function getSilverAwards()
+    {
+        return $this->silverAwards;
+    }
+
+    /**
+     * Set bronzeAwards
+     *
+     * @param integer $bronzeAwards
+     *
+     * @return Contest
+     */
+    public function setBronzeAwards($bronzeAwards)
+    {
+        $this->bronzeAwards = $bronzeAwards;
+
+        return $this;
+    }
+
+    /**
+     * Get bronzeAwards
+     *
+     * @return integer
+     */
+    public function getBronzeAwards()
+    {
+        return $this->bronzeAwards;
     }
 
     public function setPublic(bool $public): Contest

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -794,7 +794,7 @@ class Contest extends BaseApiEntity
      *
      * @return integer
      */
-    public function getBronzeAwards()
+    public function getBronzeAwards(): int
     {
         return $this->bronzeAwards;
     }

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -82,7 +82,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Whether to award medals for this contest.',
+            'help' => 'Whether to process awards for this contest.',
         ]);
         $builder->add('awardsCategories', EntityType::class, [
             'required' => false,
@@ -91,19 +91,19 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (TeamCategory $category) {
                 return $category->getName();
             },
-            'help' => 'The categories that will receive awards for this contest.',
+            'help' => 'List of team categories that will receive awards for this contest.',
         ]);
         $builder->add('goldAwards', IntegerType::class, [
             'required' => false,
-            'help' => 'The number of gold medals for this contest.',
+            'help' => 'The number of gold awards for this contest.',
         ]);
         $builder->add('silverAwards', IntegerType::class, [
             'required' => false,
-            'help' => 'The number of silver medals for this contest.',
+            'help' => 'The number of silver awards for this contest.',
         ]);
         $builder->add('bronzeAwards', IntegerType::class, [
             'required' => false,
-            'help' => 'The number of bronze medals for this contest.',
+            'help' => 'The number of bronze awards for this contest.',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -74,6 +75,35 @@ class ContestType extends AbstractExternalIdEntityType
                 'No' => false,
             ],
             'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
+        ]);
+        $builder->add('processAwards', ChoiceType::class, [
+            'expanded' => true,
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+            'help' => 'Whether to award medals for this contest.',
+        ]);
+        $builder->add('awardsCategories', EntityType::class, [
+            'required' => false,
+            'class' => TeamCategory::class,
+            'multiple' => true,
+            'choice_label' => function (TeamCategory $category) {
+                return $category->getName();
+            },
+            'help' => 'The categories could be awarded for this contest if process awards.',
+        ]);
+        $builder->add('goldAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'The number of gold medals for this contest.',
+        ]);
+        $builder->add('silverAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'The number of silver medals for this contest.',
+        ]);
+        $builder->add('bronzeAwards', IntegerType::class, [
+            'required' => false,
+            'help' => 'The number of bronze medals for this contest.',
         ]);
         $builder->add('public', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -91,7 +91,7 @@ class ContestType extends AbstractExternalIdEntityType
             'choice_label' => function (TeamCategory $category) {
                 return $category->getName();
             },
-            'help' => 'The categories could be awarded for this contest if process awards.',
+            'help' => 'The categories that will receive awards for this contest.',
         ]);
         $builder->add('goldAwards', IntegerType::class, [
             'required' => false,

--- a/webapp/src/Migrations/Version20210611141202.php
+++ b/webapp/src/Migrations/Version20210611141202.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210611141202 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE contestteamcategoryforawards (cid INT UNSIGNED NOT NULL COMMENT \'Contest ID\', categoryid INT UNSIGNED NOT NULL COMMENT \'Team category ID\', INDEX IDX_40B1F5544B30D9C4 (cid), INDEX IDX_40B1F5549B32FD3 (categoryid), PRIMARY KEY(cid, categoryid)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE contestteamcategoryforawards ADD CONSTRAINT FK_40B1F5544B30D9C4 FOREIGN KEY (cid) REFERENCES contest (cid) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE contestteamcategoryforawards ADD CONSTRAINT FK_40B1F5549B32FD3 FOREIGN KEY (categoryid) REFERENCES team_category (categoryid) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE contest ADD process_awards TINYINT(1) DEFAULT \'0\' NOT NULL COMMENT \'Are there awards for this contest?\', ADD gold_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of gold medals\', ADD silver_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of silver medals\', ADD bronze_awards SMALLINT UNSIGNED DEFAULT 0 NOT NULL COMMENT \'Number of bronze medals\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE contestteamcategoryforawards');
+        $this->addSql('ALTER TABLE contest DROP process_awards, DROP gold_awards, DROP silver_awards, DROP bronze_awards');
+    }
+}

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -107,6 +107,24 @@
                     <td>{{ contest.processBalloons | printYesNo }}</td>
                 </tr>
                 <tr>
+                    <th>Process awards</th>
+                    <td>{{ contest.processAwards | printYesNo }}</td>
+                </tr>
+                <tr>
+                    <th>Awards</th>
+                    <td>
+                        {% if contest.processAwards %}
+                            <a>{{ contest.goldAwards|default('-') }} Gold Medal</a>
+                            </br>
+                            <a>{{ contest.silverAwards|default('-') }} Silver Medal</a>
+                            </br>
+                            <a>{{ contest.bronzeAwards|default('-') }} Bronze Medal</a>
+                        {% else %}
+                            <em>none</em>
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
                     <th>Publicly visible</th>
                     <td>{{ contest.public | printYesNo }}</td>
                 </tr>

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -115,10 +115,18 @@
                     <td>
                         {% if contest.processAwards %}
                             <a>{{ contest.goldAwards|default('-') }} Gold Medal</a>
-                            </br>
+                            <br>
                             <a>{{ contest.silverAwards|default('-') }} Silver Medal</a>
-                            </br>
+                            <br>
                             <a>{{ contest.bronzeAwards|default('-') }} Bronze Medal</a>
+                            <br>
+                            {% for category in contest.awardsCategories %}
+                                For all teams from
+                                <a href="{{ path('jury_team_category', {'categoryId': category.categoryid}) }}">
+                                    {{ category.name }}
+                                </a>
+                                <br>
+                            {% endfor %}
                         {% else %}
                             <em>none</em>
                         {% endif %}

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -18,6 +18,13 @@
         {{ form_row(form.unfreezetimeString) }}
         {{ form_row(form.deactivatetimeString) }}
         {{ form_row(form.processBalloons) }}
+        {{ form_row(form.processAwards) }}
+        <div data-awards-field>
+            {{ form_row(form.awardsCategories) }}
+            {{ form_row(form.goldAwards) }}
+            {{ form_row(form.silverAwards) }}
+            {{ form_row(form.bronzeAwards) }}
+        </div>
         {{ form_row(form.public) }}
         {{ form_row(form.openToAllTeams) }}
         <div data-teams-field>
@@ -132,5 +139,16 @@
 
         $('#contest_openToAllTeams_1, #contest_openToAllTeams_0').on('change', showHideTeams);
         showHideTeams();
+
+        function showHideAwards() {
+            if ($('#contest_processAwards_0').is(':checked')) {
+                $('[data-awards-field]').show();
+            } else {
+                $('[data-awards-field]').hide();
+            }
+        }
+
+        $('#contest_processAwards_1, #contest_processAwards_0').on('change', showHideAwards);
+        showHideAwards();
     })
 </script>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -121,15 +121,15 @@
 
         {# process awards color #}
         {% set awardColor = '' %}
-        {% if showLegends and processAwards and score.team.category.name in awardsCategories %}
+        {% if showLegends and processAwards and score.team.category in awardsCategories %}
             {% if goldAwards > 0 %}
-                {% set awardColor = ' gold-medal' %}
+                {% set awardColor = ' gold-award' %}
                 {% set goldAwards = goldAwards - 1 %}
             {% elseif silverAwards > 0 %}
-                {% set awardColor = ' silver-medal' %}
+                {% set awardColor = ' silver-award' %}
                 {% set silverAwards = silverAwards - 1 %}
             {% elseif bronzeAwards > 0 %}
-                {% set awardColor = ' bronze-medal' %}
+                {% set awardColor = ' bronze-award' %}
                 {% set bronzeAwards = bronzeAwards - 1 %}
             {% endif %}
         {% endif %}
@@ -368,14 +368,14 @@
             </tr>
             </thead>
             <tbody>
-                <tr class="gold-medal">
-                    <td>Gold Medal</td>
+                <tr class="gold-award">
+                    <td>Gold Award</td>
                 </tr>
-                <tr class="silver-medal">
-                    <td>Silver Medal</td>
+                <tr class="silver-award">
+                    <td>Silver Award</td>
                 </tr>
-                <tr class="bronze-medal">
-                    <td>Bronze Medal</td>
+                <tr class="bronze-award">
+                    <td>Bronze Award</td>
                 </tr>
             </tbody>
         </table>
@@ -399,16 +399,6 @@
                 {{ cMax }} 96%);
         }
     {% endfor %}
-
-    .gold-medal {
-        background-color: #EEC710
-    }
-    .silver-medal {
-        background-color: #AAA
-    }
-    .bronze-medal {
-        background-color: #C08E55
-    }
 </style>
 <script>
     document.querySelectorAll(".forceWidth:not(.toolong)").forEach(el => {

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -18,6 +18,11 @@
 {% set hasDifferentCategoryColors = scoreboard.categoryColors(limitToTeamIds) %}
 {% set scores = scoreboard.scores | filter(score => limitToTeams is null or score.team.teamid in limitToTeamIds) %}
 {% set problems = scoreboard.problems %}
+{% set processAwards = contest.processAwards %}
+{% set awardsCategories = contest.awardsCategories %}
+{% set goldAwards = contest.goldAwards %}
+{% set silverAwards = contest.silverAwards %}
+{% set bronzeAwards = contest.bronzeAwards %}
 
 {% if maxWidth > 0 %}
     <style>
@@ -114,6 +119,21 @@
             {% set previousTeam = null %}
         {% endif %}
 
+        {# process awards color #}
+        {% set awardColor = '' %}
+        {% if showLegends and processAwards and score.team.category.name in awardsCategories %}
+            {% if goldAwards > 0 %}
+                {% set awardColor = ' gold-medal' %}
+                {% set goldAwards = goldAwards - 1 %}
+            {% elseif silverAwards > 0 %}
+                {% set awardColor = ' silver-medal' %}
+                {% set silverAwards = silverAwards - 1 %}
+            {% elseif bronzeAwards > 0 %}
+                {% set awardColor = ' bronze-medal' %}
+                {% set bronzeAwards = bronzeAwards - 1 %}
+            {% endif %}
+        {% endif %}
+
         {# check whether this is us, otherwise use category colour #}
         {% if myTeamId is defined and myTeamId == score.team.teamid %}
             {% set classes = classes | merge(['scorethisisme']) %}
@@ -122,7 +142,7 @@
             {% set color = score.team.category.color %}
         {% endif %}
         <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}">
-            <td class="scorepl">
+            <td class="scorepl{{awardColor}}">
                 {# Only print rank when score is different from the previous team #}
                 {% if not displayRank %}
                     ?
@@ -339,6 +359,27 @@
             </tbody>
         </table>
     {% endif %}
+
+    {% if processAwards %}
+        <table class="scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+            <thead>
+            <tr>
+                <th scope="col">Awards</th>
+            </tr>
+            </thead>
+            <tbody>
+                <tr class="gold-medal">
+                    <td>Gold Medal</td>
+                </tr>
+                <tr class="silver-medal">
+                    <td>Silver Medal</td>
+                </tr>
+                <tr class="bronze-medal">
+                    <td>Bronze Medal</td>
+                </tr>
+            </tbody>
+        </table>
+    {% endif %}
 {% endif %}
 
 <style>
@@ -358,6 +399,16 @@
                 {{ cMax }} 96%);
         }
     {% endfor %}
+
+    .gold-medal {
+        background-color: #EEC710
+    }
+    .silver-medal {
+        background-color: #AAA
+    }
+    .bronze-medal {
+        background-color: #C08E55
+    }
 </style>
 <script>
     document.querySelectorAll(".forceWidth:not(.toolong)").forEach(el => {


### PR DESCRIPTION
Feature for fixes #1102.

Changes:
- Add award attributes for contest: these attributes could be configured in jury's contest add/edit page.
    -  `process_awards`: Is to process awards for this contest
    -  `contest_team_category_for_awards`: Only teams belonging to these categories can be awarded
    - `gold_awards`: number of gold medals for awards
    - `silver_awards`: number of silver medals for awards
    -  `bronze_awards`: number of bronze medals for awards
- Render awards' color on scoreboard if `process_awards=True`

Here are some Pictures for these feature:
- Awards in scoreboard
![2](https://user-images.githubusercontent.com/29372915/121727445-7f4ad480-cb1e-11eb-829e-f38ad3b75103.png)
![1](https://user-images.githubusercontent.com/29372915/121727437-7bb74d80-cb1e-11eb-963a-57ba2c69b1fb.png)
- Configuration in jury pages
![5](https://user-images.githubusercontent.com/29372915/121727524-9c7fa300-cb1e-11eb-94b4-0d198fe0c888.png)
![4](https://user-images.githubusercontent.com/29372915/121727460-840f8880-cb1e-11eb-9d1b-46af67465a92.png)
![6](https://user-images.githubusercontent.com/29372915/121727527-9e496680-cb1e-11eb-885a-b8b003fa8f00.png)
![3](https://user-images.githubusercontent.com/29372915/121727454-8245c500-cb1e-11eb-8991-16c84ee89d71.png)


