### PR TITLE
CCS Specs API information in root endpoint

### DIFF
--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -39,8 +39,8 @@ class GeneralInfoController extends AbstractFOSRestController
 {
     protected const API_VERSION = 4;
 
-    public const CCS_SPEC_API_VERSION = '2021-11';
-    public const CCS_SPEC_API_URL = 'https://ccs-specs.icpc.io/2021-11/contest_api';
+    public const CCS_SPEC_API_VERSION = 'draft';
+    public const CCS_SPEC_API_URL = 'https://ccs-specs.icpc.io/master/contest_api';
 
     protected EntityManagerInterface $em;
     protected DOMJudgeService $dj;
@@ -98,7 +98,7 @@ class GeneralInfoController extends AbstractFOSRestController
      *     @OA\JsonContent(
      *         type="object",
      *         @OA\Property(property="version", type="string", description="Version of the CCS Specs Contest API the API adheres to"),
-     *         @OA\Property(property="version_url", type="string", description="URL with the speification of the Contest API"),
+     *         @OA\Property(property="version_url", type="string", description="URL with the specification of the Contest API"),
      *         @OA\Property(
      *             property="domjudge",
      *             type="object",

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -39,6 +39,9 @@ class GeneralInfoController extends AbstractFOSRestController
 {
     protected const API_VERSION = 4;
 
+    public const CCS_SPEC_API_VERSION = '2021-11';
+    public const CCS_SPEC_API_URL = 'https://ccs-specs.icpc.io/2021-11/contest_api';
+
     protected EntityManagerInterface $em;
     protected DOMJudgeService $dj;
     protected ConfigurationService $config;
@@ -94,20 +97,33 @@ class GeneralInfoController extends AbstractFOSRestController
      *     description="Information about the API and DOMjudge",
      *     @OA\JsonContent(
      *         type="object",
-     *         @OA\Property(property="api_version", type="integer"),
-     *         @OA\Property(property="domjudge_version", type="string"),
-     *         @OA\Property(property="environment", type="string"),
-     *         @OA\Property(property="doc_url", type="string")
+     *         @OA\Property(property="version", type="string", description="Version of the CCS Specs Contest API the API adheres to"),
+     *         @OA\Property(property="version_url", type="string", description="URL with the speification of the Contest API"),
+     *         @OA\Property(
+     *             property="domjudge",
+     *             type="object",
+     *             description="DOMjudge information",
+     *             properties={
+     *                 @OA\Property(property="api_version", type="integer", description="Version of the API"),
+     *                 @OA\Property(property="domjudge_version", type="string", description="Version of DOMjudge"),
+     *                 @OA\Property(property="environment", type="string", description="Environment DOMjudge is running in"),
+     *                 @OA\Property(property="doc_url", type="string", description="URL to DOMjudge API docs")
+     *             }
+     *         )
      *     )
      * )
      */
     public function getInfoAction(): array
     {
         return [
-            'api_version' => static::API_VERSION,
-            'domjudge_version' => $this->getParameter('domjudge.version'),
-            'environment' => $this->getParameter('kernel.environment'),
-            'doc_url' => $this->router->generate('app.swagger_ui', [], RouterInterface::ABSOLUTE_URL),
+            'version' => self::CCS_SPEC_API_VERSION,
+            'version_url' => self::CCS_SPEC_API_URL,
+            'domjudge' => [
+                'api_version' => static::API_VERSION,
+                'version' => $this->getParameter('domjudge.version'),
+                'environment' => $this->getParameter('kernel.environment'),
+                'doc_url' => $this->router->generate('app.swagger_ui', [], RouterInterface::ABSOLUTE_URL),
+            ],
         ];
     }
 

--- a/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Controller\API;
 
+use App\Controller\API\GeneralInfoController;
 use App\DataFixtures\Test\SampleSubmissionsFixture;
 use App\Service\DOMJudgeService;
 use Generator;
@@ -32,11 +33,12 @@ class GeneralInfoControllerTest extends BaseTest
             $response = $this->verifyApiJsonResponse('GET', $endpoint, 200);
 
             static::assertIsArray($response);
-            static::assertCount(4, $response);
-            static::assertEquals(static::API_VERSION, $response['api_version']);
-            static::assertMatchesRegularExpression('/^\d+\.\d+\.\d+/', $response['domjudge_version']);
-            static::assertEquals('test', $response['environment']);
-            static::assertStringStartsWith('http', $response['doc_url']);
+            static::assertCount(3, $response);
+            static::assertEquals(GeneralInfoController::CCS_SPEC_API_VERSION, $response['version']);
+            static::assertEquals(GeneralInfoController::CCS_SPEC_API_URL, $response['version_url']);
+            static::assertMatchesRegularExpression('/^\d+\.\d+\.\d+/', $response['domjudge']['version']);
+            static::assertEquals('test', $response['domjudge']['environment']);
+            static::assertStringStartsWith('http', $response['domjudge']['doc_url']);
         }
     }
 


### PR DESCRIPTION
The API spec wants us to expose these two fields in the root, see [here](https://ccs-specs.icpc.io/master/contest_api#api-version).

I put the existing DOMjudge specific fields in a `domjudge` object since IMHO otherwise the root keys are a bit strange.