### PR TITLE
Use bats-assert and bats-support for easier checks.

### DIFF
--- a/submit/assert.bash
+++ b/submit/assert.bash
@@ -1,0 +1,72 @@
+# Inspired by https://github.com/ztombol/bats-assert.
+
+fail()
+{
+    local -r expected="$1"
+    { 
+        echo "Expected: '$expected'"
+	echo "Output:"
+	for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+		echo "${lines[$idx]}"
+	done
+    } >&2
+    return 1
+}
+
+assert_line() {
+    local -r expected="$1"
+    for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$expected" ]]; then
+	    return 0
+	fi
+    done
+    fail "$expected"
+}
+
+refute_line() {
+    local -r unexpected="$1"
+    for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$unexpected" ]]; then
+	    echo "Unexpected string '$unexpected' found."
+	    return 1
+	fi
+    done
+    return 0
+}
+
+assert_regex() {
+    local -r expected="$1"
+    for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} =~ $expected ]]; then
+	    return 0
+	fi
+    done
+    fail "$expected"
+}
+
+assert_partial() {
+    local -r expected="$1"
+    for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == *"$expected"* ]]; then
+	    return 0
+	fi
+    done
+    fail "$expected"
+}
+
+assert_success() {
+    if (( status != 0 )); then
+	echo "Expected success, status=$status."
+        return 1
+    fi
+    return 0
+}
+
+assert_failure() {
+    local -r expected_exit_code="$1"
+    if (( status != "$expected_exit_code" )); then
+	echo "Expected failure with exit code = $expected_exit_code, status=$status."
+        return 1
+    fi
+    return 0
+}

--- a/submit/submit_online.bats
+++ b/submit/submit_online.bats
@@ -3,6 +3,8 @@
 # These tests assume presence of a running DOMjudge instance at the
 # baseurl specified in the `paths.mk` file one directory up.
 
