### PR TITLE
Also show problem badges when no color is selected by defaulting to white. Fixes #1264.

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1232,7 +1232,7 @@ EOF;
 
     public function problemBadge(ContestProblem $problem): string
     {
-        $rgb = Utils::convertToHex($problem->getColor());
+        $rgb = Utils::convertToHex($problem->getColor() ?? '#ffffff');
         $background = Utils::parseHexColor($rgb);
 
         // Pick a border that's a bit darker

--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -18,9 +18,7 @@
                                 <div class="card">
                                     <div class="card-body">
                                         <h2 class="card-title">
-                                            {% if problem.color %}
-                                                {{ problem | problemBadge }}
-                                            {% endif %}
+                                            {{ problem | problemBadge }}
                                         </h2>
                                         <h3 class="card-subtitle mb-2 text-muted">
                                             {{ problem.problem.name }}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -85,9 +85,7 @@
                 {% endif %}
                 <th title="problem {{ problem.problem.name }}" scope="col">
                     <a {% if link %}href="{{ link }}"{% endif %} target="{{ target }}">
-                        {% if problem.color is not empty %}
-                            {{  problem | problemBadge }}
-                        {% endif %}
+                        {{  problem | problemBadge }}
                         {% if showPoints %}
                             <span class='problempoints'>
                                 [{% if problem.points == 1 %}1 point{% else %}{{ problem.points }} points{% endif %}]


### PR DESCRIPTION
I also noticed this issue reported by Jaap. This makes the labels show up with a white color, which to me seems the most logical to do if we have no color.