### PR TITLE
Try to be more explicit when wrong file type is imported.

### DIFF
--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -235,7 +235,12 @@ class ImportExportController extends BaseController
         if ($contestImportForm->isSubmitted() && $contestImportForm->isValid()) {
             /** @var UploadedFile $file */
             $file = $contestImportForm->get('file')->getData();
-            $data = Yaml::parseFile($file->getRealPath(), Yaml::PARSE_DATETIME);
+            try {
+                $data = Yaml::parseFile($file->getRealPath(), Yaml::PARSE_DATETIME);
+            } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
+                $this->addFlash('danger', "Parse error in YAML/JSON file: " . $e->getMessage());
+                return $this->redirectToRoute('jury_import_export');
+            }
             if ($this->importExportService->importContestData($data, $message, $cid)) {
                 $this->addFlash('success',
                                 sprintf('The file %s is successfully imported.', $file->getClientOriginalName()));
@@ -252,7 +257,12 @@ class ImportExportController extends BaseController
         if ($problemsImportForm->isSubmitted() && $problemsImportForm->isValid()) {
             /** @var UploadedFile $file */
             $file = $problemsImportForm->get('file')->getData();
-            $data = Yaml::parseFile($file->getRealPath(), Yaml::PARSE_DATETIME);
+            try {
+                $data = Yaml::parseFile($file->getRealPath(), Yaml::PARSE_DATETIME);
+            } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
+                $this->addFlash('danger', "Parse error in YAML/JSON file: " . $e->getMessage());
+                return $this->redirectToRoute('jury_import_export');
+            }
             if ($this->importExportService->importProblemsData($problemsImportForm->get('contest')->getData(), $data)) {
                 $this->addFlash('success',
                     sprintf('The file %s is successfully imported.', $file->getClientOriginalName()));

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -518,7 +518,7 @@ class ImportExportService
         }
         $regex = sprintf("/^(File_Version|%s)\t%s$/i", $type, $versionMatch);
         if (!preg_match($regex, $version)) {
-            $message = sprintf("Unknown format or version: %s != %s", $version, $versionMatch);
+            $message = sprintf("TSV has unknown format or version: %s != %s", $version, $versionMatch);
             return -1;
         }
 

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -88,8 +88,15 @@ class ImportProblemService
 
         $defaultTimelimit = 10;
 
-        // Read problem properties
         $propertiesString = $zip->getFromName($propertiesFile);
+        $problemYaml = $zip->getFromName($yamlFile);
+
+        if ($propertiesString === false && $problemYaml === false) {
+            $messages[] = sprintf('Error: zip contains neither %s nor %s, not a valid Problem Archive?',
+                $propertiesFile, $yamlFile);
+            return null;
+        }
+
         $properties = [];
 
         if ($propertiesString !== false) {
@@ -225,8 +232,6 @@ class ImportProblemService
             return null;
         }
 
-        // parse problem.yaml
-        $problemYaml = $zip->getFromName($yamlFile);
         if ($problemYaml !== false) {
             $yamlData = Yaml::parse($problemYaml);
 


### PR DESCRIPTION
This is to help users who upload the wrong thing in the wrong box.

* For YAML (and JSON which is YAML): catch a parse error and make explict that we're parsing YAML/JSON here in the error message.

* For TSV: parse error already handled (checks file header), make message explict that we're trying TSV's here to avoid misunderstanding.

* For Problem package: would stumble on for any zip file that is uploaded and create a half-baked problem. ZIP als file format is already filtered in the UI. The spec is not 100% clear on what the minimum is to know if something is an actual problem package. I assumed that it needs at least one of `domjudge-problem.ini`,`problem.yaml` to be present. If it's not, error out early and explicitly.