### PR TITLE
Cleanup misc-tools scripts

### DIFF
--- a/misc-tools/compare-cds.sh
+++ b/misc-tools/compare-cds.sh
@@ -141,15 +141,17 @@ CDS_PID=$!
 wait_for_quiet cds.log 10
 echo "CDS initialized"
 
+CDS_URL="https://localhost:8443/api/contests/$DOMJUDGE_CID"
+
 echo "Load the CDS Contest endpoint to make it start reading the event feed"
-curl -k --connect-timeout 5 --max-time 10 -u admin:$CDS_ADMIN_PASS https://localhost:8443/api/contests/$DOMJUDGE_CID >/dev/null 2>&1
+curl -k --connect-timeout 5 --max-time 10 -u "admin:$CDS_ADMIN_PASS" "$CDS_URL" >/dev/null 2>&1
 wait_for_quiet cds.log 10
 
 # Clear old files from previous runs
 rm -f cds-events.json cds-scoreboard.json dj-events.json dj-scoreboard.json
 
 echo "Getting the eventfeed from the cds(please be patient)"
-curl -s -k --connect-timeout 5 --no-buffer -u admin:$CDS_ADMIN_PASS https://localhost:8443/api/contests/$DOMJUDGE_CID/event-feed > cds-events.json 2>/dev/null &
+curl -s -k --connect-timeout 5 --no-buffer -u admin:$CDS_ADMIN_PASS "$CDS_URL/event-feed" > cds-events.json 2>/dev/null &
 CURL_PID=$!
 wait_for_quiet cds-events.json
 # shellcheck disable=SC2015
@@ -164,7 +166,7 @@ wait_for_quiet dj-events.json
 { kill $CURL_PID && wait $CURL_PID || true; } >/dev/null 2>&1
 
 echo "Get the scoreboard from the cds"
-curl -s -k --connect-timeout 5 --no-buffer -u admin:$CDS_ADMIN_PASS https://localhost:8443/api/contests/$DOMJUDGE_CID/scoreboard > cds-scoreboard.json 2>/dev/null
+curl -s -k --connect-timeout 5 --no-buffer -u "admin:$CDS_ADMIN_PASS" "$CDS_URL/scoreboard" > cds-scoreboard.json 2>/dev/null
 echo "Get the scoreboard from domjudge"
 curl -s -k --connect-timeout 5 --no-buffer -u "$CCS_USER:$CCS_PASS" "$CCS_URL/scoreboard" > dj-scoreboard.json 2>/dev/null
 

