### PR TITLE
Fix warning about unjudgeable reasons.

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -269,14 +269,10 @@
         </table>
     {% endif %}
 
-    {% if selectedJudging is null %}
-        <div class="alert alert-warning">Not (re)judged yet</div>
-
-        {% if unjudgableReasons is not empty %}
-            {% for reason in unjudgableReasons %}
-                <div class="alert alert-danger">{{ reason }}</div>
-            {% endfor %}
-        {% endif %}
+    {% if unjudgableReasons is not empty %}
+        {% for reason in unjudgableReasons %}
+            <div class="alert alert-danger">{{ reason }}</div>
+        {% endfor %}
     {% endif %}
 
     {% if selectedJudging is not null or externalJudgement is not null %}


### PR DESCRIPTION
This was broken by two things:
- we pre-create the judging nowadays
- the judgehost restrictions were removed and queries not fully updated.