### PR TITLE
Add separate ICPC ID field to team affiliation table.

### DIFF
--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -86,6 +86,7 @@ It should be a JSON array with objects, each object should contain the following
 fields:
 
 - ``id``: the external affiliation ID. Must be unique
+- ``icpc_id`` (optional): an external ID, e.g. from the ICPC CMS, may be empty
 - ``name``: the affiliation short name as used in the jury interface and certain
   exports
 - ``formal_name``: the affiliation name as used on the scoreboard
@@ -95,11 +96,13 @@ Example ``organizations.json``::
 
   [{
     "id": "INST-42",
+    "icpc_id": "42",
     "name": "LU",
     "formal_name": "Lund University",
     "country": "SWE"
   }, {
     "id": "INST-43",
+    "icpc_id": "43",
     "name": "FAU",
     "formal_name": "Friedrich-Alexander-University Erlangen-Nuremberg",
     "country": "DEU"

--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -22,7 +22,8 @@ Prepare a file called ``groups.json`` which contains the team categories.
 It should be a JSON array with objects, each object should contain the following
 fields:
 
-- ``id``: the (integer) category ID to use. Must be unique
+- ``id``: the category ID to use. Must be unique
+- ``icpc_id`` (optional): an external ID, e.g. from the ICPC CMS, may be empty
 - ``name``: the name of the team category as shown on the scoreboard
 - ``hidden`` (defaults to ``false``): if ``true``, teams in this category will
   not be shown on the scoreboard
@@ -33,6 +34,7 @@ Example ``groups.json``::
 
   [{
     "id": "13337",
+    "icpc_id": "123",
     "name": "Companies",
     "hidden": true
   }, {
@@ -57,7 +59,7 @@ Prepare a file called ``groups.tsv`` which contains the team categories.
 The first line should contain ``File_Version 1`` (tab-separated).
 Each of the following lines must contain the following elements separated by tabs:
 
-- the (integer) )category ID. Must be unique
+- the category ID. Must be unique
 - the name of the team category as shown on the scoreboard
 
 Example ``groups.tsv``::

--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -129,7 +129,7 @@ Prepare a file called ``teams.json`` which contains the teams.
 It should be a JSON array with objects, each object should contain the following
 fields:
 
-- ``id``: the (integer) team ID. Must be unique
+- ``id``: the team ID. Must be unique
 - ``icpc_id`` (optional): an external ID, e.g. from the ICPC CMS, may be empty
 - ``group_ids``: an array with one element: the category ID this team belongs to
 - ``name``: the team name as used in the web interface
@@ -168,7 +168,7 @@ Prepare a file called ``teams2.tsv`` which contains the teams.
 The first line should contain ``File_Version	2`` (tab-separated).
 Each of the following lines must contain the following elements separated by tabs:
 
-- the (integer) team ID. Must be unique
+- the team ID. Must be unique
 - an external ID, e.g. from the ICPC CMS, may be empty
 - the category ID this team belongs to
 - the team name as used in the web interface

--- a/webapp/migrations/Version20220210142638.php
+++ b/webapp/migrations/Version20220210142638.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220210142638 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add ICPC ID field to team affiliations';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE team_affiliation ADD icpcid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'External identifier from ICPC CMS\' AFTER `externalid`');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE team_affiliation DROP icpcid');
+    }
+}

--- a/webapp/migrations/Version20220210155918.php
+++ b/webapp/migrations/Version20220210155918.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220210155918 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add external and ICPC ID fields to team categories';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE team_category ADD externalid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'Team category ID in an external system\' AFTER `categoryid`, ADD icpcid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'External identifier from ICPC CMS\' AFTER `externalid`');
+        $this->addSql('CREATE UNIQUE INDEX externalid ON team_category (externalid(190))');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX externalid ON team_category');
+        $this->addSql('ALTER TABLE team_category DROP externalid, DROP icpcid');
+    }
+}

