### PR TITLE
Keep casing of submission language

### DIFF
--- a/webapp/templates/partials/javascript_language_detect.html.twig
+++ b/webapp/templates/partials/javascript_language_detect.html.twig
@@ -4,7 +4,7 @@
         switch (ext) {
                 {% for language in submission_languages %}
                 {% for extension in language.extensions %}
-            case '{{ extension }}':
+            case '{{ extension|lower }}':
                 return '{{ language.langid }}';
                 {% endfor %}
                 {% endfor %}


### PR DESCRIPTION
Languages like R have their extension as .R instead of .r, as this is
convention we should respect that. The lowercase for the filename itself
is kept as that will most likely lead to the shortname of the problem.

The alternative is to lowercase all extensions, but than we could have collisions when there are languages where capital extension would be something else compared to lowercase.

According to: https://en.wikipedia.org/wiki/C%2B%2B this could be the case for C->C++ and c->c

closes: https://github.com/DOMjudge/domjudge/issues/1408

As the issue is filed against 7.3 we might want to cherry-pick this.