### PR TITLE
Balloon nonpublic scoreboard

### DIFF
--- a/webapp/src/Controller/Jury/ScoreboardController.php
+++ b/webapp/src/Controller/Jury/ScoreboardController.php
@@ -5,15 +5,15 @@ namespace App\Controller\Jury;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
 use Exception;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
  * @Route("/jury/scoreboard")
- * @IsGranted("ROLE_JURY")
+ * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
  */
 class ScoreboardController extends AbstractController
 {
@@ -37,7 +37,7 @@ class ScoreboardController extends AbstractController
         $refreshUrl = $this->generateUrl('jury_scoreboard');
         $contest    = $this->dj->getCurrentContest();
         $data       = $this->scoreboardService->getScoreboardTwigData(
-            $request, $response, $refreshUrl, true, false, false, $contest
+            $request, $response, $refreshUrl, $this->isGranted('ROLE_JURY'), false, false, $contest
         );
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/src/DataFixtures/Test/DemoNonPublicContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoNonPublicContestFixture.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoNonPublicContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setPublic(false);
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPostDeactivateContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPostDeactivateContestFixture.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPostDeactivateContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setStarttimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') - 2
+            )
+        )->setDeactivatetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') - 1
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreActivationContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreActivationContestFixture.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreActivationContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setActivatetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 1
+            )
+        )->setStarttimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 2
+            )
+        );
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreDeactivateContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreDeactivateContestFixture.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreDeactivateContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setEndtimeString(
+            sprintf(
+                '%s-06-06 09:00:00 Europe/Amsterdam',
+                date('Y') - 1
+            )
+        )->setUnfreezetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y')
+            )
+        )->setDeactivatetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 2
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreEndContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreEndContestFixture.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreEndContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setStarttimeString('2020-01-01 09:00:00 Europe/Amsterdam')
+        ->setFreezetimeString('2021-01-03 12:34:56 Europe/Amsterdam')
+        ->setEndtimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 1
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreFreezeContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreFreezeContestFixture.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreFreezeContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setStarttimeString('2021-01-01 09:00:00 Europe/Amsterdam')
+        ->setFreezetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 1
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreStartContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreStartContestFixture.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreStartContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setActivatetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y')
+            )
+        )->setStarttimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 1
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/DemoPreUnfreezeContestFixture.php
+++ b/webapp/src/DataFixtures/Test/DemoPreUnfreezeContestFixture.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use Doctrine\Persistence\ObjectManager;
+
+class DemoPreUnfreezeContestFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest->setEndtimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y')
+            )
+        )
+        ->setFreezetimeString('2021-01-03 12:34:56 Europe/Amsterdam')
+        ->setUnfreezetimeString(
+            sprintf(
+                '%s-01-01 09:00:00 Europe/Amsterdam',
+                date('Y') + 1
+            )
+        ); // Set the time explicit to guard against changes in the Default fixture.
+        $manager->persist($demoContest);
+        $manager->flush();
+    }
+}

--- a/webapp/src/DataFixtures/Test/SampleSubmissionsMultipleTriesFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleSubmissionsMultipleTriesFixture.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Service\ScoreboardService;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleSubmissionsMultipleTriesFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $submissionData = [
+            // team name,         problem shortname, language, submittime,            entry point, result
+            ['Example teamname',  'boolfind',        'cpp',    '2021-02-01 01:00:56', null,        'timelimit'],
+            ['Example teamname',  'boolfind',        'c',      '2021-02-01 03:15:56', null,        'run-error'],
+            ['Example teamname',  'boolfind',        'java',   '2021-02-01 18:00:00', 'Main',      'wrong-answer'],
+            ['Example teamname',  'boolfind',        'py3',    '2021-02-01 18:00:34', 'main',      'compiler-error'],
+        ];
+
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        foreach ($submissionData as $index => $submissionItem) {
+            $problem = $contest->getProblems()->filter(
+                fn(ContestProblem $problem) => $problem->getShortname() === $submissionItem[1]
+            )->first();
+            $submission = (new Submission())
+                ->setContest($contest)
+                ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => $submissionItem[0]]))
+                ->setContestProblem($problem)
+                ->setLanguage($manager->getRepository(Language::class)->find($submissionItem[2]))
+                ->setSubmittime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEntryPoint($submissionItem[4]);
+            $judging = (new Judging())
+                ->setContest($contest)
+                ->setStarttime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEndtime(Utils::toEpochFloat($submissionItem[3]) + 5)
+                ->setValid(true)
+                ->setSubmission($submission)
+                ->setResult($submissionItem[5]);
+            $submission->addJudging($judging);
+            $manager->persist($submission);
+            $manager->persist($judging);
+            $manager->flush();
+            // Add a reference, since the submission ID changes during testing because of the auto increment
+            $this->addReference(sprintf('%s:%d', static::class, $index), $submission);
+        }
+    }
+}

