### PR TITLE
Slightly change table/column definitions to have no migration diff anymore after upgrade to Doctrine 3.x

### DIFF
--- a/webapp/src/Entity/AuditLog.php
+++ b/webapp/src/Entity/AuditLog.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="auditlog",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of all actions performed"})
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of all actions performed"})
  */
 class AuditLog
 {

--- a/webapp/src/Entity/Balloon.php
+++ b/webapp/src/Entity/Balloon.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="balloon",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Balloons to be handed out"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Balloons to be handed out"},
  *     indexes={@ORM\Index(name="submitid", columns={"submitid"})}
  *     )
  */

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -14,7 +14,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="clarification",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Clarification requests by teams and responses by the jury"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Clarification requests by teams and responses by the jury"},
  *     indexes={
  *         @ORM\Index(name="respid", columns={"respid"}),
  *         @ORM\Index(name="probid", columns={"probid"}),

--- a/webapp/src/Entity/Configuration.php
+++ b/webapp/src/Entity/Configuration.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Entity()
  * @ORM\Table(name="configuration",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Global configuration variables"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Global configuration variables"},
  *     uniqueConstraints={@ORM\UniqueConstraint(name="name", columns={"name"})})
  */
 class Configuration

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="contest",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Contests that will be run with this install"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Contests that will be run with this install"},
  *     indexes={@ORM\Index(name="cid", columns={"cid", "enabled"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
@@ -148,7 +148,7 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     private $finalizetime = null;
 
     /**
-     * @ORM\Column(type="text", name="finalizecomment",
+     * @ORM\Column(type="text", name="finalizecomment", length=65535,
      *     options={"comment"="Comments by the finalizer"},
      *     nullable=true)
      * @Serializer\Exclude()

--- a/webapp/src/Entity/ContestProblem.php
+++ b/webapp/src/Entity/ContestProblem.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="contestproblem",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Many-to-Many mapping of contests and problems"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Many-to-Many mapping of contests and problems"},
  *     indexes={
  *         @ORM\Index(name="cid", columns={"cid"}),
  *         @ORM\Index(name="probid", columns={"probid"})

--- a/webapp/src/Entity/DebugPackage.php
+++ b/webapp/src/Entity/DebugPackage.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
  *     indexes={
  *         @ORM\Index(name="judgingid", columns={"judgingid"}),
  *     },
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Debug packages."}
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Debug packages."}
  *     )
  */
 class DebugPackage

--- a/webapp/src/Entity/Event.php
+++ b/webapp/src/Entity/Event.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *     name="event",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of all events during a contest"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of all events during a contest"},
  *     indexes={
  *         @ORM\Index(name="eventtime", columns={"cid","eventtime"}),
  *         @ORM\Index(name="cid", columns={"cid"}),

--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -15,7 +15,7 @@ use ZipArchive;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="executable",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4",
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4",
  *              "comment"="Compile, compare, and run script executable bundles"}
  *     )
  */

--- a/webapp/src/Entity/ExecutableFile.php
+++ b/webapp/src/Entity/ExecutableFile.php
@@ -10,7 +10,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="executable_file",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Files associated to an executable"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Files associated to an executable"},
  *     indexes={@ORM\Index(name="immutable_execid", columns={"immutable_execid"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="rankindex", columns={"immutable_execid", "ranknumber"}),

--- a/webapp/src/Entity/ExternalContestSource.php
+++ b/webapp/src/Entity/ExternalContestSource.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="external_contest_source",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4",
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4",
  *              "comment"="Sources for external contests"}
  * )
  */

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -12,7 +12,7 @@ use JMS\Serializer\Annotation as Serializer;
  *
  * @ORM\Table(
  *     name="external_judgement",
- *     options={"comment":"Judgement in external system"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment":"Judgement in external system"},
  *     indexes={
  *         @ORM\Index(name="submitid", columns={"submitid"}),
  *         @ORM\Index(name="cid", columns={"cid"}),

--- a/webapp/src/Entity/ExternalRun.php
+++ b/webapp/src/Entity/ExternalRun.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *     name="external_run",
- *     options={"comment":"Run in external system"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment":"Run in external system"},
  *     indexes={
  *         @ORM\Index(name="extjudgementid", columns={"extjudgementid"}),
  *         @ORM\Index(name="testcaseid", columns={"testcaseid"})

--- a/webapp/src/Entity/ExternalSourceWarning.php
+++ b/webapp/src/Entity/ExternalSourceWarning.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(
  *     name="external_source_warning",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4",
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4",
  *              "comment"="Warnings for external sources"},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="hash", columns={"extsourceid", "hash"}, options={"lengths"={NULL,190}})

--- a/webapp/src/Entity/ImmutableExecutable.php
+++ b/webapp/src/Entity/ImmutableExecutable.php
@@ -12,7 +12,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="immutable_executable",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4",
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4",
  *              "comment"="Immutable wrapper for a collection of files for executable bundles."}
  *     )
  */

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -13,7 +13,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="internal_error",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of judgehost internal errors"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Log of judgehost internal errors"},
  *     indexes={
  *         @ORM\Index(name="judgingid", columns={"judgingid"}),
  *         @ORM\Index(name="cid", columns={"cid"})

--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         @ORM\Index(name="judgehostid_valid_priority", columns={"judgehostid", "valid", "priority"}),
  *         @ORM\Index(name="specific_type", columns={"judgehostid", "starttime", "valid", "type", "priority", "judgetaskid"}),
  *     },
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Individual judge tasks."}
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Individual judge tasks."}
  *     )
  */
 class JudgeTask

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judgehost",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Hostnames of the autojudgers"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Hostnames of the autojudgers"},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="hostname", columns={"hostname"})
  *     })

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -14,7 +14,7 @@ use Ramsey\Uuid\Uuid;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judging",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Result of judging a submission"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Result of judging a submission"},
  *     indexes={
  *         @ORM\Index(name="submitid", columns={"submitid"}),
  *         @ORM\Index(name="cid", columns={"cid"}),

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -13,7 +13,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="judging_run",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Result of a testcase run within a judging"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Result of a testcase run within a judging"},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="testcaseid", columns={"judgingid", "testcaseid"})
  *     },

