### PR TITLE
Fix CI error on action length

### DIFF
--- a/webapp/src/Entity/AuditLog.php
+++ b/webapp/src/Entity/AuditLog.php
@@ -65,7 +65,7 @@ class AuditLog
 
     /**
      * @var string
-     * @ORM\Column(type="string", name="action", length=64,
+     * @ORM\Column(type="string", name="action", length=128,
      *     options={"comment"="Description of action performed"},
      *     nullable=true)
      */


### PR DESCRIPTION
See https://storage.googleapis.com/gitlab-gprd-artifacts/79/28/79288caf3a8c4b2ed5c33881aa309ba9582547af0cce2ca7b894bed63e261a21/2021_12_04/1850322700/2003921975/job.log?response-content-type=text%2Fplain%3B%20charset%3Dutf-8&response-content-disposition=inline&GoogleAccessId=gitlab-object-storage-prd@gitlab-production.iam.gserviceaccount.com&Signature=ZQpz%2B%2BSIiRfjaVE%2FkA3E49eL9TEPQeupQIpHPEH4HjzNeQnrLVhRGjq2Gi37%0ARRg2ge2ehgZYSALpVNtFPefofk%2BUvHQABJu%2FbbCWuNBlLXgnTtNDqcRf%2Bw9Z%0AabxS2jVqn74z%2BwHUhlKQEvbGl53JD1KB2JPwcDx%2FEd%2B1UrUI6dk%2FdTuNssL1%0AKhrFMGbDPFp08rfAA8K2X8as6vqCavW9CmIw6ChEOkutGY2cWUmPGOR5OCKX%0As0v2RLHd8MdlTRLfbkvrUGOiCfKa2LgcLNTQ4dWieC5PqKgY8V1OD%2FHlSJJB%0ApsMLGnLlrXeXIJ9EhJr92un0jmxzEWniM6wfekSnLg%3D%3D&Expires=1638655411 for the failing log,

on entry: given back for judgehost runner-zxwgkjap-project-11698361-concurrent-0-0 which is 72 chars, so we can pick a lower value if thats better.