### PR TITLE
Show testcase names on problem testcase page. Fixes #1304.

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -824,12 +824,13 @@ class ProblemController extends BaseController
         if ($type === 'image') {
             $extension = $testcase->getImageType();
             $mimetype  = sprintf('image/%s', $extension);
+            $filename  = sprintf('p%d.t%d.%s', $probId, $rank, $extension);
         } else {
             $extension = substr($type, 0, -3);
             $mimetype  = 'text/plain';
+            $filename  = sprintf('%s.%s', $testcase->getDownloadName(), $extension);
         }
 
-        $filename = sprintf('p%d.t%d.%s', $probId, $rank, $extension);
         $content  = null;
 
         switch ($type) {

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -325,4 +325,13 @@ class Testcase
     {
         return $this->external_runs;
     }
+
+    public function getDownloadName(): string
+    {
+        if ($this->getOrigInputFilename()) {
+            return $this->getOrigInputFilename();
+        }
+
+        return sprintf('p%d.t%d', $this->getProblem()->getProbid(), $this->getRank());
+    }
 }

--- a/webapp/templates/jury/problem_testcases.html.twig
+++ b/webapp/templates/jury/problem_testcases.html.twig
@@ -68,7 +68,7 @@
                     </td>
                     <td class="filename">
                         <a href="{{ path('jury_problem_testcase_fetch', {'probId': problem.probid, 'rank': testcase.rank, 'type': 'input'}) }}">
-                            p{{ problem.probid }}.t{{ testcase.rank }}.in
+                            {{ testcase.downloadName }}.in
                         </a>
                     </td>
                     <td class="size">
@@ -94,7 +94,7 @@
                 <tr>
                     <td class="filename">
                         <a href="{{ path('jury_problem_testcase_fetch', {'probId': problem.probid, 'rank': testcase.rank, 'type': 'output'}) }}">
-                            p{{ problem.probid }}.t{{ testcase.rank }}.out
+                            {{ testcase.downloadName }}.out
                         </a>
                     </td>
                     <td class="size">


### PR DESCRIPTION
This will always use the original file name if there is one, falling back to the previous behaviour if there is none.