+load 'assert'
+
 setup() {
     export SUBMITCONTEST="demo"
     export SUBMITBASEURL="$(grep '^BASEURL' ../paths.mk | tr -s ' ' | cut -d ' ' -f 3)"
@@ -10,90 +12,93 @@ setup() {
 
 @test "contest via parameter overrides environment" {
     run ./submit -c bestaatniet
-    echo $output | grep "error: no (valid) contest specified"
+    assert_failure 1
+    assert_partial "error: no (valid) contest specified"
+
     run ./submit --contest=bestaatookniet
-    echo $output | grep "error: no (valid) contest specified"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_partial "error: no (valid) contest specified"
 }
 
 @test "hello problem id and name are in help output" {
     run ./submit --help
-    echo $output | grep "hello *- *Hello World"
-    [ "$status" -eq 0 ]
+    assert_success
+    assert_regex "hello *- *Hello World"
 }
 
 @test "languages and extensions are in help output" {
     run ./submit --help
-    echo $output | grep "C: *c"
-    echo $output | grep "C++: *c++, cc, cpp, cxx"
-    echo $output | grep "Java: *java"
+    assert_success
+    assert_regex "C: *c"
+    assert_regex "C\+\+: *c\+\+, cc, cpp, cxx"
+    assert_regex "Java: *java"
 }
 
 @test "stale file emits warning" {
     touch -d '2000-01-01' $BATS_TMPDIR/test-hello.c
     run ./submit -p hello $BATS_TMPDIR/test-hello.c <<< "n"
-    echo $output | grep "test-hello.c' has not been modified for [0-9]* minutes!"
+    assert_regex "test-hello.c' has not been modified for [0-9]* minutes!"
 }
 
 @test "recent file omits warning" {
     touch $BATS_TMPDIR/test-hello.c
     run ./submit -p hello $BATS_TMPDIR/test-hello.c <<< "n"
-    echo $output | grep -v "test-hello.c' has not been modified for [0-9]* minutes!"
+    refute_line -e "test-hello.c' has not been modified for [0-9]* minutes!"
 }
 
 @test "binary file emits warning" {
     cp $(which bash) $BATS_TMPDIR/binary.c
     run ./submit -p hello $BATS_TMPDIR/binary.c <<< "n"
-    echo $output | grep "binary.c' is detected as binary/data!"
+    assert_partial "binary.c' is detected as binary/data!"
 }
 
 @test "empty file emits warning" {
     touch $BATS_TMPDIR/empty.c
     run ./submit -p hello $BATS_TMPDIR/empty.c <<< "n"
-    echo $output | grep "empty.c' is empty"
+    assert_partial "empty.c' is empty"
 }
 
 @test "detect problem name and language" {
     cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
     run ./submit $BATS_TMPDIR/hello.java <<< "n"
-    [ "${lines[0]}" = "Submission information:" ]
-    [ "${lines[3]}" = "  problem:     hello" ]
-    [ "${lines[4]}" = "  language:    Java" ]
+    assert_line "Submission information:"
+    assert_line "  problem:     hello"
+    assert_line "  language:    Java"
 }
 
 @test "options override detection of problem name and language" {
     cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
     run ./submit -p boolfind -l cpp $BATS_TMPDIR/hello.java <<< "n"
-    [ "${lines[0]}" = "Submission information:" ]
-    [ "${lines[3]}" = "  problem:     boolfind" ]
-    [ "${lines[4]}" = "  language:    C++" ]
+    assert_line "Submission information:"
+    assert_line "  problem:     boolfind"
+    assert_line "  language:    C++"
 }
 
 @test "non existing problem name emits erorr" {
     cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
     run ./submit -p nonexistent -l cpp $BATS_TMPDIR/hello.java <<< "n"
-    echo $output | grep "error: no known problem specified or detected"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_partial "error: no known problem specified or detected"
 }
 
 @test "non existing language name emits erorr" {
     cp ../tests/test-hello.java $BATS_TMPDIR/hello.java
     run ./submit -p boolfind -l nonexistent $BATS_TMPDIR/hello.java <<< "n"
-    echo $output | grep "error: no known language specified or detected"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_partial "error: no known language specified or detected"
 }
 
 @test "detect entry point Java" {
     skip "Java does not require an entry point in the default installation"
     run ./submit -p hello ../tests/test-hello.java <<< "n"
-    echo "$output" | grep '  entry point: test-hello'
+    assert_line '  entry point: test-hello'
 }
 
 @test "detect entry point Python" {
     skip "Python does not require an entry point in the default installation"
     touch $BATS_TMPDIR/test-extra.py
     run ./submit -p hello ../tests/test-hello.py $BATS_TMPDIR/test-extra.py <<< "n"
-    echo "$output" | grep '  entry point: test-hello.py'
+    assert_line '  entry point: test-hello.py'
 }
 
 @test "detect entry point Kotlin" {
@@ -102,29 +107,31 @@ setup() {
         skip "Kotlin not enabled"
     fi
     run ./submit -p hello ../tests/test-hello.kt <<< "n"
-    echo "$output" | grep '  entry point: Test_helloKt'
+    assert_line '  entry point: Test_helloKt'
 }
 
 @test "options override entry point" {
     run ./submit -p hello -e Main ../tests/test-hello.java <<< "n"
-    echo "$output" | grep '  entry point: Main'
+    assert_line '  entry point: Main'
+
     run ./submit -p hello --entry_point=mypackage.Main ../tests/test-hello.java <<< "n"
-    echo "$output" | grep '  entry point: mypackage.Main'
+    assert_line '  entry point: mypackage.Main'
 }
 
 @test "accept multiple files" {
     cp ../tests/test-hello.java ../tests/test-classname.java ../tests/test-package.java $BATS_TMPDIR/
     run ./submit -p hello $BATS_TMPDIR/test-*.java <<< "n"
-    [ "${lines[1]}" = "  filenames:   $BATS_TMPDIR/test-classname.java $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java" ]
+    assert_line "  filenames:   $BATS_TMPDIR/test-classname.java $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java"
 }
 
 @test "deduplicate multiple files" {
     cp ../tests/test-hello.java ../tests/test-package.java $BATS_TMPDIR/
     run ./submit -p hello $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java <<< "n"
-    [ "${lines[1]}" = "  filenames:   $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java" ]
+    assert_line "  filenames:   $BATS_TMPDIR/test-hello.java $BATS_TMPDIR/test-package.java"
 }
 
 @test "submit solution" {
     run ./submit -y -p hello ../tests/test-hello.c
-    echo $output | grep "Submission received, id = s[0-9]*"
+    assert_success
+    assert_regex "Submission received, id = s[0-9]*"
 }

--- a/submit/submit_standalone.bats
+++ b/submit/submit_standalone.bats
@@ -1,66 +1,73 @@
 #!/usr/bin/env bats
+# These tests can be run without a working DOMjudge API endpoint.
 
-# These tests can be run without a working DOMjudge api endpoint.
-
-@test "version output" {
-    run ./submit --version
-    [ "$status" -eq 0 ]
-    echo "${lines[0]}" | grep "^submit -- part of DOMjudge"
-    [ "${lines[1]}" = "Written by the DOMjudge developers" ]
-}
+load 'assert'
 
 setup() {
     export SUBMITBASEHOST="domjudge.example.org"
     export SUBMITBASEURL="https://${SUBMITBASEHOST}/somejudge"
 }
 
+@test "version output" {
+    run ./submit --version
+    assert_success
+    assert_regex "^submit -- part of DOMjudge"
+    assert_line "Written by the DOMjudge developers"
+}
+
 @test "baseurl set in environment" {
     run ./submit
-    echo $output | grep -E "$SUBMITBASEHOST.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_regex "$SUBMITBASEHOST.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
 }
 
 @test "baseurl via parameter overrides environment" {
     run ./submit --url https://domjudge.example.edu
-    echo $output | grep -E "domjudge.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
+    assert_failure 1
+    assert_regex "domjudge.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
+
     run ./submit -u https://domjudge3.example.edu
-    echo $output | grep -E "domjudge3.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_regex "domjudge3.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
 }
 
 @test "baseurl can end in slash" {
     run ./submit --url https://domjudge.example.edu/domjudge/
-    echo $output | grep -E "domjudge.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
-    [ "$status" -eq 1 ]
+    assert_failure 1
+    assert_regex "domjudge.example.edu.*/api(/.*)?/contests.*: \[Errno -2\] Name or service not known"
 }
 
 @test "display basic usage information" {
     run ./submit --help
-    [ "${lines[1]}" = "usage: submit [--version] [-h] [-c CONTEST] [-p PROBLEM] [-l LANGUAGE] [-e ENTRY_POINT]" ]
-    [ "${lines[2]}" = "              [-v [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]] [-q] [-y] [-u URL]" ]
-    [ "${lines[3]}" = "              (filename )?[filename ...]" ]
-    [ "${lines[4]}" = "Submit a solution for a problem." ]
-    [ "$status" -eq 0 ]
+    assert_success
+    assert_line "usage: submit [--version] [-h] [-c CONTEST] [-p PROBLEM] [-l LANGUAGE] [-e ENTRY_POINT]"
+    assert_line "              [-v [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]] [-q] [-y] [-u URL]"
+    # The help printer does print this differently on versions of argparse for nargs=*.
+    assert_regex "              (filename )?[filename ...]"
+    assert_line "Submit a solution for a problem."
 }
 
 @test "usage information displays API url" {
     run ./submit --help
-    echo $output | grep "The (pre)configured URL is '$SUBMITBASEURL/'."
+    assert_success
+    assert_line "The (pre)configured URL is '$SUBMITBASEURL/'"
 }
 
 @test "netrc is mentioned in usage documentation" {
     run ./submit --help
-    echo $output | grep "~/\\.netrc"
+    assert_success
+    assert_regex "~/\\.netrc"
 }
 
 @test "nonexistent option shows error" {
     run ./submit --doesnotexist
+    assert_failure 2
     # Do not count from the start, but take the last line.
-    [ "${lines[-1]}" = "submit: error: unrecognized arguments: --doesnotexist" ]
-    [ "$status" -eq 2 ]
+    assert_line "submit: error: unrecognized arguments: --doesnotexist"
 }
 
 @test "verbosity option defaults to INFO" {
     run ./submit -v
-    echo $output | grep "set verbosity to INFO"
+    assert_failure 1
+    assert_partial "set verbosity to INFO"
 }


### PR DESCRIPTION
This will also show what the original output was and make it easier to
debug things when they go wrong.