### PR TITLE
Get rid of PHP 8.1 deprecations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,8 +3,11 @@ DOMjudge Programming Contest Judging System
 Version 8.1.0 - DEV
 -------------------
  - Document that minimum PHP version is now 7.4.0.
- - Add support for PHP 8.1
+ - Add support for PHP 8.1.
  - Upgrade Symfony to 5.4 LTS and upgrade other library dependencies.
+ - Replace calls to deprecated `strftime` with `date`. Note: if you have
+   configured a custom `time_format`, you need to update it to the format
+   supported by `date`.
 
 Version 8.0.0 - 30 January 2022
 -------------------------------

--- a/composer.lock
+++ b/composer.lock
@@ -4239,20 +4239,21 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "1.1.4",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "ab2237657ad99667a5143e32ba2683c8029563d4"
+                "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/ab2237657ad99667a5143e32ba2683c8029563d4",
-                "reference": "ab2237657ad99667a5143e32ba2683c8029563d4",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/cccc74ee5e328031b15640b51056ee8d3bb66c0a",
+                "reference": "cccc74ee5e328031b15640b51056ee8d3bb66c0a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8"
+                "php": "^7.3 || ^8",
+                "symfony/polyfill-php81": "^1.23"
             },
             "require-dev": {
                 "captainhook/captainhook": "^5.3",
@@ -4262,6 +4263,7 @@
                 "hamcrest/hamcrest-php": "^2",
                 "jangregor/phpstan-prophecy": "^0.8",
                 "mockery/mockery": "^1.3",
+                "phpspec/prophecy-phpunit": "^2.0",
                 "phpstan/extension-installer": "^1",
                 "phpstan/phpstan": "^0.12.32",
                 "phpstan/phpstan-mockery": "^0.12.5",
@@ -4289,7 +4291,7 @@
                     "homepage": "https://benramsey.com"
                 }
             ],
