### PR TITLE
Improve internal error handling.

### DIFF
--- a/etc/verdicts.php
+++ b/etc/verdicts.php
@@ -13,5 +13,5 @@ return [
     'presentation-error' => 'PE', /* dropped since 5.0 */
     'no-output'          => 'NO',
     'correct'            => 'AC',
-    ''                   => '?',
+    ''                   => 'JE', /* happens for aborted judgings */
 ];

--- a/etc/verdicts.php
+++ b/etc/verdicts.php
@@ -13,5 +13,4 @@ return [
     'presentation-error' => 'PE', /* dropped since 5.0 */
     'no-output'          => 'NO',
     'correct'            => 'AC',
-    ''                   => 'JE', /* happens for aborted judgings */
 ];

--- a/etc/verdicts.php
+++ b/etc/verdicts.php
@@ -13,4 +13,5 @@ return [
     'presentation-error' => 'PE', /* dropped since 5.0 */
     'no-output'          => 'NO',
     'correct'            => 'AC',
+    ''                   => '?',
 ];

--- a/webapp/src/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/Controller/Jury/InternalErrorController.php
@@ -161,9 +161,9 @@ class InternalErrorController extends BaseController
                     $internalError->getContest(),
                     true
                 );
-                $this->dj->auditlog('internal_error', $internalError->getErrorid(),
-                                    sprintf('internal error: %s', $status));
             }
+            $this->dj->auditlog('internal_error', $internalError->getErrorid(),
+                sprintf('internal error: %s', $status));
         });
 
         return $this->redirectToRoute('jury_internal_error', ['errorId' => $internalError->getErrorid()]);

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -252,6 +252,7 @@ class RejudgingController extends BaseController
 
         $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
         $verdicts       = include $verdictsConfig;
+        $verdicts[''] = 'JE'; /* happens for aborted judgings */
 
         $used         = [];
         $verdictTable = [];

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -3,6 +3,7 @@ namespace App\Entity;
 
 use App\Doctrine\DBAL\Types\InternalErrorStatusType;
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
 
 /**
  * Log of judgehost internal errors.
@@ -79,6 +80,12 @@ class InternalError
      * @ORM\JoinColumn(name="judgingid", referencedColumnName="judgingid", onDelete="SET NULL")
      */
     private $judging;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Judging", mappedBy="internalError")
+     * @Serializer\Exclude()
+     */
+    private $affectedJudgings;
 
     public function setErrorid(int $errorid): InternalError
     {
@@ -168,5 +175,11 @@ class InternalError
     public function getJudging(): ?Judging
     {
         return $this->judging;
+    }
+
+    public function getAffectedJudgings()
+    {
+        dump($this->affectedJudgings);
+        return $this->affectedJudgings;
     }
 }

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -180,6 +180,14 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
      */
     private $debug_packages;
 
+    /**
+     * Rejudgings have one parent judging.
+     * @ORM\ManyToOne(targetEntity="InternalError")
+     * @ORM\JoinColumn(name="errorid", referencedColumnName="errorid", onDelete="SET NULL")
+     * @Serializer\Exclude()
+     */
+    private $internalError;
+
     public function getMaxRuntime(): ?float
     {
         if ($this->runs->isEmpty()) {
@@ -446,6 +454,17 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     public function getRuns(): Collection
     {
         return $this->runs;
+    }
+
+    public function setInternalError(?InternalError $internalError = null): Judging
+    {
+        $this->internalError = $internalError;
+        return $this;
+    }
+
+    public function getInternalError(): ?InternalError
+    {
+        return $this->internalError;
     }
 
     /**

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -181,7 +181,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
     private $debug_packages;
 
     /**
-     * Rejudgings have one parent judging.
+     * A judging may have been aborted by an internal error (before this judging even was started).
      * @ORM\ManyToOne(targetEntity="InternalError", inversedBy="affectedJudgings")
      * @ORM\JoinColumn(name="errorid", referencedColumnName="errorid", onDelete="SET NULL")
      * @Serializer\Exclude()

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -182,7 +182,7 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
 
     /**
      * Rejudgings have one parent judging.
-     * @ORM\ManyToOne(targetEntity="InternalError")
+     * @ORM\ManyToOne(targetEntity="InternalError", inversedBy="affectedJudgings")
      * @ORM\JoinColumn(name="errorid", referencedColumnName="errorid", onDelete="SET NULL")
      * @Serializer\Exclude()
      */

--- a/webapp/src/Migrations/Version20210914192815.php
+++ b/webapp/src/Migrations/Version20210914192815.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210914192815 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add internal error to judging.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judging ADD errorid INT UNSIGNED DEFAULT NULL COMMENT \'Internal error ID\'');
+        $this->addSql('ALTER TABLE judging ADD CONSTRAINT FK_4CA80CED4BCA8D9D FOREIGN KEY (errorid) REFERENCES internal_error (errorid) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_4CA80CED4BCA8D9D ON judging (errorid)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE judging DROP FOREIGN KEY FK_4CA80CED4BCA8D9D');
+        $this->addSql('DROP INDEX IDX_4CA80CED4BCA8D9D ON judging');
+        $this->addSql('ALTER TABLE judging DROP errorid');
+    }
+}

--- a/webapp/templates/jury/internal_error.html.twig
+++ b/webapp/templates/jury/internal_error.html.twig
@@ -43,6 +43,22 @@
                         </td>
                     </tr>
                 {% endif %}
+                {% if internalError.affectedJudgings is not null %}
+                    <tr>
+                        <th>Additional affected judgings</th>
+                        <td>
+                            <ul>
+                            {%- for judging in internalError.affectedJudgings -%}
+                                <li>
+                                    <a href="{{ path('jury_submission_by_judging', {jid: judging.judgingid}) }}">
+                                        j{{ judging.judgingid }}
+                                    </a>
+                                </li>
+                            {%- endfor -%}
+                            </ul>
+                        </td>
+                    </tr>
+                {% endif %}
                 {% if internalError.contest is not null %}
                     <tr>
                         <th>Related contest</th>

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -42,6 +42,15 @@
         </div>
     {% endif %}
 
+    {% if selectedJudging is not null and selectedJudging.internalError is not null %}
+        <div class="alert alert-danger">
+            This judging was aborted; for more information check the internal error
+            <a href="{{ path('jury_internal_error', {errorId: selectedJudging.internalError.errorid}) }}">
+                {{ selectedJudging.internalError.errorid }}
+            </a>
+        </div>
+    {% endif %}
+
     <div class="mb-3">
         <h1 style="display: inline;">
             Submission {{ submission.submitid }}


### PR DESCRIPTION
On internal errors, we disable the other outstanding judgings, or more precise judgetasks. Once the error is resolved, these would have been previously just dangling.

Now, we create a rejudging to trigger computing a verdict.

In the future, we might consider making this configurable (e.g. offer the user to judge all remaining instead of creating new judgings), but that can be done as a separate PR.