### PR TITLE
Dependa security indirect

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 0
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
     allow:
         - dependency-type: "all"
   - package-ecosystem: "composer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,14 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 0
     versioning-strategy: lockfile-only
+    allow:
+        - dependency-type: "all"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0
     versioning-strategy: lockfile-only
+    allow:
+        - dependency-type: "all"
     target-branch: "7.3"


### PR DESCRIPTION
The lockfile change might be to early as the coverage is currently lowish
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy

The allow should now target more: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow but should stay (if the 2nd commit is not applied)