### PR TITLE
Move Unit tests to dedicated folder

### DIFF
--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -322,7 +322,7 @@ class GeneralInfoController extends AbstractFOSRestController
         $flagFile = sprintf('%s/public/flags/%s/%s.svg', $this->dj->getDomjudgeWebappDir(), $size, $alpha2code);
 
         if (!file_exists($flagFile)) {
-            throw new NotFoundHttpException("country flag for $alpha3code not found");
+            throw new NotFoundHttpException("country flag for $alpha3code of size $size not found");
         }
 
         $response = new BinaryFileResponse($flagFile, 200, [], true, null, true);

--- a/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
@@ -41,9 +41,9 @@ class GeneralInfoControllerTest extends BaseTest
     }
 
     /**
-     * Test that when a country flag does not exist, the correct message is returned
+     * Test that when a country flag of given size does not exist, the correct message is returned
      *
-     * @dataProvider provideCountryFlagNotFound
+     * @dataProvider provideCountryFlagSizeNotFound
      */
     public function testCountryFlagNotFound(string $countryCode, string $size)
     {
@@ -51,19 +51,39 @@ class GeneralInfoControllerTest extends BaseTest
         /** @var BinaryFileResponse $response */
         $response = $this->client->getResponse();
         static::assertEquals(404, $response->getStatusCode());
-        static::assertEquals('country flag not found', json_decode($response->getContent(), true)['message']);
+        static::assertEquals(sprintf('country flag for %s of size %s not found', strtoupper($countryCode), $size), json_decode($response->getContent(), true)['message']);
+    }
+
+    public function provideCountryFlagSizeNotFound(): Generator
+    {
+        yield ['NLD', '2x2'];
+        yield ['nld', '2x2'];
+    }
+
+    /**
+     * Test that when a country does not exist, the correct message is returned
+     *
+     * @dataProvider provideCountryFlagNotFound
+     */
+    public function testCountryNotFound(string $countryCode, string $size)
+    {
+        $this->client->request('GET', "/api/country-flags/$countryCode/$size.svg");
+        /** @var BinaryFileResponse $response */
+        $response = $this->client->getResponse();
+        static::assertEquals(404, $response->getStatusCode());
+        static::assertEquals(sprintf('country %s does not exist', strtoupper($countryCode)), json_decode($response->getContent(), true)['message']);
     }
 
     public function provideCountryFlagNotFound(): Generator
     {
         yield ['ABC', '4x3'];
         yield ['XX', '1x1'];
-        yield ['NLD', '2x2'];
         yield ['this is not a flag', '4x3'];
+        yield ['THIS IS NOT A FLAG', '4x3'];
     }
 
     /**
-     * Test that if flags are disable, no flag is returned
+     * Test that if flags are disabled, no flag is returned
      *
      * @dataProvider provideCountryFlagExists
      */
@@ -74,7 +94,7 @@ class GeneralInfoControllerTest extends BaseTest
             /** @var BinaryFileResponse $response */
             $response = $this->client->getResponse();
             static::assertEquals(404, $response->getStatusCode());
-            static::assertEquals('country flag not found', json_decode($response->getContent(), true)['message']);
+            static::assertEquals('country flags disabled', json_decode($response->getContent(), true)['message']);
         });
     }
 }

--- a/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
-namespace App\Tests\Controller\API;
+namespace App\Tests\Unit\Controller\API;
 
 use App\Service\DOMJudgeService;
-use App\Tests\BaseTest;
+use App\Tests\Unit\BaseTest;
 use Generator;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\Intl\Countries;

--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace App\Tests\Controller\API;
+namespace App\Tests\Unit\Controller\API;
 
 use App\DataFixtures\Test\SampleAffilicationsFixture;
 


### PR DESCRIPTION
I think this was introduced from a PR which was opened before the split of E2E and Unit.