-            "description": "A PHP 7.2+ library for representing and manipulating collections.",
+            "description": "A PHP library for representing and manipulating collections.",
             "keywords": [
                 "array",
                 "collection",
@@ -4300,7 +4302,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/1.1.4"
+                "source": "https://github.com/ramsey/collection/tree/1.2.2"
             },
             "funding": [
                 {
@@ -4312,7 +4314,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-30T00:58:27+00:00"
+            "time": "2021-10-10T03:01:02+00:00"
         },
         {
             "name": "ramsey/uuid",

--- a/composer.lock
+++ b/composer.lock
@@ -2762,54 +2762,62 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.25.5",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0"
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1817faadd1846cd08be9a49e905dc68823bc38c0",
-                "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9",
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0"
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "php-amqplib/php-amqplib": "~2.4",
+                "elasticsearch/elasticsearch": "^7",
+                "graylog2/gelf-php": "^1.4.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
-                "phpunit/phpunit": "~4.5",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
+                "phpspec/prophecy": "^1.6.1",
+                "phpstan/phpstan": "^0.12.91",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90@dev",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2825,11 +2833,11 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "homepage": "https://github.com/Seldaek/monolog",
             "keywords": [
                 "log",
                 "logging",
@@ -2837,7 +2845,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/1.25.5"
+                "source": "https://github.com/Seldaek/monolog/tree/2.3.5"
             },
             "funding": [
                 {
@@ -2849,7 +2857,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:35:51+00:00"
+            "time": "2021-10-01T21:08:31+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -223,7 +223,7 @@
             description: Print times of contest events relative to contest start (instead of absolute).
         -   name: time_format
             type: string
-            default_value: "%H:%M"
+            default_value: "H:i"
             public: false
             description: The format used to print times. For formatting options see the PHP 'strftime' function.
         -   name: thumbnail_size

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -225,7 +225,7 @@
             type: string
             default_value: "H:i"
             public: false
-            description: The format used to print times. For formatting options see the PHP 'strftime' function.
+            description: The format used to print times. For formatting options see the PHP 'date' function.
         -   name: thumbnail_size
             type: int
             default_value: 200

--- a/lib/lib.error.php
+++ b/lib/lib.error.php
@@ -50,7 +50,7 @@ function logmsg(int $msglevel, string $string)
     $string = substr($string, 0, 10000);
 
     $msec = sprintf("%03d", (int)(explode(' ', microtime())[0]*1000));
-    $stamp = "[" . strftime("%b %d %H:%M:%S") . ".$msec] " . SCRIPT_ID .
+    $stamp = "[" . date('M d H:i:s') . ".$msec] " . SCRIPT_ID .
         (function_exists('posix_getpid') ? "[" . posix_getpid() . "]" : "") .
         ": ";
 

--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -87,7 +87,7 @@ class AuditLogController extends AbstractController
 
             $time = $logline->getLogTime();
             $data['when']['value'] = Utils::printtime($time, $timeFormat);
-            $data['when']['title'] = Utils::printtime($time, "%Y-%m-%d %H:%M:%S (%Z)");
+            $data['when']['title'] = Utils::printtime($time, "Y-m-d H:i:s (T)");
             $data['when']['sortvalue'] = $time;
 
             $data['who']['value'] = $logline->getUser();

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -131,7 +131,7 @@ class ContestController extends BaseController
             }
 
             $now       = (int)floor(Utils::now());
-            $nowstring = strftime('%Y-%m-%d %H:%M:%S ', $now) . date_default_timezone_get();
+            $nowstring = date('Y-m-d H:i:s ', $now) . date_default_timezone_get();
             $this->dj->auditlog('contest', $contest->getCid(), $time . ' now', $nowstring);
 
             // Special case delay/resume start (only sets/unsets starttime_undefined).
@@ -350,7 +350,7 @@ class ContestController extends BaseController
                     $timeTitle = '-';
                 } else {
                     $timeValue = Utils::printtime($time, $timeFormat);
-                    $timeTitle = Utils::printtime($time, '%Y-%m-%d %H:%M:%S (%Z)');
+                    $timeTitle = Utils::printtime($time, 'Y-m-d H:i:s (T)');
                 }
                 $contestdata[$timeField . 'time']['value']     = $timeValue;
                 $contestdata[$timeField . 'time']['sortvalue'] = $time;
@@ -631,7 +631,7 @@ class ContestController extends BaseController
     {
         $contest = new Contest();
         // Set default activate time
-        $contest->setActivatetimeString(strftime('%Y-%m-%d %H:%M:00 ') . date_default_timezone_get());
+        $contest->setActivatetimeString(date('Y-m-d H:i:00 ') . date_default_timezone_get());
 
         $form = $this->createForm(ContestType::class, $contest);
 
@@ -773,7 +773,7 @@ class ContestController extends BaseController
         $blockers = [];
         if (Utils::difftime((float)$contest->getEndtime(), Utils::now()) > 0) {
             $blockers[] = sprintf('Contest not ended yet (will end at %s)',
-                                  Utils::printtime($contest->getEndtime(), '%Y-%m-%d %H:%M:%S (%Z)'));
+                                  Utils::printtime($contest->getEndtime(), 'Y-m-d H:i:s (T)'));
         }
 
         /** @var int[] $submissionIds */

--- a/webapp/src/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/Controller/Jury/InternalErrorController.php
@@ -79,7 +79,7 @@ class InternalErrorController extends BaseController
                 }
             }
 
