### PR TITLE
Use badges for submission stats and move them to the top.

### DIFF
--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -18,6 +18,23 @@
 {% if submissions is empty %}
     <div class="alert alert-warning">No submissions</div>
 {% else %}
+    <div>
+        <span class="badge badge-info">{{ submissionCounts.total }} submitted</span>
+        <span class="badge badge-success">{{ submissionCounts.correct }} correct</span>
+
+        {% if submissionCounts.unverified > 0 %}
+            <span class="badge badge-warning">{{ submissionCounts.unverified }} unverified</span>
+        {% endif %}
+
+        {% if submissionCounts.ignored > 0 %}
+            <span class="badge badge-dark">{{ submissionCounts.ignored }} ignored</span>
+        {% endif %}
+
+        {% if submissionCounts.queued > 0 %}
+            <span class="badge badge-primary">{{ submissionCounts.queued }} queued</span>
+        {% endif %}
+    </div>
+
     <table class="data-table table table-hover table-striped table-sm submissions-table">
         <thead class="thead-light">
         <tr>
@@ -276,17 +293,4 @@
 
         </tbody>
     </table>
-
-    <p>
-        Total correct: {{ submissionCounts.correct }}, submitted: {{ submissionCounts.total }}
-        {%- if submissionCounts.unverified > 0 -%}
-            , unverified: {{ submissionCounts.unverified }}
-        {%- endif -%}
-        {%- if submissionCounts.ignored > 0 -%}
-            , ignored: {{ submissionCounts.ignored }}
-        {%- endif -%}
-        {%- if submissionCounts.queued > 0 -%}
-            , judgement pending: {{ submissionCounts.queued }}
-        {%- endif -%}
-    </p>
 {% endif %}


### PR DESCRIPTION
### **Before**:

![before](https://user-images.githubusercontent.com/418721/133848050-c94d0af5-b46c-4f70-8da4-d2c899697d29.png)



### **After**:

![after](https://user-images.githubusercontent.com/418721/133848089-55ec14b4-36d4-49f0-9562-bef1ef293a44.png)

I often found myself scrolling down, so I moved them to to the top and then decided to use badges instead.
