### PR TITLE
Retry gitlabci jobs when failing

### DIFF
--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -2,7 +2,7 @@
 .clean_ordering:
   needs: []
   retry:
-    max: 0 #Max is 2, set when gitlab is flacky
+    max: 2 #Max is 2, set when gitlab is flacky
     when:
       - always
   artifacts:


### PR DESCRIPTION
Because Gitlab ci cannot always reach its repos or container registry. This will auto restart failing jobs as we cannot detect if the error is a "correct" error (the PR introduces failures) or fails because of gitlab not finishing in time.