### PR TITLE
Remove <br/> tags from table column header names.

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -223,7 +223,7 @@ class ContestController extends BaseController
         $timeFormat = (string)$this->config->get('time_format');
 
         if ($this->getParameter('removed_intervals')) {
-            $table_fields['num_removed_intervals'] = ['title' => '# removed<br/>intervals', 'sort' => true];
+            $table_fields['num_removed_intervals'] = ['title' => "# removed\nintervals", 'sort' => true];
             $removedIntervals                      = $em->createQueryBuilder()
                 ->from(RemovedInterval::class, 'i')
                 ->join('i.contest', 'c')
@@ -262,7 +262,7 @@ class ContestController extends BaseController
         // Insert external ID field when configured to use it
         if ($externalIdField = $this->eventLogService->externalIdFieldForEntity(Contest::class)) {
             $table_fields = array_slice($table_fields, 0, 1, true) +
-                [$externalIdField => ['title' => 'external<br/>ID', 'sort' => true]] +
+                [$externalIdField => ['title' => "external ID", 'sort' => true]] +
                 array_slice($table_fields, 1, null, true);
         }
 

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -83,7 +83,7 @@
                     <th scope="col" class="
                         {%- if column.sort is defined and column.sort %}sortable{%- endif %}
                         {%- if (column.search is not defined) or column.search %} searchable{%- endif %}">
-                        {{- column.title -}}
+                        {{- column.title|nl2br -}}
                     </th>
                 {%- endfor %}
                 {%- if num_actions > 0 %}


### PR DESCRIPTION
This was showing as raw `<br/>` text. Instead use the nl2br macro
to render this correctly, and remove it for "Contest ID" as it
saves little space, while the header layout looks worse.