### PR TITLE
Lookat freeze error

### DIFF
--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -42,9 +42,9 @@ UNIX_TIMESTAMP=$(date +%s)
 STARTTIME=$((UNIX_TIMESTAMP-TIMEHELP))
 export TZ="Europe/Amsterdam"
 STARTTIME_STRING="$(date  -d @$STARTTIME +'%F %T Europe/Amsterdam')"
-FREEZETIME=$((UNIX_TIMESTAMP+15))
+FREEZETIME=$((UNIX_TIMESTAMP+TIMEHELP))
 FREEZETIME_STRING="$(date  -d @$FREEZETIME +'%F %T Europe/Amsterdam')"
-ENDTIME=$((UNIX_TIMESTAMP+TIMEHELP))
+ENDTIME=$((UNIX_TIMESTAMP+TIMEHELP+TIMEHELP))
 ENDTIME_STRING="$(date  -d @$ENDTIME +'%F %T Europe/Amsterdam')"
 # Database changes to make the REST API and event feed match better.
 cat <<EOF | mysql domjudge


### PR DESCRIPTION
Currently the integration test ends with PHP errors. One of those is a freeze which cannot be applied. This PR was to get the DB in certain states to investigate why this is happening and if it should be fixed.

It now also proposes a fix to remove the error.

When this is fixed and the other errors are properly fixed we can add an explicit check for PHP errors and fail on those to handle a simple contest as that's what the integration test currently simulates.