### PR TITLE
Fix outdated CCS specs links

### DIFF
--- a/doc/manual/config-basic.rst
+++ b/doc/manual/config-basic.rst
@@ -140,4 +140,4 @@ it need not have started yet). You can verify whether the submissions
 gave the expected answer in the Judging Verifier, available from
 the jury index page.
 
-.. _ICPC-compatible teams.tsv files: https://ccs-specs.icpc.io/ccs_system_requirements#teamstsv
+.. _ICPC-compatible teams.tsv files: https://ccs-specs.icpc.io/2021-11/ccs_system_requirements#teamstsv

--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -173,5 +173,5 @@ Loading development fixture data
 To debug failing Unit tests the fixtures can be loaded with:
 ``./webapp/bin/console domjudge:load-development-data SampleSubmissionsFixture`` in the current database.
 
-.. _CCS Contest API specification: https://ccs-specs.icpc.io/contest_api
+.. _CCS Contest API specification: https://ccs-specs.icpc.io/2021-11/contest_api
 .. _OpenAPI Specification ver. 3: https://swagger.io/specification/

--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -328,6 +328,6 @@ exist or updated when they do. Teams will be set to 'enabled' if their ICPC CMS
 status is 'ACCEPTED', of disabled otherwise. Affilations are not updated or
 deleted even when all teams cancel.
 
-.. _CCS specification: https://ccs-specs.icpc.io/ccs_system_requirements#appendix-file-formats
+.. _CCS specification: https://ccs-specs.icpc.io/2021-11/ccs_system_requirements#appendix-file-formats
 .. _.netrc: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
 .. _httpie: https://httpie.org/

--- a/doc/manual/shadow.rst
+++ b/doc/manual/shadow.rst
@@ -118,8 +118,8 @@ differences:
 * If the primary system has a different verdict than DOMjudge, a warning will be
   displayed.
 
-.. _Contest API specification: https://ccs-specs.icpc.io/contest_api
+.. _Contest API specification: https://ccs-specs.icpc.io/2021-11/contest_api
 .. _ICPC Tools CDS: https://tools.icpc.global/cds
 .. _Kattis: https://www.kattis.com
 .. _PC-Squared: http://pc2.ecs.csus.edu
-.. _CCS requirements specification: https://ccs-specs.icpc.io/ccs_system_requirements
+.. _CCS requirements specification: https://ccs-specs.icpc.io/2021-11/ccs_system_requirements

--- a/etc/shadowing.yaml.dist
+++ b/etc/shadowing.yaml.dist
@@ -1,7 +1,7 @@
 # This is an example configuration file for using DOMjudge as a shadow system.
 # The `import/import-event-feed` command uses the file etc/shadowing.yaml to
 # read configuration options for shadowing another system following the
-# Contest API specification (https://ccs-specs.icpc.io/contest_api).
+# Contest API specification (https://ccs-specs.icpc.io/2021-11/contest_api).
 
 # The root keys are identifiers used to pass to `import/import-event-feed`, e.g.
 # use `import/import-event-feed exampleA` to import the first contest.

--- a/etc/verdicts.php
+++ b/etc/verdicts.php
@@ -2,7 +2,7 @@
 
 // Mapping of DOMjudge verdict strings to those defined in the
 // CCS specification (and a few more common ones) at:
-// https://ccs-specs.icpc.io/ccs_system_requirements#judge-responses
+// https://ccs-specs.icpc.io/2021-11/ccs_system_requirements#judge-responses
 return [
     'compiler-error'     => 'CE',
     'memory-limit'       => 'MLE',

--- a/import/import-event-feed.in
+++ b/import/import-event-feed.in
@@ -4,7 +4,7 @@
  * @configure_input@
  *
  * Import contest data from an event feed following the Contest API specification.
- * See https://ccs-specs.icpc.io/contest_api
+ * See https://ccs-specs.icpc.io/2021-11/contest_api
  *
  * The following assumptions and caveats are of note:
  * - The contest that will be imported to should already contain the problems,

--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -218,7 +218,7 @@ class ImportEventFeedCommand extends Command
                              'the Contest API specification')
             ->setHelp(
                 'Import contest data from an event feed following the Contest API specification:' . PHP_EOL .
-                'https://ccs-specs.icpc.io/contest_api' . PHP_EOL . PHP_EOL .
+                'https://ccs-specs.icpc.io/2021-11/contest_api' . PHP_EOL . PHP_EOL .
                 'Note the following assumptions and caveats:' . PHP_EOL .
                 '- The contest to import into should already contain the problems,' . PHP_EOL .
                 '  because the event feed does not contain the testcases.' . PHP_EOL .

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -704,7 +704,7 @@ class EventLogService implements ContainerAwareInterface
     /**
      * Add all static events that are still missing. Static events are events for endpoints that
      * are marked as 'Configuration' on
-     * https://ccs-specs.icpc.io/contest_api#types-of-endpoints
+     * https://ccs-specs.icpc.io/2021-11/contest_api#types-of-endpoints
      *
      * @param Contest $contest
      * @throws NonUniqueResultException

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -1060,7 +1060,7 @@ class ImportExportService
                     // allow any username in the form "abc" where a and c are arbitrary
                     // strings that contain no numbers and b only contains numbers. The teamid
                     // id is then "b".
-                    // Note that https://ccs-specs.icpc.io/ccs_system_requirements#accountstsv
+                    // Note that https://ccs-specs.icpc.io/2021-11/ccs_system_requirements#accountstsv
                     // assumes team accounts of the form "team-nnn" where
                     // nnn is a zero-padded team number.
                     $teamId = preg_replace('/^[^0-9]*0*([0-9]+)[^0-9]*$/', '\1', $line[2]);

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -97,7 +97,7 @@
         <li><a href="{{ asset('doc/manual/html/index.html') }}">DOMjudge manual</a></li>
         <li><a href="{{ asset('doc/manual/domjudge-team-manual.pdf') }}">Team manual <i class="fas fa-file-pdf"></i></a></li>
         <li><a href="{{ path('app.swagger_ui') }}">API documentation</a><br />
-            See also the <a href="https://ccs-specs.icpc.io/contest_api">ICPC Contest API</a>.</li>
+            See also the <a href="https://ccs-specs.icpc.io/2021-11/contest_api">ICPC Contest API</a>.</li>
         </ul>
       </div>
     </div>

--- a/webapp/templates/jury/user_generate_passwords.html.twig
+++ b/webapp/templates/jury/user_generate_passwords.html.twig
@@ -10,7 +10,7 @@
     will cause them to be logged out immediately.</div>
 
     The passwords will be downloaded as tab-separated file as documented
-    <a href="https://ccs-specs.icpc.io/ccs_system_requirements?highlight=teams.tsv#accountstsv">here</a>.
+    <a href="https://ccs-specs.icpc.io/2021-11/ccs_system_requirements?highlight=teams.tsv#accountstsv">here</a>.
 
     {{ form(form) }}
 


### PR DESCRIPTION
Around ~22 days ago they switched the layout of the spec website, changing the URLs. All the previous URLs now return 404s, since they don't include the specs version.

This find-and-replaces all the links from [https://ccs-specs.icpc.io/](https://ccs-specs.icpc.io/) to [https://ccs-specs.icpc.io/2020-03/](https://ccs-specs.icpc.io/2020-03/). The available versions, at the time of writing, are 2020-03, 2021-11 and master.

**I'm not sure which is the correct version**, and I've just assumed it's the older one. As you can see, some of the occurrences involve publicly visible links, including one in the home page of the jury interface.