### PR TITLE
Improve test coverage api

### DIFF
--- a/webapp/src/Controller/API/ProblemController.php
+++ b/webapp/src/Controller/API/ProblemController.php
@@ -95,9 +95,11 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
 
             $objects = [];
             foreach ($ordinalArray->getItems() as $item) {
-                /** @var ContestProblemWrapper $contestProblemWrapper */
-                $contestProblemWrapper = $item->getItem();
-                $contestProblem        = $contestProblemWrapper->getContestProblem();
+                /** @var ContestProblemWrapper|ContestProblem $contestProblem */
+                $contestProblem = $item->getItem();
+                if ($contestProblem instanceof ContestProblemWrapper) {
+                    $contestProblem = $contestProblem->getContestProblem();
+                }
                 $probid                = $this->getIdField() === 'p.probid' ? $contestProblem->getProbid() : $contestProblem->getExternalId();
                 if (in_array($probid, $ids)) {
                     $objects[] = $item;

--- a/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class AwardsControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'awards';
+
+    protected static $skipMessageIDs = "Filtering on IDs not implemented in this endpoint.";
+
+    /**
+     * In the default test setup there are no judgings yet and one team.
+     * This means that there's only the winner/gold award.
+     */
+    protected $expectedObjects = [
+            'winner' => ["id" => "winner", "citation" => "Contest winner", "team_ids" => [2]],
+            'gold-medal' => ["id" => "gold-medal", "citation" => "Gold medal winner", "team_ids" => [2]],
+    ];
+
+    protected $expectedAbsent = ['bronze-medal', 'first-to-solve'];
+
+    public function testListWithIds(): void {
+        static::markTestSkipped(static::$skipMessageIDs);
+    }
+
+    public function testListWithIdsNotArray(): void {
+        static::markTestSkipped(static::$skipMessageIDs);
+    }
+
+    public function testListWithAbsentIds(): void {
+        static::markTestSkipped(static::$skipMessageIDs);
+    }
+
+}

--- a/webapp/tests/Unit/Controller/API/BalloonsControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/BalloonsControllerTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+use Generator;
+
+class BalloonsControllerTest extends BaseTest
+{
+    /**
+     * In the default test setup there are no judgings yet so no balloons
+     */
+    public function testBalloonsNoJudgings()
+    {
+        $contestId = $this->getDemoContestId();
+
+        $response = $this->verifyApiJsonResponse('GET', "/contests/$contestId/balloons", 200, 'admin');
+
+        static::assertEquals([], $response);
+    }
+
+    public function testBalloonsNoJudgingsToDo()
+    {
+        $contestId = $this->getDemoContestId();
+
+        $response = $this->verifyApiJsonResponse('GET', "/contests/$contestId/balloons?todo=1", 200, 'admin');
+
+        static::assertEquals([], $response);
+    }
+
+    /**
+     * @dataProvider provideUnprivilegedUsers
+     */
+    public function testBalloonsAccessForPrivilegedUsersOnly(?string $user, int $result)
+    {
+        $contestId = $this->getDemoContestId();
+
+        $this->verifyApiJsonResponse('GET', "/contests/$contestId/balloons", $result, $user);
+    }
+
+    public function provideUnprivilegedUsers(): Generator
+    {
+        yield [null, 401];
+        yield ['demo', 403];
+    }
+}

--- a/webapp/tests/Unit/Controller/API/BaseTest.php
+++ b/webapp/tests/Unit/Controller/API/BaseTest.php
@@ -10,7 +10,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 abstract class BaseTest extends BaseBaseTest
 {
-    protected static $rootEndpoints = ['contests','judgehosts'];
+    protected static $rootEndpoints = ['contests','judgehosts','users'];
     
     /** @var KernelBrowser */
     protected $client;
@@ -341,6 +341,9 @@ abstract class BaseTest extends BaseBaseTest
     {
         if (($apiEndpoint = $this->apiEndpoint) === null) {
             static::markTestSkipped('No endpoint defined');
+        }
+        if (in_array($apiEndpoint, static::$rootEndpoints)) {
+            static::markTestSkipped('Endpoint does not have contests prefix');
         }
         // Note that the 42 and 123 here is a contest that doesn't exist
         if ($apiEndpoint === 'contests') {

--- a/webapp/tests/Unit/Controller/API/BaseTest.php
+++ b/webapp/tests/Unit/Controller/API/BaseTest.php
@@ -366,7 +366,6 @@ abstract class BaseTest extends BaseBaseTest
             static::markTestSkipped('No endpoint defined');
         }
         $url = $this->helperGetEndpointURL($apiEndpoint,$id);
-        var_dump($url);
         $this->verifyApiJsonResponse('GET', $url, 404, $this->apiUser);
     }
 

--- a/webapp/tests/Unit/Controller/API/BaseTest.php
+++ b/webapp/tests/Unit/Controller/API/BaseTest.php
@@ -345,16 +345,13 @@ abstract class BaseTest extends BaseBaseTest
         if (in_array($apiEndpoint, static::$rootEndpoints)) {
             static::markTestSkipped('Endpoint does not have contests prefix');
         }
-        // Note that the 42 and 123 here is a contest that doesn't exist
-        if ($apiEndpoint === 'contests') {
-            $url = '/contests/42';
-            $message = 'Object with ID \'42\' not found';
-        } else {
-            $url = "/contests/42/$apiEndpoint/123";
-            $message = 'Contest with ID \'42\' not found';
-        }
-        $respone = $this->verifyApiJsonResponse('GET', $url, 404, $this->apiUser);
-        static::assertEquals($message, $respone['message']);
+
+        // Note that the 42 here is a contest that doesn't exist
+        $url = "/contests/42/$apiEndpoint/123";
+        $message = 'Contest with ID \'42\' not found';
+
+        $response = $this->verifyApiJsonResponse('GET', $url, 404, $this->apiUser);
+        static::assertEquals($message, $response['message']);
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/ExecutableControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ExecutableControllerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+use App\Service\DOMJudgeService;
+
+class ExecutableControllerTest extends BaseTest
+{
+    /**
+     * Test that a non logged in user can not access the executables
+     */
+    public function testExecutablesNoAnonAccess()
+    {
+        $this->verifyApiResponse('GET', "/executables/compare", 401);
+    }
+
+    /**
+     * Test that a team user can not access the executables
+     */
+    public function testExecutablesNoTeamAccess()
+    {
+        $this->verifyApiResponse('GET', "/executables/compare", 403, 'demo');
+    }
+
+    /**
+     * Test that a non-existant executable can not be fetched
+     */
+    public function testExecutablesDoesNotExist()
+    {
+        $this->verifyApiResponse('GET', "/executables/volare", 404, 'admin');
+    }
+
+    /**
+     * Test that an executable can be fetched
+     */
+    public function testFetchExecutable()
+    {
+        $response = $this->verifyApiJsonResponse('GET', "/executables/compare", 200, 'admin');
+        $contents = $this->base64unzip($response);
+
+        static::assertArrayHasKey('build', $contents);
+        static::assertStringContainsString('g++ -g', $contents['build']);
+        static::assertArrayHasKey('compare.cc', $contents);
+        static::assertStringContainsString("Space!  Can't live with it, can't live without it", $contents['compare.cc']);
+    }
+
+    protected function base64unzip(string $content): array
+    {
+        $decoded = base64_decode($content, true);
+
+        $zip = new \ZipArchive();
+        $tempFilename = tempnam(static::$container->get(DOMJudgeService::class)->getDomjudgeTmpDir(), "api-executables-test-");
+        file_put_contents($tempFilename, $decoded);
+
+        $zip->open($tempFilename);
+        $return = [];
+        for($i = 0; $i < $zip->count(); ++$i) {
+            $return[$zip->getNameIndex($i)] = $zip->getFromIndex($i); 
+        }
+        $zip->close();
+
+        unlink($tempFilename);
+        return $return;
+    }
+
+
+}

--- a/webapp/tests/Unit/Controller/API/JudgehostControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/JudgehostControllerTest.php
@@ -42,10 +42,6 @@ class JudgehostControllerTest extends BaseTest
         }
     }
 
