### PR TITLE
Apply ResizeObserver only on non static scoreboard, even if `static` is not in the URL.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -718,13 +718,16 @@ function initializeAjaxModals()
 
 function pinScoreheader()
 {
-    var static_in_url = new URL(window.location.toString().toLowerCase()).searchParams.get("static");
-    var static_scoreboard = static_in_url==="true" || static_in_url==='1';
+    var $scoreHeader = $('.scoreheader');
+    if (!$scoreHeader.length) {
+        return;
+    }
+    var static_scoreboard = $scoreHeader.data('static');
     if (!static_scoreboard) {
         $('.scoreheader th').css('top', $('.fixed-top').css('height'));
         if ('ResizeObserver' in window) {
             var resizeObserver = new ResizeObserver(() => {
-                $('.scoreheader th').css('top', $('.fixed-top').css('height'));
+                $scoreHeader.find('th').css('top', $('.fixed-top').css('height'));
             });
             resizeObserver.observe($('.fixed-top')[0]);
         }

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -65,7 +65,7 @@
     {% endif %}
 
     <thead>
-    <tr class="scoreheader">
+    <tr class="scoreheader" data-static="{{ static }}">
         <th title="rank" scope="col">rank</th>
         <th title="team name" scope="col" colspan="{{ teamColspan }}">team</th>
         <th title="# solved / penalty time" colspan="2" scope="col">score</th>


### PR DESCRIPTION
As discussed on Slack. Also fixes JS errors when there is no active contest.