### PR TITLE
Allow shortname as first item of yaml dictionary in problem import

### DIFF
--- a/misc-tools/import-contest.sh
+++ b/misc-tools/import-contest.sh
@@ -90,7 +90,7 @@ if [[ $response =~ ^(yes|y| ) ]] || [[ -z $response ]]; then
     if [ -z "${cid+x}" ]; then
       read -r -p "Please specify the contest id: " cid
     fi
-    for prob in $(cat problemset.yaml  | grep "short-name: " | sed -e 's|^ *short-name: ||'); do
+    for prob in $(cat problemset.yaml  | grep "short-name: " | sed -e 's|^.*short-name: ||'); do
       echo "Preparing problem '$prob'."
       if [ -r "${prob}.zip" ]; then
         echo "Deleting old zipfile."


### PR DESCRIPTION
Before the regex would break on `  - shortname: foobar`. Now this works fine