-    public function testSingleContestNotFound(): void {
-        static::markTestSkipped('No API relation between contest and judgehost.');
-    }
-
     /**
      * Test that the endpoint returns an empty list for objects that don't exist
      *

--- a/webapp/tests/Unit/Controller/API/JudgementTypesControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/JudgementTypesControllerTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class JudgementTypesControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'judgement-types';
+
+    protected $expectedObjects = [
+        'AC' => [
+            'id'        => 'AC',
+            'name'      => 'correct',
+            'penalty'   => false,
+            'solved'    => true,
+        ],
+        'WA' => [
+            'id'        => 'WA',
+            'name'      => 'wrong answer',
+            'penalty'   => true,
+            'solved'    => false,
+        ],
+        'CE' => [
+            'id'        => 'CE',
+            'name'      => 'compiler error',
+            'penalty'   => false,
+            'solved'    => false,
+        ],
+    ];
+
+    protected $expectedAbsent = ['nonexistent'];
+
+    public function testJudgementTypeChangedPenalty()
+    {
+        $this->withChangedConfiguration('compile_penalty', true, function () {
+            $contestId = $this->getDemoContestId();
+            $endpointId = $this->apiEndpoint;
+
+            $response = $this->verifyApiJsonResponse('GET', "/contests/$contestId/$endpointId/CE", 200);
+
+            $expected = ["id" => "CE", "name" => "compiler error", "penalty" => true, "solved" => false];
+            static::assertEquals($expected, $response);
+        });
+    }
+}

--- a/webapp/tests/Unit/Controller/API/ProblemControllerAdminTest.php
+++ b/webapp/tests/Unit/Controller/API/ProblemControllerAdminTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class ProblemControllerAdminTest extends ProblemControllerTest
+{
+    protected $apiUser = 'admin';
+
+    protected function setUp(): void
+    {
+        // When queried as admin, extra information is returned about each problem
+        $this->expectedObjects[1]['test_data_count'] = 1;
+        $this->expectedObjects[2]['test_data_count'] = 3;
+        $this->expectedObjects[3]['test_data_count'] = 1;
+        parent::setUp();
+    }
+}

--- a/webapp/tests/Unit/Controller/API/ProblemControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ProblemControllerTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class ProblemControllerTest extends BaseTest
+{
+    /* This tests with the anonymous user;
+       for tests with the admin user see ProblemControllerAdminTest.
+     */
+
+    protected $apiEndpoint = 'problems';
+
+    protected $expectedObjects = [
+      3 => [
+        "ordinal" => 0,
+        "id" => "3",
+        "short_name" => "boolfind",
+        "label" => "boolfind",
+        "time_limit" => 5,
+        "externalid" => "boolfind",
+        "name" => "Boolean switch search",
+        "rgb" => "#32CD32",
+        "color" => "limegreen",
+      ],
+      2 => [
+        "ordinal" => 1,
+        "id" => "2",
+        "short_name" => "fltcmp",
+        "label" => "fltcmp",
+        "time_limit" => 5,
+        "externalid" => "fltcmp",
+        "name" => "Float special compare test",
+        "rgb" => "#FFFF00",
+        "color" => "yellow",
+      ],
+      1 => [
+        "ordinal" => 2,
+        "id" => "1",
+        "short_name" => "hello",
+        "label" => "hello",
+        "time_limit" => 5,
+        "externalid" => "hello",
+        "name" => "Hello World",
+        "rgb" => "#FF00FF",
+        "color" => "magenta",
+      ],
+    ];
+
+    protected $expectedAbsent = ['4242', 'nonexistent'];
+
+}

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+class UserControllerTest extends BaseTest
+{
+    protected $apiEndpoint = 'users';
+
+    protected $apiUser = 'admin';
+
+    protected $expectedObjects = [
+        1 => [
+            "team" => "DOMjudge",
+            "roles" => [
+                "admin",
+                "team"
+            ],
+            "id" => "1",
+            "username" => "admin",
+            "name" => "Administrator",
+            "email" => null,
+            "last_ip" => "127.0.0.1",
+            "ip" => null,
+            "enabled" => true
+        ],
+        2 => [
+            "team" => null,
+            "roles" => [
+                "judgehost"
+            ],
+            "id" => "2",
+            "username" => "judgehost",
+            "name" => "User for judgedaemons",
+            "email" => null,
+            "last_ip" => "127.0.0.1",
+            "ip" => null,
+            "enabled" => true
+        ],
+        3 => [
+            "team" => "Example teamname",
+            "roles" => [
+                 "team"
+            ],
+            "id" => "3",
+            "username" => "demo",
+            "name" => "demo user for example team",
+            "email" => null,
+            "last_ip" => null,
+            "ip" => null,
+            "enabled" => true
+        ],
+    ];
+
+    protected $expectedAbsent = ['4242', 'nonexistent'];
+
+}

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -19,7 +19,6 @@ class UserControllerTest extends BaseTest
             "username" => "admin",
             "name" => "Administrator",
             "email" => null,
-            "last_ip" => "127.0.0.1",
             "ip" => null,
             "enabled" => true
         ],
@@ -32,7 +31,6 @@ class UserControllerTest extends BaseTest
             "username" => "judgehost",
             "name" => "User for judgedaemons",
             "email" => null,
-            "last_ip" => "127.0.0.1",
             "ip" => null,
             "enabled" => true
         ],
@@ -45,7 +43,6 @@ class UserControllerTest extends BaseTest
             "username" => "demo",
             "name" => "demo user for example team",
             "email" => null,
-            "last_ip" => null,
             "ip" => null,
             "enabled" => true
         ],


### PR DESCRIPTION
The tests for balloons and awards are limited because we do not yet have completed judgings in the fixtures.