### PR TITLE
Hide commit hash in webpage when testing

### DIFF
--- a/gitlab/visualreg.css
+++ b/gitlab/visualreg.css
@@ -1,3 +1,3 @@
-#timeleft, #lastmod, #contesttimer {
+#timeleft, #lastmod, #contesttimer, #dj_version {
         visibility: hidden;
 }

--- a/webapp/templates/jury/config_check.html.twig
+++ b/webapp/templates/jury/config_check.html.twig
@@ -8,7 +8,7 @@
   <div class="card-body">
   <h5 class="card-title">System information</h5>
   <table class="w-100">
-  <tr><td>DOMjudge:</td><td>{{ DOMJUDGE_VERSION }}</td></tr>
+  <tr><td>DOMjudge:</td><td id="dj_version">{{ DOMJUDGE_VERSION }}</td></tr>
   <tr><td>Environment:</td><td>{{ app.environment }}</td></tr>
   <tr><td>Debug:</td><td>{{ app.debug|printYesNo }}</td></tr>
   <tr><td colspan="2">&nbsp;</td></tr>

--- a/webapp/templates/security/login.html.twig
+++ b/webapp/templates/security/login.html.twig
@@ -118,7 +118,7 @@ Use the form below to change login.' %}
             </form>
         </div>
 
-        <p class="mt-5 mb-3 small text-muted">DOMjudge {{ DOMJUDGE_VERSION }}</p>
+        <p class="mt-5 mb-3 small text-muted" id="dj_version">DOMjudge {{ DOMJUDGE_VERSION }}</p>
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Currently we display the commithash on the config page which triggers a
visual change. Although indeed correct this should not be in scope when
evaluating a PR.