### PR TITLE
Add Git Commit ID

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 AC_INIT([DOMjudge],
-        m4_esyscmd([grep 'version' README.md | sed -n '1s/^.*version //p' | tr -d '\n']),
+        m4_esyscmd([grep 'version' README.md | sed -n '1s/^.*version //p' | sed "s/$/$(command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git rev-parse --short HEAD | sed 's|^|\\/|' || echo '' )/" | tr -d '\n']),
         [domjudge-devel@domjudge.org])
 AC_PREREQ([2.64])
 AC_CONFIG_HEADERS([etc/config.h])


### PR DESCRIPTION
Implementation for https://github.com/DOMjudge/domjudge/issues/1418.

BTW, if build by directly downloading the code, will not be able to get the `Git Commit ID`, like the we get the code [in the current docker build](https://github.com/DOMjudge/domjudge-packaging/blob/2d440b10c0f4d168f325e460ba5c775836722fc0/docker/build.sh#L23).

Preview:

<img width="294" alt="image" src="https://user-images.githubusercontent.com/38343778/155481278-f95f17c4-d7bb-4537-b6b6-a8ca3a6b7733.png">

<img width="565" alt="image" src="https://user-images.githubusercontent.com/38343778/155481360-881f604b-6f15-4f42-a763-095a2d3677b5.png">

![image](https://user-images.githubusercontent.com/38343778/155487237-c08f6396-2c98-4b61-ae6b-8b5340981b7c.png)

<img width="496" alt="image" src="https://user-images.githubusercontent.com/38343778/155487529-56061aab-5e19-4bba-8c1d-310e9c3de3cb.png">