-            $internalerrordata['time']['value'] = Utils::printtime($internalerrordata['time']['value'], '%F %T');
+            $internalerrordata['time']['value'] = Utils::printtime($internalerrordata['time']['value'], 'Y-m-d H:i:s');
 
             // Save this to our list of rows
             $internal_errors_table[] = [

--- a/webapp/src/Controller/Jury/QueueTaskController.php
+++ b/webapp/src/Controller/Jury/QueueTaskController.php
@@ -86,7 +86,7 @@ class QueueTaskController extends BaseController
 
             // Format start time
             if (!empty($queueTaskData['starttime']['value'])) {
-                $queueTaskData['starttime']['value'] = Utils::printtime($queueTaskData['starttime']['value'], "%Y-%m-%d %H:%M:%S (%Z)");
+                $queueTaskData['starttime']['value'] = Utils::printtime($queueTaskData['starttime']['value'], "Y-m-d H:i:s (T)");
             } else {
                 $queueTaskData['starttime']['value'] = 'not started yet';
             }
@@ -208,7 +208,7 @@ class QueueTaskController extends BaseController
 
             // Format start time
             if (!empty($judgeTaskData['starttime']['value'])) {
-                $judgeTaskData['starttime']['value'] = Utils::printtime($judgeTaskData['starttime']['value'], "%Y-%m-%d %H:%M:%S (%Z)");
+                $judgeTaskData['starttime']['value'] = Utils::printtime($judgeTaskData['starttime']['value'], "Y-m-d H:i:s (T)");
             } else {
                 $judgeTaskData['starttime']['value'] = 'not started yet';
             }

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -1016,7 +1016,7 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
             }
 
             $resultItem['label'] = sprintf('%s time', ucfirst($time));
-            $resultItem['time']  = Utils::printtime($timeValue, '%Y-%m-%d %H:%M (%Z)');
+            $resultItem['time']  = Utils::printtime($timeValue, 'Y-m-d H:i:s (T)');
             if ($time === 'start' && !$this->getStarttimeEnabled()) {
                 $resultItem['class'] = 'ignore';
             }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     uniqueConstraints={@ORM\UniqueConstraint(name="username", columns={"username"}, options={"lengths":{190}})})
  * @UniqueEntity("username", message="The username '{{ value }}' is already in use.")
  */
