### PR TITLE
[8.1] Malformed CIDs do not pass URL validation.

### DIFF
--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -25,6 +25,7 @@ use Symfony\Component\Intl\Exception\NotImplementedException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class AwardsController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/BalloonController.php
+++ b/webapp/src/Controller/API/BalloonController.php
@@ -19,6 +19,7 @@ use Symfony\Component\Intl\Exception\NotImplementedException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_API_READER') or is_granted('ROLE_BALLOON')")
  */
 class BalloonController extends AbstractRestController

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class ClarificationController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -41,6 +41,7 @@ use Symfony\Component\Yaml\Yaml;
  * @OA\Tag(name="Contests")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class ContestController extends AbstractRestController
 {
@@ -235,10 +236,6 @@ class ContestController extends AbstractRestController
      * @OA\Response(
      *     response="200",
      *     description="Contest start time changed successfully",
-     * )
-     * @OA\Response(
-     *     response="400",
-     *     description="Invalid input data"
      * )
      * @OA\Response(
      *     response="403",

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -29,6 +29,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @OA\Tag(name="General")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class GeneralInfoController extends AbstractFOSRestController
 {

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class GroupController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -50,6 +50,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @Rest\Route("/judgehosts")
  * @OA\Tag(name="Judgehosts")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class JudgehostController extends AbstractFOSRestController
 {

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class JudgementController extends AbstractRestController implements QueryObjectTransformer
 {

--- a/webapp/src/Controller/API/JudgementTypeController.php
+++ b/webapp/src/Controller/API/JudgementTypeController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Intl\Exception\NotImplementedException;
 /**
  * @Rest\Route("/contests/{cid}/judgement-types")
  * @OA\Tag(name="Judgement types")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class JudgementTypeController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/LanguageController.php
+++ b/webapp/src/Controller/API/LanguageController.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class LanguageController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class OrganizationController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/ProblemController.php
+++ b/webapp/src/Controller/API/ProblemController.php
@@ -32,6 +32,7 @@ use Symfony\Component\Yaml\Yaml;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class ProblemController extends AbstractRestController implements QueryObjectTransformer
 {

--- a/webapp/src/Controller/API/RunController.php
+++ b/webapp/src/Controller/API/RunController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class RunController extends AbstractRestController implements QueryObjectTransformer
 {

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -28,6 +28,7 @@ use Symfony\Component\Intl\Exception\NotImplementedException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class ScoreboardController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -38,6 +38,7 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class SubmissionController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * @OA\Parameter(ref="#/components/parameters/cid")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class TeamController extends AbstractRestController
 {

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  * @OA\Tag(name="Users")
  * @OA\Response(response="404", ref="#/components/responses/NotFound")
  * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
  */
 class UserController extends AbstractRestController
 {


### PR DESCRIPTION
Documentation needs 400 for all inputs, so we loose currently a more
specific message. Alternative is duplication of code.