### PR TITLE
Remount build directory for shared gitlab-runners

### DIFF
--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -82,6 +82,13 @@ cd ${DIR}/submit
 make check-full
 section_end submit_client
 
+section_start mount "Show runner mounts"
+mount
+# Currently gitlab has some runners with noexec/nodev,
+# This can be removed if we have more stable runners.
+mount -o remount,exec,dev /builds
+section_end mount
+
 section_start judgehost "Configure judgehost"
 cd /opt/domjudge/judgehost/
 sudo cp /opt/domjudge/judgehost/etc/sudoers-domjudge /etc/sudoers.d/


### PR DESCRIPTION
Some of the current gitlab runners have the /build with nodev,noexec
which breaks the chroot installation. Remounting is currently still
allowed. For debugging the mount table is added.