--- a/webapp/src/Entity/JudgingRunOutput.php
+++ b/webapp/src/Entity/JudgingRunOutput.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(
  *     name="judging_run_output",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Stores output of judging run"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Stores output of judging run"},
  *     indexes={@ORM\Index(name="runid", columns={"runid"})})
  */
 class JudgingRunOutput

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="language",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Programming languages in which teams can submit solutions"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Programming languages in which teams can submit solutions"},
  *     indexes={@ORM\Index(name="compile_script", columns={"compile_script"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="problem",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Problems the teams can submit solutions for"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Problems the teams can submit solutions for"},
  *     indexes={
  *         @ORM\Index(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
  *         @ORM\Index(name="special_run", columns={"special_run"}),

--- a/webapp/src/Entity/ProblemAttachment.php
+++ b/webapp/src/Entity/ProblemAttachment.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="problem_attachment",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Attachments belonging to problems"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Attachments belonging to problems"},
  *     indexes={
  *         @ORM\Index(name="name", columns={"attachmentid", "name"}, options={"lengths": {null, 190}})
  *     })

--- a/webapp/src/Entity/ProblemAttachmentContent.php
+++ b/webapp/src/Entity/ProblemAttachmentContent.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(
  *     name="problem_attachment_content",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Stores contents of problem attachments"})
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Stores contents of problem attachments"})
  */
 class ProblemAttachmentContent
 {

--- a/webapp/src/Entity/QueueTask.php
+++ b/webapp/src/Entity/QueueTask.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *         @ORM\Index(name="teamid", columns={"teamid"}),
  *         @ORM\Index(name="starttime", columns={"starttime"}),
  *     },
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Work items."}
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Work items."}
  *     )
  */
 class QueueTask

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="rankcache",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Scoreboard rank cache"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Scoreboard rank cache"},
  *     indexes={
  *         @ORM\Index(name="order_restricted", columns={"cid","points_restricted","totaltime_restricted"}),
  *         @ORM\Index(name="order_public", columns={"cid","points_public","totaltime_public"}),

--- a/webapp/src/Entity/Rejudging.php
+++ b/webapp/src/Entity/Rejudging.php
@@ -12,7 +12,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="rejudging",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Rejudge group"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Rejudge group"},
  *     indexes={
  *         @ORM\Index(name="userid_start", columns={"userid_start"}),
  *         @ORM\Index(name="userid_finish", columns={"userid_finish"})

--- a/webapp/src/Entity/RemovedInterval.php
+++ b/webapp/src/Entity/RemovedInterval.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="removed_interval",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Time intervals removed from the contest for scoring"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Time intervals removed from the contest for scoring"},
  *     indexes={@ORM\Index(name="cid", columns={"cid"})})
  */
 class RemovedInterval

