### PR TITLE
Add support for building the Ubuntu chroot for other architectures.

### DIFF
--- a/judge/chroot-startstop.sh.in
+++ b/judge/chroot-startstop.sh.in
@@ -30,7 +30,10 @@
 set -e
 
 # Chroot subdirs needed: (optional lib64 only needed for amd64 architecture)
-SUBDIRMOUNTS="etc usr lib lib64 bin"
+SUBDIRMOUNTS="etc usr lib bin"
+if [ "$(uname -m)" = "x86_64" ]; then
+	SUBDIRMOUNTS="$SUBDIRMOUNTS lib64"
+fi
 
 # Location of the pre-built chroot tree and where to bind mount from:
 CHROOTORIGINAL="@judgehost_chrootdir@"

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -178,7 +178,19 @@ DEBOOTDEB="debootstrap_1.0.118ubuntu1_all.deb"
 # variables; if none are given the following defaults are used.
 
 # Ubuntu mirror, modify to match closest mirror
-[ -z "$DEBMIRROR" ] && DEBMIRROR="http://us.archive.ubuntu.com./ubuntu/"
+if [ -z "$DEBMIRROR" ]; then
+	# x86_64 can use the main Ubuntu repo's, other
+	# architectures need to use a mirror from ubuntu-ports.
+	# Besides the main mirror (ports.ubuntu.com) currently
+	# only the one from kumi.systems seems to have most ports
+	# and it is faster than ports.ubuntu.com so we use that as
+	# default.
+	if [ "$(uname -m)" = "x86_64" ]; then
+		DEBMIRROR="http://us.archive.ubuntu.com./ubuntu/"
+	else
+		DEBMIRROR="http://mirror.kumi.systems/ubuntu-ports/"
+	fi
+fi
 
 # A local caching proxy to use for apt-get,
 # (typically an install of aptcacher-ng), for example:


### PR DESCRIPTION
Also only check for lib64 on x86_64 hardware.

See also DOMjudge/domjudge-packaging#99