### PR TITLE
Add snippets for setting up a trusted proxy and add to documentation.

### DIFF
--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -131,6 +131,32 @@ though. To use this configuration, perform the following steps::
 The judgehosts connect to DOMjudge via the DOMjudge API so need
 to be able to access at least this part of the web interface.
 
+Running behind a proxy or loadbalancer
+--------------------------------------
+
+When running the DOMserver behind a proxy or loadbalancer, you might still want
+to have the webserver and/or the DOMserver know the original client IP. By
+default DOMjudge and the webserver (both nginx and Apache) will not use the
+client IP, but rather the IP of the proxy / loadbalancer.
+
+The preferred way to do this is in the webserver configuration. See
+``/etc/apache2/conf-available/domjudge.conf`` for Apache and
+``/etc/nginx/sites-enabled/domjudge`` for nginx. Look for ``loadbalancer``
+in the file. When using this approach both the webserver and DOMjudge itself
+will know the actual IP of the client.
+
+If you cannot edit the webserver configuration for some reason, there is an
+alternative way to configure this. Edit the file ``webapp/.env.local`` (create
+it if it does not exist) and add a line in the form of::
+
+  TRUSTED_PROXIES=1.2.3.4
+
+Where ``1.2.3.4`` is the IP address of the proxy or loadbalancer. You can set
+multiple IP addresses by separating them by a comma (``,``). The drawback to
+this approach is that the webserver is not aware of the actual client IP. This
+means that access logs for the webserver will still report the IP of the proxy
+or loadbalancer.
+
 Log in to DOMjudge
 ------------------
 The DOMserver should now be operational. You can access the web application

--- a/etc/apache.conf.in
+++ b/etc/apache.conf.in
@@ -99,6 +99,18 @@ RewriteRule Makefile$ - [F]
     RewriteEngine Off
 </Directory>
 
+# When running a proxy or loadbalancer in front of this apache instance,
+# you can use these directives to trust the proxy / loadbalancer and let
+# this apache instance use the correct client IP. Note that if you use a
+# virtual host, these directives can also be placed inside the
+# VirtualHost block
+
+# The header to get the client IP from
+# RemoteIPHeader X-Forwarded-For
+# The IP address of the proxy / loadbalancer. Use this directive multiple
+# times if you need to use more than one IP address
+# RemoteIPInternalProxy 1.2.3.4
+
 # vim: syntax=apachestyle
 # Local Variables:
 # mode: apache

--- a/etc/nginx-conf-inner.in
+++ b/etc/nginx-conf-inner.in
@@ -53,3 +53,13 @@ add_header X-XSS-Protection "1; mode=block";
 
 error_log /var/log/nginx/domjudge.log;
 access_log /var/log/nginx/domjudge.log;
+
+# When running a proxy or loadbalancer in front of this nginx instance,
+# you can use these directives to trust the proxy / loadbalancer and let
+# this nginx instance use the correct client IP
+
+# The header to get the client IP from
+# real_ip_header X-Forwarded-For;
+# The IP address of the proxy / loadbalancer. Use this directive multiple
+# times if you need to use more than one IP address
+# set_real_ip_from 1.2.3.4;


### PR DESCRIPTION
CC @dup4, what do you think? Not useful for the Docker image though, although we could add it there (i.e. sed the nginx config file instead of the `.env.local`)