### PR TITLE
Add missing `global $myhost;`

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1000,6 +1000,7 @@ function read_metadata(string $filename)
 
 function cleanup_judging(string $workdir) : void
 {
+    global $myhost;
     // revoke readablity for domjudge-run user to this workdir
     chmod($workdir, 0700);
 


### PR DESCRIPTION
`$myhost` is used but was not imported from the global scope.

I've found this simply because vscode was complaining that `$myhost` was not declared few lines below. Why was this not caught by the CI?