### PR TITLE
Prevent auditlog spam from queuetask deletion when no actual queuetas…

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1381,6 +1381,10 @@ class JudgehostController extends AbstractFOSRestController
         // This is case 1) from above: continue what we have started.
         $lastJobId = $this->em->createQueryBuilder()
             ->from(JudgeTask::class, 'jt')
+            // Note: we are joining on queue tasks here since if there is no more queue task, there is also no more
+            // work to be done. If we would not do this join, the getJudgetasks would try to delete the queue task,
+            // which is both slow and results in spamming the auditlog
+            ->innerJoin(QueueTask::class, 'qt', Join::WITH, 'qt.jobid = jt.jobid')
             ->select('jt.jobid')
             ->andWhere('jt.judgehost = :judgehost')
             ->andWhere('jt.type = :type')


### PR DESCRIPTION
…k is deleted. Fixes #1369.

This happened because [in this case](http://github.com/DOMjudge/domjudge/blob/88fc65b6a24ba63221e71dd3addf05270e9b7171/webapp/src/Controller/API/JudgehostController.php#L1382-L1394) we loaded the last judging for a judgehost. That might be with a queuetask that is already deleted: it *is* always this when a judgehost is idle. So we add a check if something actually got deleted.