### PR TITLE
Fix CID: 1405295

### DIFF
--- a/judge/runpipe.cc
+++ b/judge/runpipe.cc
@@ -226,6 +226,7 @@ void resize_pipe(int fd)
 		if ( fscanf(f, "%d", &max_pipe_size)!=1 ) {
 			max_pipe_size = -2;
 			warning(errno, "could not read from '%s'", PROC_MAX_PIPE_SIZE);
+			if ( fclose(f)!=0 ) warning(errno, "could not close '%s'", PROC_MAX_PIPE_SIZE);
 			return;
 		}
 		if ( fclose(f)!=0 ) {


### PR DESCRIPTION
The filedescriptor is left open when the program exits. If closing fails
the code will now only warn as trying to fix this at this point (in a
failure) makes little sense.