--- a/webapp/src/Entity/Role.php
+++ b/webapp/src/Entity/Role.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="role",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Possible user roles"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Possible user roles"},
  *     uniqueConstraints={@ORM\UniqueConstraint(name="role", columns={"role"})})
  */
 class Role

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="scorecache",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Scoreboard cache"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Scoreboard cache"},
  *     indexes={
  *         @ORM\Index(name="cid", columns={"cid"}),
  *         @ORM\Index(name="teamid", columns={"teamid"}),
@@ -46,7 +46,7 @@ class ScoreCache
      * @var double|string
      * @ORM\Column(type="decimal", precision=32, scale=9, name="solvetime_restricted",
      *     options={"comment"="Seconds into contest when problem solved (restricted audience)",
-     *              "default"=0},
+     *              "default"="0.000000000"},
      *     nullable=false)
      */
     private $solvetime_restricted = 0;
@@ -80,7 +80,7 @@ class ScoreCache
      * @var double|string
      * @ORM\Column(type="decimal", precision=32, scale=9, name="solvetime_public",
      *     options={"comment"="Seconds into contest when problem solved (public)",
-     *              "default"="0"},
+     *              "default"="0.000000000"},
      *     nullable=false)
      */
     private $solvetime_public = 0;

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -15,7 +15,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="submission",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="All incoming submissions"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="All incoming submissions"},
  *     indexes={
  *         @ORM\Index(name="teamid", columns={"cid","teamid"}),
  *         @ORM\Index(name="teamid_2", columns={"teamid"}),

--- a/webapp/src/Entity/SubmissionFile.php
+++ b/webapp/src/Entity/SubmissionFile.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="submission_file",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Files associated to a submission"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Files associated to a submission"},
  *     indexes={@ORM\Index(name="submitid", columns={"submitid"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="rankindex", columns={"submitid", "ranknumber"}),

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4"},
  *     indexes={
  *         @ORM\Index(name="affilid", columns={"affilid"}),
  *         @ORM\Index(name="categoryid", columns={"categoryid"})

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team_affiliation",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Affilitations for teams (e.g.: university, company)"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Affilitations for teams (e.g.: university, company)"},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
  *     })

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="team_category",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Categories for teams (e.g.: participants, observers, ...)"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Categories for teams (e.g.: participants, observers, ...)"},
  *     indexes={@ORM\Index(name="sortorder", columns={"sortorder"})},
  *     uniqueConstraints={
  *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths": {190}}),
@@ -64,7 +64,7 @@ class TeamCategory extends BaseApiEntity
     private string $name;
 
     /**
-     * @ORM\Column(type="tinyint", name="sortorder", length=1,
+     * @ORM\Column(type="tinyint", name="sortorder",
      *     options={"comment"="Where to sort this category on the scoreboard",
      *              "unsigned"=true,"default"="0"},
      *     nullable=false)

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -12,7 +12,7 @@ use JMS\Serializer\Annotation as Serializer;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="testcase",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Stores testcases per problem"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Stores testcases per problem"},
  *     indexes={
  *         @ORM\Index(name="probid", columns={"probid"}),
  *         @ORM\Index(name="sample", columns={"sample"})

--- a/webapp/src/Entity/TestcaseContent.php
+++ b/webapp/src/Entity/TestcaseContent.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(
  *     name="testcase_content",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Stores contents of testcase"})
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4","comment"="Stores contents of testcase"})
  */
 class TestcaseContent
 {

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity()
  * @ORM\Table(
  *     name="user",
- *     options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Users that have access to DOMjudge"},
+ *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Users that have access to DOMjudge"},
  *     indexes={@ORM\Index(name="teamid", columns={"teamid"})},
  *     uniqueConstraints={@ORM\UniqueConstraint(name="username", columns={"username"}, options={"lengths":{190}})})
  * @UniqueEntity("username", message="The username '{{ value }}' is already in use.")


### PR DESCRIPTION
* `s/collate/collation`.
* Remove length=1 from a place where it should not be there.
* Set an explicit length on one column to have it be `text` instead of the new default `longtext`.