### PR TITLE
Make table rows instead of table cells clickable

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -708,4 +708,12 @@ function humanReadableBytes(bytes) {
 
 $(function () {
     $('[data-toggle="tooltip"]').tooltip();
+
+    $('tr[data-link]').on('click', function(){
+        window.location=$(this).data('link');
+    });
+
+    $('div[data-ajax-refresh-target]').on('click', 'tr[data-link]', function(){
+        window.location=$(this).data('link');
+    });
 });

--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -162,3 +162,7 @@ div.submission-summary > span {
 .importexport div.tile h3 {
     font-size: 22px;
 }
+
+tr[data-link] {
+    cursor: pointer;
+}

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -297,31 +297,27 @@
                     </thead>
                     <tbody>
                     {% for problem in problems %}
-                        <tr>
-                            {% set link = path('jury_problem', {'probId': problem.probid}) %}
-                            <td><a href="{{ link }}">p{{ problem.probid }}</a></td>
-                            <td><a href="{{ link }}">{{ problem.problem.name }}</a></td>
-                            <td><a href="{{ link }}">{{ problem.shortname }}</a></td>
-                            <td><a href="{{ link }}">{{ problem.points }}</a></td>
-                            <td><a href="{{ link }}">{{ problem.allowSubmit | printYesNo }}</a></td>
-                            <td><a href="{{ link }}">{{ problem.allowJudge | printYesNo }}</a></td>
+                        {% set link = path('jury_problem', {'probId': problem.probid}) %}
+                        <tr data-link="{{ link }}">
+                            <td>p{{ problem.probid }}</td>
+                            <td>{{ problem.problem.name }}</td>
+                            <td>{{ problem.shortname }}</td>
+                            <td>{{ problem.points }}</td>
+                            <td>{{ problem.allowSubmit | printYesNo }}</td>
+                            <td>{{ problem.allowJudge | printYesNo }}</td>
                             {% if problem.color is empty %}
-                                <td><a href="{{ link }}">&nbsp;</a></td>
+                                <td>&nbsp;</td>
                             {% else %}
                                 <td title="{{ problem.color }}">
-                                    <a href="{{ link }}">
                                         {{ problem | problemBadge }}
-                                    </a>
                                 </td>
                             {% endif %}
                             <td>
-                                <a href="{{ link }}">
                                     {% if problem.lazyEvalResults is not null %}
                                         {{ problem.lazyEvalResults | printYesNo }}
                                     {% else %}
                                         -
                                     {% endif %}
-                                </a>
                             </td>
                             <td>
                                 {% if is_granted('ROLE_ADMIN') %}

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -99,7 +99,9 @@
             {%- for row in data %}
 
                 <tr class="{{ row.cssclass|default('') }}"
-                        {%- if row.style is defined %} style="{{ row.style }}"{% endif %}>
+                        {%- if row.style is defined %} style="{{ row.style }}"{% endif %}
+                        {%- if row.link is defined %} data-link="{{ row.link }}"{% endif %}
+                        >
                     {%- for key,column in fields %}
                         {%- set item = attribute(row.data, key) %}
 
@@ -107,8 +109,7 @@
                            class="{{ item.cssclass|default('') }}{% if key == "status" %} {{ item.value|statusClass() }}{% endif %}"
                                 {%- if item.title is defined %} title="{{ item.title }}"{% endif %}
                                 {%- if item.sortvalue is defined %} data-sort="{{ item.sortvalue }}"{% endif %}>
-                            {%- if item.link is defined %}<a href="{{ item.link }}">
-                                {%- elseif row.link is defined %}<a href="{{ row.link }}">{% endif %}
+                            {%- if item.link is defined %}<a href="{{ item.link }}">{% endif %}
                                     {% if key == "status" %}
                                     {{- (item.value|default(item.default|default('')))|statusIcon -}}
                                     {% elseif key == "country" %}
@@ -116,7 +117,7 @@
                                     {% else %}
                                     {{- (item.value|default(item.default|default(''))) -}}
                                     {% endif %}
-                                    {%- if item.link is defined or row.link is defined -%}</a>{% endif %}
+                                    {%- if item.link is defined -%}</a>{% endif %}
                         </td>
                     {%- endfor %}
                     {%- for action in row.actions %}

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -28,17 +28,17 @@
     {%- for clarification in clarifications %}
         {%- set link = path('jury_clarification', {id: clarification.clarid}) %}
 
-        <tr>
-            <td><a href="{{ link }}">{{ clarification.clarid }}</a></td>
+        <tr data-link="{{ link }}">
+            <td>{{ clarification.clarid }}</td>
             {% if showExternalId %}
-                <td><a href="{{ link }}">{{ clarification.externalid }}</a></td>
+                <td>{{ clarification.externalid }}</td>
             {% endif %}
             {%- if current_contests | length > 1 %}
 
-                <td><a href="{{ link }}">{{ clarification.contest.shortname }}</a></td>
+                <td>{{ clarification.contest.shortname }}</td>
             {%- endif %}
 
-            <td><a href="{{ link }}">{{ clarification.submittime | printtime(null, clarification.contest) }}</a></td>
+            <td>{{ clarification.submittime | printtime(null, clarification.contest) }}</td>
             {%- if clarification.sender is null %}
                 {%- set sender = 'Jury' %}
                 {%- if clarification.recipient is null %}
@@ -51,9 +51,9 @@
                 {%- set sender = clarification.sender.effectiveName %}
             {%- endif %}
 
-            <td><a href="{{ link }}" title="{{ sender }}">{{ sender | u.truncate(teamname_max_length, '…') }}</a></td>
-            <td><a href="{{ link }}" title="{{ recipient }}">{{ recipient | u.truncate(teamname_max_length, '…') }}</a></td>
-            <td><a href="{{ link }}">
+            <td>{{ sender | u.truncate(teamname_max_length, '…') }}</td>
+            <td>{{ recipient | u.truncate(teamname_max_length, '…') }}</td>
+            <td>
                     {%- if clarification.problem -%}
                         problem {{ clarification.problem.contestProblems.first.shortname -}}
                     {%- elseif clarification.category -%}
@@ -61,9 +61,9 @@
                     {%- else -%}
                         general
                     {%- endif -%}
-            </a></td>
+            </td>
 
-            <td><a href="{{ link }}">{{ clarification.summary }}</a></td>
+            <td>{{ clarification.summary }}</td>
             {%- set claim = false %}
             {%- if clarification.answered %}
                 {%- set answered = '<i class="fas fa-check" title="is answered"></i>' %}
@@ -76,7 +76,7 @@
                 {%- endif %}
             {%- endif %}
 
-            <td><a href="{{ link }}">{{ answered | raw }}</a></td>
+            <td>{{ answered | raw }}</td>
             <td><form action="{{ path('jury_clarification_claim', {clarId: clarification.clarid}) }}" method="post" class="form-inline">
                 {%- if claim and clarification.sender -%}
                     <button name="claimed" value="1"
@@ -85,7 +85,7 @@
                     <button name="claimed" value="0"
                        class="btn btn-outline-success btn-sm">Unclaim</button>
                 {%- else -%}
-                    <a href="{{ link }}">{{ clarification.juryMember | default('') }}</a>
+                    {{ clarification.juryMember | default('') }}
                 {%- endif -%}
 		</form>
             </td>

--- a/webapp/templates/jury/partials/judgehost_judgings.html.twig
+++ b/webapp/templates/jury/partials/judgehost_judgings.html.twig
@@ -15,28 +15,24 @@
         <tbody>
         {% for judging in judgings %}
             {% set link = path('jury_submission_by_judging', {jid: judging.judgingid}) %}
-            <tr class="{% if not judging.valid %}disabled{% endif %}">
-                <td><a href="{{ link }}">{{ judging.judgingid }}</a></td>
-                <td><a href="{{ link }}">{{ judging.starttime | printtime }}</a></td>
+            <tr class="{% if not judging.valid %}disabled{% endif %}" data-link="{{ link }}">
+                <td>{{ judging.judgingid }}</td>
+                <td>{{ judging.starttime | printtime }}</td>
                 <td>
-                    <a href="{{ link }}">
                         {% if judging.aborted %}
                             [aborted]
                         {% else %}
                             {{ judging.starttime | printtimediff(judging.endtime) }}
                         {% endif %}
-                    </a>
                 </td>
                 <td>
-                    <a href="{{ link }}">
                         {{ judging.result | printResult(judging.valid) }}
                         {% if judging.stillBusy %}
                             (&hellip;)
                         {% endif %}
-                    </a>
                 </td>
-                <td><a href="{{ link }}">{{ judging.valid | printYesNo }}</a></td>
-                <td><a href="{{ link }}">{{ judging.verified | printYesNo }}</a></td>
+                <td>{{ judging.valid | printYesNo }}</td>
+                <td>{{ judging.verified | printYesNo }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -94,52 +94,38 @@
                 data-team-id="{{ submission.team.teamid }}"
                 data-language-id="{{ submission.language.langid }}"
                 data-submission-id="{{ submission.submitid }}"
-                data-result="{{ submission | printValidJurySubmissionResult(false) }}">
+                data-result="{{ submission | printValidJurySubmissionResult(false) }}"
+                data-link="{{ link }}">
                 {% if showExternalResult and showExternalTestcases %}
-                    <td class="{{ tdExtraClass }}">
-                        <a href="{{ link }}">
-                            Local
-                        </a>
-                    </td>
+                    <td class="{{ tdExtraClass }}"> Local </td>
                 {% endif %}
                 <td class="{{ tdExtraClass }}">
-                    <a href="{{ link }}">
                         s{{ submission.submitid }}
                         {% if submission.externalid %}
                             ({{ submission.externalid }})
                         {% endif %}
-                    </a>
                 </td>
                 {%- if showContest %}
-                    <td class="{{ tdExtraClass }}"><a href="{{ link }}">c{{ submission.contest.cid }}</a></td>
+                    <td class="{{ tdExtraClass }}">c{{ submission.contest.cid }}</td>
                 {%- endif %}
 
                 <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
-                    <a href="{{ link }}">{{ submission.submittime | printtime(null, submission.contest) }}</a>
+                    {{ submission.submittime | printtime(null, submission.contest) }}</a>
                 </td>
-                <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
-                    <a href="{{ link }}"
-                       title="t{{ submission.team.teamid }}">{{ submission.team.name | u.truncate(teamname_max_length, '…') }}</a>
+                <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}" title="t{{ submission.team.teamid }}">
+                    {{ submission.team.name | u.truncate(teamname_max_length, '…') }}
                 </td>
-                <td class="probid{{ tdExtraClass }}" rowspan="{{ rowSpan }}">
-                    <a href="{{ link }}"
-                       title="{{ submission.problem.name }}">{{ submission.contestProblem.shortname }}</a>
+                <td class="probid{{ tdExtraClass }}" rowspan="{{ rowSpan }}" title="{{ submission.problem.name }}">
+                    {{ submission.contestProblem.shortname }}
                 </td>
-                <td class="langid{{ tdExtraClass }}" rowspan="{{ rowSpan }}">
-                    <a href="{{ link }}"
-                       title="{{ submission.language.name }}">{{ submission.language.langid }}</a>
+                <td class="langid{{ tdExtraClass }}" rowspan="{{ rowSpan }}" title="{{ submission.language.name }}">
+                    {{ submission.language.langid }}
                 </td>
                 {% if showExternalResult and showExternalTestcases %}
-                    <td class="{{ tdExtraClass }}">
-                        <a href="{{ link }}">
-                            Local
-                        </a>
-                    </td>
+                    <td class="{{ tdExtraClass }}"> Local </td>
                 {% endif %}
                 <td class="{{ tdExtraClass }}">
-                    <a href="{{ link }}">
                         {{ submission | printValidJurySubmissionResult }}
-                    </a>
                 </td>
                 {% if showExternalResult and not showExternalTestcases %}
                     {% if submission.externalJudgements.empty %}
@@ -148,7 +134,6 @@
                         {% set externalJudgement = submission.externalJudgements.first %}
                     {% endif %}
                     <td class="{{ tdExtraClass }}">
-                        <a href="{{ link }}">
                             {% if submission.externalid is null %}
                                 {{- 'n / a' | printValidJuryResult -}}
                             {% elseif externalJudgement is null or externalJudgement.result is empty %}
@@ -156,7 +141,6 @@
                             {% else %}
                                 {{- externalJudgement.result | printValidJuryResult -}}
                             {% endif %}
-                        </a>
                     </td>
                 {% endif %}
                 {%- set claim = false %}
@@ -208,7 +192,7 @@
                         {%- set claimArg = {unclaim: 1} %}
                     {%- endif %}
                 {% endif %}
-                <td class="{{ tdExtraClass }}"><a href="{{ link }}">{{ verified }}</a></td>
+                <td class="{{ tdExtraClass }}">{{ verified }}</td>
                 {% if not showExternalResult or not showExternalTestcases %}
                     <td class="{{ tdExtraClass }}">
                         {%- if rejudging is defined %}
@@ -222,7 +206,7 @@
                         {%- elseif (not submission.judgings.first or not submission.judgings.first.verified) and juryMember == app.user.username -%}
                             <a class="btn btn-info btn-sm" href="{{ claimLink }}">unclaim</a>
                         {%- else -%}
-                            <a href="{{ link }}">{{ juryMember }}</a>
+                            {{ juryMember }}
                         {%- endif -%}
                     </td>
                 {% endif %}
@@ -239,7 +223,6 @@
                     </td>
                 {%- endif %}
 
-            </tr>
             {% if showExternalResult and showExternalTestcases %}
                 {% if submission.externalJudgements.empty %}
                     {% set externalJudgement = null %}
@@ -289,6 +272,7 @@
                     {{- submission | testcaseResults(true) -}}
                 </td>
             {% endif %}
+            </tr>
         {%- endfor %}
 
         </tbody>

--- a/webapp/templates/jury/problem.html.twig
+++ b/webapp/templates/jury/problem.html.twig
@@ -147,32 +147,18 @@
                     <tbody>
                     {% for contestProblem in problem.contestProblems %}
                         {% set link = path('jury_contest', {'contestId': contestProblem.cid}) %}
-                        <tr>
-                            <td>
-                                <a href="{{ link }}">c{{ contestProblem.cid }}</a>
-                            </td>
-                            <td>
-                                <a href="{{ link }}">{{ contestProblem.contest.shortname }}</a>
-                            </td>
-                            <td>
-                                <a href="{{ link }}">{{ contestProblem.contest.name }}</a>
-                            </td>
-                            <td>
-                                <a href="{{ link }}">{{ contestProblem.shortname }}</a>
-                            </td>
-                            <td>
-                                <a href="{{ link }}">{{ contestProblem.allowSubmit | printYesNo }}</a>
-                            </td>
-                            <td>
-                                <a href="{{ link }}">{{ contestProblem.allowJudge | printYesNo }}</a>
-                            </td>
+                        <tr data-link="{{ link }}">
+                            <td> c{{ contestProblem.cid }} </td>
+                            <td> {{ contestProblem.contest.shortname }} </td>
+                            <td> {{ contestProblem.contest.name }} </td>
+                            <td> {{ contestProblem.shortname }} </td>
+                            <td> {{ contestProblem.allowSubmit | printYesNo }} </td>
+                            <td> {{ contestProblem.allowJudge | printYesNo }} </td>
                             {% if contestProblem.color is empty %}
-                                <td><a href="{{ link }}">&nbsp;</a></td>
+                                <td>&nbsp;</td>
                             {% else %}
                                 <td title="{{ contestProblem.color }}">
-                                    <a href="{{ link }}">
                                         {{ contestProblem | problemBadge }}
-                                    </a>
                                 </td>
                             {% endif %}
                         </tr>

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -228,44 +228,32 @@
             <tbody>
             {% for judging in judgings %}
                 {% set link = path('jury_submission', {submitId: submission.submitid, jid: judging.judgingid}) %}
-                <tr {% if not judging.valid %}class="disabled"{% endif %}>
+                <tr {% if not judging.valid %}class="disabled"{% endif %} data-link="{{ link }}">
                     <td>
-                        <a href="{{ link }}">
                             {% if selectedJudging is not null and selectedJudging.judgingid == judging.judgingid %}
                                 <i class="fas fa-long-arrow-alt-right"></i>
                             {% else %}
                                 &nbsp;
                             {% endif %}
-                        </a>
                     </td>
-                    <td><a href="{{ link }}">j{{ judging.judgingid }}</a></td>
-                    <td><a href="{{ link }}">{{ judging.starttime | printtime(null, submission.contest) }}</a></td>
+                    <td>j{{ judging.judgingid }}</td>
+                    <td>{{ judging.starttime | printtime(null, submission.contest) }}</td>
                     <td>
-                        <a href="{{ link }}">
                             {% if maxRunTimes[judging.judgingId] is not null %}
                                 {{ maxRunTimes[judging.judgingId] }}s
                             {% endif %}
-                        </a>
                     </td>
+                    <td> {{ judging.judgehosts | printHosts }} </td>
                     <td>
-                        <a href="{{ link }}">
-                            {{ judging.judgehosts | printHosts }}
-                        </a>
-                    </td>
-                    <td>
-                        <a href="{{ link }}">
                             {{ judging.result | printResult(judging.valid, true) }}
                             {% if judging.stillBusy %}
                                 (&hellip;)
                             {% endif %}
-                        </a>
                     </td>
                     <td>
-                        <a href="{{ link }}">
                             {% if judging.rejudging is not null %}
                                 r{{ judging.rejudging.rejudgingid }} ({{ judging.rejudging.reason }})
                             {% endif %}
-                        </a>
                     </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Adds a `data-link="{{ link }}"` to all table rows where (almost) all
cells have the same click target, and removes the `<a href=..` from the
individual cells.

This needs some javascript in the page footer to handle the clicks,
which is added on (I hope) all relevant pages.
It's probably better to move it to a single central place, but the `domjudge.js`
file looks like it doesn't have similar code at the moment.

There are 2 ways of handling clicks: on the `tr[data-link]` directly,
or via `$('div[data-ajax-refresh-target]').on('click', 'tr[data-link]', ...)`,
which is needed when rows are dynamically added/removed (i.e. for the
auto-refresh submissions table).
We could just use that/something similar everywhere for consistency.

Also adds CSS to change the mouse into a pointer when needed.

Fix #1273