### PR TITLE
Warn role user

### DIFF
--- a/webapp/src/Controller/RootController.php
+++ b/webapp/src/Controller/RootController.php
@@ -45,6 +45,10 @@ class RootController extends BaseController
                 return $this->redirectToRoute('jury_balloons');
             }
         }
+        $this->addFlash(
+            'danger',
+            'Your user has no DOMjudge roles, you are deauthenticated.'
+        );
         return $this->redirectToRoute('public_index');
     }
 }


### PR DESCRIPTION
As reported by Azeeto in Slack,

When someone has no roles in DOMjudge but does a login (s)he is redirected to public. This only adds a warning explaining this behaviour.