### PR TITLE
Don't install LaTeX files with team manual and fix 9b1e62fe62770286f.

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -26,7 +26,7 @@ endif
 
 install-docs: docs
 	$(call install_tree,$(DESTDIR)$(domjudge_docdir)/manual,build/html)
-	$(call install_tree,$(DESTDIR)$(domjudge_docdir)/manual,build/team)
+	$(INSTALL_DATA) -t $(DESTDIR)$(domjudge_docdir)/manual build/domjudge-team-manual.pdf
 
 maintainer-install: docs
 	ln -sf build/html
@@ -50,6 +50,7 @@ html: conf_ref.rst
 
 team:
 	sphinx-build -b latex . build/team $(subst 1,-Q,$(QUIET))
-	make -C build/team domjudge-team-manual.pdf
+	$(MAKE) -C build/team domjudge-team-manual.pdf
+	cp build/team/domjudge-team-manual.pdf build
 
 .PHONY: docs distdocs install-docs maintainer-install html team

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -95,7 +95,7 @@
       <div class="card-body">
         <ul>
         <li><a href="{{ asset('doc/manual/html/index.html') }}">DOMjudge manual</a></li>
-        <li><a href="{{ asset('doc/manual/team/domjudge-team-manual.pdf') }}">Team manual <i class="fas fa-file-pdf"></i></a></li>
+        <li><a href="{{ asset('doc/manual/domjudge-team-manual.pdf') }}">Team manual <i class="fas fa-file-pdf"></i></a></li>
         <li><a href="{{ path('app.swagger_ui') }}">API documentation</a><br />
             See also the <a href="https://ccs-specs.icpc.io/contest_api">ICPC Contest API</a>.</li>
         </ul>


### PR DESCRIPTION
The build directory build/team contains a lot of files besides
the generated team manual that should not get installed. So
after building the team manual PDF, copy it to one directory
higher and install it from there. That also fixes the bug in
9b1e62fe62770286f that `make clean` in build/team would also
remove the built PDF file.