### PR TITLE
Expose team_id again in users endpoint.

### DIFF
--- a/gitlab/ci_settings.sh
+++ b/gitlab/ci_settings.sh
@@ -44,6 +44,8 @@ function show_phpinfo() {
     phpversion=$1
     section_start_collap phpinfo "Show the new PHP info"
     update-alternatives --set php /usr/bin/php"${phpversion}"
+    update-alternatives --set phpize /usr/bin/phpize"${phpversion}"
+    update-alternatives --set php-config /usr/bin/php-config"${phpversion}"
     php -v
     php -m
     section_end phpinfo

--- a/gitlab/unit-tests.sh
+++ b/gitlab/unit-tests.sh
@@ -7,6 +7,12 @@ version=$1
 
 show_phpinfo $version
 
+if [ "$CODECOVERAGE" -eq 1 ]; then
+    # PHP 7.4 misses pcov by default, so install it
+    pecl install pcov
+    cp /etc/php/8.0/mods-available/pcov.ini /etc/php/7.4/cli/conf.d/20-pcov.ini
+fi
+
 # Set up
 "$( dirname "${BASH_SOURCE[0]}" )"/base.sh
 

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -346,6 +346,16 @@ class User implements UserInterface, EquatableInterface, \Serializable
         return $this->getTeam() ? $this->getTeam()->getEffectiveName() : null;
     }
 
+    /**
+     * @Serializer\VirtualProperty()
+     * @Serializer\SerializedName("team_id")
+     * @Serializer\Type("string")
+     */
+    public function getTeamId(): ?int
+    {
+        return $this->getTeam() ? $this->getTeam()->getTeamid() : null;
+    }
+
     public function __construct()
     {
         $this->user_roles = new ArrayCollection();

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -11,6 +11,7 @@ class UserControllerTest extends BaseTest
     protected $expectedObjects = [
         1 => [
             "team" => "DOMjudge",
+            "team_id" => 1,
             "roles" => [
                 "admin",
                 "team"
@@ -24,6 +25,7 @@ class UserControllerTest extends BaseTest
         ],
         2 => [
             "team" => null,
+            "team_id" => null,
             "roles" => [
                 "judgehost"
             ],
@@ -36,6 +38,7 @@ class UserControllerTest extends BaseTest
         ],
         3 => [
             "team" => "Example teamname",
+            "team_id" => "2",
             "roles" => [
                  "team"
             ],


### PR DESCRIPTION
As discussed on Slack, we didn't expose `team_id` anymore in the /users API endpoint. Now we do.

This is based on code from #1513.