### PR TITLE
Register endpoint does not exist when no categories are available

### DIFF
--- a/webapp/src/Controller/SecurityController.php
+++ b/webapp/src/Controller/SecurityController.php
@@ -110,7 +110,7 @@ class SecurityController extends AbstractController
         $selfRegistrationCategoriesCount = $em->getRepository(TeamCategory::class)->count(['allow_self_registration' => 1]);
 
         if ($selfRegistrationCategoriesCount === 0) {
-            throw new HttpException(400, "Registration not enabled");
+            throw new HttpException(403, "Registration not enabled");
         }
 
         $user              = new User();

--- a/webapp/tests/Unit/Controller/PublicControllerTest.php
+++ b/webapp/tests/Unit/Controller/PublicControllerTest.php
@@ -22,4 +22,9 @@ class PublicControllerTest extends BaseTest
         $this->verifyPageResponse('GET', '/public', 200);
         self::assertSelectorExists('p.nodata:contains("No active contest")');
     }
+
+    public function testNoSelfRegister(): void
+    {
+        $this->verifyPageResponse('GET', '/register', 403);
+    }
 }


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4
HTTP404 is cachable so I chose the less standard 409 as the problem is
on the server side.