### PR TITLE
Reorder sast

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,27 +1,15 @@
-variables:
-  SAST_EXCLUDED_ANALYZERS: "brakeman,eslint,flawfinder,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
-  SECURE_LOG_LEVEL: debug
-  SAST_EXCLUDED_PATHS: "html,tests,localhost,gitlab"
-  SAST_FLAWFINDER_LEVEL: 5
-
-semgrep-sast:
-  variables:
-    SAST_ANALYZER_IMAGE_TAG: "2.13.1"
+include:
+  - '/gitlab/.sast-ci.yml'
 
 stages:
+  - test
   - visual_pre
   - integration
   - compare
   - accessibility
-  - test
   - unit
   - style
-
-include:
-  - template: Security/Secret-Detection.gitlab-ci.yml
-  - template: Dependency-Scanning.gitlab-ci.yml
-  - template: SAST.gitlab-ci.yml
-  - template: License-Scanning.gitlab-ci.yml
+  - sast
 
 .db_config: &mysql_db
   services:

--- a/gitlab/.sast-ci.yml
+++ b/gitlab/.sast-ci.yml
@@ -1,0 +1,30 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+  - template: SAST.gitlab-ci.yml
+
+variables:
+  SAST_EXCLUDED_ANALYZERS: "brakeman,eslint,flawfinder,kubesec,mobsf,nodejs-scan,pmd-apex,security-code-scan,sobelow,spotbugs"
+  SECURE_LOG_LEVEL: debug
+  SAST_EXCLUDED_PATHS: "html,tests,localhost,gitlab"
+  SAST_FLAWFINDER_LEVEL: 5
+
+.sast_ordering: &when_possible
+  stage: sast
+  needs: []
+
+semgrep-sast:
+  <<: *when_possible
+  variables:
+    SAST_ANALYZER_IMAGE_TAG: "2.13.1"
+
+bandit-sast:
+  <<: *when_possible
+
+phpcs-security-audit-sast:
+  <<: *when_possible
+
+gemnasium-dependency_scanning:
+  <<: *when_possible
+
+dependency_scanning:
+  <<: *when_possible


### PR DESCRIPTION
This should have a small effect, but as this also makes steering these tests easier I think its fine to do this. The file can be included from any location so could also be stored in the gitlab folder.

Also removed the dependency scanning as we already have something in GitHub and the GitLab interface is hard to get to for these things. We already have Snyk emails in case something is really "unsafe".