### PR TITLE
Fix CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,6 +80,7 @@ jobs:
 
     - name: Compile the build scripts for languages
       run: |
+        rm -rf sql/files/examples/boolfind_run*
         make build-scripts
 
     - name: Compile judgehost


### PR DESCRIPTION
For some reason codeQL now broke when any process got a non-zero exit code. Because we miss a build file for the bool_find we need to remove this from the build-scripts as otherwise codeQL will stop the build.