-class User implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface, \Serializable
+class User implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
 {
     /**
      * @var int
@@ -159,22 +159,22 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         $this->plainPassword = null;
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(array(
+        return [
             $this->userid,
             $this->username,
             $this->password,
-        ));
+        ];
     }
 
-    public function unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        list(
+        [
             $this->userid,
             $this->username,
-            $this->password
-        ) = unserialize($serialized);
+            $this->password,
+        ] = $data;
     }
 
     public function getUserid(): ?int

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -216,7 +216,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
-     * Print a time formatted as specified. The format is according to strftime().
+     * Print a time formatted as specified. The format is according to date().
      * @param string|float $datetime
      * @param string|null  $format
      * @param Contest|null $contest If given, print time relative to that contest start.
@@ -272,7 +272,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $datetime = Utils::now();
         }
         return '<span title="' .
-            Utils::printtime($datetime, '%Y-%m-%d %H:%M (%Z)') . '">' .
+            Utils::printtime($datetime, 'Y-m-d H:i:s (T)') . '">' .
             $this->printtime($datetime, null, $contest) .
             '</span>';
     }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -463,7 +463,7 @@ class Utils
     }
 
     /**
-     * Print a time formatted as specified. The format is according to strftime().
+     * Print a time formatted as specified. The format is according to date().
      * @param string|float $datetime
      * @param string       $format
      * @return string
@@ -473,7 +473,7 @@ class Utils
         if (empty($datetime)) {
             return '';
         }
-        return Utils::specialchars(strftime($format, (int)$datetime));
+        return Utils::specialchars(date($format, (int)$datetime));
     }
 
     /**

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -450,7 +450,7 @@ class Utils
 
         $exact = true;
         for ($i = 0; $i < count($units) && $display > $factor; $i++) {
-            if (($display % $factor)!=0) {
+            if (((int)$display % $factor)!=0) {
                 $exact = false;
             }
             $display /= $factor;

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -202,7 +202,7 @@
                 <table class="table table-sm table-striped">
                     <tr>
                         <th>Finalized at</th>
-                        <td>{{ contest.finalizetime | printtime('%Y-%m-%d %H:%M:%S (%Z)') }}</td>
+                        <td>{{ contest.finalizetime | printtime('Y-m-d H:i:s (T)') }}</td>
                     </tr>
                     <tr>
                         <th>B</th>

--- a/webapp/templates/jury/contests.html.twig
+++ b/webapp/templates/jury/contests.html.twig
@@ -72,7 +72,7 @@
                 <strong>No active contest.</strong> Upcoming:<br/>
                 <p>
                     <i>{{ upcoming_contest.name }} ({{ upcoming_contest.shortname }})</i>;
-                    active from {{ upcoming_contest.activatetime | printtime('%a %d %b %Y %T %Z') }}
+                    active from {{ upcoming_contest.activatetime | printtime('D d M Y H:i:s T') }}
                 </p>
                 <form action="{{ path('jury_contests') }}" method="post">
                     <input type="hidden" name="contest" value="{{ upcoming_contest.cid }}"/>

--- a/webapp/templates/jury/internal_error.html.twig
+++ b/webapp/templates/jury/internal_error.html.twig
@@ -27,7 +27,7 @@
                 </tr>
                 <tr>
                     <th>Time</th>
-                    <td>{{ internalError.time | printtime('%F %T') }}</td>
+                    <td>{{ internalError.time | printtime('Y-m-d H:i:s') }}</td>
                 </tr>
                 <tr>
                     <th>Status</th>

--- a/webapp/templates/jury/rejudging.html.twig
+++ b/webapp/templates/jury/rejudging.html.twig
@@ -56,7 +56,7 @@
                     <th>Start time</th>
                     <td>
                         {% if rejudging.starttime %}
-                            <span title="{{ rejudging.starttime | printtime('%Y-%m-%d %H:%M:%S (%Z)') }}">
+                            <span title="{{ rejudging.starttime | printtime('Y-m-d H:i:s (T)') }}">
                                 {{ rejudging.starttime | printtime }}
                             </span>
                         {% else %}
@@ -68,7 +68,7 @@
                     <th>Apply time</th>
                     <td>
                         {% if rejudging.endtime %}
-                            <span title="{{ rejudging.endtime | printtime('%Y-%m-%d %H:%M:%S (%Z)') }}">
+                            <span title="{{ rejudging.endtime | printtime('Y-m-d H:i:s (T)') }}">
                                 {{ rejudging.endtime | printtime }}
                             </span>
                         {% else %}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -135,7 +135,7 @@
 
         <span>
             <i class="fas fa-clock" title="Submittime:"></i>
-            <span title="{{ submission.submittime | printtime('%Y-%m-%d %H:%M:%S (%Z)') }}">
+            <span title="{{ submission.submittime | printtime('Y-m-d H:i:s (T)') }}">
                 {{ submission.submittime | printtime(null, submission.contest) }}
             </span>
         </span>
@@ -365,7 +365,7 @@
                         {% set judgehostLink = path('jury_judgehost', {judgehostid: judgehostid}) %}
                         <a href="{{ judgehostLink }}">{{ hostname | printHost }}</a>
                     {% endfor %} -
-                    <span class="judgetime">Judging started: {{ selectedJudging.starttime | printtime('%H:%M:%S') }}
+                    <span class="judgetime">Judging started: {{ selectedJudging.starttime | printtime('H:i:s') }}
                         {%- if selectedJudging.endtime -%}
                             , finished in {{ selectedJudging.starttime | printtimediff(selectedJudging.endtime) }}s
                         {%- elseif selectedJudging.valid or selectedJudging.rejudging -%}
@@ -376,7 +376,7 @@
                     </span>
                 {% endif -%}
                 {%- if externalJudgement is not null %}
-                    <span class="judgetime">(external judging started: {{ externalJudgement.starttime | printtime('%H:%M:%S') }}
+                    <span class="judgetime">(external judging started: {{ externalJudgement.starttime | printtime('H:i:s') }}
                         {%- if externalJudgement.endtime -%}
                             , finished in {{ externalJudgement.starttime | printtimediff(externalJudgement.endtime) }}s
                         {%- else -%}

--- a/webapp/templates/jury/team.html.twig
+++ b/webapp/templates/jury/team.html.twig
@@ -47,7 +47,7 @@
                     <th>First login</th>
                     <td>
                         {% if team.users is not empty and team.users.first.firstLogin %}
-                            {{ team.users.first.firstLogin | printtime('%a %d %b %Y %T %Z') }}
+                            {{ team.users.first.firstLogin | printtime('D d M Y H:i:s T') }}
                         {% else %}
                             -
                         {% endif %}

--- a/webapp/templates/jury/user.html.twig
+++ b/webapp/templates/jury/user.html.twig
@@ -94,7 +94,7 @@
                     <th>First login</th>
                     <td>
                         {% if user.firstLogin %}
-                            {{ user.firstLogin | printtime('%a %d %b %Y %T %Z') }}
+                            {{ user.firstLogin | printtime('D d M Y H:i:s T') }}
                         {% else %}
                             -
                         {% endif %}
@@ -104,7 +104,7 @@
                     <th>Last login</th>
                     <td>
                         {% if user.lastLogin %}
-                            {{ user.lastLogin | printtime('%a %d %b %Y %T %Z') }}
+                            {{ user.lastLogin | printtime('D d M Y H:i:s T') }}
                         {% else %}
                             -
                         {% endif %}

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -150,7 +150,7 @@
     {% endif %} {# not scoreboard is null and not jury #}
 
     <p id="lastmod">
-        Last Update: {{ null | printtime('%a %d %b %Y %T %Z') }}<br/>
+        Last Update: {{ null | printtime('D d M Y H:i:s T') }}<br/>
         using <a href="https://www.domjudge.org/" target="_top">DOMjudge</a>
     </p>
 {% endif %}

--- a/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
+++ b/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
@@ -124,7 +124,7 @@ class MiscControllerTest extends BaseTest
     public function testChangeContest(bool $withReferrer) : void
     {
         $start       = (int)floor(microtime(true) - 1800);
-        $startString = strftime('%Y-%m-%d %H:%M:%S ',
+        $startString = date('Y-m-d H:i:s ',
                 $start) . date_default_timezone_get();
 
         // Create a second contest.

--- a/webapp/tests/Unit/Utils/UtilsTest.php
+++ b/webapp/tests/Unit/Utils/UtilsTest.php
@@ -184,7 +184,7 @@ class UtilsTest extends TestCase
      */
     public function testPrinttimeNotime() : void
     {
-        self::assertEquals('', Utils::printTime(null, "%H:%M"));
+        self::assertEquals('', Utils::printTime(null, "H:i"));
     }
 
     /**
@@ -196,7 +196,7 @@ class UtilsTest extends TestCase
         date_default_timezone_set('UTC');
         $timestamp = 1544964581.3604;
         $expected = '2018-12-16 12:49';
-        self::assertEquals($expected, Utils::printtime($timestamp, '%Y-%m-%d %H:%M'));
+        self::assertEquals($expected, Utils::printtime($timestamp, 'Y-m-d H:i'));
         date_default_timezone_set($tz);
     }
 


### PR DESCRIPTION
This does a few things:

* Update monolog and ramsey/collection to get rid of some external deprecations related to (un)serialize and DateTime.
* Use the new way of (un)serializing in the User class.
* Explicitly cast a variable to int somewhere for one less deprecation.
* Replace `strftime` with `date`.

Most are trivial changes, except for the last one. To quote PHP, strftime

> has been DEPRECATED as of PHP 8.1.0. Relying on this function is highly discouraged.

So we use the suggested (at least on the internet by multiple people) replacement `date`. That does change the format arguments, so I hope I did all of them correctly. People who have a custom `time_format` config setting need to change it, but I don't know where/how we could mention that.

After this we lost thousands of deprecations warnings in the test suite, where the 5 deprecations that we do have left are now equal between PHP 7.4, 8.0 and 8.1.