--- a/webapp/src/DataFixtures/Test/SampleSubmissionsThreeTriesCorrectFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleSubmissionsThreeTriesCorrectFixture.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Service\ScoreboardService;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleSubmissionsThreeTriesCorrectFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $submissionData = [
+            // team name,         problem shortname, language, submittime,            entry point, result
+            ['Example teamname',  'hello',           'cpp',    '2021-01-01 12:34:56', null,        'timelimit'],
+            ['Example teamname',  'hello',           'java',   '2021-01-02 12:00:00', 'Main',      'wrong-answer'],
+            ['Example teamname',  'hello',           'c',      '2021-01-04 12:34:56', null,        'correct'],
+        ];
+
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        foreach ($submissionData as $index => $submissionItem) {
+            $problem = $contest->getProblems()->filter(
+                fn(ContestProblem $problem) => $problem->getShortname() === $submissionItem[1]
+            )->first();
+            $submission = (new Submission())
+                ->setContest($contest)
+                ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => $submissionItem[0]]))
+                ->setContestProblem($problem)
+                ->setLanguage($manager->getRepository(Language::class)->find($submissionItem[2]))
+                ->setSubmittime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEntryPoint($submissionItem[4]);
+            $judging = (new Judging())
+                ->setContest($contest)
+                ->setStarttime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEndtime(Utils::toEpochFloat($submissionItem[3]) + 5)
+                ->setValid(true)
+                ->setSubmission($submission)
+                ->setResult($submissionItem[5]);
+            $submission->addJudging($judging);
+            $manager->persist($submission);
+            $manager->persist($judging);
+            $manager->flush();
+            // Add a reference, since the submission ID changes during testing because of the auto increment
+            $this->addReference(sprintf('%s:%d', static::class, $index), $submission);
+        }
+    }
+}

--- a/webapp/src/DataFixtures/Test/SampleSubmissionsThreeTriesCorrectSameLanguageFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleSubmissionsThreeTriesCorrectSameLanguageFixture.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Service\ScoreboardService;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleSubmissionsThreeTriesCorrectSameLanguageFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $submissionData = [
+            // team name,         problem shortname, language, submittime,            entry point, result
+            ['Example teamname',  'fltcmp',          'cpp',    '2021-01-01 12:34:56', null,        'timelimit'],
+            ['Example teamname',  'fltcmp',          'cpp',    '2021-01-01 12:35:30', null,        'wrong-answer'],
+            ['Example teamname',  'fltcmp',          'cpp',    '2021-01-01 12:36:51', null,        'correct'],
+        ];
+
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        foreach ($submissionData as $index => $submissionItem) {
+            $problem = $contest->getProblems()->filter(
+                fn(ContestProblem $problem) => $problem->getShortname() === $submissionItem[1]
+            )->first();
+            $submission = (new Submission())
+                ->setContest($contest)
+                ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => $submissionItem[0]]))
+                ->setContestProblem($problem)
+                ->setLanguage($manager->getRepository(Language::class)->find($submissionItem[2]))
+                ->setSubmittime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEntryPoint($submissionItem[4]);
+            $judging = (new Judging())
+                ->setContest($contest)
+                ->setStarttime(Utils::toEpochFloat($submissionItem[3]))
+                ->setEndtime(Utils::toEpochFloat($submissionItem[3]) + 5)
+                ->setValid(true)
+                ->setSubmission($submission)
+                ->setResult($submissionItem[5]);
+            $submission->addJudging($judging);
+            $manager->persist($submission);
+            $manager->persist($judging);
+            $manager->flush();
+            // Add a reference, since the submission ID changes during testing because of the auto increment
+            $this->addReference(sprintf('%s:%d', static::class, $index), $submission);
+        }
+    }
+}

