### PR TITLE
Fix composer install for maintainer-config

### DIFF
--- a/webapp/config/autoload.php.in
+++ b/webapp/config/autoload.php.in
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * @configure_input@
  *


### PR DESCRIPTION
I suspect that the autoload has no strict types so autoloading is possible. It was excluded in the past so seem reasonable to ignore strict types here.