### PR TITLE
Clarifications api roles tests

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -59,7 +59,9 @@ class ClarificationController extends AbstractRestController
     /**
      * Get the given clarifications for this contest.
      *
-     * Note that we restrict the returned clarifications in the query builder.
+     * Note that we restrict the returned clarifications based on the user's role.
+     * Admin and api_reader get everything, anonymous gets only general clarifications,
+     * team user gets general clarifications plus those sent from or to the team.
      * @throws NonUniqueResultException
      * @Rest\Get("/{id}")
      * @OA\Response(

--- a/webapp/src/DataFixtures/Test/ClarificationFixture.php
+++ b/webapp/src/DataFixtures/Test/ClarificationFixture.php
@@ -42,16 +42,17 @@ class ClarificationFixture extends AbstractTestDataFixture
         $juryGeneralToTeam = new Clarification();
         $juryGeneralToTeam
             ->setContest($contest)
-            ->setSubmittime(15183856633.689197000)
+            ->setSubmittime(1518385663.689197000)
             ->setRecipient($team)
             ->setJuryMember('admin')
             ->setProblem($problem)
             ->setBody("There was a mistake in judging this problem. Please try again")
             ->setAnswered(true);
 
-        $manager->persist($unhandledClarification);
-        $manager->persist($juryGeneral);
-        $manager->persist($juryGeneralToTeam);
-        $manager->flush();
+        foreach ([$unhandledClarification, $juryGeneral, $juryGeneralToTeam] as $index => $clar) {
+            $manager->persist($clar);
+            $manager->flush();
+            $this->addReference(sprintf('%s:%d', static::class, $index), $clar);
+        }
     }
 }

--- a/webapp/tests/Unit/BaseTest.php
+++ b/webapp/tests/Unit/BaseTest.php
@@ -299,9 +299,9 @@ abstract class BaseTest extends WebTestCase
     /**
      * Resolve the entity ID for the given class if not running in local mode.
      */
-    protected function resolveEntityId(string $class, string $id): string
+    protected function resolveEntityId(string $class, ?string $id): ?string
     {
-        if (!$this->dataSourceIsLocal()) {
+        if ($id !== null && !$this->dataSourceIsLocal()) {
             $entity = static::$container->get(EntityManagerInterface::class)->getRepository($class)->find($id);
             // If we can't find the entity, assume we use an invalid one.
             if ($entity === null) {

--- a/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
@@ -95,7 +95,7 @@ class ClarificationControllerTest extends BaseTest
         $this->assertEquals("Can you tell me how to solve this problem?", $clarificationFromApi[0]['text']);
 
         $this->assertEquals("2", $clarificationFromApi[1]['to_team_id']);
-        $this->assertEquals("> Can you tell me how to solve this problem?\n\nNo, read the problem statement.", $clarificationFromApi[1]['text']);
+        $this->assertEquals("> Can you tell me how to solve this problem?\r\n\r\nNo, read the problem statement.", $clarificationFromApi[1]['text']);
 
         $this->assertEquals("2", $clarificationFromApi[2]['from_team_id']);
         $this->assertEquals("Is it necessary to read the problem statement carefully?", $clarificationFromApi[2]['text']);


### PR DESCRIPTION
Provides testing that the different roles get different output from the clarifications API.

Needed to change the BaseTest because problem_id can be a problem_id or null, needed to deal with the latter case.