### PR TITLE
Improve detection of binary file encoding when editing executables.

### DIFF
--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -413,9 +413,9 @@ class ExecutableController extends BaseController
             /** @var ExecutableFile $file */
             $filename = $file->getFilename();
             $content = $file->getFileContent();
-            if (!mb_check_encoding($content, 'ASCII')) {
+            if (!mb_detect_encoding($content, null, true)) {
                 $skippedBinary[] = $filename;
-                continue; // skip binary files
+                continue; // Skip binary files.
             }
             $filenames[] = $filename;
             $file_contents[] = $content;

--- a/webapp/templates/jury/executable_content.html.twig
+++ b/webapp/templates/jury/executable_content.html.twig
@@ -13,11 +13,11 @@
     <h1>View content of executable {{ executable.execid }}</h1>
 
     {% if skippedBinary is not empty %}
-        <div>
-            Binary files:
+        <div class="alert alert-warning">
+            We exclude these files from editing since we could not detect their encoding (e.g. they are binary files):
             <ul>
                 {% for file in skippedBinary %}
-                    <li>{{ file }}</li>
+                    <li><code>{{ file }}</code></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
This now allows to have non-ASCII characters as `ąśćżźć` to not trigger
false positives.

Also show a nicer alert message while we are changing this code.

Part of #1526.