--- a/webapp/migrations/Version20220210171746.php
+++ b/webapp/migrations/Version20220210171746.php
@@ -14,7 +14,7 @@ final class Version20220210171746 extends AbstractMigration
 {
     public function getDescription() : string
     {
-        return 'Add externak ID field to teams';
+        return 'Add external ID field to teams';
     }
 
     public function up(Schema $schema) : void

--- a/webapp/migrations/Version20220210171746.php
+++ b/webapp/migrations/Version20220210171746.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220210171746 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add externak ID field to teams';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX icpcid ON team');
+        $this->addSql('ALTER TABLE team ADD externalid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'Team affiliation ID in an external system\' AFTER `teamid`');
+        $this->addSql('CREATE UNIQUE INDEX externalid ON team (externalid(190))');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX externalid ON team');
+        $this->addSql('ALTER TABLE team DROP externalid');
+        $this->addSql('CREATE UNIQUE INDEX icpcid ON team (icpcid(190))');
+    }
+}

--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -1048,7 +1048,8 @@ class ImportEventFeedCommand extends Command
 
         $affiliation
             ->setName($event['data']['formal_name'] ?? $event['data']['name'])
-            ->setShortname($event['data']['name']);
+            ->setShortname($event['data']['name'])
+            ->setIcpcid($event['data']['icpc_id'] ?? null);
         if (isset($event['data']['country'])) {
             $affiliation->setCountry($event['data']['country']);
         }

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -98,7 +98,9 @@ class GroupController extends AbstractRestController
         }
 
         $group = $saved[0];
-        $id = $group->getCategoryid();
+        $idField = $this->eventLogService->externalIdFieldForEntity(TeamCategory::class) ?? 'teamid';
+        $method = sprintf('get%s', ucfirst($idField));
+        $id = call_user_func([$group, $method]);
 
         return $this->renderCreateData($request, $saved[0], 'group', $id);
     }
@@ -122,6 +124,6 @@ class GroupController extends AbstractRestController
 
     protected function getIdField(): string
     {
-        return 'c.categoryid';
+        return sprintf('c.%s', $this->eventLogService->externalIdFieldForEntity(TeamCategory::class) ?? 'categoryid');
     }
 }

