### PR TITLE
Suppress codecov bot comments to reduce spam.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,4 @@ coverage:
       default:
         target: 0%
         threshold: 2%
+comment: false


### PR DESCRIPTION
These comments cannot be muted and also waste a lot of
space in the PR thread. The code coverage report can
still be viewed from the link in the CI section at the
bottom of the PR.