### PR TITLE
Re-order CI stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,12 @@ variables:
 
 stages:
   - visual_pre
+  - integration
   - compare
   - accessibility
   - test
-  - sast
+  - unit
+  - style
  
 include:
   - template: Security/Secret-Detection.gitlab-ci.yml
@@ -15,29 +17,35 @@ include:
   - template: License-Scanning.gitlab-ci.yml
 
 .retry_config: &retry_job
-  needs: []
   retry:
     max: 0 #Max is 2, set when gitlab is flacky
     when:
       - always
 
 .retry_config: &matrix_retry_job
-  needs: []
   retry:
     max: 2 #Max is 2, set when gitlab is flacky
     when:
       - always
 
+.clean_ordering: &clean_ordering
+  needs: []
+# These seem to be overwritten when a job actually specifies these
+
 .retry_time: &tiny_job
+  <<: *clean_ordering
   timeout: 3m
 
 .retry_time: &short_job
+  <<: *clean_ordering
   timeout: 7m
 
 .retry_time: &normal_job
+  <<: *clean_ordering
   timeout: 15m
 
 .retry_time: &long_job
+  <<: *clean_ordering
   timeout: 25m
 # Due to the retry this will be worst case 3*timeout before the job fails
 
@@ -73,7 +81,7 @@ webstandard_check_role:
 check syntax:
   <<: *retry_job
   <<: *short_job
-  stage: test
+  stage: style
   image: domjudge/gitlabci:2.1
   script:
     - ./gitlab/syntax.sh
@@ -81,7 +89,7 @@ check syntax:
 check static codecov:
   <<: *retry_job
   <<: *tiny_job
-  stage: test
+  stage: style
   script:
     - curl -s https://codecov.io/bash > newcodecov
     - diff newcodecov gitlab/uploadcodecov.sh
@@ -89,7 +97,7 @@ check static codecov:
 run unit tests:
   <<: *retry_job
   <<: *normal_job
-  stage: test
+  stage: unit
   image: domjudge/gitlabci:2.1
   # Disabled for now as it drastically speeds up running unit tests and we don't use it yet
   # before_script:
@@ -193,7 +201,7 @@ visual_compare:
 .job_template: &job_integration
   <<: *retry_job
   <<: *long_job
-  stage: test
+  stage: integration
   image: domjudge/gitlabci:2.1
   variables:
     MYSQL_ROOT_PASSWORD: password
@@ -230,7 +238,7 @@ integration_mariadb:
 
 phpcs_compatibility:
   <<: *tiny_job
-  stage: test
+  stage: style
   image: pipelinecomponents/php-codesniffer:latest
   before_script:
     - set -euxo pipefail
@@ -255,7 +263,7 @@ phpcs_compatibility:
 # This finds different problems from codesniffer
 php linter:
   <<: *tiny_job
-  stage: test
+  stage: style
   image: pipelinecomponents/php-linter:latest
   script:
     - ls
@@ -271,6 +279,7 @@ php linter:
 
 php-cs-fixer:
   <<: *tiny_job
+  stage: style
   image:
     name: cytopia/php-cs-fixer
     entrypoint: [""]
@@ -283,4 +292,3 @@ php-cs-fixer:
   script:
     - /usr/bin/php-cs-fixer fix --format=gitlab --dry-run --diff . > code-quality.json || true
     - cp code-quality.json code_quality_debug.json
-


### PR DESCRIPTION
The standard configuration puts the SAST scans in the test stage, by
labeling the other stages we can add the needs: [] to start the jobs
earlier while also reordering longer jobs in the beginning.