### PR TITLE
Pick backup color for imported problemset.yaml

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -299,7 +299,7 @@ class ImportExportService
                 $contestProblem = new ContestProblem();
                 $contestProblem
                     ->setShortname($problemLabel)
-                    ->setColor($problemData['rgb'])
+                    ->setColor($problemData['rgb'] ?? $problemData['color'])
                     // We need to set both the entities as well as the ID's because of the composite primary key
                     ->setProblem($problem)
                     ->setContest($contest);


### PR DESCRIPTION
The spec currently requests both values.

So the importer either should be more strict or can have this safe backup when the user does not set those values.