### PR TITLE
Fix #1219: Always wrap combined run&compare scripts

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -391,7 +391,7 @@ function fetch_executable_internal(
             logmsg(LOG_DEBUG, "Building executable in $execdir, under 'build/'");
             system(LIBJUDGEDIR . '/build_executable.sh ' . dj_escapeshellarg($execdir), $retval);
             if ($retval!==0) {
-                return [null, "Failed to build executable in $execdir.", "$execdir/build.log", null];
+                return [null, "Failed to build executable in $execdir.", "$execdir/build.log"];
             }
             chmod($execrunpath, 0755);
         }


### PR DESCRIPTION
Before, they would only be wrapped if no build file was already present.
With this fix, first we (create and) execute the build file as usual,
and only then do we rename 'run' to 'runjury' and create a new 'run'
file.

This also moves the `touch($execdeploypath)` into the if-statement. In
case you actually care about touching to update the timestamp, I should
move it outside again.


I didn't actually test this yet - will do that in a few days.

Fixes #1219 (apparently putting it in the title and commit message still doesn't make it appear in `linked issues` in the sidebar.)