--- a/webapp/src/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/Controller/Jury/TeamAffiliationController.php
@@ -67,6 +67,7 @@ class TeamAffiliationController extends BaseController
 
         $table_fields = [
             'affilid' => ['title' => 'ID', 'sort' => true],
+            'icpcid' => ['title' => 'ICPC ID', 'sort' => true],
             'shortname' => ['title' => 'shortname', 'sort' => true],
             'name' => ['title' => 'name', 'sort' => true, 'default_sort' => true],
         ];

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -64,6 +64,7 @@ class TeamCategoryController extends BaseController
             ->getQuery()->getResult();
         $table_fields   = [
             'categoryid' => ['title' => 'ID', 'sort' => true],
+            'icpcid' => ['title' => 'ICPC ID', 'sort' => true],
             'sortorder' => ['title' => 'sort', 'sort' => true, 'default_sort' => true],
             'name' => ['title' => 'name', 'sort' => true],
             'num_teams' => ['title' => '# teams', 'sort' => true],

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -109,8 +109,7 @@ class TeamController extends BaseController
         $table_fields = [
             'teamid' => ['title' => 'ID', 'sort' => true,],
             'icpcid' => ['title' => 'ICPC ID', 'sort' => true,],
-            'name' => ['title' => 'teamname', 'sort' => true, 'default_sort' => true],
-            'display_name' => ['title' => 'display name', 'sort' => true, 'default_sort' => true],
+            'effective_name' => ['title' => 'name', 'sort' => true, 'default_sort' => true],
             'category' => ['title' => 'category', 'sort' => true,],
             'affiliation' => ['title' => 'affiliation', 'sort' => true,],
             'num_contests' => ['title' => '# contests', 'sort' => true,],

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -120,6 +120,13 @@ class TeamController extends BaseController
             'stats' => ['title' => 'stats', 'sort' => true,],
         ];
 
+        // Insert external ID field when configured to use it
+        if ($externalIdField = $this->eventLogService->externalIdFieldForEntity(Team::class)) {
+            $table_fields = array_slice($table_fields, 0, 1, true) +
+                [$externalIdField => ['title' => 'external ID', 'sort' => true]] +
+                array_slice($table_fields, 1, null, true);
+        }
+
         $userDataPerTeam = $this->em->createQueryBuilder()
             ->from(Team::class, 't', 't.teamid')
             ->leftJoin('t.users', 'u')

--- a/webapp/src/DataFixtures/DefaultData/TeamCategoryFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/TeamCategoryFixture.php
@@ -20,9 +20,9 @@ class TeamCategoryFixture extends AbstractDefaultDataFixture
     public function load(ObjectManager $manager): void
     {
         $data = [
-            // Name,            Sort order, Color,     Visible
-            ['System',          9,          '#ff2bea', false],
-            ['Self-Registered', 8,          '#33cc44', true],
+            // Name,            Sort order, Color,     Visible, External ID
+            ['System',          9,          '#ff2bea', false,   'system'],
+            ['Self-Registered', 8,          '#33cc44', true,    'self-registered'],
         ];
 
         foreach ($data as $item) {
@@ -31,7 +31,8 @@ class TeamCategoryFixture extends AbstractDefaultDataFixture
                     ->setName($item[0])
                     ->setSortorder($item[1])
                     ->setColor($item[2])
-                    ->setVisible($item[3]);
+                    ->setVisible($item[3])
+                    ->setExternalid($item[4]);
                 $manager->persist($category);
                 $manager->flush();
             } else {

--- a/webapp/src/DataFixtures/DefaultData/TeamFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/TeamFixture.php
@@ -23,6 +23,7 @@ class TeamFixture extends AbstractDefaultDataFixture implements DependentFixture
         if (!($team = $manager->getRepository(Team::class)->findOneBy(['name' => 'DOMjudge']))) {
             $team = (new Team())
                 ->setName('DOMjudge')
+                ->setExternalid('domjudge')
                 ->setCategory($this->getReference(TeamCategoryFixture::SYSTEM_REFERENCE));
             $manager->persist($team);
         } else {

--- a/webapp/src/DataFixtures/ExampleData/TeamCategoryFixture.php
+++ b/webapp/src/DataFixtures/ExampleData/TeamCategoryFixture.php
@@ -12,20 +12,24 @@ class TeamCategoryFixture extends AbstractExampleDataFixture
     public function load(ObjectManager $manager): void
     {
         $participants = new TeamCategory();
-        $participants->setName('Participants');
+        $participants
+            ->setName('Participants')
+            ->setExternalid('participants');
 
         $observers = new TeamCategory();
         $observers
             ->setName('Observers')
             ->setSortorder(1)
-            ->setColor('#ffcc33');
+            ->setColor('#ffcc33')
+            ->setExternalid('observers');
 
         $organisation = new TeamCategory();
         $organisation
             ->setName('Organisation')
             ->setSortorder(1)
             ->setColor('#ff99cc')
-            ->setVisible(false);
+            ->setVisible(false)
+            ->setExternalid('organization');
 
         $manager->persist($participants);
         $manager->persist($observers);

--- a/webapp/src/DataFixtures/ExampleData/TeamFixture.php
+++ b/webapp/src/DataFixtures/ExampleData/TeamFixture.php
@@ -14,6 +14,7 @@ class TeamFixture extends AbstractExampleDataFixture implements DependentFixture
     {
         $team = new Team();
         $team
+            ->setExternalid('exteam')
             ->setIcpcid('exteam')
             ->setName('Example teamname')
             ->setAffiliation($this->getReference(TeamAffiliationFixture::AFFILIATION_REFERENCE))

--- a/webapp/src/DataFixtures/Test/SampleAffiliationsFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleAffiliationsFixture.php
@@ -11,9 +11,9 @@ class SampleAffiliationsFixture extends Fixture
     public function load(ObjectManager $manager): void
     {
         $affiliationData = [
-            // short name, name,                                                country
-            ['FAU',        'Friedrich-Alexander-Universität Erlangen-Nürnberg', 'DEU'],
-            ['ABC',        'Affiliation without country',                        null],
+            // short name, name,                                                country, ICPC ID
+            ['FAU',        'Friedrich-Alexander-Universität Erlangen-Nürnberg', 'DEU',   '1234'],
+            ['ABC',        'Affiliation without country',                        null,   'abc-icpc-id'],
         ];
 
         foreach ($affiliationData as $index => $affiliationItem) {
@@ -21,7 +21,8 @@ class SampleAffiliationsFixture extends Fixture
                 ->setExternalid($affiliationItem[0])
                 ->setShortname($affiliationItem[0])
                 ->setName($affiliationItem[1])
-                ->setCountry($affiliationItem[2]);
+                ->setCountry($affiliationItem[2])
+                ->setIcpcid($affiliationItem[3]);
             $manager->persist($affiliation);
             $manager->flush();
             // Add a reference, since the submission ID changes during testing because of the auto increment

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -565,7 +565,10 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
      */
     public function getExternalRelationships(): array
     {
-        return ['organization_id' => $this->getAffiliation()];
+        return [
+            'organization_id' => $this->getAffiliation(),
+            'group_ids'       => [$this->getCategory()],
+        ];
     }
 
     /**

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  *         @ORM\Index(name="categoryid", columns={"categoryid"})
  *     },
  *     uniqueConstraints={
- *         @ORM\UniqueConstraint(name="icpcid", columns={"icpcid"}, options={"lengths": {190}}),
+ *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
  *     })
- * @UniqueEntity("icpcid")
+ * @UniqueEntity("externalid")
  */
 class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface, AssetEntityInterface
 {
@@ -41,6 +41,15 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
      * @Serializer\Type("string")
      */
     protected ?int $teamid = null;
+
+    /**
+     * @ORM\Column(type="string", name="externalid", length=255,
+     *     options={"comment"="Team affiliation ID in an external system",
+     *              "collation"="utf8mb4_bin"},
+     *     nullable=true)
+     * @Serializer\Exclude()
+     */
+    protected ?string $externalid = null;
 
     /**
      * @ORM\Column(type="string", name="icpcid", length=255, options={"comment"="Team ID in the ICPC system",
@@ -199,6 +208,17 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
     public function getTeamid(): ?int
     {
         return $this->teamid;
+    }
+
+    public function setExternalid(?string $externalid): Team
+    {
+        $this->externalid = $externalid;
+        return $this;
+    }
+
+    public function getExternalid(): ?string
+    {
+        return $this->externalid;
     }
 
     public function setIcpcid(?string $icpcid): Team

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -21,11 +21,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
  *     })
  * @Serializer\VirtualProperty(
- *     "icpcId",
- *     exp="object.getAffilid()",
- *     options={@Serializer\Type("string")}
- * )
- * @Serializer\VirtualProperty(
  *     "shortName",
  *     exp="object.getShortname()",
  *     options={@Serializer\Type("string"), @Serializer\SerializedName("shortname"), @Serializer\Groups({"Nonstrict"})}
@@ -53,6 +48,15 @@ class TeamAffiliation extends BaseApiEntity implements AssetEntityInterface
      * @Serializer\Exclude()
      */
     protected ?string $externalid = null;
+
+    /**
+     * @ORM\Column(type="string", name="icpcid", length=255,
+     *     options={"comment"="External identifier from ICPC CMS",
+     *              "collation"="utf8mb4_bin"},
+     *     nullable=true)
+     * @Serializer\SerializedName("icpc_id")
+     */
+    protected ?string $icpcid = null;
 
     /**
      * @ORM\Column(type="string", name="shortname", length=32,
@@ -128,6 +132,17 @@ class TeamAffiliation extends BaseApiEntity implements AssetEntityInterface
     public function getExternalid(): ?string
     {
         return $this->externalid;
+    }
+
+    public function setIcpcid(?string $icpcid): TeamAffiliation
+    {
+        $this->icpcid = $icpcid;
+        return $this;
+    }
+
+    public function getIcpcid(): ?string
+    {
+        return $this->icpcid;
     }
 
     public function setShortname(string $shortname): TeamAffiliation

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -5,6 +5,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -14,17 +15,16 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(
  *     name="team_category",
  *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Categories for teams (e.g.: participants, observers, ...)"},
- *     indexes={@ORM\Index(name="sortorder", columns={"sortorder"})})
+ *     indexes={@ORM\Index(name="sortorder", columns={"sortorder"})},
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
+ *     })
  * @Serializer\VirtualProperty(
  *     "hidden",
  *     exp="!object.getVisible()",
  *     options={@Serializer\Type("boolean")}
  * )
- * @Serializer\VirtualProperty(
- *     "icpc_id",
- *     exp="object.getCategoryid()",
- *     options={@Serializer\Type("string")}
- * )
+ * @UniqueEntity("externalid")
  */
 class TeamCategory extends BaseApiEntity
 {
@@ -37,6 +37,24 @@ class TeamCategory extends BaseApiEntity
      * @Serializer\Type("string")
      */
     protected ?int $categoryid = null;
+
+    /**
+     * @ORM\Column(type="string", name="externalid", length=255,
+     *     options={"comment"="Team category ID in an external system",
+     *              "collation"="utf8mb4_bin"},
+     *     nullable=true)
+     * @Serializer\Exclude()
+     */
+    protected ?string $externalid = null;
+
+    /**
+     * @ORM\Column(type="string", name="icpcid", length=255,
+     *     options={"comment"="External identifier from ICPC CMS",
+     *              "collation"="utf8mb4_bin"},
+     *     nullable=true)
+     * @Serializer\SerializedName("icpc_id")
+     */
+    protected ?string $icpcid = null;
 
     /**
      * @ORM\Column(type="string", name="name", length=255,
@@ -109,6 +127,28 @@ class TeamCategory extends BaseApiEntity
     public function __toString(): string
     {
         return $this->name;
+    }
+
+    public function setExternalid(?string $externalid): TeamCategory
+    {
+        $this->externalid = $externalid;
+        return $this;
+    }
+
+    public function getExternalid(): ?string
+    {
+        return $this->externalid;
+    }
+
+    public function setIcpcid(?string $icpcid): TeamCategory
+    {
+        $this->icpcid = $icpcid;
+        return $this;
+    }
+
+    public function getIcpcid(): ?string
+    {
+        return $this->icpcid;
     }
 
     public function setCategoryid(int $categoryid): TeamCategory

--- a/webapp/src/Form/Type/TeamAffiliationType.php
+++ b/webapp/src/Form/Type/TeamAffiliationType.php
@@ -13,11 +13,13 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class TeamAffiliationType extends AbstractExternalIdEntityType
 {
@@ -43,6 +45,19 @@ class TeamAffiliationType extends AbstractExternalIdEntityType
         }
 
         $this->addExternalIdField($builder, TeamAffiliation::class);
+        $builder->add('icpcid', TextType::class, [
+            'label'       => 'ICPC ID',
+            'required'    => false,
+            'help'        => 'Optional ID of the organization in the ICPC CMS.',
+            'constraints' => [
+                new Regex(
+                    [
+                        'pattern' => '/^[a-zA-Z0-9_-]+$/i',
+                        'message' => 'Only letters, numbers, dashes and underscores are allowed.',
+                    ]
+                )
+            ]
+        ]);
         $builder->add('shortname');
         $builder->add('name');
         if ($this->configuration->get('show_flags')) {

--- a/webapp/src/Form/Type/TeamCategoryType.php
+++ b/webapp/src/Form/Type/TeamCategoryType.php
@@ -3,18 +3,32 @@
 namespace App\Form\Type;
 
 use App\Entity\TeamCategory;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Regex;
 
-class TeamCategoryType extends AbstractType
+class TeamCategoryType extends AbstractExternalIdEntityType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $this->addExternalIdField($builder, TeamCategory::class);
+        $builder->add('icpcid', TextType::class, [
+            'label'       => 'ICPC ID',
+            'required'    => false,
+            'help'        => 'Optional ID of the category in the ICPC CMS.',
+            'constraints' => [
+                new Regex(
+                    [
+                        'pattern' => '/^[a-zA-Z0-9_-]+$/i',
+                        'message' => 'Only letters, numbers, dashes and underscores are allowed.',
+                    ]
+                )
+            ]
+        ]);
         $builder->add('name');
         $builder->add('sortorder', IntegerType::class);
         $builder->add('color', TextType::class, [

--- a/webapp/src/Form/Type/TeamType.php
+++ b/webapp/src/Form/Type/TeamType.php
@@ -3,17 +3,15 @@
 namespace App\Form\Type;
 
 use App\Entity\Contest;
-use App\Entity\Role;
 use App\Entity\Team;
 use App\Entity\TeamAffiliation;
 use App\Entity\TeamCategory;
 use App\Entity\User;
 use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use Exception;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -27,26 +25,26 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Regex;
 
-class TeamType extends AbstractType
+class TeamType extends AbstractExternalIdEntityType
 {
     protected EntityManagerInterface $em;
     protected DOMJudgeService $dj;
 
-    public function __construct(EntityManagerInterface $em, DOMJudgeService $dj)
-    {
+    public function __construct(
+        EventLogService $eventLogService,
+        EntityManagerInterface $em,
+        DOMJudgeService $dj
+    ) {
+        parent::__construct($eventLogService);
         $this->em = $em;
         $this->dj = $dj;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $this->addExternalIdField($builder, Team::class);
         $builder->add('name', TextType::class, [
             'label' => 'Team name',
-        ]);
-        $builder->add('displayName', TextType::class, [
-            'label'    => 'Display name',
-            'required' => false,
-            'help'     => 'If provided, will display this instead of the team name in certain places, like the scoreboard.',
         ]);
         $builder->add('icpcid', TextType::class, [
             'label'       => 'ICPC ID',
@@ -60,6 +58,11 @@ class TeamType extends AbstractType
                     ]
                 )
             ]
+        ]);
+        $builder->add('displayName', TextType::class, [
+            'label'    => 'Display name',
+            'required' => false,
+            'help'     => 'If provided, will display this instead of the team name in certain places, like the scoreboard.',
         ]);
         $builder->add('category', EntityType::class, [
             'class' => TeamCategory::class,

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -35,7 +35,7 @@ class EventLogService implements ContainerAwareInterface
     const KEY_URL = 'url';
     const KEY_ENTITY = 'entity';
     const KEY_TABLES = 'tables';
-    const KEY_EXTERNAL_ID = 'extid';
+    const KEY_USE_EXTERNAL_ID = 'use-external-id';
     const KEY_ALWAYS_USE_EXTERNAL_ID = 'always-use-external-id';
 
     // Types of endpoints
@@ -55,7 +55,7 @@ class EventLogService implements ContainerAwareInterface
         'contests' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_URL => '',
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'judgement-types' => [ // hardcoded in $VERDICTS and the API
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
@@ -64,29 +64,30 @@ class EventLogService implements ContainerAwareInterface
         ],
         'languages' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
             self::KEY_ALWAYS_USE_EXTERNAL_ID => true,
         ],
         'problems' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_TABLES => ['problem', 'contestproblem'],
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'groups' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_ENTITY => TeamCategory::class,
             self::KEY_TABLES => ['team_category'],
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'organizations' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_ENTITY => TeamAffiliation::class,
             self::KEY_TABLES => ['team_affiliation'],
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'teams' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_TABLES => ['team', 'contestteam'],
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'state' => [
             self::KEY_TYPE => self::TYPE_AGGREGATE,
@@ -95,7 +96,7 @@ class EventLogService implements ContainerAwareInterface
         ],
         'submissions' => [
             self::KEY_TYPE => self::TYPE_LIVE,
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'judgements' => [
             self::KEY_TYPE => self::TYPE_LIVE,
@@ -109,7 +110,7 @@ class EventLogService implements ContainerAwareInterface
         ],
         'clarifications' => [
             self::KEY_TYPE => self::TYPE_LIVE,
-            self::KEY_EXTERNAL_ID => 'externalid',
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
         'awards' => [
             self::KEY_TYPE => self::TYPE_AGGREGATE,
@@ -858,7 +859,7 @@ class EventLogService implements ContainerAwareInterface
         }
 
         $endpointData = $this->apiEndpoints[$type];
-        if (!isset($endpointData[self::KEY_EXTERNAL_ID])) {
+        if (!isset($endpointData[self::KEY_USE_EXTERNAL_ID])) {
             return $ids;
         }
 
@@ -898,10 +899,10 @@ class EventLogService implements ContainerAwareInterface
         }
 
         return array_map(
-            fn(array $item) => $item[$endpointData[self::KEY_EXTERNAL_ID]],
+            fn(array $item) => $item['externalid'],
             $this->em->createQueryBuilder()
                ->from($entity, 'e')
-               ->select(sprintf('e.%s', $endpointData[self::KEY_EXTERNAL_ID]))
+               ->select('e.externalid')
                ->andWhere(sprintf('e.%s IN (:ids)', $primaryKeyField))
                ->setParameter(':ids', $ids)
                ->getQuery()
@@ -932,13 +933,13 @@ class EventLogService implements ContainerAwareInterface
 
         $endpointData = $this->apiEndpoints[$this->entityToEndpoint[$entity]];
 
-        if (!isset($endpointData[self::KEY_EXTERNAL_ID])) {
+        if (!isset($endpointData[self::KEY_USE_EXTERNAL_ID])) {
             return null;
         }
 
-        $lookupExternalid = false;
+        $useExternalId = false;
         if ($endpointData[self::KEY_ALWAYS_USE_EXTERNAL_ID] ?? false) {
-            $lookupExternalid = true;
+            $useExternalId = true;
         } else {
             $dataSource = $this->config->get('data_source');
 
@@ -949,16 +950,16 @@ class EventLogService implements ContainerAwareInterface
                         DOMJudgeService::DATA_SOURCE_CONFIGURATION_EXTERNAL,
                         DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL
                     ])) {
-                    $lookupExternalid = true;
+                    $useExternalId = true;
                 } elseif ($endpointType === self::TYPE_LIVE &&
                     $dataSource === DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL) {
-                    $lookupExternalid = true;
+                    $useExternalId = true;
                 }
             }
         }
 
-        if ($lookupExternalid) {
-            return $endpointData[self::KEY_EXTERNAL_ID];
+        if ($useExternalId) {
+            return 'externalid';
         } else {
             return null;
         }

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -76,6 +76,7 @@ class EventLogService implements ContainerAwareInterface
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
             self::KEY_ENTITY => TeamCategory::class,
             self::KEY_TABLES => ['team_category'],
+            self::KEY_EXTERNAL_ID => 'externalid',
         ],
         'organizations' => [
             self::KEY_TYPE => self::TYPE_CONFIGURATION,
@@ -972,7 +973,7 @@ class EventLogService implements ContainerAwareInterface
         if ($field = $this->externalIdFieldForEntity($entity)) {
             return $field;
         }
-        $class    = get_class($entity);
+        $class    = is_object($entity) ? get_class($entity) : $entity;
         $metadata = $this->em->getClassMetadata($class);
         try {
             return $metadata->getSingleIdentifierFieldName();

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -689,6 +689,7 @@ class ImportExportService
                 'shortname' => @$organization['name'],
                 'name' => @$organization['formal_name'],
                 'country' => @$organization['country'],
+                'icpc_id' => $organization['icpc_id'] ?? null,
             ];
         }
 
@@ -721,7 +722,8 @@ class ImportExportService
             $teamAffiliation
                 ->setShortname($organizationItem['shortname'])
                 ->setName($organizationItem['name'])
-                ->setCountry($organizationItem['country']);
+                ->setCountry($organizationItem['country'])
+                ->setIcpcid($organizationItem['icpc_id'] ?? null);
             $this->em->flush();
             if ($contest = $this->dj->getCurrentContest()) {
                 $this->eventLogService->log('team_affiliation', $teamAffiliation->getAffilid(), $action,

--- a/webapp/templates/jury/partials/team_category_form.html.twig
+++ b/webapp/templates/jury/partials/team_category_form.html.twig
@@ -1,6 +1,10 @@
 <div class="row">
     <div class="col-lg-4">
         {{ form_start(form) }}
+        {% if form.offsetExists('externalid') %}
+            {{ form_row(form.externalid) }}
+        {% endif %}
+        {{ form_row(form.icpcid) }}
         {{ form_row(form.name) }}
         {{ form_row(form.sortorder) }}
         {{ form_row(form.color) }}

--- a/webapp/templates/jury/partials/team_form.html.twig
+++ b/webapp/templates/jury/partials/team_form.html.twig
@@ -1,9 +1,12 @@
 <div class="row">
     <div class="col-lg-4">
         {{ form_start(form) }}
+        {% if form.offsetExists('externalid') %}
+            {{ form_row(form.externalid) }}
+        {% endif %}
+        {{ form_row(form.icpcid) }}
         {{ form_row(form.name) }}
         {{ form_row(form.displayName) }}
-        {{ form_row(form.icpcid) }}
         {{ form_row(form.category) }}
         {{ form_row(form.members) }}
         {{ form_row(form.affiliation) }}

--- a/webapp/templates/jury/team.html.twig
+++ b/webapp/templates/jury/team.html.twig
@@ -19,6 +19,12 @@
                     <th>ID</th>
                     <td>{{ team.teamid }}</td>
                 </tr>
+                {% if showExternalId(team) %}
+                    <tr>
+                        <th>External ID</th>
+                        <td>{{ team.externalid }}</td>
+                    </tr>
+                {% endif %}
                 <tr>
                     <th>ICPC ID</th>
                     <td>

--- a/webapp/templates/jury/team_affiliation.html.twig
+++ b/webapp/templates/jury/team_affiliation.html.twig
@@ -26,6 +26,16 @@
                     </tr>
                 {% endif %}
                 <tr>
+                    <th>ICPC ID</th>
+                    <td>
+                        {% if teamAffiliation.icpcid %}
+                            {{ teamAffiliation.icpcid }}
+                        {% else %}
+                            -
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
                     <th>Shortname</th>
                     <td>{{ teamAffiliation.shortname }}</td>
                 </tr>

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -19,6 +19,22 @@
                     <th>ID</th>
                     <td>{{ teamCategory.categoryid }}</td>
                 </tr>
+                {% if showExternalId(teamCategory) %}
+                    <tr>
+                        <th>External ID</th>
+                        <td>{{ teamCategory.externalid }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>ICPC ID</th>
+                    <td>
+                        {% if teamCategory.icpcid %}
+                            {{ teamCategory.icpcid }}
+                        {% else %}
+                            -
+                        {% endif %}
+                    </td>
+                </tr>
                 <tr>
                     <th>Name</th>
                     <td>{{ teamCategory.name }}</td>

--- a/webapp/tests/Unit/Controller/API/GroupControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GroupControllerTest.php
@@ -9,7 +9,7 @@ class GroupControllerTest extends BaseTest
     protected array $expectedObjects = [
         '2' => [
             'hidden'    => false,
-            'icpc_id'   => '2',
+            'icpc_id'   => null,
             'id'        => '2',
             'name'      => 'Self-Registered',
             'sortorder' => 8,
@@ -17,7 +17,7 @@ class GroupControllerTest extends BaseTest
         ],
         '3' => [
             'hidden'    => false,
-            'icpc_id'   => '3',
+            'icpc_id'   => null,
             'id'        => '3',
             'name'      => 'Participants',
             'sortorder' => 0,
@@ -25,7 +25,7 @@ class GroupControllerTest extends BaseTest
         ],
         '4' => [
             'hidden'    => false,
-            'icpc_id'   => '4',
+            'icpc_id'   => null,
             'id'        => '4',
             'name'      => 'Observers',
             'sortorder' => 1,

--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -13,8 +13,8 @@ class OrganizationControllerTest extends BaseTest
     protected ?string $apiEndpoint = 'organizations';
 
     protected array $expectedObjects = [
-        '1'                                      => [
-            'icpc_id'      => '1',
+        '1'                                     => [
+            'icpc_id'      => null,
             'shortname'    => 'UU',
             'id'           => '1',
             'name'         => 'UU',
@@ -34,9 +34,10 @@ class OrganizationControllerTest extends BaseTest
                     'height' => 512,
                 ],
             ],
-            'logo' => null,
+            'logo'         => null,
         ],
         SampleAffiliationsFixture::class . ':0' => [
+            'icpc_id'      => '1234',
             'name'         => 'FAU',
             'formal_name'  => 'Friedrich-Alexander-Universität Erlangen-Nürnberg',
             'country'      => 'DEU',
@@ -56,6 +57,7 @@ class OrganizationControllerTest extends BaseTest
             ],
         ],
         SampleAffiliationsFixture::class . ':1' => [
+            'icpc_id'      => 'abc-icpc-id',
             'name'         => 'ABC',
             'formal_name'  => 'Affiliation without country',
             'country'      => null,

--- a/webapp/tests/Unit/Controller/Jury/TeamControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/TeamControllerTest.php
@@ -17,7 +17,7 @@ class TeamControllerTest extends JuryControllerTest
     protected static string  $className                = Team::class;
     protected static array   $DOM_elements             = ['h1' => ['Teams']];
     protected static string  $addForm                  = 'team[';
-    protected static array   $addEntitiesShown         = ['name', 'icpcid', 'displayName', 'room'];
+    protected static array   $addEntitiesShown         = ['icpcid', 'displayName', 'room'];
     protected static array   $addEntitiesCount         = ['contests'];
     protected static array $addEntities                = [['name'           => 'New Team',
                                                            'displayName'    => 'New Team Display Name',


### PR DESCRIPTION
This PR makes it such that:
* All endpoints we support from the CLICS spec that have an ICPC ID, have such a field in our database as well.
* We support external ID's for teams and team categories. We didn't in the past, which meant they were limited to (globally unique) integers.
* Cleans up some logic with respect to the event logging: our external ID field is always called `externalid` so no need to have that as a config variable.
* Sets default external ID's for our teams, categories and affiliations.

I have split up the code in 3 commits, one each for each entity.

I did this PR first, since I want to work on #1349 but this touches the same code.