--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -10,7 +10,7 @@
         <ul class="navbar-nav mr-auto">
 
             {% if is_granted('ROLE_BALLOON') %}
-                <li class="nav-item">
+                <li class="nav-item {% if current_route == 'jury_balloons' %}active{% endif %}">
                     <a class="nav-link" href="{{ path('jury_balloons') }}">
                         <i class="fas fa-map-marker-alt"></i> balloons
                         <span class="badge badge-info" id="num-alerts-balloons"></span>
@@ -71,7 +71,7 @@
                 </li>
             {% endif %}
 
-            {% if is_granted('ROLE_JURY') %}
+            {% if is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON') %}
                 <li class="nav-item {% if current_route == 'jury_scoreboard' %}active{% endif %}">
                     <a class="nav-link" href="{{ path('jury_scoreboard') }}"><i class="fas fa-list-ol"></i> scoreboard</a>
                 </li>

--- a/webapp/templates/jury/scoreboard.html.twig
+++ b/webapp/templates/jury/scoreboard.html.twig
@@ -11,7 +11,7 @@
 {% block content %}
 
     <div data-ajax-refresh-target data-ajax-refresh-after="pinScoreheader">
-        {% include 'partials/scoreboard.html.twig' with {jury: true} %}
+        {% include 'partials/scoreboard.html.twig' with {jury: is_granted('ROLE_JURY'), public: not is_granted('ROLE_JURY')} %}
     </div>
 
 {% endblock %}

--- a/webapp/templates/partials/scoreboard_summary.html.twig
+++ b/webapp/templates/partials/scoreboard_summary.html.twig
@@ -23,19 +23,19 @@
                     {% endif %}
                     <a {% if link %}href="{{ link }}"{% endif %}>
                         <i class="fas fa-thumbs-up fa-fw"></i>
-                        <span style="font-size:90%;" title="number of accepted submissions">
+                        <span class="submcorrect" style="font-size:90%;" title="number of accepted submissions">
                                 {{ summary.numSubmissionsCorrect[sortOrder] ?? 0 }}
                             </span>
                         <br/>
 
                         <i class="fas fa-thumbs-down fa-fw"></i>
-                        <span style="font-size:90%;" title="number of rejected submissions">
+                        <span class="submreject" style="font-size:90%;" title="number of rejected submissions">
                                 {{ summary.numSubmissions[sortOrder] ?? 0 - summary.numSubmissionsCorrect[sortOrder] ?? 0 }}
                             </span>
                         <br/>
 
                         <i class="fas fa-question-circle fa-fw"></i>
-                        <span style="font-size:90%;" title="number of pending submissions">
+                        <span class="submpend" style="font-size:90%;" title="number of pending submissions">
                                 {{ summary.numSubmissionsPending[sortOrder] ?? 0 }}
                             </span>
                         <br/>

--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -232,7 +232,7 @@ class ControllerRolesTraversalTest extends BaseTest
         $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         self::assertNotEquals(500, $response->getStatusCode(), sprintf('Failed at %s', $url));
-        if ($dropdown) {
+        if ($dropdown && strpos($url, '/public') === false) {
             self::assertSelectorExists('a#navbarDropdownContests:contains("no contest")');
         }
     }


### PR DESCRIPTION
Based on the suggestions of @nickygerritsen in https://github.com/DOMjudge/domjudge/issues/1289.

This does not close that issue as discussion there created more functionality questions.

This discloses a bit more information to balloon runners as in the past they knew nothing in default setting during a frozen scoreboard about the amount of submissions which are now disclosed as pending.