### PR TITLE
latexmk appears to be required for non-debian 11 bullseye people as well

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -35,7 +35,7 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
+    python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml latexmk
 
 On Debian 11 (Bullseye) and above, instead install::
 


### PR DESCRIPTION
I needed this on an ubuntu 18.04 host I was testing with. Is anyone else able to confirm if this is actually the case or not?