### PR TITLE
Enable unit tests again

### DIFF
--- a/gitlab/ci/unit.yml
+++ b/gitlab/ci/unit.yml
@@ -26,7 +26,7 @@
       - lib/vendor/
 
 run unit tests:
-  extends: [.unit_job,.mariadb_job]
+  extends: [.mariadb_job,.unit_job]
 
 run unit tests (MySQL):
-  extends: [.unit_job,.mysql_job]
+  extends: [.mysql_job,.unit_job]


### PR DESCRIPTION
The order seems to matter for the overwrite of the `script`