### PR TITLE
2022 unit

### DIFF
--- a/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
@@ -24,7 +24,7 @@ class ClarificationControllerTest extends BaseTest
             "to_team_id"   => null,
             "reply_to_id"  => null,
             "time"         => "2018-02-11T21:47:18.901+00:00",
-            "contest_time" => "-16525:12:41.098",
+            "contest_time" => "-25309:12:41.098",
             "text"         => "Can you tell me how to solve this problem?",
             "answered"     => true,
         ],
@@ -34,7 +34,7 @@ class ClarificationControllerTest extends BaseTest
             "to_team_id"   => "2",
             "reply_to_id"  => "1",
             "time"         => "2018-02-11T21:47:57.689+00:00",
-            "contest_time" => "-16525:12:02.310",
+            "contest_time" => "-25309:12:02.310",
             "text"         => "> Can you tell me how to solve this problem?\r\n\r\nNo, read the problem statement.",
             "answered"     => true,
         ],
@@ -44,7 +44,7 @@ class ClarificationControllerTest extends BaseTest
             "to_team_id"   => null,
             "reply_to_id"  => null,
             "time"         => "2018-02-11T21:48:58.901+00:00",
-            "contest_time" => "-16525:11:01.098",
+            "contest_time" => "-25309:11:01.098",
             "text"         => "Is it necessary to read the problem statement carefully?",
             "answered"     => false,
         ],
@@ -54,7 +54,7 @@ class ClarificationControllerTest extends BaseTest
             "to_team_id"   => null,
             "reply_to_id"  => null,
             "time"         => "2018-02-11T21:53:20.000+00:00",
-            "contest_time" => "-16525:06:40.000",
+            "contest_time" => "-25309:06:40.000",
             "text"         => "Lunch is served",
             "answered"     => true,
         ],
@@ -64,7 +64,7 @@ class ClarificationControllerTest extends BaseTest
             "to_team_id"   => "2",
             "reply_to_id"  => null,
             "time"         => "2018-02-11T21:47:43.689+00:00",
-            "contest_time" => "-16525:12:16.310",
+            "contest_time" => "-25309:12:16.310",
             "text"         => "There was a mistake in judging this problem. Please try again",
             "answered"     => true,
         ],
@@ -85,7 +85,7 @@ class ClarificationControllerTest extends BaseTest
         $this->assertCount(1, $clarificationFromApi);
         $this->assertEquals("Lunch is served", $clarificationFromApi[0]['text']);
         $this->assertEquals("2018-02-11T21:53:20.000+00:00", $clarificationFromApi[0]['time']);
-        $this->assertEquals("-16525:06:40.000", $clarificationFromApi[0]['contest_time']);
+        $this->assertEquals("-25309:06:40.000", $clarificationFromApi[0]['contest_time']);
         $this->assertArrayNotHasKey('answered', $clarificationFromApi[0]);
     }
 

--- a/webapp/tests/Unit/Controller/API/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerTest.php
@@ -10,9 +10,9 @@ class ContestControllerTest extends BaseTest
         '2' => [
             'formal_name'                => 'Demo contest',
             'penalty_time'               => 20,
-            'start_time'                 => '2020-01-01T11:00:00+00:00',
-            'end_time'                   => '2023-01-01T16:00:00+00:00',
-            'duration'                   => '26309:00:00.000',
+            'start_time'                 => '2021-01-01T11:00:00+00:00',
+            'end_time'                   => '2024-01-01T16:00:00+00:00',
+            'duration'                   => '26285:00:00.000',
             'scoreboard_freeze_duration' => '1:00:00.000',
             'id'                         => '2',
             'external_id'                => 'demo',

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -96,8 +96,8 @@ class ImportExportControllerTest extends BaseTest
         $yaml =<<<HEREDOC
 name: 'Demo contest'
 short-name: demo
-start-time: '2020-01-01T11:00:00+00:00'
-duration: '26309:00:00.000'
+start-time: '2021-01-01T11:00:00+00:00'
+duration: '26285:00:00.000'
 scoreboard-freeze-duration: '1:00:00'
 penalty-time: 20
 default-clars:


### PR DESCRIPTION
Alternative is to rewrite everything after setting the 2 example contests demo{,prac} with static dates as they are now based on the current year.

As we also use this for the final product I rather waste 1 commit per year on upgrading the testcases.