### PR TITLE
Unique selfregister shortname

### DIFF
--- a/webapp/src/Controller/SecurityController.php
+++ b/webapp/src/Controller/SecurityController.php
@@ -146,12 +146,9 @@ class SecurityController extends AbstractController
                 switch ($registration_form->get('affiliation')->getData()) {
                     case 'new':
                         $affiliation = new TeamAffiliation();
-                        $shortName = $this->getShortName($registration_form->get('affiliationShortName')->getData());
-                        $name = $this->getShortName($registration_form->get('affiliationName')->getData());
-                        $this->logger->error($shortName, ['length' => strlen($shortName), 'bool' => strlen($shortName)>$shortNameLength]);
                         $affiliation
-                            ->setName($name)
-                            ->setShortname($shortName);
+                            ->setName($registration_form->get('affiliationName')->getData())
+                            ->setShortname($registration_form->get('affiliationShortName')->getData());
                         if ($registration_form->has('affiliationCountry')) {
                             $affiliation->setCountry($registration_form->get('affiliationCountry')->getData());
                         }

--- a/webapp/src/Controller/SecurityController.php
+++ b/webapp/src/Controller/SecurityController.php
@@ -146,9 +146,12 @@ class SecurityController extends AbstractController
                 switch ($registration_form->get('affiliation')->getData()) {
                     case 'new':
                         $affiliation = new TeamAffiliation();
+                        $shortName = $this->getShortName($registration_form->get('affiliationShortName')->getData());
+                        $name = $this->getShortName($registration_form->get('affiliationName')->getData());
+                        $this->logger->error($shortName, ['length' => strlen($shortName), 'bool' => strlen($shortName)>$shortNameLength]);
                         $affiliation
-                            ->setName($registration_form->get('affiliationName')->getData())
-                            ->setShortname($registration_form->get('affiliationName')->getData());
+                            ->setName($name)
+                            ->setShortname($shortName);
                         if ($registration_form->has('affiliationCountry')) {
                             $affiliation->setCountry($registration_form->get('affiliationCountry')->getData());
                         }

--- a/webapp/src/DataFixtures/Test/EnableSelfregisterFixture.php
+++ b/webapp/src/DataFixtures/Test/EnableSelfregisterFixture.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\TeamCategory;
+use Doctrine\Persistence\ObjectManager;
+
+class EnableSelfregisterFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $selfRegisterCategory = $manager->getRepository(TeamCategory::class)->findOneBy(['name' => 'Observers']);
+        $selfRegisterCategory->setAllowSelfRegistration(true);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/EnableSelfregisterSecondCategoryFixture.php
+++ b/webapp/src/DataFixtures/Test/EnableSelfregisterSecondCategoryFixture.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\TeamCategory;
+use Doctrine\Persistence\ObjectManager;
+
+class EnableSelfregisterSecondCategoryFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $selfRegisterCategory = $manager->getRepository(TeamCategory::class)->findOneBy(['name' => 'Self-Registered']);
+        $selfRegisterCategory->setAllowSelfRegistration(true);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/SelfRegisteredUserFixture.php
+++ b/webapp/src/DataFixtures/Test/SelfRegisteredUserFixture.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\DataFixtures\ExampleData\TeamFixture;
+use App\Entity\Role;
+use App\Entity\User;
+use App\Entity\Team;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+class SelfRegisteredUserFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $user = new User();
+        $user
+            ->setUsername('selfregister')
+            ->setName('selfregistered user for example team')
+            ->setEmail('electronic@mail.tld')
+            ->setPlainPassword('demo')
+            ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => 'exteam']))
+            ->addUserRole($manager->getRepository(Role::class)->findOneBy(['dj_role' => 'team']));
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+}

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -174,7 +174,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
 
     public function setUsername(?string $username): User
     {
-        $this->username = $username;
+        $this->username = (string)$username;
         return $this;
     }
 

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -185,7 +185,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
 
     public function setName(?string $name): User
     {
-        $this->name = $name;
+        $this->name = (string)$name;
         return $this;
     }
 

--- a/webapp/src/Form/Type/UserRegistrationType.php
+++ b/webapp/src/Form/Type/UserRegistrationType.php
@@ -139,6 +139,15 @@ class UserRegistrationType extends AbstractType
                         'placeholder' => 'Affiliation name',
                     ],
                     'mapped' => false,
+                ])
+                ->add('affiliationShortName', TextType::class, [
+                    'label' => false,
+                    'required' => false,
+                    'attr' => [
+                        'placeholder' => 'Affiliation shortname',
+                        'maxlength' => '32',
+                    ],
+                    'mapped' => false,
                 ]);
             if ($this->config->get('show_flags')) {
                 $builder->add('affiliationCountry', ChoiceType::class, [
@@ -213,16 +222,19 @@ class UserRegistrationType extends AbstractType
                 $form = $context->getRoot();
                 switch ($form->get('affiliation')->getData()) {
                     case 'new':
-                        $affiliationName = $form->get('affiliationName')->getData();
-                        if (empty($affiliationName)) {
-                            $context->buildViolation('This value should not be blank.')
-                                ->atPath('affiliationName')
-                                ->addViolation();
-                        }
-                        if ($this->em->getRepository(TeamAffiliation::class)->findOneBy(['name' => $affiliationName])) {
-                            $context->buildViolation('This affiliation name is already in use.')
-                                ->atPath('affiliationName')
-                                ->addViolation();
+                        foreach(['Name','ShortName'] as $identifier) {
+                            $name = $form->get('affiliation'.$identifier)->getData();
+                            if (empty($name)) {
+                                $context->buildViolation('This value should not be blank.')
+                                    ->atPath('affiliation'.$identifier)
+                                    ->addViolation();
+                            }
+                            if ($this->em->getRepository(TeamAffiliation::class)->findOneBy([strtolower($identifier) => $name])) {
+                                $context->buildViolation('This affiliation '.strtolower($identifier).' is already in use.')
+                                    ->atPath('affiliation'.$identifier)
+                                    ->addViolation();
+                            
+                            }
                         }
                         break;
                     case 'existing':

--- a/webapp/templates/security/register.html.twig
+++ b/webapp/templates/security/register.html.twig
@@ -32,6 +32,7 @@
             if ($affiliationRadios.length) {
                 $affiliationRadios.on('change', function () {
                     var $affiliationNameGroup = $('#user_registration_affiliationName').closest('.form-group');
+                    var $affiliationShortNameGroup = $('#user_registration_affiliationShortName').closest('.form-group');
                     var $affiliationCountryGroup = $('#user_registration_affiliationCountry').closest('.form-group');
                     var $existingAffiliationGroup = $('#user_registration_existingAffiliation').closest('.form-group');
                     var value = $affiliationRadios.filter(':checked').val();
@@ -39,11 +40,13 @@
                     switch (value) {
                         case 'none':
                             $affiliationNameGroup.hide();
+                            $affiliationShortNameGroup.hide();
                             $affiliationCountryGroup.hide();
                             $existingAffiliationGroup.hide();
                             break;
                         case 'new':
                             $affiliationNameGroup.show();
+                            $affiliationShortNameGroup.show();
                             $affiliationCountryGroup.show();
                             $existingAffiliationGroup.hide();
                             break;


### PR DESCRIPTION
This is a possible fix for: https://github.com/DOMjudge/domjudge/issues/841

It still needs some styling cleanup but I would like some feedback if we indeed want this.

Also we don't have password restrictions for this form, which might be a problem for how other people use this where the people self registering are not spectators (this is how I use them for my prelims) but "real" contestants. But this is not relevant for this PR.
