### PR TITLE
Collapse contest awards in jury interface to save space. (#1250)

### DIFF
--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -115,13 +115,13 @@
                     <td>
                         {% if contest.processAwards %}
                             <div class="card">
-                                <h6 class="card-header" role="tab" id="categories">
+                                <h6 class="card-header" id="categories">
                                     <a class="collapsed d-block text-dark pt-0 pb-0" data-toggle="collapse" href="#collapsecategories" aria-expanded="true" aria-controls="collapsecategories" id="collapseheader">
                                         {{ (contest.goldAwards > 0) + (contest.silverAwards > 0) + (contest.bronzeAwards > 0) }} different types of awards (Show/Hide details)
                                         <i class="fa fa-chevron-down float-right"></i>
                                     </a>
                                 </h6>
-                                <div id="collapsecategories" class="collapse collapsed" role="tabpanel" aria-labelledby="categories">
+                                <div id="collapsecategories" class="collapse collapsed" aria-labelledby="categories">
                                     <div class="card-body pb-1">
                                         <a>{{ contest.goldAwards }} Gold Medal</a>
                                         <br>


### PR DESCRIPTION
Feature for fixes #1250.

Using card and collapse components of bootstrap to collapse the categories of the included teams on `jury/contests/{id}` page. The page rendering is as follows.

Collapse:
![1](https://user-images.githubusercontent.com/29372915/136910487-69e8a526-52cb-426f-bd36-4cacd0b31cfa.png)

Expand:
![2](https://user-images.githubusercontent.com/29372915/136910760-0e32c45d-763e-4628-8edb-6617ba284a1e.png)