--- a/misc-tools/compare-cds.sh
+++ b/misc-tools/compare-cds.sh
@@ -39,7 +39,7 @@ wait_for_quiet() {
     FILE_TO_WATCH="$1"
     DELAY="${2:-5}"
 
-    echo "Waiting for ${DELAY}s of inactivity for file: $(basename $FILE_TO_WATCH)"
+    echo "Waiting for ${DELAY}s of inactivity for file: $(basename "$FILE_TO_WATCH")"
 
     LAST_SIZE="-1"
     SIZE="$(stat -c%s "$FILE_TO_WATCH")"
@@ -49,7 +49,7 @@ wait_for_quiet() {
         else
             echo "    file has size $SIZE"
         fi
-        sleep $DELAY
+        sleep "$DELAY"
         LAST_SIZE="$SIZE"
         SIZE="$(stat -c%s "$FILE_TO_WATCH")"
     done
@@ -68,8 +68,8 @@ if [ ! -d "$CDS_DIR" ]; then
 
     echo "    Extracting cds..."
     TMPDIR="$(mktemp -d)"
-    unzip -d $TMPDIR $SOURCE_ARCHIVE >/dev/null 2>&1
-    mv $TMPDIR/wlp $CDS_DIR
+    unzip -d "$TMPDIR" "$SOURCE_ARCHIVE" >/dev/null 2>&1
+    mv "$TMPDIR/wlp" "$CDS_DIR"
     rm -r "$TMPDIR"
 fi
 echo "CDS present"
@@ -87,8 +87,8 @@ if [ ! -d "$CONTESTUTIL_DIR" ]; then
 
     echo "    Extracting contest utils..."
     TMPDIR="$(mktemp -d)"
-    unzip -d $TMPDIR/contestUtil $SOURCE_ARCHIVE >/dev/null 2>&1
-    mv $TMPDIR/contestUtil $CONTESTUTIL_DIR
+    unzip -d "$TMPDIR/contestUtil" "$SOURCE_ARCHIVE" >/dev/null 2>&1
+    mv "$TMPDIR/contestUtil" "$CONTESTUTIL_DIR"
     rm -r "$TMPDIR"
 fi
 echo "Contest utils present"
@@ -130,7 +130,7 @@ cat <<EOF > "$CDS_DIR/usr/servers/cds/users.xml"
 </server>
 EOF
 
-cd $BASEDIR/icpctools # cd so the logs directory ends up in a less annoying place
+cd "$BASEDIR/icpctools" # cd so the logs directory ends up in a less annoying place
 
 echo "Start the cds"
 CDS="$CDS_DIR/bin/server run cds"
@@ -157,7 +157,7 @@ wait_for_quiet cds-events.json
 
 
 echo "Get the event-feed from domjudge(please be patient)"
-curl -s -k --connect-timeout 5 --no-buffer -u $CCS_USER:$CCS_PASS $CCS_URL/event-feed > dj-events.json 2>/dev/null &
+curl -s -k --connect-timeout 5 --no-buffer -u "$CCS_USER:$CCS_PASS" "$CCS_URL/event-feed" > dj-events.json 2>/dev/null &
 CURL_PID=$!
 wait_for_quiet dj-events.json
 # shellcheck disable=SC2015
@@ -166,7 +166,7 @@ wait_for_quiet dj-events.json
 echo "Get the scoreboard from the cds"
 curl -s -k --connect-timeout 5 --no-buffer -u admin:$CDS_ADMIN_PASS https://localhost:8443/api/contests/$DOMJUDGE_CID/scoreboard > cds-scoreboard.json 2>/dev/null
 echo "Get the scoreboard from domjudge"
-curl -s -k --connect-timeout 5 --no-buffer -u $CCS_USER:$CCS_PASS $CCS_URL/scoreboard > dj-scoreboard.json 2>/dev/null
+curl -s -k --connect-timeout 5 --no-buffer -u "$CCS_USER:$CCS_PASS" "$CCS_URL/scoreboard" > dj-scoreboard.json 2>/dev/null
 
 
 
@@ -177,13 +177,13 @@ echo "    stopped"
 
 echo "Comparing the eventfeeds"
 set +e
-$CONTESTUTIL_DIR/eventFeed.sh --compare cds-events.json dj-events.json
+"$CONTESTUTIL_DIR/eventFeed.sh" --compare cds-events.json dj-events.json
 EVENTFEED_CHECK=$?
 set -e
 
 echo "Comparing the scoreboards"
 set +e
-$CONTESTUTIL_DIR/scoreboardUtil.sh cds-scoreboard.json dj-scoreboard.json
+"$CONTESTUTIL_DIR/scoreboardUtil.sh" cds-scoreboard.json dj-scoreboard.json
 SCOREBOARD_CHECK=$?
 set -e
 

--- a/misc-tools/compare-cds.sh
+++ b/misc-tools/compare-cds.sh
@@ -4,12 +4,12 @@ BASEDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 ARG1=${1:-}
 if [[ $ARG1 == "--help" || $ARG1 == "-h" ]]; then
-  echo "Usage: $0 <DOMJUDGE_URL> <CONTESTID>"
-  echo ""
-  echo "<DOMJUDGE_URL>    The base URL of your domjudge installation"
-  echo "                  (default: http://localhost/domjudge)"
-  echo "<CONTESTID>       The contest id you want to validate(default: 2)"
-  exit 1
+    echo "Usage: $0 <DOMJUDGE_URL> <CONTESTID>"
+    echo ""
+    echo "<DOMJUDGE_URL>    The base URL of your domjudge installation"
+    echo "                  (default: http://localhost/domjudge)"
+    echo "<CONTESTID>       The contest id you want to validate(default: 2)"
+    exit 1
 fi
 
 DOMJUDGE_URL="${1:-http://localhost/domjudge}"
@@ -36,42 +36,41 @@ CDS_URL="https://github.com/icpctools/icpctools/releases/download/v${CDS_VERSION
 UTILS_URL="https://github.com/icpctools/icpctools/releases/download/v${UTILS_VERSION}/contestUtil-${UTILS_VERSION}.zip"
 
 wait_for_quiet() {
-  FILE_TO_WATCH="$1"
-  DELAY="${2:-5}"
+    FILE_TO_WATCH="$1"
+    DELAY="${2:-5}"
 
-  echo "Waiting for ${DELAY}s of inactivity for file: $(basename $FILE_TO_WATCH)"
+    echo "Waiting for ${DELAY}s of inactivity for file: $(basename $FILE_TO_WATCH)"
 
-  LAST_SIZE="-1"
-  SIZE="$(stat -c%s "$FILE_TO_WATCH")"
-  while (( LAST_SIZE < SIZE )); do
-    if (( LAST_SIZE > 0 )); then
-      echo "    file has size $SIZE(was $LAST_SIZE), still changing"
-    else
-      echo "    file has size $SIZE"
-    fi
-    sleep $DELAY
-    LAST_SIZE="$SIZE"
+    LAST_SIZE="-1"
     SIZE="$(stat -c%s "$FILE_TO_WATCH")"
-  done
+    while (( LAST_SIZE < SIZE )); do
+        if (( LAST_SIZE > 0 )); then
+            echo "    file has size $SIZE(was $LAST_SIZE), still changing"
+        else
+            echo "    file has size $SIZE"
+        fi
+        sleep $DELAY
+        LAST_SIZE="$SIZE"
+        SIZE="$(stat -c%s "$FILE_TO_WATCH")"
+    done
 }
 
 
 echo "Checking for cds"
 CDS_DIR="$BASEDIR/icpctools/cds-$CDS_VERSION"
 if [ ! -d "$CDS_DIR" ]; then
+    mkdir -p icpctools/source_archives
+    SOURCE_ARCHIVE="icpctools/source_archives/icpctools-cds-$CDS_VERSION.zip"
+    if [ ! -f $SOURCE_ARCHIVE ]; then
+        echo "    Downloading cds($CDS_VERSION)..."
+        curl -L --insecure "$CDS_URL" -o $SOURCE_ARCHIVE >/dev/null 2>&1
+    fi
 
-  mkdir -p icpctools/source_archives
-  SOURCE_ARCHIVE="icpctools/source_archives/icpctools-cds-$CDS_VERSION.zip"
-  if [ ! -f $SOURCE_ARCHIVE ]; then
-    echo "    Downloading cds($CDS_VERSION)..."
-    curl -L --insecure "$CDS_URL" -o $SOURCE_ARCHIVE >/dev/null 2>&1
-  fi
-
-  echo "    Extracting cds..."
-  TMPDIR="$(mktemp -d)"
-  unzip -d $TMPDIR $SOURCE_ARCHIVE >/dev/null 2>&1
-  mv $TMPDIR/wlp $CDS_DIR
-  rm -r "$TMPDIR"
+    echo "    Extracting cds..."
+    TMPDIR="$(mktemp -d)"
+    unzip -d $TMPDIR $SOURCE_ARCHIVE >/dev/null 2>&1
+    mv $TMPDIR/wlp $CDS_DIR
+    rm -r "$TMPDIR"
 fi
 echo "CDS present"
 
@@ -79,19 +78,18 @@ echo "CDS present"
 echo "Checking for contest utils"
 CONTESTUTIL_DIR="$BASEDIR/icpctools/contestutil-$UTILS_VERSION"
 if [ ! -d "$CONTESTUTIL_DIR" ]; then
+    mkdir -p icpctools/source_archives
+    SOURCE_ARCHIVE="icpctools/source_archives/icpctools-contestutil-$UTILS_VERSION.zip"
+    if [ ! -f $SOURCE_ARCHIVE ]; then
+        echo "    Downloading contest utils($UTILS_VERSION)..."
+        curl -L --insecure "$UTILS_URL" -o $SOURCE_ARCHIVE >/dev/null 2>&1
+    fi
 
-  mkdir -p icpctools/source_archives
-  SOURCE_ARCHIVE="icpctools/source_archives/icpctools-contestutil-$UTILS_VERSION.zip"
-  if [ ! -f $SOURCE_ARCHIVE ]; then
-    echo "    Downloading contest utils($UTILS_VERSION)..."
-    curl -L --insecure "$UTILS_URL" -o $SOURCE_ARCHIVE >/dev/null 2>&1
-  fi
-
-  echo "    Extracting contest utils..."
-  TMPDIR="$(mktemp -d)"
-  unzip -d $TMPDIR/contestUtil $SOURCE_ARCHIVE >/dev/null 2>&1
-  mv $TMPDIR/contestUtil $CONTESTUTIL_DIR
-  rm -r "$TMPDIR"
+    echo "    Extracting contest utils..."
+    TMPDIR="$(mktemp -d)"
+    unzip -d $TMPDIR/contestUtil $SOURCE_ARCHIVE >/dev/null 2>&1
+    mv $TMPDIR/contestUtil $CONTESTUTIL_DIR
+    rm -r "$TMPDIR"
 fi
 echo "Contest utils present"
 
@@ -99,35 +97,36 @@ echo "Contest utils present"
 echo "Checking for CDP directory"
 CDP_DIR="$BASEDIR/icpctools/cdp"
 if [ -d "$CDP_DIR" ]; then
-  echo "    cdp directory present, deleting"
-  # For some reason on my system the first rm fails
-  rm -rf "$CDP_DIR" 2>/dev/null || true
-  sleep 1
-  rm -rf "$CDP_DIR"
+    echo "    cdp directory present, deleting"
+    # For some reason on my system the first rm fails
+    rm -rf "$CDP_DIR" 2>/dev/null || true
+    sleep 1
+    rm -rf "$CDP_DIR"
 fi
 mkdir -p "$CDP_DIR"
+
 
 echo "Configuring CDS contest"
 cat <<EOF > "$CDS_DIR/usr/servers/cds/config/cdsConfig.xml"
 <cds>
-	<contest location="$BASEDIR/icpctools/cdp">
-		<ccs url="$CCS_URL" user="$CCS_USER" password="$CCS_PASS"/>
-	</contest>
+    <contest location="$BASEDIR/icpctools/cdp">
+        <ccs url="$CCS_URL" user="$CCS_USER" password="$CCS_PASS"/>
+    </contest>
 </cds>
 EOF
 
 echo "Configuring CDS users"
 cat <<EOF > "$CDS_DIR/usr/servers/cds/users.xml"
 <server description="ACM ICPC contest clients">
-   <!-- Change passwords immediately to secure the contest -->
-   <basicRegistry>
-      <user name="admin" password="$CDS_ADMIN_PASS"/>
-      <user name="balloon" password="$CDS_BALLOON_PASS"/>
-      <user name="public" password="$CDS_PUBLIC_PASS"/>
-      <user name="presentation" password="$CDS_PRESENTATION_PASS"/>
-      <user name="myicpc" password="$CDS_MYICPC_PASS"/>
-      <user name="live" password="$CDS_LIVE_PASS"/>
-   </basicRegistry>
+    <!-- Change passwords immediately to secure the contest -->
+    <basicRegistry>
+        <user name="admin" password="$CDS_ADMIN_PASS"/>
+        <user name="balloon" password="$CDS_BALLOON_PASS"/>
+        <user name="public" password="$CDS_PUBLIC_PASS"/>
+        <user name="presentation" password="$CDS_PRESENTATION_PASS"/>
+        <user name="myicpc" password="$CDS_MYICPC_PASS"/>
+        <user name="live" password="$CDS_LIVE_PASS"/>
+    </basicRegistry>
 </server>
 EOF
 
@@ -190,11 +189,11 @@ set -e
 
 RET=0
 if [ $SCOREBOARD_CHECK -ne 0 ]; then
-  echo "Scoreboard comparison failed"
-  RET=1
+    echo "Scoreboard comparison failed"
+    RET=1
 fi
 if [ $EVENTFEED_CHECK -ne 0 ]; then
-  echo "Event-Feed comparison failed"
-  RET=1
+    echo "Event-Feed comparison failed"
+    RET=1
 fi
 exit $RET

--- a/misc-tools/dj_judgehost_cleanup.in
+++ b/misc-tools/dj_judgehost_cleanup.in
@@ -34,7 +34,7 @@ Commands:
 EOF
 }
 
-if [ `id -u` -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "This program must be run as root."
     echo
     usage
@@ -44,9 +44,9 @@ fi
 case $1 in
     mount*)
         echo "Cleaning up stale mounts..."
-        for i in $(cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/") ; do
-            umount $i
-            echo "Unmounted $i"
+        cut -d ' ' -f 2 /proc/mounts | grep -E "^$JUDGINGDIR" | while IFS= read -r mountpoint; do
+            umount "$mountpoint"
+            echo "Unmounted $mountpoint"
             sleep 0.1
         done
         echo "Done."
@@ -62,7 +62,7 @@ case $1 in
             for i in testcase executable; do
                 if [ -d "$i/" ]; then
                     echo "    removing $i cache"
-                    rm -rf "$i/"
+                    rm -rf "${i:?}/"
                 fi
             done
             cd - >/dev/null
@@ -71,7 +71,7 @@ case $1 in
         ;;
 
     judging*)
-        if cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/" >/dev/null 2>&1 ; then
+        if cut -d ' ' -f 2 /proc/mounts | grep -E "^$JUDGINGDIR/" >/dev/null 2>&1; then
             echo "There are (stale) bind mounts under $JUDGINGDIR/."
             echo "Make sure that all judgedaemons on this host are stopped, and then"
             echo "run '$PROGNAME mount' to clean up any stale bind mounts."
@@ -83,10 +83,9 @@ case $1 in
             [ -d "$d" ] || continue
             cd "$d"
             echo "  in $d:"
-            for i in $(ls -d * 2>/dev/null | grep -E '^[0-9]+$' || true); do
-                [ -d "$i" ] || continue
-                echo "    removing judging data for contest $i"
-                rm -rf "$i/"
+            find . -type d -regex '\./[0-9]+' | while IFS= read -r contest; do
+                echo "    removing judging data for contest $contest"
+                rm -rf "${contest:?}/"
             done
             cd - >/dev/null
         done

--- a/misc-tools/dj_judgehost_cleanup.in
+++ b/misc-tools/dj_judgehost_cleanup.in
@@ -11,7 +11,7 @@ PROGNAME=$(basename $0)
 
 usage()
 {
-	cat <<EOF
+    cat <<EOF
 Usage: $PROGNAME <command>
 Perform various cleanup tasks on a judgehost.
 
@@ -35,72 +35,72 @@ EOF
 }
 
 if [ `id -u` -ne 0 ]; then
-	echo "This program must be run as root."
-	echo
-	usage
-	exit 1
+    echo "This program must be run as root."
+    echo
+    usage
+    exit 1
 fi
 
 case $1 in
-	mount*)
-		echo "Cleaning up stale mounts..."
-		for i in $(cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/") ; do
-			umount $i
-			echo "Unmounted $i"
-			sleep 0.1
-		done
-		echo "Done."
-		;;
+    mount*)
+        echo "Cleaning up stale mounts..."
+        for i in $(cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/") ; do
+            umount $i
+            echo "Unmounted $i"
+            sleep 0.1
+        done
+        echo "Done."
+        ;;
 
-	cache)
-		echo "Cleaning up cached data..."
-		cd "$JUDGINGDIR"
-		for d in */*; do
-			[ -d "$d" ] || continue
-			cd "$d"
-			echo "  in $d:"
-			for i in testcase executable; do
-				if [ -d "$i/" ]; then
-					echo "    removing $i cache"
-					rm -rf "$i/"
-				fi
-			done
-			cd - >/dev/null
-		done
-		echo "Done."
-		;;
+    cache)
+        echo "Cleaning up cached data..."
+        cd "$JUDGINGDIR"
+        for d in */*; do
+            [ -d "$d" ] || continue
+            cd "$d"
+            echo "  in $d:"
+            for i in testcase executable; do
+                if [ -d "$i/" ]; then
+                    echo "    removing $i cache"
+                    rm -rf "$i/"
+                fi
+            done
+            cd - >/dev/null
+        done
+        echo "Done."
+        ;;
 
