### PR TITLE
Implement account endpoints

### DIFF
--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -46,7 +46,7 @@ Example ``groups.json``::
   }]
 
 To import the file using the jury interface, go to `Import / export`, select
-`groups` under `JSON import`, select your file and click `Import`.
+`groups` under `Import JSON / YAML`, select your file and click `Import`.
 
 To import the file using the API run the following command::
 
@@ -111,7 +111,7 @@ Example ``organizations.json``::
   }]
 
 To import the file using the jury interface, go to `Import / export`, select
-`organizations` under `JSON import`, select your file and click `Import`.
+`organizations` under `Import JSON / YAML`, select your file and click `Import`.
 
 To import the file using the API run the following command::
 
@@ -155,7 +155,7 @@ Example ``teams.json``::
   }]
 
 To import the file using the jury interface, go to `Import / export`, select
-`teams` under `JSON import`, select your file and click `Import`.
+`teams` under `Import JSON / YAML`, select your file and click `Import`.
 
 To import the file using the API run the following command::
 
@@ -194,24 +194,75 @@ To import the file using the API run the following command::
 Importing accounts
 ------------------
 
+There are two formats to import accounts: a YAML format and a legacy TSV format.
+
+Using YAML
+^^^^^^^^^^
+
+Prepare a file called ``accounts.yaml`` which contains the accounts.
+It should be a YAML array with objects, each object should contain the following
+fields:
+
+- ``id``: the account ID. Must be unique
+- ``username``: the account username. Must be unique
+- ``password``: the password to use for the account
+- ``type``: the user type, one of ``team``, ``judge`` or ``admin``
+- ``team_id``: (optional) the external ID of the team this account belongs to
+- ``name``: (optional) the full name of the account
+- ``ip`` (optional): IP address to link to this account
+
+Example ``accounts.yaml``::
+
+   - id: team001
+     username: team001
+     password: P3xm33imve
+     type: team
+     name: team001
+     ip: 10.10.2.1
+
+   - id: team002
+     username: team002
+     password: qd4WHeJXbd
+     type: team
+     name: team002
+     ip: 10.10.2.2
+
+   - id: john
+     username: john
+     password: Uf4PYRA7mJ
+     type: judge
+     name: John Doe
+
 .. note::
 
-    Importing accounts is currently only possible using a TSV.
+    You can also use a JSON file instead of YAML. Make sure to name it
+    ``accounts.json`` in that case.
+
+To import the file using the jury interface, go to `Import / export`, select
+`accounts` under `Import JSON / YAML`, select your file and click `Import`.
+
+To import the file using the API run the following command::
+
+    http --check-status -b -f POST "<API_URL>/users/accounts" yaml@accounts.yaml
+
+Using the legacy TSV format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Prepare a file called ``accounts.tsv`` which contains the team credentials.
 The first line should contain ``accounts  1`` (tab-separated).
 Each of the following lines must contain the following elements separated by tabs:
 
-- the user type, one of ``team`` or ``judge``
+- the user type, one of ``team``, ``judge`` or ``admin``
 - the full name of the user
 - the username
 - the password
+- (optional) the IP address to the user
 
 Example ``accounts.tsv``::
 
    accounts	1
-   team	team001	team001	P3xm33imve
-   team	team002	team002	qd4WHeJXbd
+   team	team001	team001	P3xm33imve	10.10.2.1
+   team	team002	team002	qd4WHeJXbd	10.10.2.2
    judge	John Doe	john	Uf4PYRA7mJ
 
 To import the file using the jury interface, go to `Import / export`, select

--- a/misc-tools/import-contest.sh
+++ b/misc-tools/import-contest.sh
@@ -40,7 +40,7 @@ elif [ -r groups.tsv ]; then
         echo "Skipping groups import."
     fi
 else
-    echo "Neither 'groups.json'n or 'groups.tsv' found, skipping groups import."
+    echo "Neither 'groups.json' nor 'groups.tsv' found, skipping groups import."
 fi
 
 if [ -r organizations.json ]; then
