### PR TITLE
Expose 'answered' boolean in clarifications API (api_reader only)

### DIFF
--- a/webapp/src/Controller/API/AbstractRestController.php
+++ b/webapp/src/Controller/API/AbstractRestController.php
@@ -134,6 +134,12 @@ abstract class AbstractRestController extends AbstractFOSRestController
         if (!$request->query->has('strict') || !$request->query->getBoolean('strict')) {
             $groups[] = 'Nonstrict';
         }
+        if ($this->dj->checkrole('api_reader')) {
+            $groups[] = 'Restricted';
+        }
+        if (in_array('Nonstrict', $groups) && in_array('Restricted', $groups)) {
+            $groups[] = 'RestrictedNonstrict';
+        }
         $view->getContext()->setGroups($groups);
 
         $response = $this->handleView($view);

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -99,7 +99,7 @@ class Clarification extends BaseApiEntity implements ExternalRelationshipEntityI
      * @ORM\Column(type="boolean", name="answered",
      *     options={"comment"="Has been answered by jury?","default":"0"},
      *     nullable=false)
-     * @Serializer\Exclude()
+     * @Serializer\Groups({"RestrictedNonstrict"})
      */
     private $answered = false;
 

--- a/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
@@ -26,6 +26,7 @@ class ClarificationControllerTest extends BaseTest
             "time"         => "2018-02-11T21:47:18.901+00:00",
             "contest_time" => "-16525:12:41.098",
             "text"         => "Can you tell me how to solve this problem?",
+            "answered"     => true,
         ],
         '2' => [
             "problem_id"   => "1",
@@ -35,6 +36,7 @@ class ClarificationControllerTest extends BaseTest
             "time"         => "2018-02-11T21:47:57.689+00:00",
             "contest_time" => "-16525:12:02.310",
             "text"         => "> Can you tell me how to solve this problem?\r\n\r\nNo, read the problem statement.",
+            "answered"     => true,
         ],
         ClarificationFixture::class . ':0' => [
             "problem_id"   => "1",
@@ -44,6 +46,7 @@ class ClarificationControllerTest extends BaseTest
             "time"         => "2018-02-11T21:48:58.901+00:00",
             "contest_time" => "-16525:11:01.098",
             "text"         => "Is it necessary to read the problem statement carefully?",
+            "answered"     => false,
         ],
         ClarificationFixture::class . ':1' => [
             "problem_id"   => null,
@@ -53,6 +56,7 @@ class ClarificationControllerTest extends BaseTest
             "time"         => "2018-02-11T21:53:20.000+00:00",
             "contest_time" => "-16525:06:40.000",
             "text"         => "Lunch is served",
+            "answered"     => true,
         ],
         ClarificationFixture::class . ':2' => [
             "problem_id"   => "1",
@@ -62,6 +66,7 @@ class ClarificationControllerTest extends BaseTest
             "time"         => "2018-02-11T21:47:43.689+00:00",
             "contest_time" => "-16525:12:16.310",
             "text"         => "There was a mistake in judging this problem. Please try again",
+            "answered"     => true,
         ],
     ];
 
@@ -81,6 +86,7 @@ class ClarificationControllerTest extends BaseTest
         $this->assertEquals("Lunch is served", $clarificationFromApi[0]['text']);
         $this->assertEquals("2018-02-11T21:53:20.000+00:00", $clarificationFromApi[0]['time']);
         $this->assertEquals("-16525:06:40.000", $clarificationFromApi[0]['contest_time']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[0]);
     }
 
     public function testTeamOnlyGeneralAndRelatedToTeam()
@@ -93,18 +99,23 @@ class ClarificationControllerTest extends BaseTest
 
         $this->assertEquals("2", $clarificationFromApi[0]['from_team_id']);
         $this->assertEquals("Can you tell me how to solve this problem?", $clarificationFromApi[0]['text']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[0]);
 
         $this->assertEquals("2", $clarificationFromApi[1]['to_team_id']);
         $this->assertEquals("> Can you tell me how to solve this problem?\r\n\r\nNo, read the problem statement.", $clarificationFromApi[1]['text']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[1]);
 
         $this->assertEquals("2", $clarificationFromApi[2]['from_team_id']);
         $this->assertEquals("Is it necessary to read the problem statement carefully?", $clarificationFromApi[2]['text']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[2]);
 
         $this->assertNull($clarificationFromApi[3]['to_team_id']);
         $this->assertEquals("Lunch is served", $clarificationFromApi[3]['text']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[3]);
 
         $this->assertEquals("2", $clarificationFromApi[4]['to_team_id']);
         $this->assertEquals("There was a mistake in judging this problem. Please try again", $clarificationFromApi[4]['text']);
+        $this->assertArrayNotHasKey('answered', $clarificationFromApi[4]);
     }
 
     /**


### PR DESCRIPTION
This indicates whether or not the clarification is "handled", either
actually replied to or marked has handled through the interface.

The information is only available for privileged users. We introduce
a new serialization group "Restricted" for properties that are only
released to users with a role that includes api_reader. Because this
specific attribute is also not in the spec, we do not want to expose
it when strict=true. Since groups are "or"-ed, we need to add a
combined group of Restricted and Nonstrict. To summarise:

- Set "Restricted" on attributes that need to be exposed in
  strict (and regular) mode only to restricted users.
- Set "Nonstrict" on attributes that need to be exposed to
  all users when strict is false.
- Set "RegistrictedNonstrict" on attributes that need to be
  exposed to restricted users only when strict is false.

Closes: #1345