### PR TITLE
Fix composer installation for baseinstall.sh

### DIFF
--- a/.github/workflowscripts/baseinstall.sh
+++ b/.github/workflowscripts/baseinstall.sh
@@ -5,12 +5,16 @@ set -eux
 sudo apt update
 sudo apt install -y acl zip unzip nginx php php-fpm php-gd \
                     php-cli php-intl php-mbstring php-mysql php-curl php-json \
-                    php-xml php-zip composer ntp make sudo debootstrap \
+                    php-xml php-zip ntp make sudo debootstrap \
                     libcgroup-dev lsof php-cli php-curl php-json php-xml \
                     php-zip procps gcc g++ default-jre-headless \
                     default-jdk-headless ghc fp-compiler autoconf automake bats \
                     python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig \
-                    python3-yaml latexmk
+                    python3-yaml latexmk curl
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+HASH="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
 composer install --no-scripts
 composer run-script package-versions-dump


### PR DESCRIPTION
* `apt`-sourced `composer` is out of date -- install using composer setup script
  instead.