-	judging*)
-		if cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/" >/dev/null 2>&1 ; then
-			echo "There are (stale) bind mounts under $JUDGINGDIR/."
-			echo "Make sure that all judgedaemons on this host are stopped, and then"
-			echo "run '$PROGNAME mount' to clean up any stale bind mounts."
-			exit 1
-		fi
-		echo "Cleaning up judging data..."
-		cd "$JUDGINGDIR"
-		for d in */*; do
-			[ -d "$d" ] || continue
-			cd "$d"
-			echo "  in $d:"
-			for i in $(ls -d * 2>/dev/null | grep -E '^[0-9]+$' || true); do
-				[ -d "$i" ] || continue
-				echo "    removing judging data for contest $i"
-				rm -rf "$i/"
-			done
-			cd - >/dev/null
-		done
-		echo "Done."
-		;;
+    judging*)
+        if cat /proc/mounts | cut -d ' ' -f 2 | grep -E "^$JUDGINGDIR/" >/dev/null 2>&1 ; then
+            echo "There are (stale) bind mounts under $JUDGINGDIR/."
+            echo "Make sure that all judgedaemons on this host are stopped, and then"
+            echo "run '$PROGNAME mount' to clean up any stale bind mounts."
+            exit 1
+        fi
+        echo "Cleaning up judging data..."
+        cd "$JUDGINGDIR"
+        for d in */*; do
+            [ -d "$d" ] || continue
+            cd "$d"
+            echo "  in $d:"
+            for i in $(ls -d * 2>/dev/null | grep -E '^[0-9]+$' || true); do
+                [ -d "$i" ] || continue
+                echo "    removing judging data for contest $i"
+                rm -rf "$i/"
+            done
+            cd - >/dev/null
+        done
+        echo "Done."
+        ;;
 
-	help|--help)
-		usage
-		;;
+    help|--help)
+        usage
+        ;;
 
-	*)
-		echo "Unknown command '$1'."
-		echo
-		usage
-		exit 1
-		;;
+    *)
+        echo "Unknown command '$1'."
+        echo
+        usage
+        exit 1
+        ;;
 esac

--- a/misc-tools/dj_judgehost_cleanup.in
+++ b/misc-tools/dj_judgehost_cleanup.in
@@ -83,7 +83,7 @@ case $1 in
             [ -d "$d" ] || continue
             cd "$d"
             echo "  in $d:"
-            find . -type d -regex '\./[0-9]+' | while IFS= read -r contest; do
+            find . -maxdepth 1 -type d -regex '\./[0-9]+' | while IFS= read -r contest; do
                 echo "    removing judging data for contest $contest"
                 rm -rf "${contest:?}/"
             done

--- a/misc-tools/dj_judgehost_cleanup.in
+++ b/misc-tools/dj_judgehost_cleanup.in
@@ -7,7 +7,7 @@
 set -e
 
 JUDGINGDIR=$(readlink -fn @judgehost_judgedir@)
