### PR TITLE
fix use after free bug

### DIFF
--- a/judge/evict.c
+++ b/judge/evict.c
@@ -84,10 +84,10 @@ void evict_directory(char *dirname) {
 			}
 		  entry_done:
 
-			free(entry_path);
 			if ( fd!=-1 && close(fd)!=0 ) {
 				warning(errno, "Unable to close file: %s", entry_path);
 			}
+			free(entry_path);
 		}
 		if ( closedir(dir)!=0 ) {
 			warning(errno, "Unable to close directory: %s", dirname);


### PR DESCRIPTION
Detected by coverity as: DefectId=1464699

I suspect the string has nothing to do with the internal actual file so this switching of lines cannot affect behavior on the file.