### PR TITLE
Add distinction between inplace install and maintainer-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ dist: configure composer-dependencies composer-package-versions
 
 # Install PHP dependencies
 composer-dependencies:
-ifeq (, $(shell command -v composer))
+ifeq (, $(shell command -v composer 2> /dev/null))
 	$(error "'composer' command not found in $(PATH), install it via your package manager or https://getcomposer.org/download/")
 endif
 # We use --no-scripts here because at this point the autoload.php file is

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ inplace-conf: dist
 
 # Run Symfony in dev mode (for maintainer-mode):
 webapp/.env.local:
-	echo "# This file was automatically created by 'make maintainer-conf' to run" >> $@
+	echo "# This file was automatically created by 'make maintainer-conf' to run" > $@
 	echo "# the DOMjudge Symfony application in developer mode. Adjust as needed." >> $@
 	echo "APP_ENV=dev" >> $@
 

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,12 @@ dist: configure composer-dependencies composer-package-versions
 
 # Install PHP dependencies
 composer-dependencies:
-ifeq (, $(shell which composer))
+ifeq (, $(shell command -v composer))
 	$(error "'composer' command not found in $(PATH), install it via your package manager or https://getcomposer.org/download/")
 endif
 # We use --no-scripts here because at this point the autoload.php file is
 # not generated yet, which is needed to run the post-install scripts.
-	composer $(subst 1,-q,$(QUIET)) install --prefer-dist -o --no-scripts
+	composer $(subst 1,-q,$(QUIET)) install --prefer-dist -o -a --no-scripts
 
 composer-dependencies-dev:
 	composer $(subst 1,-q,$(QUIET)) install --prefer-dist --no-scripts

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -28,7 +28,7 @@ install-docs: docs
 	$(call install_tree,$(DESTDIR)$(domjudge_docdir)/manual,build/html)
 	$(INSTALL_DATA) -t $(DESTDIR)$(domjudge_docdir)/manual build/domjudge-team-manual.pdf
 
-maintainer-install: docs
+inplace-install: docs
 	ln -sf build/html
 	ln -sf build/team
 
@@ -53,4 +53,4 @@ team:
 	$(MAKE) -C build/team domjudge-team-manual.pdf
 	cp build/team/domjudge-team-manual.pdf build
 
-.PHONY: docs distdocs install-docs maintainer-install html team
+.PHONY: docs distdocs install-docs inplace-install html team

--- a/misc-tools/Makefile
+++ b/misc-tools/Makefile
@@ -29,7 +29,7 @@ install-judgehost:
 	$(INSTALL_PROG) -t $(DESTDIR)$(judgehost_bindir) $(SUBST_JUDGEHOST) \
 		dj_make_ubuntu_java_chroot
 
-maintainer-install:
+inplace-install:
 	for i in $(SUBST_DOMSERVER) ; do \
 		ln -sf $(CURDIR)/$$i $(domserver_bindir) ; \
 	done


### PR DESCRIPTION
The base is now the inplace-install which is the same as the other install methods but just in the directory structure. So 'production ready'.

The 'maintainer-conf' target remains and still means that you indeed want to develop on this so will install dev dependencies, set the app in dev mode and disable production optimizations, on top of the inplace-installation.