### PR TITLE
Section508 is removed from pa11y

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,11 +55,11 @@ webstandard_check_role:
   parallel:
     matrix:
       - ROLE: public
-        TEST: [w3cval,WCAG2A,WCAG2AA,Section508]
+        TEST: [w3cval,WCAG2A,WCAG2AA]
       - ROLE: team
-        TEST: [w3cval,WCAG2A,WCAG2AA,Section508]
+        TEST: [w3cval,WCAG2A,WCAG2AA]
       - ROLE: balloon
-        TEST: [w3cval,WCAG2A,WCAG2AA,Section508]
+        TEST: [w3cval,WCAG2A,WCAG2AA]
       - ROLE: jury
         TEST: [w3cval]
   stage: accessibility


### PR DESCRIPTION
Mentioned here:
https://github.com/pa11y/pa11y/commit/2544d316fefd35e2c6f5c56b1c28a92a98650934

PR just to get the number.