### PR TITLE
Document run-user-n and the corresponding isolcpus

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,6 +245,7 @@ integration_mysql:
     MYSQL_ROOT_PASSWORD: password
     MARIADB_PORT_3306_TCP_ADDR: sqlserver
     MYSQL_REQUIRE_PRIMARY_KEY: 1
+    PIN_JUDGEDAEMON: 1
 
 integration_mariadb:
   <<: *job_integration
@@ -252,6 +253,15 @@ integration_mariadb:
   variables:
     MYSQL_ROOT_PASSWORD: password
     MARIADB_PORT_3306_TCP_ADDR: sqlserver
+    PIN_JUDGEDAEMON: 1
+
+integration_unpinned_judgehost:
+  <<: *job_integration
+  <<: *maria_db
+  variables:
+    MYSQL_ROOT_PASSWORD: password
+    MARIADB_PORT_3306_TCP_ADDR: sqlserver
+    PIN_JUDGEDAEMON: 0
 
 phpcs_compatibility:
   <<: *tiny_job

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -149,6 +149,7 @@ commandline to
 Optionally the timings can be made more stable by not letting the OS schedule
 any other tasks on the same CPU core the judgedaemon is using:
 ``GRUB_CMDLINE_LINUX_DEFAULT="quiet cgroup_enable=memory swapaccount=1 isolcpus=2"``
+
 On modern distros (e.g. Debian bullseye) which have cgroup v2 enabled by
 default, you need to add ``systemd.unified_cgroup_hierarchy=0`` as well.
 Then run ``update-grub`` and reboot.
@@ -200,9 +201,10 @@ Finally start the judgedaemon::
 
 Upon its first connection to the domserver API, the judgehost will be
 auto-registered and will be by default enabled. If you wish to
-add a new judgehost but have it initially disabled, you can add it
-manually through the DOMjudge web interface and set it to disabled
-before starting the judgedaemon.
+add a new judgehost but have it initially disabled, you can change the config
+setting to automatically pause judges on first connection or manually add it
+through the DOMjudge web interface and set it to disabled before starting
+the judgedaemon.
 
 The judgedaemon can also be run as a service by running::
 

--- a/doc/manual/quick-install.rst
+++ b/doc/manual/quick-install.rst
@@ -53,7 +53,7 @@ Judgehosts
  * Run ``sudo make install-judgehost`` to install the system.
 
  * Create one or more unprivileged users:
-   ``sudo useradd -d /nonexistent -U -M -s /bin/false domjudge-run-0``.
+   ``sudo useradd -d /nonexistent -U -M -s /bin/false domjudge-run-2``.
  * Add to ``/etc/sudoers.d/`` or append to ``/etc/sudoers`` the
    sudoers configuration as in ``etc/sudoers-domjudge``.
  * Set up cgroup support: enable kernel parameters in
@@ -63,8 +63,8 @@ Judgehosts
 
  * Create the pre-built chroot tree: ``sudo bin/dj_make_chroot``
 
- * Start the judge daemon: either manually with ``bin/judgedaemon -n 1``
-   or as a service with ``systemctl enable domjudge-judgehost``.
+ * Start the judge daemon: either manually with ``bin/judgedaemon -n 2``
+   or as a service with ``systemctl enable --now domjudge-judgedaemon@2``.
 
 Submit client
 -------------


### PR DESCRIPTION
As discussed at NWERC21, this should fix the documentation and explain the isolcpus.