### PR TITLE
Prevent zero division for boxes

### DIFF
--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -61,7 +61,7 @@
                                                                 {% set submissionText = 'submissions' %}
                                                             {% endif %}
                                                             {% if not current_contest.freezeData.showFinal and current_contest.freezetime and stat.start.timestamp >= current_contest.freezetime %}
-                                                                {% set maxBucketSize = max(stats.maxBucketSizeCorrect, stats.maxBucketSizeIncorrect) %}
+                                                                {% set maxBucketSize = max(1, stats.maxBucketSizeCorrect, stats.maxBucketSizeIncorrect) %}
                                                                 {% set bucket = (count / maxBucketSize * 9) | round(0, 'ceil') %}
                                                                 {% set itemClass = 'frozen' ~ '-' ~ bucket %}
                                                                 {% set label = count ~ ' ' ~ submissionText ~ ' in freeze' %}


### PR DESCRIPTION
I'm not sure how I got in this situation, but when you're an admin and have a team, and you look at the problems as a team member this could break. But in general trying to divide by zero might not be what we want.