### PR TITLE
Dont measure coverage over content

### DIFF
--- a/webapp/phpunit.xml.dist
+++ b/webapp/phpunit.xml.dist
@@ -31,6 +31,7 @@
             <directory suffix=".php">src</directory>
             <exclude>
                 <directory suffix=".php">src/Migrations</directory>
+                <directory suffix=".php">src/DataFixtures</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
See: https://phpunit.de/manual/6.5/en/appendixes.configuration.html
Coverage over the Fixtures makes little sense as we use those as part of
the tests. We already indirect check if we get the needed content in the
actual tests.

I expect that the coverage should now go up.