### PR TITLE
Fix failing submission upload

### DIFF
--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -42,9 +42,9 @@ UNIX_TIMESTAMP=$(date +%s)
 STARTTIME=$((UNIX_TIMESTAMP-TIMEHELP))
 export TZ="Europe/Amsterdam"
 STARTTIME_STRING="$(date  -d @$STARTTIME +'%F %T Europe/Amsterdam')"
-FREEZETIME=$((UNIX_TIMESTAMP+15))
+FREEZETIME=$((UNIX_TIMESTAMP+TIMEHELP))
 FREEZETIME_STRING="$(date  -d @$FREEZETIME +'%F %T Europe/Amsterdam')"
-ENDTIME=$((UNIX_TIMESTAMP+TIMEHELP))
+ENDTIME=$((UNIX_TIMESTAMP+TIMEHELP+TIMEHELP))
 ENDTIME_STRING="$(date  -d @$ENDTIME +'%F %T Europe/Amsterdam')"
 # Database changes to make the REST API and event feed match better.
 cat <<EOF | mysql domjudge

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -247,6 +247,8 @@ curl $CURLOPTS -X POST -d 'contest=2&donow[freeze]=freeze now' http://localhost/
 curl $CURLOPTS -X POST -d 'contest=2&donow[end]=end now' http://localhost/domjudge/jury/contests || true
 curl $CURLOPTS -X POST -d 'finalize_contest[b]=0&finalize_contest[finalizecomment]=gitlab&finalize_contest[finalize]=' http://localhost/domjudge/jury/contests/2/finalize
 
+cat /opt/domjudge/domserver/webapp/var/log/prod.log | egrep '(CRITICAL|ERROR):' || true
+
 # Check the Contest API:
 $CHECK_API -n -C -e -a 'strict=1' http://admin:$ADMINPASS@localhost/domjudge/api
 section_end api_check |& tee "$GITLABARTIFACTS/check_api.log"

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -254,7 +254,9 @@ curl $CURLOPTS -X POST -d 'contest=2&donow[freeze]=freeze now' http://localhost/
 curl $CURLOPTS -X POST -d 'contest=2&donow[end]=end now' http://localhost/domjudge/jury/contests || true
 curl $CURLOPTS -X POST -d 'finalize_contest[b]=0&finalize_contest[finalizecomment]=gitlab&finalize_contest[finalize]=' http://localhost/domjudge/jury/contests/2/finalize
 
-cat /opt/domjudge/domserver/webapp/var/log/prod.log | egrep '(CRITICAL|ERROR):' || true
+if cat /opt/domjudge/domserver/webapp/var/log/prod.log | egrep '(CRITICAL|ERROR):'; then
+   exit 1
+fi
 
 # Check the Contest API:
 $CHECK_API -n -C -e -a 'strict=1' http://admin:$ADMINPASS@localhost/domjudge/api


### PR DESCRIPTION
This
Closes: https://github.com/DOMjudge/domjudge/issues/1379

This also has more than https://github.com/DOMjudge/domjudge/pull/1441 so
Closes: https://github.com/DOMjudge/domjudge/pull/1441

This also uses the commits from @meisterT in https://github.com/DOMjudge/domjudge/pull/1380 and fails if this finds something. 

The goal of the PR is to remove all PHP errors in the symfony production logs. Some are because of erroneous submissions which are to verify this behavior and the the other test is because of the freeze which is done to put all events in the event feed to test this in the integration job.