### PR TITLE
Fix Mayhem for API invocation

### DIFF
--- a/.github/workflows/mayhem-api.yml
+++ b/.github/workflows/mayhem-api.yml
@@ -30,8 +30,8 @@ jobs:
         continue-on-error: true
         with:
           mapi-token: ${{ secrets.MAPI_TOKEN }}
-          api-url: http://localhost/domjudge/api # <- ✏️ update this
-          api-spec: http://localhost/domjudge/api/doc.json # <- ✏️ update this
+          api-url: http://localhost/domjudge
+          api-spec: http://localhost/domjudge/api/doc.json # swagger/openAPI doc hosted here
           duration: 60
           sarif-report: mapi.sarif
 


### PR DESCRIPTION
I saw that Mayhem for API was added, but it doesn't 
look like the right endpoints are being hit.

The spec appears to already contain the `/api` prefix
in all paths - so no need to include it in the `api-url`
argument.