### PR TITLE
Improve w3cvalue

### DIFF
--- a/gitlab/webstandard.sh
+++ b/gitlab/webstandard.sh
@@ -77,7 +77,12 @@ if [ "$TEST" = "w3cval" ]; then
     rm -rf localhost/domjudge/bundles/nelmioapidoc*
     rm -f localhost/domjudge/css/bootstrap.min.css*
     rm -f localhost/domjudge/css/select2-bootstrap.min.css*
+    rm -f localhost/domjudge/jury/config/check/phpinfo*
     section_end upstream_problems
+
+    section_start_collap upstream_icpc "Remove icpc only features"
+    rm -rf localhost/domjudge/jury/import-export/export/results-icpc.html*
+    section_end upstream_icpc
 
     section_start_collap test_suite "Install testsuite"
     cd $DIR

--- a/gitlab/webstandard.sh
+++ b/gitlab/webstandard.sh
@@ -85,11 +85,11 @@ if [ "$TEST" = "w3cval" ]; then
     unzip -q vnu.linux.zip
     section_end test_suite
     FLTRALL='--filterpattern .*autocomplete.*|.*descendant.*|.*child.*'
-    FLTRJURY='|.*form.*|.*scope.*'
+    FLTRJURY='.*form.*|.*scope.*'
     if [ "$ROLE" = jury ]; then
         FLTR="$FLTRALL|$FLTRJURY"
     elif [ "$ROLE" = admin ]; then
-        FLTR="$FLTRALL|$FLTRJURY|.*tab.*|.*non-void.*|.*CSS.*|.*child.*|.*doctype.*|.*option.*|.*maxlength.*|.*ID.*"
+        FLTR="$FLTRALL|$FLTRJURY|.*option.*"
     else
         FLTR="$FLTRALL"
     fi

--- a/webapp/src/Form/Type/ContestProblemType.php
+++ b/webapp/src/Form/Type/ContestProblemType.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,7 +29,7 @@ class ContestProblemType extends AbstractType
         $builder->add('shortname', TextType::class, [
             'label' => 'Short name',
         ]);
-        $builder->add('points');
+        $builder->add('points', IntegerType::class);
         $builder->add('allowSubmit', ChoiceType::class, [
             'choices' => [
                 'Yes' => true,

--- a/webapp/templates/jury/config.html.twig
+++ b/webapp/templates/jury/config.html.twig
@@ -18,7 +18,7 @@
     <h1>Configuration</h1>
 
     <form method="post">
-        <ul class="nav nav-pills nav-fill" id="configtab" role="tablist">
+        <ul class="nav nav-pills nav-fill" id="configtablist" role="tablist">
             {% for category in options %}
                 <li class="nav-item" role="presentation">
                     <a class="nav-link {{ (category.name == 'Scoring') ? 'active' : '' }}" id="{{ category.name|replace({' ': ''}) }}-tab" data-toggle="tab" href="#{{ category.name|replace({' ': ''}) }}" role="tab">{{ category.name }}</a>

--- a/webapp/templates/jury/config_check.html.twig
+++ b/webapp/templates/jury/config_check.html.twig
@@ -26,7 +26,7 @@
   <h5 class="card-title">Installation locations</h5>
   <table>
   <tr><td>Base url (use in submit client):</td><td><kbd>{{ url('root') }}</kbd></td></tr>
-  <tr><td>API url (use in <tt>restapi.secret</tt>):</td><td><kbd>{{ url('current_api_root') | trim('/', 'right') }}</kbd></td></tr>
+  <tr><td>API url (use in <kbd>restapi.secret</kbd>):</td><td><kbd>{{ url('current_api_root') | trim('/', 'right') }}</kbd></td></tr>
   <tr><td colspan="2">&nbsp;</td></tr>
   <tr><td>DOMserver installation path:</td><td><kbd>{{ dir.project }}</kbd></td></tr>
   <tr><td>Logos/images are under:</td><td><kbd>{{ dir.project }}/webapp/public/images/</kbd></td></tr>

--- a/webapp/templates/jury/executable_edit_content.html.twig
+++ b/webapp/templates/jury/executable_edit_content.html.twig
@@ -14,7 +14,7 @@
 
     {{ form_start(form) }}
 
-    <ul class="nav nav-tabs source-tab-nav">
+    <ul class="nav nav-tabs source-tab-nav" role="tablist">
         {%- for idx, filename in filenames %}
 
             <li class="nav-item">

--- a/webapp/templates/jury/import_export.html.twig
+++ b/webapp/templates/jury/import_export.html.twig
@@ -7,7 +7,7 @@
     <h1>Import and export</h1>
 
     <div class="importexport">
-    <h2 id="problems">Problems</h2>
+    <h2 id="problemarchive">Problems</h2>
     <div class="row">
         <div class="col-md-6">
             <div class="tile">
@@ -33,7 +33,7 @@
         </div>
     </div>
 
-    <h2 id="contests">Problems</h2>
+    <h2 id="problems">Problems</h2>
     <div class="row">
         <div class="col-md-6">
             <div class="tile">

--- a/webapp/templates/jury/problem_testcases.html.twig
+++ b/webapp/templates/jury/problem_testcases.html.twig
@@ -25,7 +25,7 @@
             <thead>
             <tr>
                 {% if is_granted('ROLE_ADMIN') %}
-                    <th/>
+                    <th></th>
                 {% endif %}
                 <th class="testrank">#</th>
                 <th class="testsample">sample</th>


### PR DESCRIPTION
The only one which cannot be removed is the one about <option> without text in it. We use this to have a dropdown menu with nothing selected.

We can either:
- cheat by adding a <style display:none>, 
- add a label with a default text but that will show up in the UI.
- add a default text and leave the attribute value empty.

none of these are better IMO.