### PR TITLE
Add SECURITY.md to show committed PHP versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .git* export-ignore
+SECURITY.md export-ignore

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-| Version | Supported          | PHP version supported |
-| ------- | ------------------ | --------------------- |
-| 8.x.x   | :warning:          | 7.4-8.1               |
-| 8.0.x   | :white_check_mark: | 7.2-8.0               |
-| 7.3.x   | :white_check_mark: | 7.2-7.4               |
-| < 7.3   | :x:                | :x:                   |
+| DOMjudge Version | Supported          | PHP version supported |
+| ---------------- | ------------------ | --------------------- |
+| 8.x.x            | :warning:          | 7.4-8.1               |
+| 8.0.x            | :white_check_mark: | 7.2-8.0               |
+| 7.3.x            | :white_check_mark: | 7.2-7.4               |
+| < 7.3            | :x:                | :x:                   |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          | PHP version supported |
+| ------- | ------------------ | --------------------- |
+| 8.x.x   | :warning:          | 7.4-8.1               |
+| 8.0.x   | :white_check_mark: | 7.2-8.0               |
+| 7.3.x   | :white_check_mark: | 7.2-7.4               |
+| < 7.3   | :x:                | :x:                   |
+
+## Reporting a Vulnerability
+
+Please provide a PR to fix the vulnerability when possible without affecting the supported PHP versions.
+If this is not possible please send us an email at team@domjudge.org, or contact us at Slack (see https://www.domjudge.org/chat)
+
+We try to keep you updated at least once a month in case of larger vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,12 @@
 
 ## Reporting a Vulnerability
 
-Please provide a PR to fix the vulnerability when possible without affecting the supported PHP versions.
-If this is not possible please send us an email at team@domjudge.org, or contact us at Slack (see https://www.domjudge.org/chat)
+If you want to report a vulnerability, please do not use the issue tracker
+or pull request, but instead contact security@domjudge.org so we can assess
+the issue and publish a fix when making it public.
 
-We try to keep you updated at least once a month in case of larger vulnerabilities.
+Please mention the affected DOMjudge version and details of the vulnerability
+and how to reproduce it. We promise to publicly disclose the reported
+vulnerability, with the appropriate credit if desired, when we've agreed
+on a proper way to solve it. We try to keep you updated at least once a
+month in case of more complex vulnerabilities.


### PR DESCRIPTION
Mainly to have the supported PHP versions somewhere. I dont know what we should do with the following questions so I left them open for the case where this happens:

## Reporting a Vulnerability

Use this section to tell people how to report a vulnerability.

Tell them where to go, how often they can expect to get an update on a
reported vulnerability, what to expect if the vulnerability is accepted or
declined, etc.