### PR TITLE
Fix downloading of single files in executables.

### DIFF
--- a/webapp/templates/jury/executable_edit_content.html.twig
+++ b/webapp/templates/jury/executable_edit_content.html.twig
@@ -30,7 +30,7 @@
                  role="tabpanel">
                 <div class="mb-1">
                     <a class="btn btn-secondary btn-sm"
-                       href="{{ path('jury_executable_download_single', {execId: executable.execid, index: idx}) }}">
+                       href="{{ path('jury_executable_download_single', {execId: executable.execid, rank: ranks[idx]}) }}">
                         <i class="fas fa-download"></i> Download
                     </a>
                 </div>


### PR DESCRIPTION
Previously, we were incorrectly passing in the index assuming it matches
the rank but files were returned in arbitrary order.