### PR TITLE
Remove unnecessary cast to `string`.

### DIFF
--- a/webapp/src/Controller/API/AwardsController.php
+++ b/webapp/src/Controller/API/AwardsController.php
@@ -105,13 +105,13 @@ class AwardsController extends AbstractRestController
         $group_winners = $problem_winners = [];
         $groups = [];
         foreach ($scoreboard->getTeams() as $team) {
-            $teamid = (string)$team->getApiId($this->eventLogService);
+            $teamid = $team->getApiId($this->eventLogService);
             if ($scoreboard->isBestInCategory($team)) {
                 $group_winners[$team->getCategory()->getCategoryId()][] = $teamid;
                 $groups[$team->getCategory()->getCategoryid()] = $team->getCategory()->getName();
             }
             foreach($scoreboard->getProblems() as $problem) {
-                $probid = (string)$problem->getApiId($this->eventLogService);
+                $probid = $problem->getApiId($this->eventLogService);
                 if ($scoreboard->solvedFirst($team, $problem)) {
                     $problem_winners[$probid][] = $teamid;
                 }
@@ -142,7 +142,7 @@ class AwardsController extends AbstractRestController
         // can we assume this is ordered just walk the first 12+B entries?
         foreach ($scoreboard->getScores() as $teamScore) {
             $rank = $teamScore->rank;
-            $teamid = (string)$teamScore->team->getApiId($this->eventLogService);
+            $teamid = $teamScore->team->getApiId($this->eventLogService);
             if ($rank === 1) {
                 $overall_winners[] = $teamid;
             }

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -155,7 +155,7 @@ class ScoreboardController extends AbstractRestController
             }
             $row = [
                 'rank' => $teamScore->rank,
-                'team_id' => (string)$teamScore->team->getApiId($this->eventLogService),
+                'team_id' => $teamScore->team->getApiId($this->eventLogService),
                 'score' => [
                     'num_solved' => $teamScore->numPoints,
                     'total_time' => $teamScore->totalTime,
@@ -167,7 +167,7 @@ class ScoreboardController extends AbstractRestController
                 $contestProblem = $scoreboard->getProblems()[$problemId];
                 $problem        = [
                     'label' => $contestProblem->getShortname(),
-                    'problem_id' => (string)$contestProblem->getApiId($this->eventLogService),
+                    'problem_id' => $contestProblem->getApiId($this->eventLogService),
                     'num_judged' => $matrixItem->numSubmissions,
                     'num_pending' => $matrixItem->numSubmissionsPending,
                     'solved' => $matrixItem->isCorrect,

--- a/webapp/src/Serializer/ContestVisitor.php
+++ b/webapp/src/Serializer/ContestVisitor.php
@@ -63,7 +63,7 @@ class ContestVisitor implements EventSubscriberInterface
         $id = $contest->getApiId($this->eventLogService);
 
         // Banner
-        if ($banner = $this->dj->assetPath((string)$id, 'contest', true)) {
+        if ($banner = $this->dj->assetPath($id, 'contest', true)) {
             $imageSize = Utils::getImageSize($banner);
 
             $route = $this->dj->apiRelativeUrl(

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -272,7 +272,7 @@ class ImportExportService
             $this->importProblemsData($contest, $data['problems']);
         }
 
-        $cid = (string)$contest->getApiId($this->eventLogService);
+        $cid = $contest->getApiId($this->eventLogService);
 
         $this->em->flush();
         return true;
@@ -303,7 +303,7 @@ class ImportExportService
                 ->setContest($contest);
             $this->em->persist($contestProblem);
 
-            $ids[] = (string)$problem->getApiId($this->eventLogService);
+            $ids[] = $problem->getApiId($this->eventLogService);
         }
 
         $this->em->flush();


### PR DESCRIPTION
`getApiId` returns a `string` (and is type checked).