-PROGNAME=$(basename $0)
+PROGNAME=$(basename "$0")
 
 usage()
 {

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -35,15 +35,15 @@ DEBIAN_ARCHLIST="amd64,arm64,armel,armhf,i386,mips,mips64el,mipsel,ppc64el,s390x
 UBUNTU_ARCHLIST="amd64,arm64,armhf,i386,powerpc,ppc64el,s390x"
 
 # If host system is Debian or Ubuntu, use its release and architecture by default
-if [ "x$(lsb_release -i -s || true)" = 'xDebian' ] || \
-   [ "x$(lsb_release -i -s || true)" = 'xUbuntu' ]; then
+if [ "$(lsb_release -i -s || true)" = 'Debian' ] || \
+   [ "$(lsb_release -i -s || true)" = 'Ubuntu' ]; then
     DISTRO="$(lsb_release -i -s)"
     RELEASE="$(lsb_release -c -s)"
-    if [ "x$(lsb_release -i -s)" = 'xDebian' ]; then
-        if [ "x$(lsb_release -c -s)" = "xsid" ]; then
+    if [ "$(lsb_release -i -s)" = 'Debian' ]; then
+        if [ "$(lsb_release -c -s)" = "sid" ]; then
             RELEASE='unstable'
         fi
-        if [ "x$(lsb_release -r -s)" = 'xtesting' ]; then
+        if [ "$(lsb_release -r -s)" = 'testing' ]; then
             RELEASE='testing'
         fi
     fi
@@ -286,14 +286,14 @@ cp -r /usr/share/ca-certificates/* "$CHROOTDIR/usr/share/ca-certificates" || tru
 cp -r /usr/local/share/ca-certificates/* "$CHROOTDIR/usr/local/share/ca-certificates" || true
 
 if [ "$DISTRO" = 'Debian' ]; then
-    if [ "x$RELEASE" = 'xtesting' -o "x$RELEASE" = 'xunstable' ]; then
+    if [ "$RELEASE" = 'testing' ] || [ "$RELEASE" = 'unstable' ]; then
         DISABLE_SECURITY='#'
     fi
     SECURITY_RELEASE="$RELEASE-security"
-    if [ "x$RELEASE" = 'xjessie' -o "x$RELEASE" = 'xstretch' -o "x$RELEASE" = 'xbuster' ]; then
+    if [ "$RELEASE" = 'jessie' ] || [ "$RELEASE" = 'stretch' ] || [ "$RELEASE" = 'buster' ]; then
         SECURITY_RELEASE="$RELEASE/updates"
     fi
-cat > "$CHROOTDIR/etc/apt/sources.list" <<EOF
+    cat > "$CHROOTDIR/etc/apt/sources.list" <<EOF
 # Release as specified or taken from host (incl. optional security repository):
 
 # $RELEASE
@@ -303,7 +303,7 @@ ${DISABLE_SECURITY}deb http://security.debian.org    $SECURITY_RELEASE    main
 EOF
 fi
 if [ "$DISTRO" = 'Ubuntu' ]; then
-cat > "$CHROOTDIR/etc/apt/sources.list" <<EOF
+    cat > "$CHROOTDIR/etc/apt/sources.list" <<EOF
 deb $DEBMIRROR $RELEASE main
 deb $DEBMIRROR $RELEASE universe
 deb $DEBMIRROR $RELEASE-updates main

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -205,8 +205,8 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
 
 fi
 
-INSTALLDEBS="$INSTALLDEBS $(echo $INSTALLDEBS_EXTRA | tr , ' ')"
-REMOVEDEBS=" $REMOVEDEBS  $(echo $REMOVEDEBS_EXTRA  | tr , ' ')"
+INSTALLDEBS="$INSTALLDEBS $(echo "$INSTALLDEBS_EXTRA" | tr , ' ')"
+REMOVEDEBS="$REMOVEDEBS   $(echo "$REMOVEDEBS_EXTRA"  | tr , ' ')"
 
 # To prevent (libc6) upgrade questions:
 export DEBIAN_FRONTEND=noninteractive
@@ -374,7 +374,7 @@ if [ -n "$LOCALDEBS" ]; then
     DIR=$(mktemp -d -p "$CHROOTDIR/tmp" 'dj_chroot_debs_XXXXXX')
     # shellcheck disable=SC2046
     cp $(echo "$LOCALDEBS" | tr , ' ') "$DIR"
-    chroot "$CHROOTDIR" /bin/sh -c "dpkg -i /${DIR#$CHROOTDIR}/*.deb"
+    chroot "$CHROOTDIR" /bin/sh -c "dpkg -i /${DIR#"$CHROOTDIR"}/*.deb"
 fi
 
 # Do some cleanup of the chroot

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -37,24 +37,24 @@ UBUNTU_ARCHLIST="amd64,arm64,armhf,i386,powerpc,ppc64el,s390x"
 # If host system is Debian or Ubuntu, use its release and architecture by default
 if [ "x$(lsb_release -i -s || true)" = 'xDebian' ] || \
    [ "x$(lsb_release -i -s || true)" = 'xUbuntu' ]; then
-	DISTRO="$(lsb_release -i -s)"
-	RELEASE="$(lsb_release -c -s)"
-	if [ "x$(lsb_release -i -s)" = 'xDebian' ]; then
-		if [ "x$(lsb_release -c -s)" = "xsid" ]; then
-			RELEASE='unstable'
-		fi
-		if [ "x$(lsb_release -r -s)" = 'xtesting' ]; then
-			RELEASE='testing'
-		fi
-	fi
-	if [ -z "$ARCH" ]; then
-		ARCH="$(dpkg --print-architecture)"
-	fi
+    DISTRO="$(lsb_release -i -s)"
+    RELEASE="$(lsb_release -c -s)"
+    if [ "x$(lsb_release -i -s)" = 'xDebian' ]; then
+        if [ "x$(lsb_release -c -s)" = "xsid" ]; then
+            RELEASE='unstable'
+        fi
+        if [ "x$(lsb_release -r -s)" = 'xtesting' ]; then
+            RELEASE='testing'
+        fi
+    fi
+    if [ -z "$ARCH" ]; then
+        ARCH="$(dpkg --print-architecture)"
+    fi
 fi
 
 usage()
 {
-	cat <<EOF
+    cat <<EOF
 Usage: $0 [options]...
 Creates a chroot environment with Java JRE support using the
 Debian or Ubuntu GNU/Linux distribution.
@@ -92,41 +92,41 @@ error()
 
 # Read command-line parameters:
 while getopts 'a:d:D:R:i:r:l:yh' OPT ; do
-	case $OPT in
-		a) ARCH=$OPTARG ;;
-		d) CHROOTDIR=$OPTARG ;;
-		D) DISTRO=$OPTARG ;;
-		R) RELEASE=$OPTARG ;;
-		i) INSTALLDEBS_EXTRA=$OPTARG ;;
-		r) REMOVEDEBS_EXTRA=$OPTARG ;;
-		l) LOCALDEBS=$OPTARG ;;
-		y) FORCEYES=1 ;;
-		h) SHOWHELP=1 ;;
-		\?) error "Could not parse options." ;;
-	esac
+    case $OPT in
+        a) ARCH=$OPTARG ;;
+        d) CHROOTDIR=$OPTARG ;;
+        D) DISTRO=$OPTARG ;;
+        R) RELEASE=$OPTARG ;;
+        i) INSTALLDEBS_EXTRA=$OPTARG ;;
+        r) REMOVEDEBS_EXTRA=$OPTARG ;;
+        l) LOCALDEBS=$OPTARG ;;
+        y) FORCEYES=1 ;;
+        h) SHOWHELP=1 ;;
+        \?) error "Could not parse options." ;;
+    esac
 done
 shift $((OPTIND-1))
 if [ $# -gt 0 ]; then
-	error "Additional arguments specified."
+    error "Additional arguments specified."
 fi
 
 if [ -n "$SHOWHELP" ]; then
-	usage
-	exit 0
+    usage
+    exit 0
 fi
 
 if [ "$DISTRO" != 'Debian' ] && [ "$DISTRO" != 'Ubuntu' ]; then
-	error "Invalid distribution specified, only 'Debian' and 'Ubuntu' are supported."
+    error "Invalid distribution specified, only 'Debian' and 'Ubuntu' are supported."
 fi
 
 # Use the correct default release based on the distro:
 if [ "$DISTRO" = "Debian" ] && [ -z "$RELEASE" ]; then
-	RELEASE="stable"
-	echo "Defaulting to '$RELEASE' release for Debian"
+    RELEASE="stable"
+    echo "Defaulting to '$RELEASE' release for Debian"
 fi
 if [ "$DISTRO" = "Ubuntu" ] && [ -z "$RELEASE" ]; then
-	RELEASE="focal"
-	echo "Defaulting to '$RELEASE' release for Ubuntu"
+    RELEASE="focal"
+    echo "Defaulting to '$RELEASE' release for Ubuntu"
 fi
 
 if [ "$(id -u)" != 0 ]; then
@@ -139,69 +139,69 @@ fi
 # Various settings that can be tweaked, specific per distribution:
 if [ "$DISTRO" = 'Debian' ]; then
 
-# Packages to include during bootstrap process (comma separated):
-INCLUDEDEBS="ca-certificates"
+    # Packages to include during bootstrap process (comma separated):
+    INCLUDEDEBS="ca-certificates"
 
-# Packages to install after upgrade (space separated):
-INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy3 python3 locales"
-# For C# support add: mono-runtime libmono-system2.0-cil
-# However running mono within chroot still gives errors...
+    # Packages to install after upgrade (space separated):
+    INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy3 python3 locales"
+    # For C# support add: mono-runtime libmono-system2.0-cil
+    # However running mono within chroot still gives errors...
 
-# Packages to remove after upgrade (space separated):
-REMOVEDEBS=""
+    # Packages to remove after upgrade (space separated):
+    REMOVEDEBS=""
 
-# Which debootstrap package to install on non-Debian systems:
-DEBOOTDEB="debootstrap_1.0.114_all.deb"
+    # Which debootstrap package to install on non-Debian systems:
+    DEBOOTDEB="debootstrap_1.0.114_all.deb"
 
-# The Debian mirror/proxy below can be passed as environment
-# variables; if none are given the following defaults are used.
+    # The Debian mirror/proxy below can be passed as environment
+    # variables; if none are given the following defaults are used.
 
-# Debian mirror. deb.debian.org will pick the 'closest'.
-[ -z "$DEBMIRROR" ] && DEBMIRROR="http://deb.debian.org/debian"
+    # Debian mirror. deb.debian.org will pick the 'closest'.
+    [ -z "$DEBMIRROR" ] && DEBMIRROR="http://deb.debian.org/debian"
 
-# A local caching proxy to use for apt-get,
-# (typically an install of aptcacher-ng), for example:
-#DEBPROXY="http://aptcacher-ng.example.com:3142/"
-[ -z "$DEBPROXY" ] && DEBPROXY=""
+    # A local caching proxy to use for apt-get,
+    # (typically an install of aptcacher-ng), for example:
+    #DEBPROXY="http://aptcacher-ng.example.com:3142/"
+    [ -z "$DEBPROXY" ] && DEBPROXY=""
 
 fi
 
 if [ "$DISTRO" = 'Ubuntu' ]; then
 
-# Packages to include during bootstrap process (comma separated):
-INCLUDEDEBS=""
+    # Packages to include during bootstrap process (comma separated):
+    INCLUDEDEBS=""
 
-# Packages to install after upgrade (space separated):
-INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy pypy3 python3 locales"
-# For C# support add: mono-mcs mono-devel
-# However running mono within chroot still gives errors...
+    # Packages to install after upgrade (space separated):
+    INSTALLDEBS="gcc g++ make default-jdk-headless default-jre-headless pypy pypy3 python3 locales"
+    # For C# support add: mono-mcs mono-devel
+    # However running mono within chroot still gives errors...
 
-# Packages to remove after upgrade (space separated):
-REMOVEDEBS=""
+    # Packages to remove after upgrade (space separated):
+    REMOVEDEBS=""
 
-# Which debootstrap package to install on non-Ubuntu systems:
-# This is only used when the default distro changed from Debian to
-# Ubuntu. The version below corresponds to Ubuntu 20.04 Focal.
-DEBOOTDEB="debootstrap_1.0.118ubuntu1_all.deb"
+    # Which debootstrap package to install on non-Ubuntu systems:
+    # This is only used when the default distro changed from Debian to
+    # Ubuntu. The version below corresponds to Ubuntu 20.04 Focal.
+    DEBOOTDEB="debootstrap_1.0.118ubuntu1_all.deb"
 
-# The Debian mirror/proxy below can be passed as environment
-# variables; if none are given the following defaults are used.
+    # The Debian mirror/proxy below can be passed as environment
+    # variables; if none are given the following defaults are used.
 
-# Ubuntu mirror, modify to match closest mirror
-if [ -z "$DEBMIRROR" ]; then
-	# x86_64 can use the main Ubuntu repo's, other
-	# architectures need to use a mirror from ubuntu-ports.
-	if [ "$(uname -m)" = "x86_64" ]; then
-		DEBMIRROR="http://us.archive.ubuntu.com/ubuntu/"
-	else
-		DEBMIRROR="http://ports.ubuntu.com/ubuntu-ports/"
-	fi
-fi
+    # Ubuntu mirror, modify to match closest mirror
+    if [ -z "$DEBMIRROR" ]; then
+        # x86_64 can use the main Ubuntu repo's, other
+        # architectures need to use a mirror from ubuntu-ports.
+        if [ "$(uname -m)" = "x86_64" ]; then
+            DEBMIRROR="http://us.archive.ubuntu.com/ubuntu/"
+        else
+            DEBMIRROR="http://ports.ubuntu.com/ubuntu-ports/"
+        fi
+    fi
 
-# A local caching proxy to use for apt-get,
-# (typically an install of aptcacher-ng), for example:
-#DEBPROXY="http://aptcacher-ng.example.com:3142/"
-[ -z "$DEBPROXY" ] && DEBPROXY=""
+    # A local caching proxy to use for apt-get,
+    # (typically an install of aptcacher-ng), for example:
+    #DEBPROXY="http://aptcacher-ng.example.com:3142/"
+    [ -z "$DEBPROXY" ] && DEBPROXY=""
 
 fi
 
@@ -212,15 +212,15 @@ REMOVEDEBS=" $REMOVEDEBS  $(echo $REMOVEDEBS_EXTRA  | tr , ' ')"
 export DEBIAN_FRONTEND=noninteractive
 
 if [ -e "$CHROOTDIR" ]; then
-	if [ ! "$FORCEYES" ]; then
-		printf "'%s' already exists. Remove? (y/N) " "$CHROOTDIR"
-		read -r yn
-		if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
-			error "Chrootdir already exists, exiting."
-		fi
-	fi
-	cleanup
-	rm -rf "$CHROOTDIR"
+    if [ ! "$FORCEYES" ]; then
+        printf "'%s' already exists. Remove? (y/N) " "$CHROOTDIR"
+        read -r yn
+        if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
+            error "Chrootdir already exists, exiting."
+        fi
+    fi
+    cleanup
+    rm -rf "$CHROOTDIR"
 fi
 
 mkdir -p "$CHROOTDIR"
@@ -229,42 +229,42 @@ CHROOTDIR="$PWD"
 
 if [ ! -x /usr/sbin/debootstrap ]; then
 
-	echo "This script will install debootstrap on your system."
-	if [ ! "$FORCEYES" ]; then
-		printf "Continue? (y/N) "
-		read -r yn
-		if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
-			exit 1;
-		fi
-	fi
+    echo "This script will install debootstrap on your system."
+    if [ ! "$FORCEYES" ]; then
+        printf "Continue? (y/N) "
+        read -r yn
+        if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
+            exit 1;
+        fi
+    fi
 
-	if [ -f /etc/debian_version ]; then
+    if [ -f /etc/debian_version ]; then
 
-		cd /
-		apt-get install debootstrap
+        cd /
+        apt-get install debootstrap
 
-	else
-		mkdir "$CHROOTDIR/debootstrap"
-		cd "$CHROOTDIR/debootstrap"
+    else
+        mkdir "$CHROOTDIR/debootstrap"
+        cd "$CHROOTDIR/debootstrap"
 
-		wget "$DEBMIRROR/pool/main/d/debootstrap/${DEBOOTDEB}"
+        wget "$DEBMIRROR/pool/main/d/debootstrap/${DEBOOTDEB}"
 
-		ar -x "$DEBOOTDEB"
-		cd /
-		zcat "$CHROOTDIR/debootstrap/data.tar.gz" | tar xv
+        ar -x "$DEBOOTDEB"
+        cd /
+        zcat "$CHROOTDIR/debootstrap/data.tar.gz" | tar xv
 
-		rm -rf "$CHROOTDIR/debootstrap"
-	fi
+        rm -rf "$CHROOTDIR/debootstrap"
+    fi
 fi
 
 INCLUDEOPT=""
 if [ -n "$INCLUDEDEBS" ]; then
-	INCLUDEOPT="--include=$INCLUDEDEBS"
+    INCLUDEOPT="--include=$INCLUDEDEBS"
 fi
 EXCLUDEOPT=""
 # shellcheck disable=SC2153
 if [ -n "$EXCLUDEDEBS" ]; then
-	EXCLUDEOPT="--exclude=$EXCLUDEDEBS"
+    EXCLUDEOPT="--exclude=$EXCLUDEDEBS"
 fi
 
 BOOTSTRAP_COMMAND="/usr/sbin/debootstrap"
@@ -277,7 +277,7 @@ echo "Running debootstrap to install base system, this may take a while..."
 # Add extra paths that are not set by default on Redhat-like systems.
 # shellcheck disable=SC2086
 eval PATH="$PATH:/bin:/sbin:/usr/sbin" $BOOTSTRAP_COMMAND $INCLUDEOPT $EXCLUDEOPT \
-	--variant=minbase --arch "$ARCH" "$RELEASE" "$CHROOTDIR" "$DEBMIRROR"
+  --variant=minbase --arch "$ARCH" "$RELEASE" "$CHROOTDIR" "$DEBMIRROR"
 
 rm -f "$CHROOTDIR/etc/resolv.conf"
 cp /etc/resolv.conf /etc/hosts /etc/hostname "$CHROOTDIR/etc" || true
@@ -286,19 +286,19 @@ cp -r /usr/share/ca-certificates/* "$CHROOTDIR/usr/share/ca-certificates" || tru
 cp -r /usr/local/share/ca-certificates/* "$CHROOTDIR/usr/local/share/ca-certificates" || true
 
 if [ "$DISTRO" = 'Debian' ]; then
-	if [ "x$RELEASE" = 'xtesting' -o "x$RELEASE" = 'xunstable' ]; then
-		DISABLE_SECURITY='#'
-	fi
-	SECURITY_RELEASE="$RELEASE-security"
-	if [ "x$RELEASE" = 'xjessie' -o "x$RELEASE" = 'xstretch' -o "x$RELEASE" = 'xbuster' ]; then
-		SECURITY_RELEASE="$RELEASE/updates"
-	fi
+    if [ "x$RELEASE" = 'xtesting' -o "x$RELEASE" = 'xunstable' ]; then
+        DISABLE_SECURITY='#'
+    fi
+    SECURITY_RELEASE="$RELEASE-security"
+    if [ "x$RELEASE" = 'xjessie' -o "x$RELEASE" = 'xstretch' -o "x$RELEASE" = 'xbuster' ]; then
+        SECURITY_RELEASE="$RELEASE/updates"
+    fi
 cat > "$CHROOTDIR/etc/apt/sources.list" <<EOF
 # Release as specified or taken from host (incl. optional security repository):
 
 # $RELEASE
-deb $DEBMIRROR			$RELEASE		main
-${DISABLE_SECURITY}deb http://security.debian.org	$SECURITY_RELEASE	main
+deb $DEBMIRROR            $RELEASE        main
+${DISABLE_SECURITY}deb http://security.debian.org    $SECURITY_RELEASE    main
 
 EOF
 fi
@@ -337,33 +337,33 @@ mount --bind /dev/pts "$CHROOTDIR/dev/pts"
 export LC_ALL=C
 
 chroot "$CHROOTDIR" /bin/sh -c debconf-set-selections <<EOF
-passwd	passwd/root-password-crypted	password
-passwd	passwd/user-password-crypted	password
-passwd	passwd/root-password		password
-passwd	passwd/root-password-again	password
-passwd	passwd/user-password-again	password
-passwd	passwd/user-password		password
-passwd	passwd/shadow			boolean	true
-passwd	passwd/username-bad		note
-passwd	passwd/password-mismatch	note
-passwd	passwd/username			string
-passwd	passwd/make-user		boolean	true
-passwd	passwd/md5			boolean	false
-passwd	passwd/user-fullname		string
-passwd	passwd/user-uid			string
-passwd	passwd/password-empty		note
-debconf	debconf/priority	select	high
-debconf	debconf/frontend	select	Noninteractive
-locales	locales/locales_to_be_generated	multiselect
-locales	locales/default_environment_locale	select	None
+passwd     passwd/root-password-crypted          password
+passwd     passwd/user-password-crypted          password
+passwd     passwd/root-password                  password
+passwd     passwd/root-password-again            password
+passwd     passwd/user-password-again            password
+passwd     passwd/user-password                  password
+passwd     passwd/shadow                         boolean        true
+passwd     passwd/username-bad                   note
+passwd     passwd/password-mismatch              note
+passwd     passwd/username                       string
+passwd     passwd/make-user                      boolean        true
+passwd     passwd/md5                            boolean        false
+passwd     passwd/user-fullname                  string
+passwd     passwd/user-uid                       string
+passwd     passwd/password-empty                 note
+debconf    debconf/priority                      select         high
+debconf    debconf/frontend                      select         Noninteractive
+locales    locales/locales_to_be_generated       multiselect
+locales    locales/default_environment_locale    select         None
 EOF
 
 if [ "$DISTRO" = 'Ubuntu' ]; then
-# Disable upstart init scripts(so upgrades work), we don't need to actually run
-# any services in the chroot, so this is fine.
-# Refer to: http://ubuntuforums.org/showthread.php?t=1326721
-chroot "$CHROOTDIR" /bin/sh -c "dpkg-divert --local --rename --add /sbin/initctl"
-chroot "$CHROOTDIR" /bin/sh -c "ln -s /bin/true /sbin/initctl"
+    # Disable upstart init scripts(so upgrades work), we don't need to actually run
+    # any services in the chroot, so this is fine.
+    # Refer to: http://ubuntuforums.org/showthread.php?t=1326721
+    chroot "$CHROOTDIR" /bin/sh -c "dpkg-divert --local --rename --add /sbin/initctl"
+    chroot "$CHROOTDIR" /bin/sh -c "ln -s /bin/true /sbin/initctl"
 fi
 
 # Upgrade the system, and install/remove packages as desired
@@ -371,10 +371,10 @@ chroot "$CHROOTDIR" /bin/sh -c "apt-get update && apt-get dist-upgrade"
 chroot "$CHROOTDIR" /bin/sh -c "apt-get clean"
 chroot "$CHROOTDIR" /bin/sh -c "apt-get install $INSTALLDEBS"
 if [ -n "$LOCALDEBS" ]; then
-	DIR=$(mktemp -d -p "$CHROOTDIR/tmp" 'dj_chroot_debs_XXXXXX')
-	# shellcheck disable=SC2046
-	cp $(echo "$LOCALDEBS" | tr , ' ') "$DIR"
-	chroot "$CHROOTDIR" /bin/sh -c "dpkg -i /${DIR#$CHROOTDIR}/*.deb"
+    DIR=$(mktemp -d -p "$CHROOTDIR/tmp" 'dj_chroot_debs_XXXXXX')
+    # shellcheck disable=SC2046
+    cp $(echo "$LOCALDEBS" | tr , ' ') "$DIR"
+    chroot "$CHROOTDIR" /bin/sh -c "dpkg -i /${DIR#$CHROOTDIR}/*.deb"
 fi
 
 # Do some cleanup of the chroot
@@ -384,9 +384,9 @@ chroot "$CHROOTDIR" /bin/sh -c "apt-get clean"
 
 # Remove unnecessary setuid bits
 chroot "$CHROOTDIR" /bin/sh -c "chmod a-s /usr/bin/wall /usr/bin/newgrp \
-	/usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
-	/usr/bin/gpasswd /usr/bin/passwd \
-	/bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true
+  /usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
+  /usr/bin/gpasswd /usr/bin/passwd \
+  /bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true
 
 # Disable root account
 sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
@@ -394,7 +394,7 @@ sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
 # Create a file to test that in the judging environment no
 # access to group root readable files is available:
 echo "This file should not be readable inside the judging environment!" \
-	> "$CHROOTDIR/etc/root-permission-test.txt"
+  > "$CHROOTDIR/etc/root-permission-test.txt"
 chmod 0640 "$CHROOTDIR/etc/root-permission-test.txt"
 
 umount "$CHROOTDIR/dev/pts"

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -337,10 +337,10 @@ mount --bind /dev/pts "$CHROOTDIR/dev/pts"
 export LC_ALL=C
 
 in_chroot() {
-    chroot "$CHROOTDIR" "$@"
+    chroot "$CHROOTDIR" /bin/sh -c "$@"
 }
 
-in_chroot /bin/sh -c debconf-set-selections <<EOF
+in_chroot debconf-set-selections <<EOF
 passwd     passwd/root-password-crypted          password
 passwd     passwd/user-password-crypted          password
 passwd     passwd/root-password                  password
@@ -366,28 +366,28 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
     # Disable upstart init scripts(so upgrades work), we don't need to actually run
     # any services in the chroot, so this is fine.
     # Refer to: http://ubuntuforums.org/showthread.php?t=1326721
-    in_chroot /bin/sh -c "dpkg-divert --local --rename --add /sbin/initctl"
-    in_chroot /bin/sh -c "ln -s /bin/true /sbin/initctl"
+    in_chroot "dpkg-divert --local --rename --add /sbin/initctl"
+    in_chroot "ln -s /bin/true /sbin/initctl"
 fi
 
 # Upgrade the system, and install/remove packages as desired
-in_chroot /bin/sh -c "apt-get update && apt-get dist-upgrade"
-in_chroot /bin/sh -c "apt-get clean"
-in_chroot /bin/sh -c "apt-get install $INSTALLDEBS"
+in_chroot "apt-get update && apt-get dist-upgrade"
+in_chroot "apt-get clean"
+in_chroot "apt-get install $INSTALLDEBS"
 if [ -n "$LOCALDEBS" ]; then
     DIR=$(mktemp -d -p "$CHROOTDIR/tmp" 'dj_chroot_debs_XXXXXX')
     # shellcheck disable=SC2046
     cp $(echo "$LOCALDEBS" | tr , ' ') "$DIR"
-    in_chroot /bin/sh -c "dpkg -i /${DIR#"$CHROOTDIR"}/*.deb"
+    in_chroot "dpkg -i /${DIR#"$CHROOTDIR"}/*.deb"
 fi
 
 # Do some cleanup of the chroot
-in_chroot /bin/sh -c "apt-get remove --purge $REMOVEDEBS"
-in_chroot /bin/sh -c "apt-get autoremove --purge"
-in_chroot /bin/sh -c "apt-get clean"
+in_chroot "apt-get remove --purge $REMOVEDEBS"
+in_chroot "apt-get autoremove --purge"
+in_chroot "apt-get clean"
 
 # Remove unnecessary setuid bits
-in_chroot /bin/sh -c "chmod a-s /usr/bin/wall /usr/bin/newgrp \
+in_chroot "chmod a-s /usr/bin/wall /usr/bin/newgrp \
   /usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
   /usr/bin/gpasswd /usr/bin/passwd \
   /bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -336,7 +336,11 @@ mount --bind /dev/pts "$CHROOTDIR/dev/pts"
 # Prevent perl locale warnings in the chroot:
 export LC_ALL=C
 
-chroot "$CHROOTDIR" /bin/sh -c debconf-set-selections <<EOF
+in_chroot() {
+    chroot "$CHROOTDIR" "$@"
+}
+
+in_chroot /bin/sh -c debconf-set-selections <<EOF
 passwd     passwd/root-password-crypted          password
 passwd     passwd/user-password-crypted          password
 passwd     passwd/root-password                  password
@@ -362,28 +366,28 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
     # Disable upstart init scripts(so upgrades work), we don't need to actually run
     # any services in the chroot, so this is fine.
     # Refer to: http://ubuntuforums.org/showthread.php?t=1326721
-    chroot "$CHROOTDIR" /bin/sh -c "dpkg-divert --local --rename --add /sbin/initctl"
-    chroot "$CHROOTDIR" /bin/sh -c "ln -s /bin/true /sbin/initctl"
+    in_chroot /bin/sh -c "dpkg-divert --local --rename --add /sbin/initctl"
+    in_chroot /bin/sh -c "ln -s /bin/true /sbin/initctl"
 fi
 
 # Upgrade the system, and install/remove packages as desired
-chroot "$CHROOTDIR" /bin/sh -c "apt-get update && apt-get dist-upgrade"
-chroot "$CHROOTDIR" /bin/sh -c "apt-get clean"
-chroot "$CHROOTDIR" /bin/sh -c "apt-get install $INSTALLDEBS"
+in_chroot /bin/sh -c "apt-get update && apt-get dist-upgrade"
+in_chroot /bin/sh -c "apt-get clean"
+in_chroot /bin/sh -c "apt-get install $INSTALLDEBS"
 if [ -n "$LOCALDEBS" ]; then
     DIR=$(mktemp -d -p "$CHROOTDIR/tmp" 'dj_chroot_debs_XXXXXX')
     # shellcheck disable=SC2046
     cp $(echo "$LOCALDEBS" | tr , ' ') "$DIR"
-    chroot "$CHROOTDIR" /bin/sh -c "dpkg -i /${DIR#"$CHROOTDIR"}/*.deb"
+    in_chroot /bin/sh -c "dpkg -i /${DIR#"$CHROOTDIR"}/*.deb"
 fi
 
 # Do some cleanup of the chroot
-chroot "$CHROOTDIR" /bin/sh -c "apt-get remove --purge $REMOVEDEBS"
-chroot "$CHROOTDIR" /bin/sh -c "apt-get autoremove --purge"
-chroot "$CHROOTDIR" /bin/sh -c "apt-get clean"
+in_chroot /bin/sh -c "apt-get remove --purge $REMOVEDEBS"
+in_chroot /bin/sh -c "apt-get autoremove --purge"
+in_chroot /bin/sh -c "apt-get clean"
 
 # Remove unnecessary setuid bits
-chroot "$CHROOTDIR" /bin/sh -c "chmod a-s /usr/bin/wall /usr/bin/newgrp \
+in_chroot /bin/sh -c "chmod a-s /usr/bin/wall /usr/bin/newgrp \
   /usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
   /usr/bin/gpasswd /usr/bin/passwd \
   /bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true

--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -277,7 +277,7 @@ echo "Running debootstrap to install base system, this may take a while..."
 # Add extra paths that are not set by default on Redhat-like systems.
 # shellcheck disable=SC2086
 eval PATH="$PATH:/bin:/sbin:/usr/sbin" $BOOTSTRAP_COMMAND $INCLUDEOPT $EXCLUDEOPT \
-  --variant=minbase --arch "$ARCH" "$RELEASE" "$CHROOTDIR" "$DEBMIRROR"
+    --variant=minbase --arch "$ARCH" "$RELEASE" "$CHROOTDIR" "$DEBMIRROR"
 
 rm -f "$CHROOTDIR/etc/resolv.conf"
 cp /etc/resolv.conf /etc/hosts /etc/hostname "$CHROOTDIR/etc" || true
@@ -388,9 +388,9 @@ in_chroot "apt-get clean"
 
 # Remove unnecessary setuid bits
 in_chroot "chmod a-s /usr/bin/wall /usr/bin/newgrp \
-  /usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
-  /usr/bin/gpasswd /usr/bin/passwd \
-  /bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true
+    /usr/bin/chage /usr/bin/chfn /usr/bin/chsh /usr/bin/expiry \
+    /usr/bin/gpasswd /usr/bin/passwd \
+    /bin/su /bin/mount /bin/umount /sbin/unix_chkpwd" || true
 
 # Disable root account
 sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
@@ -398,7 +398,7 @@ sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
 # Create a file to test that in the judging environment no
 # access to group root readable files is available:
 echo "This file should not be readable inside the judging environment!" \
-  > "$CHROOTDIR/etc/root-permission-test.txt"
+    > "$CHROOTDIR/etc/root-permission-test.txt"
 chmod 0640 "$CHROOTDIR/etc/root-permission-test.txt"
 
 umount "$CHROOTDIR/dev/pts"

--- a/misc-tools/dj_make_chroot_docker.in
+++ b/misc-tools/dj_make_chroot_docker.in
@@ -17,7 +17,7 @@ CHROOTDIR="@judgehost_chrootdir@"
 
 usage()
 {
-	cat <<EOF
+    cat <<EOF
 Usage: $0 [options]...
 Creates a chroot environment from a docker image
 
@@ -47,22 +47,22 @@ SHOWHELP=0
 FORCEYES=0
 IMAGE=""
 while getopts 'i:d:yh' OPT ; do
-	case $OPT in
-		i) IMAGE=$OPTARG ;;
-		d) CHROOTDIR=$OPTARG ;;
-		y) FORCEYES=1 ;;
-		h) SHOWHELP=1 ;;
-		\?) error "Could not parse options." ;;
-	esac
+    case $OPT in
+        i) IMAGE=$OPTARG ;;
+        d) CHROOTDIR=$OPTARG ;;
+        y) FORCEYES=1 ;;
+        h) SHOWHELP=1 ;;
+        \?) error "Could not parse options." ;;
+    esac
 done
 shift $((OPTIND-1))
 if [ $# -gt 0 ]; then
-	error "Additional arguments specified."
+    error "Additional arguments specified."
 fi
 
 if [ "$SHOWHELP" -eq "1" ]; then
-	usage
-	exit 0
+    usage
+    exit 0
 fi
 
 if [ "$(id -u)" != 0 ]; then
@@ -73,15 +73,15 @@ fi
 [ -z "$IMAGE" ] && error "No docker image specified(-i image:tag)"
 
 if [ -e "$CHROOTDIR" ]; then
-	if [ ! "$FORCEYES" ]; then
-		printf "'%s' already exists. Remove? (y/N) " "$CHROOTDIR"
-		read -r yn
-		if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
-			error "Chrootdir already exists, exiting."
-		fi
-	fi
-	cleanup
-	rm -rf "$CHROOTDIR"
+    if [ ! "$FORCEYES" ]; then
+        printf "'%s' already exists. Remove? (y/N) " "$CHROOTDIR"
+        read -r yn
+        if [ "$yn" != "y" ] && [ "$yn" != "Y" ]; then
+            error "Chrootdir already exists, exiting."
+        fi
+    fi
+    cleanup
+    rm -rf "$CHROOTDIR"
 fi
 
 mkdir -p "$CHROOTDIR"
@@ -142,7 +142,7 @@ sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
 # Create a file to test that in the judging environment no
 # access to group root readable files is available:
 echo "This file should not be readable inside the judging environment!" \
-	> "$CHROOTDIR/etc/root-permission-test.txt"
+  > "$CHROOTDIR/etc/root-permission-test.txt"
 chmod 0640 "$CHROOTDIR/etc/root-permission-test.txt"
 
 

--- a/misc-tools/dj_make_chroot_docker.in
+++ b/misc-tools/dj_make_chroot_docker.in
@@ -101,14 +101,14 @@ echo "{}" > "$WORKDIR/docker-config.json"
 echo "Launching docker daemon so we can download/extract files"
 export PATH="$DOCKER_BINARY_PATH:$PATH"
 "$DOCKER_BINARY_PATH/dockerd" \
-  --data-root   "$WORKDIR/docker-data" \
-  --exec-root   "$WORKDIR/docker-exec" \
-  --pidfile     "$WORKDIR/docker.pid" \
-  --config-file "$WORKDIR/docker-config.json" \
-  --host        "unix://$WORKDIR/docker.sock" \
-  --group       root \
-  --iptables=false \
-  --bridge=none &
+    --data-root   "$WORKDIR/docker-data" \
+    --exec-root   "$WORKDIR/docker-exec" \
+    --pidfile     "$WORKDIR/docker.pid" \
+    --config-file "$WORKDIR/docker-config.json" \
+    --host        "unix://$WORKDIR/docker.sock" \
+    --group       root \
+    --iptables=false \
+    --bridge=none &
 
 DOCKER="$DOCKER_BINARY_PATH/docker -H unix://$WORKDIR/docker.sock"
 
@@ -143,7 +143,7 @@ sed -i "s/^root::/root:*:/" "$CHROOTDIR/etc/shadow"
 # Create a file to test that in the judging environment no
 # access to group root readable files is available:
 echo "This file should not be readable inside the judging environment!" \
-  > "$CHROOTDIR/etc/root-permission-test.txt"
+    > "$CHROOTDIR/etc/root-permission-test.txt"
 chmod 0640 "$CHROOTDIR/etc/root-permission-test.txt"
 
 

--- a/misc-tools/dj_make_chroot_docker.in
+++ b/misc-tools/dj_make_chroot_docker.in
@@ -94,7 +94,8 @@ DOCKER_BINARY_PATH="$WORKDIR/docker-binary"
 mkdir "$DOCKER_BINARY_PATH"
 
 echo "Downloading and extracting docker binaries"
-curl https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz | tar -C $DOCKER_BINARY_PATH --strip-components=1 -xzf -
+DOCKER_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz"
+curl "$DOCKER_DOWNLOAD_URL" | tar -C "$DOCKER_BINARY_PATH" --strip-components=1 -xzf -
 echo "{}" > "$WORKDIR/docker-config.json"
 
 echo "Launching docker daemon so we can download/extract files"

--- a/misc-tools/dj_make_chroot_docker.in
+++ b/misc-tools/dj_make_chroot_docker.in
@@ -70,7 +70,7 @@ if [ "$(id -u)" != 0 ]; then
 fi
 
 [ -z "$CHROOTDIR" ] && error "No chroot directory given or default known."
-[ -z "$IMAGE" ] && error "No docker image specified(-i image:tag)"
+[ -z "$IMAGE" ] && error "No docker image specified (-i image:tag)"
 
 if [ -e "$CHROOTDIR" ]; then
     if [ ! "$FORCEYES" ]; then
@@ -99,31 +99,31 @@ echo "{}" > "$WORKDIR/docker-config.json"
 
 echo "Launching docker daemon so we can download/extract files"
 export PATH="$DOCKER_BINARY_PATH:$PATH"
-$DOCKER_BINARY_PATH/dockerd \
-  --data-root $WORKDIR/docker-data \
-  --exec-root $WORKDIR/docker-exec \
-  --pidfile $WORKDIR/docker.pid \
-  --config-file $WORKDIR/docker-config.json \
-  --host unix://$WORKDIR/docker.sock \
-  --group root \
+"$DOCKER_BINARY_PATH/dockerd" \
+  --data-root   "$WORKDIR/docker-data" \
+  --exec-root   "$WORKDIR/docker-exec" \
+  --pidfile     "$WORKDIR/docker.pid" \
+  --config-file "$WORKDIR/docker-config.json" \
+  --host        "unix://$WORKDIR/docker.sock" \
+  --group       root \
   --iptables=false \
   --bridge=none &
 
 DOCKER="$DOCKER_BINARY_PATH/docker -H unix://$WORKDIR/docker.sock"
 
 echo "Running docker to download/extract the contents of an image"
-container="$($DOCKER create $IMAGE)"
-$DOCKER export "$container" | tar -C $CHROOTDIR -xf -
+container="$($DOCKER create "$IMAGE")"
+$DOCKER export "$container" | tar -C "$CHROOTDIR" -xf -
 
 echo "Shutting down docker daemon"
-kill -9 "$(cat $WORKDIR/docker.pid)"
+kill -9 "$(cat "$WORKDIR/docker.pid")"
 
 # Wait a bit to make sure all files are closed and we can umount
 sleep 1
 
-# Unmount anything mounted there(docker leaves some things behind)
-awk "\$2 ~ \"^$WORKDIR\" { print \$2 }" /proc/mounts | while read -r mountpoint; do
-    umount $mountpoint
+# Unmount anything mounted there (docker leaves some things behind)
+awk "\$2 ~ \"^$WORKDIR\" { print \$2 }" /proc/mounts | while IFS= read -r mountpoint; do
+    umount "$mountpoint"
 done
 
 rm -rf "$WORKDIR" || true

--- a/misc-tools/dj_make_ubuntu_java_chroot
+++ b/misc-tools/dj_make_ubuntu_java_chroot
@@ -32,22 +32,22 @@ mount -t sysfs sysfs "$CHROOTDIR/sys"
 mount --bind /dev/pts "$CHROOTDIR/dev/pts"
 
 in_chroot() {
-    chroot "$CHROOTDIR" "$@"
+    chroot "$CHROOTDIR" /bin/sh -c "$@"
 }
 
-in_chroot /bin/sh -c debconf-set-selections <<EOF
+in_chroot debconf-set-selections <<EOF
 debconf shared/accepted-oracle-license-v1-1 select true
 debconf shared/accepted-oracle-license-v1-1 seen true
 EOF
 
 
 PROXYSETTINGS="http_proxy=\"$DEBPROXY\" https_proxy=\"$DEBPROXY\""
-in_chroot /bin/sh -c "$PROXYSETTINGS apt-add-repository -y ppa:webupd8team/java"
-in_chroot /bin/sh -c "$PROXYSETTINGS apt-get update"
-in_chroot /bin/sh -c "$PROXYSETTINGS apt-get install oracle-java8-installer"
+in_chroot "$PROXYSETTINGS apt-add-repository -y ppa:webupd8team/java"
+in_chroot "$PROXYSETTINGS apt-get update"
+in_chroot "$PROXYSETTINGS apt-get install oracle-java8-installer"
 
-in_chroot /bin/sh -c "apt-get autoremove --purge"
-in_chroot /bin/sh -c "apt-get clean"
+in_chroot "apt-get autoremove --purge"
+in_chroot "apt-get clean"
 
 umount "$CHROOTDIR/dev/pts"
 umount "$CHROOTDIR/sys"

--- a/misc-tools/dj_make_ubuntu_java_chroot
+++ b/misc-tools/dj_make_ubuntu_java_chroot
@@ -31,19 +31,23 @@ mount -t sysfs sysfs "$CHROOTDIR/sys"
 # Required for some warning messages about writing to log files
 mount --bind /dev/pts "$CHROOTDIR/dev/pts"
 
-chroot "$CHROOTDIR" /bin/sh -c debconf-set-selections <<EOF
+in_chroot() {
+    chroot "$CHROOTDIR" "$@"
+}
+
+in_chroot /bin/sh -c debconf-set-selections <<EOF
 debconf shared/accepted-oracle-license-v1-1 select true
 debconf shared/accepted-oracle-license-v1-1 seen true
 EOF
 
 
 PROXYSETTINGS="http_proxy=\"$DEBPROXY\" https_proxy=\"$DEBPROXY\""
-chroot "$CHROOTDIR" /bin/sh -c "$PROXYSETTINGS apt-add-repository -y ppa:webupd8team/java"
-chroot "$CHROOTDIR" /bin/sh -c "$PROXYSETTINGS apt-get update"
-chroot "$CHROOTDIR" /bin/sh -c "$PROXYSETTINGS apt-get install oracle-java8-installer"
+in_chroot /bin/sh -c "$PROXYSETTINGS apt-add-repository -y ppa:webupd8team/java"
+in_chroot /bin/sh -c "$PROXYSETTINGS apt-get update"
+in_chroot /bin/sh -c "$PROXYSETTINGS apt-get install oracle-java8-installer"
 
-chroot "$CHROOTDIR" /bin/sh -c "apt-get autoremove --purge"
-chroot "$CHROOTDIR" /bin/sh -c "apt-get clean"
+in_chroot /bin/sh -c "apt-get autoremove --purge"
+in_chroot /bin/sh -c "apt-get clean"
 
 umount "$CHROOTDIR/dev/pts"
 umount "$CHROOTDIR/sys"

--- a/misc-tools/dj_run_chroot.in
+++ b/misc-tools/dj_run_chroot.in
@@ -23,7 +23,7 @@ CHROOTDIR="@judgehost_chrootdir@"
 
 usage()
 {
-	cat <<EOF
+    cat <<EOF
 Usage: $0 [options]... [command]
 Runs <command> inside the prebuilt chroot environment. If no command is
 given, then an interactive shell inside the chroot is started.
@@ -57,21 +57,21 @@ error()
 
 # Read command-line parameters:
 while getopts 'd:h' OPT ; do
-	case $OPT in
-		d) CHROOTDIR=$OPTARG ;;
-		h) SHOWHELP=1 ;;
-		\?) error "Could not parse options." ;;
-	esac
+    case $OPT in
+        d) CHROOTDIR=$OPTARG ;;
+        h) SHOWHELP=1 ;;
+        \?) error "Could not parse options." ;;
+    esac
 done
 shift $((OPTIND-1))
 
 if [ -n "$SHOWHELP" ]; then
-	usage
-	exit 0
+    usage
+    exit 0
 fi
 
 if [ $# -eq 0 ]; then
-	INTERACTIVE=1
+    INTERACTIVE=1
 fi
 
 if [ "$(id -u)" != 0 ]; then
@@ -102,9 +102,9 @@ export LC_ALL=C
 [ -n "$INTERACTIVE" ] && echo "Entering chroot in '$CHROOTDIR'."
 
 if [ -n "$INTERACTIVE" ]; then
-	chroot "$CHROOTDIR"
+    chroot "$CHROOTDIR"
 else
-	chroot "$CHROOTDIR" /bin/sh -c "$*"
+    chroot "$CHROOTDIR" /bin/sh -c "$*"
 fi
 
 umount "$CHROOTDIR/dev/pts"

--- a/misc-tools/fix_permissions.in
+++ b/misc-tools/fix_permissions.in
@@ -12,8 +12,8 @@ WEBSERVER_GROUP="@WEBSERVER_GROUP@"
 set -e
 
 if [ `id -u` -ne 0 ]; then
-	echo "Error: can only change permissions as root."
-	exit 1
+    echo "Error: can only change permissions as root."
+    exit 1
 fi
 
 # DESTDIR may optionally be past through the environment by make.

--- a/misc-tools/fix_permissions.in
+++ b/misc-tools/fix_permissions.in
@@ -11,13 +11,13 @@ WEBSERVER_GROUP="@WEBSERVER_GROUP@"
 
 set -e
 
-if [ `id -u` -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "Error: can only change permissions as root."
     exit 1
 fi
 
 # DESTDIR may optionally be past through the environment by make.
-chown -R ${DOMJUDGE_USER}:${WEBSERVER_GROUP} ${DESTDIR}${WEBAPPDIR}/var
-chmod -R g+rwxs                              ${DESTDIR}${WEBAPPDIR}/var
-setfacl -R -m d:g::rwX                       ${DESTDIR}${WEBAPPDIR}/var
-setfacl -R -m d:u:${DOMJUDGE_USER}:rwX       ${DESTDIR}${WEBAPPDIR}/var
+chown -R ${DOMJUDGE_USER}:${WEBSERVER_GROUP} "${DESTDIR}${WEBAPPDIR}/var"
+chmod -R g+rwxs                              "${DESTDIR}${WEBAPPDIR}/var"
+setfacl -R -m d:g::rwX                       "${DESTDIR}${WEBAPPDIR}/var"
+setfacl -R -m d:u:${DOMJUDGE_USER}:rwX       "${DESTDIR}${WEBAPPDIR}/var"

--- a/misc-tools/import-contest.sh
+++ b/misc-tools/import-contest.sh
@@ -6,8 +6,8 @@
 set -euo pipefail
 
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 <domjudge-api-url>"
-  exit 1
+    echo "Usage: $0 <domjudge-api-url>"
+    exit 1
 fi
 api_url="$1"
 

--- a/misc-tools/import-contest.sh
+++ b/misc-tools/import-contest.sh
@@ -157,11 +157,11 @@ if [ -r problems.yaml ] || [ -r problems.json ] || [ -r problemset.yaml ]; then
             read -r -p "Please specify the contest id: " cid
         fi
         if [ -r problems.yaml ]; then
-            probs=$(cat problems.yaml | grep -oP "(?<=id:\s)[',\"]?[[:alnum:]]*[',\"]?(?=,|$)")
+            probs=$(grep -oP "(?<=id:\s)[',\"]?[[:alnum:]]*[',\"]?(?=,|$)" problems.yaml)
         elif [ -r problems.json ]; then
-            probs=$(cat problems.json | jq -r '.[].id')
+            probs=$(jq -r '.[].id' < problems.json)
         else
-            probs=$(cat problemset.yaml | grep -oP "(?<=short-name:\s)[',\"]?[[:alnum:]]*[',\"]?(?=,|$)")
+            probs=$(grep -oP "(?<=short-name:\s)[',\"]?[[:alnum:]]*[',\"]?(?=,|$)" problemset.yaml)
         fi
         for prob in $probs; do
             prob="${prob//[,\',\"]/}"

--- a/misc-tools/jvm_footprint
+++ b/misc-tools/jvm_footprint
@@ -10,7 +10,7 @@
 # Part of the DOMjudge Programming Contest Jury System and licensed
 # under the GNU GPL. See README and COPYING for details.
 
-cd "$(mktemp -d)" || exit -1
+cd "$(mktemp -d)" || exit 1
 
 GROUPNAME=jvmtest
 SUBGROUP=foo

--- a/misc-tools/jvm_footprint
+++ b/misc-tools/jvm_footprint
@@ -22,72 +22,72 @@ USED_HEAP=$((SANDBOX_MEM-JVM_STACK))
 STEP=5
 
 function write_and_compile_java() {
-  FIRST_BLOCK=$((80*USED_HEAP/100))
-  cat > "$JAVA_CLASS".java <<EOF
+    FIRST_BLOCK=$((80*USED_HEAP/100))
+    cat > "$JAVA_CLASS".java <<EOF
 import java.util.*;
 class Dummy {
-  int value;
-  Dummy next;
-  Dummy(int value) {
-    this.value = value;
-    if (value % 2 == 0) {
-      next = new Dummy(value - 1);
+    int value;
+    Dummy next;
+    Dummy(int value) {
+        this.value = value;
+        if (value % 2 == 0) {
+            next = new Dummy(value - 1);
+        }
     }
-  }
 }
 public class $JAVA_CLASS {
-  public static final int USED_HEAP = $USED_HEAP;
-  public static final int FIRST_BLOCK = $FIRST_BLOCK;
-  public static int[][][] mem = new int[256][1024][FIRST_BLOCK];
-  public static int[][][] mem2;
-  public static void main(String[] args) throws Exception {
-    try {
-      ArrayList<Dummy> list = new ArrayList<>();
-      for (int i = 0; i < 1000; i++) {
-        int[][][] foo = new int[256][1024][5];
-	for (int j = 0; j < 100; j++) {
-	  list.add(new Dummy(i));
-	  list.add(new Dummy(j));
-	}
-	foo[1][2][3] = list.get(42 + i).value;
-      }
-      list = null;
-      mem2 = new int[256][1024][USED_HEAP - FIRST_BLOCK];
-      stack();
-    } catch (StackOverflowError soe) {
-      System.err.println("\\\\o/");
+    public static final int USED_HEAP = $USED_HEAP;
+    public static final int FIRST_BLOCK = $FIRST_BLOCK;
+    public static int[][][] mem = new int[256][1024][FIRST_BLOCK];
+    public static int[][][] mem2;
+    public static void main(String[] args) throws Exception {
+        try {
+            ArrayList<Dummy> list = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                int[][][] foo = new int[256][1024][5];
+                for (int j = 0; j < 100; j++) {
+                    list.add(new Dummy(i));
+                    list.add(new Dummy(j));
+                }
+                foo[1][2][3] = list.get(42 + i).value;
+            }
+            list = null;
+            mem2 = new int[256][1024][USED_HEAP - FIRST_BLOCK];
+            stack();
+        } catch (StackOverflowError soe) {
+            System.err.println("\\\\o/");
+        }
     }
-  }
 
-  public static void stack() {
-    stack();
-  }
+    public static void stack() {
+        stack();
+    }
 }
 EOF
-  javac "$JAVA_CLASS".java
+    javac "$JAVA_CLASS".java
 }
 
 function exec_java() {
-  echo "- trying with: sandbox: ${SANDBOX_MEM}MB, stack: ${JVM_STACK}MB, heap: ${JVM_HEAP}MB, out of which ${USED_HEAP}MB will be used."
-  cgcreate -g memory,cpu:"$GROUPNAME"
-  cgcreate -g memory,cpu:"$GROUPNAME"/"$SUBGROUP"
-  SANDBOX_BYTE=$((SANDBOX_MEM*1024*1024))
-  echo "$SANDBOX_BYTE" > /sys/fs/cgroup/memory/"$GROUPNAME"/"$SUBGROUP"/memory.limit_in_bytes
-  echo "$SANDBOX_BYTE" > /sys/fs/cgroup/memory/"$GROUPNAME"/"$SUBGROUP"/memory.memsw.limit_in_bytes
-  cgexec -g memory,cpu:"$GROUPNAME"/"$SUBGROUP" java -XX:+UseSerialGC -Xmx"$JVM_HEAP"m -Xms"$JVM_HEAP"m -Xss"$JVM_STACK"m "$JAVA_CLASS" &> log
+    echo "- trying with: sandbox: ${SANDBOX_MEM}MB, stack: ${JVM_STACK}MB, heap: ${JVM_HEAP}MB, out of which ${USED_HEAP}MB will be used."
+    cgcreate -g memory,cpu:"$GROUPNAME"
+    cgcreate -g memory,cpu:"$GROUPNAME"/"$SUBGROUP"
+    SANDBOX_BYTE=$((SANDBOX_MEM*1024*1024))
+    echo "$SANDBOX_BYTE" > /sys/fs/cgroup/memory/"$GROUPNAME"/"$SUBGROUP"/memory.limit_in_bytes
+    echo "$SANDBOX_BYTE" > /sys/fs/cgroup/memory/"$GROUPNAME"/"$SUBGROUP"/memory.memsw.limit_in_bytes
+    cgexec -g memory,cpu:"$GROUPNAME"/"$SUBGROUP" java -XX:+UseSerialGC -Xmx"$JVM_HEAP"m -Xms"$JVM_HEAP"m -Xss"$JVM_STACK"m "$JAVA_CLASS" &> log
 }
 
 while true; do
-	write_and_compile_java
-	if exec_java; then
-	  break;
-	fi
-	if grep OutOfMemoryError log; then
-	  USED_HEAP=$((USED_HEAP-STEP))
-	else
-	  JVM_HEAP=$((JVM_HEAP-STEP))
-	fi
-	cgdelete -g memory,cpu:"$GROUPNAME" -r
+    write_and_compile_java
+    if exec_java; then
+        break;
+    fi
+    if grep OutOfMemoryError log; then
+        USED_HEAP=$((USED_HEAP-STEP))
+    else
+        JVM_HEAP=$((JVM_HEAP-STEP))
+    fi
+    cgdelete -g memory,cpu:"$GROUPNAME" -r
 done
 MAX=$(cat /sys/fs/cgroup/memory/"$GROUPNAME"/"$SUBGROUP"/memory.memsw.max_usage_in_bytes)
 echo "Memory usage in sandbox:" $((MAX/1024/1024)) "MB (should be close to ${SANDBOX_MEM}MB)"


### PR DESCRIPTION
This PR tries to cleanup a bit the scripts inside misc-tools/. Since many lines are involved in the process, I've tried to split the PR in multiple commits for an easier review. They all try to "clean up the scripts", so in the end they can be squashed into a single commit if you want.

The idea of this PR is to clean up without making changes to the overall behaviour of the scripts, so I hope to not have introduced any side effect. Overall this PR does:

- uniform the indentation of the various scripts (4 spaces + 2 spaces for alignment)
- fix SC2086 (missing quotes) ¹
- fix other shellcheck warnings ²
- try to reduce code duplication by extracting some variables and functions (most notably `in_chroot` in the last commit)

¹ I'm aware of [this script](https://github.com/DOMjudge/domjudge/blob/main/tests/syntax#L52) that should run shellcheck on the scripts, and I see why SC2086 is ignored by default. Sill, I think that, to be on the safe side, the quotes should be added.

² I don't know why many of the warnings I've fixed were not found by that script in the CI (is it included in the pipeline?). In any case I used `shellcheck 0.7.2`.

**Disclaimer**: I've tried to test the changes as much as possible, but I'm not able to run few of the scripts: `compare-cds.sh`, `dj_make_chroot_docker` (~doesn't work yet on my machine, maybe a new PR will arrive 👀~, I've fixed it, a new PR will arrive soon since it's unrelated to this), `fix_permissions`, `import-contest.sh`, `jvm_footprint`.