### PR TITLE
Allow judge remaining for problems, languages and categories

### DIFF
--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -90,6 +90,7 @@
         {%- if is_granted('ROLE_ADMIN') -%}
             {{ button(path('jury_language_edit', {'langId': language.langid}), 'Edit', 'primary', 'edit') }}
             {{ button(path('jury_language_delete', {'langId': language.langid}), 'Delete', 'danger', 'trash-alt', true) }}
+            {{ button(path('jury_language_request_remaining', {'langId': language.langid}), 'Judge remaining', 'secondary', 'gavel') }}
         {% endif %}
         {% include 'jury/partials/rejudge_form.html.twig' with {table: 'language', id: language.langid, buttonClass: 'btn-secondary'} %}
     </div>

--- a/webapp/templates/jury/problem.html.twig
+++ b/webapp/templates/jury/problem.html.twig
@@ -119,6 +119,7 @@
         {%- if is_granted('ROLE_ADMIN') -%}
             {{ button(path('jury_problem_edit', {'probId': problem.probid}), 'Edit', 'primary', 'edit') }}
             {{ button(path('jury_problem_delete', {'probId': problem.probid}), 'Delete', 'danger', 'trash-alt', true) }}
+            {{ button(path('jury_problem_request_remaining', {'probId': problem.probid}), 'Judge remaining', 'secondary', 'gavel') }}
         {% endif %}
         {{ button(path('jury_export_problem', {'problemId': problem.probid}), 'Export', 'secondary', 'download') }}
         {% include 'jury/partials/rejudge_form.html.twig' with {table: 'problem', id: problem.probid, buttonClass: 'btn-secondary'} %}

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -65,6 +65,7 @@
         <p>
             {{ button(path('jury_team_category_edit', {'categoryId': teamCategory.categoryid}), 'Edit', 'primary', 'edit') }}
             {{ button(path('jury_team_category_delete', {'categoryId': teamCategory.categoryid}), 'Delete', 'danger', 'trash-alt', true) }}
+            {{ button(path('jury_team_category_request_remaining', {'categoryId': teamCategory.categoryid}), 'Judge remaining', 'secondary', 'gavel') }}
         </p>
     {% endif %}
 


### PR DESCRIPTION
IMO this closes https://github.com/DOMjudge/domjudge/issues/1353.

Reason for the Team categories is that we default only look at judgings for visible categories and otherwise we can never get the jury solutions (apart from 1 by 1). Language is because it could be used as a soft rejudge where you want to know if a certain change leads to errors (for example)