### PR TITLE
Remove commit hash from crawled filenames

### DIFF
--- a/gitlab/visualpr.sh
+++ b/gitlab/visualpr.sh
@@ -146,6 +146,14 @@ if [ $RET -ne 4 ] && [ $RET -ne 8 ] && [ $RET -ne 0 ]; then
 fi
 section_end scrape
 
+section_start_collap removecommithash "Remove HEAD hash from files"
+while IFS= read -r -d '' file; do
+    newname=${file%@v=*}
+    echo $newname
+    mv $file $newname
+done < <(find ./ -type f -name "*@v=*" -print0)
+section_end removecommithash
+
 section_start_collap cpstatic "Store scraped files in nginx"
 cd "$DIR"
 mkdir /var/www/html/"$URL"/

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -162,7 +162,6 @@ class PublicController extends BaseController
             $this->dj->getTwigDataForProblemsAction(-1, $this->stats));
     }
 
-
     /**
      * @Route("/problems/{probId<\d+>}/text", name="public_problem_text")
      */


### PR DESCRIPTION
Currently all PRs list most URLs as newly added and also as removed. This is because we compare the filenames including the short commithash. This PR is for testing if this can be easily fixed.