### PR TITLE
Left align the clarifications text filter

### DIFF
--- a/webapp/templates/jury/clarifications.html.twig
+++ b/webapp/templates/jury/clarifications.html.twig
@@ -116,6 +116,11 @@
                 'aoColumnDefs': [
                     {aTargets: ['_all'], bSortable: true, bSearchable: true}
                 ],
+                // Left align the filter box. Modified from the Bootstrap 5 default at
+                // https://datatables.net/reference/option/dom
+                'dom': "<'row'f>" +
+                       "<'row'<'col-sm-12'tr>>" +
+                       "<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
             });
             $('.qbut').on('change', function () {
                 var icon = $("#qig" + $(this).attr('data-clarid') );


### PR DESCRIPTION
There is a lot of weird whitespace between headings and the tables
containing clarifications, because the filter is right aligned by
default. This moves it to the left to be consistent with other filters
and makes it more visible (I had not noticed it before).

after:
![image](https://user-images.githubusercontent.com/6233682/137646730-8f34e25e-7b4e-465e-a35e-4e5e27200c47.png)

(somehow the left hand side does feel more cluttered now, so maybe this isn't net positive after all.)