### PR TITLE
Capital nocontest

### DIFF
--- a/webapp/templates/partials/menu_change_contest.html.twig
+++ b/webapp/templates/partials/menu_change_contest.html.twig
@@ -6,7 +6,7 @@
     <div class="dropdown-menu scrollable-menu" aria-labelledby="navbarDropdown">
         <a class="dropdown-item disabled" href="#">Change Contest</a>
         {% if show_no_contest and contest is not empty %}
-            <a class="dropdown-item" href="{{ path(change_path, {'contestId': -1}) }}">No contest</a>
+            <a class="dropdown-item" href="{{ path(change_path, {'contestId': -1}) }}">no contest</a>
             <div class="dropdown-divider"></div>
         {% endif %}
         {% for c in contests | filter(c => c != contest) %}


### PR DESCRIPTION
During the Open2021 we found some pages which broke when there was no active contest. This test should detect those pages.