### PR TITLE
Reorder CI jobs to start the slowest job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,8 +159,8 @@ visual_main:
         ROLE: [none,jury,admin,balloon,team]
   script:
     - git fetch
-    - git checkout -B master origin/master
-    - git branch --set-upstream-to=origin/master master
+    - git checkout -B main origin/main
+    - git branch --set-upstream-to=origin/main main
     - git pull
     - git checkout $CI_COMMIT_SHA -- gitlab/visualpr.sh # Always compare with the same tests
     - git checkout $CI_COMMIT_SHA -- gitlab/default-nginx

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,21 +2,26 @@ variables:
   SAST_DEFAULT_ANALYZERS: "flawfinder, phpcs-security-audit, eslint, secrets"
 
 stages:
-  - test
+  - visual_pre
   - compare
-
+  - accessibility
+  - test
+  - sast
+ 
 include:
   - template: Dependency-Scanning.gitlab-ci.yml
   - template: SAST.gitlab-ci.yml
   - template: License-Scanning.gitlab-ci.yml
 
 .retry_config: &retry_job
+  needs: []
   retry:
     max: 0 #Max is 2, set when gitlab is flacky
     when:
       - always
 
 .retry_config: &matrix_retry_job
+  needs: []
   retry:
     max: 2 #Max is 2, set when gitlab is flacky
     when:
@@ -48,7 +53,7 @@ webstandard_check_role:
         TEST: [w3cval,WCAG2A,WCAG2AA,Section508]
       - ROLE: jury
         TEST: [w3cval]
-  stage: test
+  stage: accessibility
   image: domjudge/gitlabci:2.1
   services:
     - mariadb
@@ -112,7 +117,7 @@ run unit tests:
 visual_pr:
   <<: *retry_job
   <<: *long_job
-  stage: test
+  stage: visual_pre
   image: domjudge/gitlabci:2.1
   services:
     - mariadb
@@ -138,7 +143,7 @@ visual_pr:
 visual_main:
   <<: *retry_job
   <<: *long_job
-  stage: test
+  stage: visual_pre
   image: domjudge/gitlabci:2.1
   services:
     - mariadb


### PR DESCRIPTION
If we change the SAST jobs to only start in the sast stage we would trigger the tests failing most often faster to keep a balance between full testing and getting response on possible issues with the PR.

The needs: [] sorts the jobs in such a way that a stage does not have to finish but can already start jobs from a next stage.