@@ -78,6 +78,36 @@ else
     echo "Neither 'teams.json' nor 'teams2.tsv' found, skipping teams import."
 fi
 
+if [ -r accounts.json ]; then
+    read -r -p "Import accounts (from accounts.json)? [y/N] " response
+    response=${response,,}
+    if [[ $response =~ ^(yes|y| ) ]]; then
+        echo "Importing accounts."
+        myhttp -b -f POST "$api_url/users/accounts" json@accounts.json
+    else
+        echo "Skipping accounts import."
+    fi
+elif [ -r accounts.yaml ]; then
+    read -r -p "Import accounts (from accounts.yaml)? [y/N] " response
+    response=${response,,}
+    if [[ $response =~ ^(yes|y| ) ]]; then
+        echo "Importing accounts."
+        myhttp -b -f POST "$api_url/users/accounts" yaml@accounts.yaml
+    else
+        echo "Skipping accounts import."
+    fi
+elif [ -r accounts.tsv ]; then
+    read -r -p "Import accounts (from accounts.tsv)? [y/N] " response
+    response=${response,,}
+    if [[ $response =~ ^(yes|y| ) ]]; then
+        echo "Importing accounts."
+        myhttp -b -f POST "$api_url/users/accounts" tsv@accounts.tsv
+    else
+        echo "Skipping accounts import."
+    fi
+else
+    echo "Neither 'accounts.json', 'accounts.yaml' nor 'groups.tsv' found, skipping accounts import."
+fi
 if [ -r accounts.tsv ]; then
     read -r -p "Import accounts (from accounts.tsv)? [Y/n] " response
     response=${response,,}

--- a/webapp/migrations/Version20220408071147.php
+++ b/webapp/migrations/Version20220408071147.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220408071147 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix comment for team external ID.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE team CHANGE externalid externalid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'Team ID in an external system\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE team CHANGE externalid externalid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'Team affiliation ID in an external system\'');
+    }
+}

--- a/webapp/migrations/Version20220408073801.php
+++ b/webapp/migrations/Version20220408073801.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220408073801 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user ADD externalid VARCHAR(255) DEFAULT NULL COLLATE `utf8mb4_bin` COMMENT \'User ID in an external system\'');
+        $this->addSql('CREATE UNIQUE INDEX externalid ON user (externalid(190))');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX externalid ON user');
+        $this->addSql('ALTER TABLE user DROP externalid');
+    }
+}

--- a/webapp/src/Controller/API/AccountController.php
+++ b/webapp/src/Controller/API/AccountController.php
@@ -119,6 +119,6 @@ class AccountController extends AbstractRestController
 
     protected function getIdField(): string
     {
-        return 'u.userid';
+        return sprintf('u.%s', $this->eventLogService->externalIdFieldForEntity(User::class) ?? 'userid');
     }
 }

