### PR TITLE
Fix missing optional parameter in fetch_executable_internal

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -281,7 +281,7 @@ function fetch_executable(
 // - an error message (null if successful)
 // - optional extra build log.
 function fetch_executable_internal(
-    string $workdirpath, string $type, string $execid, string $hash, bool $combined_run_compare) : array
+    string $workdirpath, string $type, string $execid, string $hash, bool $combined_run_compare = false) : array
 {
     $execdir         = join('/', [
         $workdirpath,


### PR DESCRIPTION
During the refactor of #1243 an instance of the call to `fetch_executable_internal` was missing a required parameter (`bool $combined_run_compare`). This makes the judgedaemon crash when a submission debug package is requested.

The error message is:

```
[Jan 11 20:21:16.415] judgedaemon[49]: error: Too few arguments to function fetch_executable_internal(), 4 passed in /opt/domjudge/judgehost/lib/judge/judgedaemon.main.php on line 782 and exactly 5 expected
```

The incriminated call site is:

https://github.com/DOMjudge/domjudge/blob/fb492805365c4d2fcd14e418c910f43d6c377fcd/judge/judgedaemon.main.php#L778-L783

The only other call site of that function is:

https://github.com/DOMjudge/domjudge/blob/fb492805365c4d2fcd14e418c910f43d6c377fcd/judge/judgedaemon.main.php#L257

And in that place the value of `$combined_run_compare` comes from the function argument which defaults to `false`. Furthermore, before the refactor the value passed was still `false`.