### PR TITLE
Feature table cell stretched

### DIFF
--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -198,7 +198,43 @@ table.submissions-table {
     color: white;
 }
 
+.table-full-clickable-cell {
+    border-collapse: separate; /* Because we need to set display:table for <a> we need to override this */
+    border-spacing: 0px 0px;
+}
+
+.table-full-clickable-cell tbody td:not(.testcase-results) {
+    padding: 0;
+}
+
+.table-full-clickable-cell tbody tr td:not(.testcase-results) a:not(.btn-sm), .table-full-clickable-cell tbody tr td:not(.testcase-results) a:hover:not(.btn-sm) {
+    display: table;
+}
+
+.table-full-clickable-cell tbody td:not(.testcase-results) a {
+    width: 100%;
+    height: 100%;
+    padding: 1px .25rem;
+    display: block; /* This is needed to make cells with .showlink fully clickable */
+}
+
+.table-full-clickable-cell tbody td:not(.testcase-results) a.btn-sm {
+    padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+}
+
+/* Below is to re-align the `claim` button on the submission list overview */
+table.table-full-clickable-cell thead.thead-light tr th.table-button-head-right {
+    padding-left: 0;
+}
+
+table.table-full-clickable-cell thead.thead-light tr th.table-button-head-left {
+    padding-right: 0.5rem;
+}
+
+table.table-full-clickable-cell tr .table-button-head-right-right{
+    padding-left: 0.5rem;
+}
+
 .execid {
     font-family: monospace;
 }
-

--- a/webapp/templates/jury/check_judgings.html.twig
+++ b/webapp/templates/jury/check_judgings.html.twig
@@ -31,7 +31,7 @@
     {% macro verifyResults(id, header, results, collapse) %}
         {% if results is not empty %}
             <h2><a class="collapse-link" href="javascript:collapse('#detail{{ id }}')">{{ header }}</a></h2>
-            <table id="detail{{ id }}" class="{% if collapse | default(false) %}d-none{% endif %} data-table table table-hover table-striped table-sm submissions-table">
+            <table id="detail{{ id }}" class="{% if collapse | default(false) %}d-none{% endif %} data-table table table-hover table-striped table-sm submissions-table table-full-clickable-cell">
                 <tr>
                     <th></th><th>problem</th><th>file(s)</th>
                     <th>actual</th>

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -60,7 +60,6 @@
     <script src="{{ asset('js/dataTables.bootstrap5.min.js') }}"></script>
     <style>
         .data-table td a:not(.showlink), .data-table td a:hover:not(.showlink) {
-            display: block;
             text-decoration: none;
             color: inherit;
         }
@@ -88,7 +87,7 @@
 {% macro table(data, fields, options) %}
 
     <div class="table-wrapper">
-        <table class="data-table table table-sm table-striped" style="width:auto">
+        <table class="data-table table table-sm table-striped table-full-clickable-cell" style="width:auto">
             <thead class="">
             <tr>
                 {%- set num_actions = data | numTableActions %}

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -1,5 +1,5 @@
 <div class="table-wrapper">
-<table class="data-table table table-striped table-hover table-sm" style="width:auto">
+<table class="data-table table table-striped table-hover table-sm table-full-clickable-cell" style="width:auto">
     <thead>
     <tr>
         <th scope="col">ID</th>

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -43,7 +43,7 @@
         {% endif %}
     </div>
 
-    <table class="data-table table table-hover table{% if showExternalResult and showExternalTestcases %}-3{% endif %}-striped table-sm submissions-table">
+    <table class="data-table table table-hover table{% if showExternalResult and showExternalTestcases %}-3{% endif %}-striped table-sm submissions-table table-full-clickable-cell">
         <thead class="thead-light">
         <tr>
             {% if showExternalResult and showExternalTestcases %}
@@ -69,8 +69,8 @@
                 <th scope="col">external result</th>
             {% endif %}
             {% if not showExternalResult or not showExternalTestcases %}
-                <th scope="col">verified</th>
-                <th scope="col">by</th>
+                <th scope="col" class="table-button-head-left">verified</th>
+                <th scope="col" class="table-button-head-right">by</th>
             {% endif %}
             {%- if rejudging is defined %}
 
@@ -78,7 +78,7 @@
             {%- endif %}
             {%- if showTestcases is defined and showTestcases %}
 
-                <th scope="col" class="not-sortable not-searchable">test results</th>
+                <th scope="col" class="not-sortable not-searchable table-button-head-right-right">test results</th>
             {%- endif %}
 
         </tr>
@@ -219,7 +219,7 @@
                 {%- endif %}
                 {%- if showTestcases is defined and showTestcases %}
 
-                    <td class="testcase-results{{ tdExtraClass }}">
+                    <td class="testcase-results{{ tdExtraClass }} table-button-head-right-right">
                         {{- submission | testcaseResults -}}
                     </td>
                 {%- endif %}


### PR DESCRIPTION
~This is a partial fix for: https://github.com/DOMjudge/domjudge/issues/1273, this solution seems to work in firefox but does not work in Edge (chromium based).~

~Given that most major contest do install firefox I think merging this is still acceptable.~

~I've now kept the border to show which element is stretched but that will be removed when merging.~

I've now implemented a solution with 2 browserhacks. In the end we can set 1 and override the shared properties in the browserhack after it. The browserhack for firefox looks depricated but according to https://sass-lang.com/documentation/breaking-changes/moz-document/ this specific behaviour is kept (so reasonable safe to use).