--- a/webapp/src/Controller/API/AccountController.php
+++ b/webapp/src/Controller/API/AccountController.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\API;
+
+use App\Entity\User;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\QueryBuilder;
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use OpenApi\Annotations as OA;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @Rest\Route("/contests/{cid}")
+ * @OA\Tag(name="Accounts")
+ * @OA\Parameter(ref="#/components/parameters/cid")
+ * @OA\Response(response="404", ref="#/components/responses/NotFound")
+ * @OA\Response(response="401", ref="#/components/responses/Unauthorized")
+ * @OA\Response(response="400", ref="#/components/responses/InvalidResponse")
+ */
+class AccountController extends AbstractRestController
+{
+    // Note: this controller is basically a copy of the UserController but then with account endpoints.
+    // There are two differences that make it impossible to add it to that controller or extend it:
+    // - The /api/contests/<cid> prefix to load the contest
+    // - The fact that we have /api/contests/<cid>/account
+    // Also it seems to not be possible to overwrite the OA\Tag or the base controller route when
+    // extending a controller
+
+    /**
+     * Get all the accounts
+     * @Rest\Get("/accounts")
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_READER')")
+     * @OA\Response(
+     *     response="200",
+     *     description="Returns all the accounts for this contest",
+     *     @OA\JsonContent(
+     *         type="array",
+     *         @OA\Items(ref=@Model(type=User::class))
+     *     )
+     * )
+     * @OA\Parameter(ref="#/components/parameters/idlist")
+     * @OA\Parameter(ref="#/components/parameters/strict")
+     * @OA\Parameter(
+     *     name="team_id",
+     *     in="query",
+     *     description="Only show accounts for the given team",
+     *     @OA\Schema(type="string")
+     * )
+     * @throws NonUniqueResultException
+     */
+    public function listAction(Request $request): Response
+    {
+        // Get the contest ID to make sure the contest exists
+        $this->getContestId($request);
+        return parent::performListAction($request);
+    }
+
+    /**
+     * Get the given account
+     * @throws NonUniqueResultException
+     * @Rest\Get("/accounts/{id}")
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_API_READER')")
+     * @OA\Response(
+     *     response="200",
+     *     description="Returns the given account",
+     *     @Model(type=User::class)
+     * )
+     * @OA\Parameter(ref="#/components/parameters/id")
+     * @OA\Parameter(ref="#/components/parameters/strict")
+     */
+    public function singleAction(Request $request, string $id): Response
+    {
+        // Get the contest ID to make sure the contest exists
+        $this->getContestId($request);
+        return parent::performSingleAction($request, $id);
+    }
+
+    /**
+     * Get information about the currently logged in account
+     * @Rest\Get("/account")
+     * @OA\Response(
+     *     response="200",
+     *     description="Information about the logged in account",
+     *     @Model(type=User::class)
+     * )
+     * @OA\Parameter(ref="#/components/parameters/strict")
+     */
+    public function getCurrentAction(Request $request): Response
+    {
+        // Get the contest ID to make sure the contest exists
+        $this->getContestId($request);
+
+        $user = $this->dj->getUser();
+        if ($user === null) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->renderData($request, $user);
+    }
+
+    protected function getQueryBuilder(Request $request): QueryBuilder
+    {
+        $queryBuilder = $this->em->createQueryBuilder()
+                                 ->from(User::class, 'u')
+                                 ->select('u');
+
+        if ($request->query->has('team')) {
+            $queryBuilder
+                ->andWhere('u.team = :team')
+                ->setParameter('team', $request->query->get('team'));
+        }
+
+        return $queryBuilder;
+    }
+
+    protected function getIdField(): string
+    {
+        return 'u.userid';
+    }
+}

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -567,6 +567,9 @@ class ContestController extends AbstractRestController
                 // entity, not the ContestProblem entity, so the above loop will not
                 // detect it.
                 $skippedProperties['problems'][] = 'externalid';
+
+                // Users are called accounts
+                $skippedProperties['accounts'] = $skippedProperties['users'];
             }
 
             // Initialize all static events

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -12,7 +12,6 @@ use App\Service\ImportExportService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\QueryBuilder;
-use Exception;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Annotations as OA;
@@ -370,6 +369,6 @@ class UserController extends AbstractRestController
 
     protected function getIdField(): string
     {
-        return 'u.userid';
+        return sprintf('u.%s', $this->eventLogService->externalIdFieldForEntity(User::class) ?? 'userid');
     }
 }

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -82,6 +82,13 @@ class UserController extends BaseController
             'status' => ['title' => '', 'sort' => true],
         ];
 
+        // Insert external ID field when configured to use it
+        if ($externalIdField = $this->eventLogService->externalIdFieldForEntity(User::class)) {
+            $table_fields = array_slice($table_fields, 0, 1, true) +
+                [$externalIdField => ['title' => 'external ID', 'sort' => true]] +
+                array_slice($table_fields, 1, null, true);
+        }
+
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $users_table      = [];
         $timeFormat  = (string)$this->config->get('time_format');

