### PR TITLE
Show debug of Python SAST scanner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  SAST_EXCLUDED_ANALYZERS: "brakeman,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
+  SAST_EXCLUDED_ANALYZERS: "brakeman,eslint,flawfinder,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
 
 stages:
   - visual_pre

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
   SAST_EXCLUDED_ANALYZERS: "brakeman,eslint,flawfinder,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
+  SECURE_LOG_LEVEL: debug
 
 stages:
   - visual_pre

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ variables:
   SECURE_LOG_LEVEL: debug
   SAST_EXCLUDED_PATHS: "html,tests,localhost,gitlab"
   SAST_FLAWFINDER_LEVEL: 5
+  SAST_ANALYZER_IMAGE_TAG: "2.13.1"
 
 stages:
   - visual_pre

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 variables:
   SAST_EXCLUDED_ANALYZERS: "brakeman,eslint,flawfinder,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
   SECURE_LOG_LEVEL: debug
+  SAST_EXCLUDED_PATHS: "html,tests,localhost,gitlab"
+  SAST_FLAWFINDER_LEVEL: 5
 
 stages:
   - visual_pre


### PR DESCRIPTION
According to: https://semgrep.dev/docs/troubleshooting/gitlab-sast/https://semgrep.dev/docs/troubleshooting/gitlab-sast/
this should show the output which is now hidden for: https://gitlab.com/DOMjudge/domjudge/-/jobs/1745207873