### PR TITLE
Use the spec required fields

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -124,8 +124,10 @@ class ImportExportService
             $color              = $contestProblem->getColor() === null ? null : Utils::convertToColor($contestProblem->getColor());
             $data['problems'][] = [
                 'label' => $contestProblem->getShortname(),
+                'letter' => $contestProblem->getShortname(),
                 'name' => $contestProblem->getProblem()->getName(),
-                'color' => $color === null ? $contestProblem->getColor() : $color,
+                'short-name' => $contestProblem->getProblem()->getExternalid(),
+                'color' => $color ?? $contestProblem->getColor(),
                 'rgb' => $contestProblem->getColor() === null ? null : Utils::convertToHex($contestProblem->getColor()),
             ];
         }

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -152,17 +152,23 @@ languages:
 problems:
     -
         label: boolfind
+        letter: boolfind
         name: 'Boolean switch search'
+        short-name: boolfind
         color: green
         rgb: '#008000'
     -
         label: fltcmp
+        letter: fltcmp
         name: 'Float special compare test'
+        short-name: fltcmp
         color: indianred
         rgb: '#CD5C5C'
     -
         label: hello
+        letter: hello
         name: 'Hello World'
+        short-name: hello
         color: skyblue
         rgb: '#87CEEB'
 


### PR DESCRIPTION
One of my earlier PRs was based on that short-name was missing. If I understand the spec correctly it should be there so we can export this based on another value.

I did not verify if `name` always has content which is allowed for short-name.