--- a/webapp/src/DataFixtures/DefaultData/UserFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/UserFixture.php
@@ -41,6 +41,7 @@ class UserFixture extends AbstractDefaultDataFixture implements DependentFixture
 
             $adminUser = new User();
             $adminUser
+                ->setExternalid('admin')
                 ->setUsername('admin')
                 ->setName('Administrator')
                 ->setPassword($this->passwordHasher->hashPassword($adminUser, trim($adminpasswordContents)))
@@ -59,6 +60,7 @@ class UserFixture extends AbstractDefaultDataFixture implements DependentFixture
         if (!($judgehostUser = $manager->getRepository(User::class)->findOneBy(['username' => 'judgehost']))) {
             $judgehostUser = new User();
             $judgehostUser
+                ->setExternalid('judgehost')
                 ->setUsername('judgehost')
                 ->setName('User for judgedaemons')
                 ->setPassword($this->passwordHasher->hashPassword($judgehostUser, $this->getRestapiPassword()))

--- a/webapp/src/DataFixtures/ExampleData/UserFixture.php
+++ b/webapp/src/DataFixtures/ExampleData/UserFixture.php
@@ -13,6 +13,7 @@ class UserFixture extends AbstractExampleDataFixture implements DependentFixture
     {
         $user = new User();
         $user
+            ->setExternalid('demo')
             ->setUsername('demo')
             ->setName('demo user for example team')
             ->setPlainPassword('demo')

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -44,7 +44,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
 
     /**
      * @ORM\Column(type="string", name="externalid", length=255,
-     *     options={"comment"="Team affiliation ID in an external system",
+     *     options={"comment"="Team ID in an external system",
      *              "collation"="utf8mb4_bin"},
      *     nullable=true)
      * @Serializer\Exclude()

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -22,10 +22,13 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     name="user",
  *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Users that have access to DOMjudge"},
  *     indexes={@ORM\Index(name="teamid", columns={"teamid"})},
- *     uniqueConstraints={@ORM\UniqueConstraint(name="username", columns={"username"}, options={"lengths":{190}})})
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="username", columns={"username"}, options={"lengths":{190}}),
+ *         @ORM\UniqueConstraint(name="externalid", columns={"externalid"}, options={"lengths":{190}}),
+ *     })
  * @UniqueEntity("username", message="The username '{{ value }}' is already in use.")
  */
-class User implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface, ExternalRelationshipEntityInterface
+class User extends BaseApiEntity implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface, ExternalRelationshipEntityInterface
 {
     /**
      * @ORM\Id
@@ -36,6 +39,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      * @Serializer\Type("string")
      */
     private ?int $userid = null;
+
+    /**
+     * @ORM\Column(type="string", name="externalid", length=255,
+     *     options={"comment"="User ID in an external system",
+     *              "collation"="utf8mb4_bin"},
+     *     nullable=true)
+     * @Serializer\Exclude()
+     */
+    protected ?string $externalid = null;
 
     /**
      * @ORM\Column(type="string", name="username", length=255,
@@ -174,6 +186,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     public function getUserid(): ?int
     {
         return $this->userid;
+    }
+
+    public function setExternalid(?string $externalid): User
+    {
+        $this->externalid = $externalid;
+        return $this;
+    }
+
+    public function getExternalid(): ?string
+    {
+        return $this->externalid;
     }
 
     public function setUsername(?string $username): User

--- a/webapp/src/Form/Type/JsonImportType.php
+++ b/webapp/src/Form/Type/JsonImportType.php
@@ -16,6 +16,7 @@ class JsonImportType extends AbstractType
                 'groups' => 'groups',
                 'organizations' => 'organizations',
                 'teams' => 'teams',
+                'accounts' => 'accounts',
             ],
         ]);
         $builder->add('file', BootstrapFileType::class, [

--- a/webapp/src/Form/Type/UserType.php
+++ b/webapp/src/Form/Type/UserType.php
@@ -5,6 +5,7 @@ namespace App\Form\Type;
 use App\Entity\Role;
 use App\Entity\Team;
 use App\Entity\User;
+use App\Service\EventLogService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -20,17 +21,19 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserType extends AbstractType
+class UserType extends AbstractExternalIdEntityType
 {
     protected EntityManagerInterface $em;
 
-    public function __construct(EntityManagerInterface $em)
+    public function __construct(EntityManagerInterface $em, EventLogService $eventLogService)
     {
+        parent::__construct($eventLogService);
         $this->em = $em;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $this->addExternalIdField($builder, Team::class);
         /** @var Team[] $teams */
         $teams = $this->em->createQueryBuilder()
             ->from(Team::class, 't', 't.teamid')

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -11,6 +11,7 @@ use App\Entity\JudgingRun;
 use App\Entity\Submission;
 use App\Entity\TeamAffiliation;
 use App\Entity\TeamCategory;
+use App\Entity\User;
 use App\Utils\Utils;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManagerInterface;
@@ -126,6 +127,12 @@ class EventLogService implements ContainerAwareInterface
             self::KEY_TYPE => self::TYPE_AGGREGATE,
             self::KEY_ENTITY => null,
             self::KEY_TABLES => ['event'],
+        ],
+        'accounts' => [
+            self::KEY_TYPE => self::TYPE_CONFIGURATION,
+            self::KEY_ENTITY => User::class,
+            self::KEY_TABLES => ['user'],
+            self::KEY_USE_EXTERNAL_ID => true,
         ],
     ];
 

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -721,9 +721,10 @@ class ExternalContestSourceService
             ->findOneBy(['externalid' => $groupId]);
 
         if ($event['op'] === EventLogService::ACTION_DELETE) {
-            // We need to check if the the category is known
+            // We need to check if the category is known
             if ($category) {
                 $this->addOrUpdateWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
+                return;
             }
             $this->removeWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
             return;
@@ -757,9 +758,10 @@ class ExternalContestSourceService
             ->findOneBy(['externalid' => $organizationId]);
 
         if ($event['op'] === EventLogService::ACTION_DELETE) {
-            // We need to check if the the affiliation is known
+            // We need to check if the affiliation is known
             if ($affiliation) {
                 $this->addOrUpdateWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
+                return;
             }
             $this->removeWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
             return;
@@ -843,9 +845,10 @@ class ExternalContestSourceService
             ->findOneBy(['externalid' => $teamId]);
 
         if ($event['op'] === EventLogService::ACTION_DELETE) {
-            // We need to check if the the team is known
+            // We need to check if the team is known
             if ($team) {
                 $this->addOrUpdateWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
+                return;
             }
 
             $this->removeWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
@@ -888,6 +891,7 @@ class ExternalContestSourceService
             // We need to check if the user is known
             if ($user) {
                 $this->addOrUpdateWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);
+                return;
             }
 
             $this->removeWarning($event, ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST);

--- a/webapp/templates/jury/import_export.html.twig
+++ b/webapp/templates/jury/import_export.html.twig
@@ -68,7 +68,7 @@
     <div class="row">
         <div class="col-md-6">
             <div class="tile">
-            <h3>Import JSON</h3>
+            <h3>Import JSON / YAML</h3>
                 {{ form(json_form) }}
             </div>
         </div>

--- a/webapp/templates/jury/partials/user_form.html.twig
+++ b/webapp/templates/jury/partials/user_form.html.twig
@@ -1,6 +1,9 @@
 <div class="row">
     <div class="col-lg-4">
         {{ form_start(form) }}
+        {% if form.offsetExists('externalid') %}
+            {{ form_row(form.externalid) }}
+        {% endif %}
         {% if form.offsetExists('username') %}
             {{ form_row(form.username) }}
         {% endif %}

--- a/webapp/templates/jury/user.html.twig
+++ b/webapp/templates/jury/user.html.twig
@@ -19,6 +19,12 @@
                     <th>ID</th>
                     <td>{{ user.userid }}</td>
                 </tr>
+                {% if showExternalId(user) %}
+                    <tr>
+                        <th>External ID</th>
+                        <td>{{ user.externalid }}</td>
+                    </tr>
+                {% endif %}
                 <tr>
                     <th>Login</th>
                     <td class="teamid">{{ user.username }}</td>

--- a/webapp/tests/Unit/Controller/API/AccountControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AccountControllerTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+use Generator;
+
+class AccountControllerTest extends BaseTest
+{
+    protected ?string $apiEndpoint = 'accounts';
+
+    protected ?string $apiUser = 'admin';
+
+    protected array $expectedObjects = [
+        1 => [
+            "id"       => "1",
+            "username" => "admin",
+            "team_id"  => "1",
+            "type"     => "admin",
+            "ip"       => null,
+        ],
+        2 => [
+            "id"       => "2",
+            "username" => "judgehost",
+            "team_id"  => null,
+            "type"     => null,
+            "ip"       => null,
+        ],
+        3 => [
+            "id"       => "3",
+            "username" => "demo",
+            "team_id"  => "2",
+            "type"     => "team",
+            "ip"       => null,
+        ],
+    ];
+
+    protected array $expectedAbsent = ['4242', 'nonexistent'];
+
+    /**
+     * @dataProvider provideCurrentAccount
+     */
+    public function testCurrentAccount(string $user, array $expectedData): void
+    {
+        $url      = $this->helperGetEndpointURL('account');
+        $response = $this->verifyApiJsonResponse('GET', $url, 200, $user);
+
+        foreach ($expectedData as $key => $value) {
+            self::assertArrayHasKey($key, $response, "$key is present");
+            self::assertEquals($value, $response[$key], "$key has correct value");
+        }
+    }
+
+    public function testCurrentAccountNotLoggedIn(): void
+    {
+        $url = $this->helperGetEndpointURL('account');
+        $this->verifyApiJsonResponse('GET', $url, 404);
+    }
+
+    public function provideCurrentAccount(): Generator
+    {
+        yield ['admin', ['id' => '1', 'team_id' => '1', 'username' => 'admin', 'type' => 'admin']];
+        yield ['demo', ['id' => '3', 'team_id' => '2', 'username' => 'demo', 'type' => 'team']];
+    }
+}

--- a/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
@@ -11,6 +11,7 @@ use App\Entity\Team;
 use App\Entity\TeamCategory;
 use App\Entity\Testcase;
 use App\Entity\TestcaseContent;
+use App\Entity\User;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -21,6 +22,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class QueuetaskIntegrationTest extends KernelTestCase
@@ -145,6 +147,16 @@ class QueuetaskIntegrationTest extends KernelTestCase
             }
         }
         $this->em->flush();
+
+        // We need *some* user token set because some of these tests initialize static events,
+        // which needs a user to check permissions.
+        // Using the TestBrowserToken is the easiest way to do this.
+        $user  = $this->em->getRepository(User::class)->findAll()[0];
+        $token = new TestBrowserToken([], $user, 'main');
+        if (method_exists($token, 'setAuthenticated')) {
+            $token->setAuthenticated(true, false);
+        }
+        self::getContainer()->get('security.untracked_token_storage')->setToken($token);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This implements the account endpoints as specified [here](https://ccs-specs.icpc.io/master/contest_api#accounts) based on our existing user endpoints.

As the comment in the AccountController says, it's a bit of a copy paste from the UserController. I don't really see how we could fix that except when we move the user calls to the account controller as well and give them the "Accounts" tag instead of "Users". Some controller actions will then have two API endpoints (for example /users and /api/contests/<cid>/accounts). What do you guys think?