### PR TITLE
Fix pdo

### DIFF
--- a/webapp/config/packages/doctrine_migrations.yaml
+++ b/webapp/config/packages/doctrine_migrations.yaml
@@ -3,3 +3,4 @@ doctrine_migrations:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
         'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    transactional: false

--- a/webapp/migrations/Version20190803123217.php
+++ b/webapp/migrations/Version20190803123217.php
@@ -9,6 +9,11 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 final class Version20190803123217 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Migrate database to DOMjudge version 7.0.0';

--- a/webapp/migrations/Version20190803143623.php
+++ b/webapp/migrations/Version20190803143623.php
@@ -7,6 +7,11 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20190803143623 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'split contest.public in contest.public and contest.open_to_all_teams';

--- a/webapp/migrations/Version20190803144354.php
+++ b/webapp/migrations/Version20190803144354.php
@@ -10,6 +10,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190803144354 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'add external judgements and runs';

--- a/webapp/migrations/Version20190803145008.php
+++ b/webapp/migrations/Version20190803145008.php
@@ -7,6 +7,11 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20190803145008 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'move testcase and judging run fields with lots of data to separate tables';

--- a/webapp/migrations/Version20190803151406.php
+++ b/webapp/migrations/Version20190803151406.php
@@ -7,6 +7,11 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20190803151406 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Change table structure to reflect Doctrine entities.';

--- a/webapp/migrations/Version20190827175633.php
+++ b/webapp/migrations/Version20190827175633.php
@@ -7,6 +7,11 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20190827175633 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add flag to filter compile files to language table';

--- a/webapp/migrations/Version20190906120011.php
+++ b/webapp/migrations/Version20190906120011.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190906120011 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Remove unnecessary unsigned=true from booleans.';

--- a/webapp/migrations/Version20190914080214.php
+++ b/webapp/migrations/Version20190914080214.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190914080214 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add table to link categories to contests';

--- a/webapp/migrations/Version20190922140905.php
+++ b/webapp/migrations/Version20190922140905.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190922140905 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add judging run metadata.';

--- a/webapp/migrations/Version20190923184715.php
+++ b/webapp/migrations/Version20190923184715.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190923184715 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Change enable_printing to print_command';

--- a/webapp/migrations/Version20190929123340.php
+++ b/webapp/migrations/Version20190929123340.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20190929123340 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add the basename of the original input file to testcases';

--- a/webapp/migrations/Version20191031203138.php
+++ b/webapp/migrations/Version20191031203138.php
@@ -17,6 +17,11 @@ final class Version20191031203138 extends AbstractMigration implements Container
 {
     use ContainerAwareTrait;
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'add .py to Python 3 extension list and remove it for Python 2';

--- a/webapp/migrations/Version20191117060701.php
+++ b/webapp/migrations/Version20191117060701.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20191117060701 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'change description of external_ccs_submission_url configuration option';

--- a/webapp/migrations/Version20191119183145.php
+++ b/webapp/migrations/Version20191119183145.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20191119183145 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add (cid, endpointtype, endpointid) index to event table';

--- a/webapp/migrations/Version20200111104226.php
+++ b/webapp/migrations/Version20200111104226.php
@@ -17,6 +17,11 @@ final class Version20200111104226 extends AbstractMigration implements Container
 {
     use ContainerAwareTrait;
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'remove unneeded columns from the configuration table';

--- a/webapp/migrations/Version20200111104415.php
+++ b/webapp/migrations/Version20200111104415.php
@@ -17,6 +17,11 @@ final class Version20200111104415 extends AbstractMigration implements Container
 {
     use ContainerAwareTrait;
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'remove configuration options with default values';

--- a/webapp/migrations/Version20200118092658.php
+++ b/webapp/migrations/Version20200118092658.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200118092658 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'rename team.externalid to team.icpcid';

--- a/webapp/migrations/Version20200118122750.php
+++ b/webapp/migrations/Version20200118122750.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200118122750 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add display name to team';

--- a/webapp/migrations/Version20200131064449.php
+++ b/webapp/migrations/Version20200131064449.php
@@ -15,6 +15,11 @@ final class Version20200131064449 extends AbstractMigration implements Container
 {
     use ContainerAwareTrait;
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'replace configuration option registration_category_name with a boolean field for each category';

--- a/webapp/migrations/Version20200425120051.php
+++ b/webapp/migrations/Version20200425120051.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200425120051 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Adds deleted boolean field to testcase.';

--- a/webapp/migrations/Version20200501102548.php
+++ b/webapp/migrations/Version20200501102548.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200501102548 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return '';

--- a/webapp/migrations/Version20200516101037.php
+++ b/webapp/migrations/Version20200516101037.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200516101037 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'add verification fields to external judgements';

--- a/webapp/migrations/Version20200522133213.php
+++ b/webapp/migrations/Version20200522133213.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200522133213 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add functionality to repeat rejudgings N times.';

--- a/webapp/migrations/Version20201107151003.php
+++ b/webapp/migrations/Version20201107151003.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201107151003 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return '';

--- a/webapp/migrations/Version20201110113446.php
+++ b/webapp/migrations/Version20201110113446.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201110113446 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Remove explicit column definitions for foreign keys.';

--- a/webapp/migrations/Version20201113094653.php
+++ b/webapp/migrations/Version20201113094653.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201113094653 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'add problem attachment tables';

--- a/webapp/migrations/Version20201122080505.php
+++ b/webapp/migrations/Version20201122080505.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201122080505 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'rank is a reserved keyword for MySQL, rename it to non reserved';

--- a/webapp/migrations/Version20201219154651.php
+++ b/webapp/migrations/Version20201219154651.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201219154651 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'DB structure for new judgehost API and related changes.';

--- a/webapp/migrations/Version20210407120356.php
+++ b/webapp/migrations/Version20210407120356.php
@@ -13,6 +13,11 @@ use ZipArchive;
  */
 final class Version20210407120356 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Populate immutable executable tables.';

--- a/webapp/migrations/Version20210611141202.php
+++ b/webapp/migrations/Version20210611141202.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210611141202 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Create medal fields';

--- a/webapp/migrations/Version20210705095555.php
+++ b/webapp/migrations/Version20210705095555.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210705095555 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return '';

--- a/webapp/migrations/Version20210806180453.php
+++ b/webapp/migrations/Version20210806180453.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210806180453 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add user reference to submission table.';

--- a/webapp/migrations/Version20210813195818.php
+++ b/webapp/migrations/Version20210813195818.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210813195818 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Remove JudgehostRestriction data';

--- a/webapp/migrations/Version20210823160249.php
+++ b/webapp/migrations/Version20210823160249.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210823160249 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Remove judgehost field from judgings table.';

--- a/webapp/migrations/Version20210829113200.php
+++ b/webapp/migrations/Version20210829113200.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210829113200 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'adding debug packages';

--- a/webapp/migrations/Version20210914192815.php
+++ b/webapp/migrations/Version20210914192815.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210914192815 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add internal error to judging.';

--- a/webapp/migrations/Version20210929123058.php
+++ b/webapp/migrations/Version20210929123058.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210929123058 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add UUID to judging for caching purposes.';

--- a/webapp/migrations/Version20211001213842.php
+++ b/webapp/migrations/Version20211001213842.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20211001213842 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Adding testcase hash.';

--- a/webapp/migrations/Version20211002100928.php
+++ b/webapp/migrations/Version20211002100928.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20211002100928 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return '';

--- a/webapp/migrations/Version20211006161627.php
+++ b/webapp/migrations/Version20211006161627.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20211006161627 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add compile metadata.';

--- a/webapp/migrations/Version20211208190658.php
+++ b/webapp/migrations/Version20211208190658.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20211208190658 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Allow larger auditlog entries';

--- a/webapp/migrations/Version20220206094350.php
+++ b/webapp/migrations/Version20220206094350.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220206094350 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Make datatype and action non-nullable in auditlog';

--- a/webapp/migrations/Version20220206113543.php
+++ b/webapp/migrations/Version20220206113543.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220206113543 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Rename some indices for Doctrine upgrade';

--- a/webapp/migrations/Version20220208180025.php
+++ b/webapp/migrations/Version20220208180025.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220208180025 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Rename judgehost active to enabled';

--- a/webapp/migrations/Version20220210142638.php
+++ b/webapp/migrations/Version20220210142638.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220210142638 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add ICPC ID field to team affiliations';

--- a/webapp/migrations/Version20220210155918.php
+++ b/webapp/migrations/Version20220210155918.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220210155918 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add external and ICPC ID fields to team categories';

--- a/webapp/migrations/Version20220210171746.php
+++ b/webapp/migrations/Version20220210171746.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220210171746 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription() : string
     {
         return 'Add external ID field to teams';

--- a/webapp/migrations/Version20220220141620.php
+++ b/webapp/migrations/Version20220220141620.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220220141620 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Add external contest source table';

--- a/webapp/migrations/Version20220220155814.php
+++ b/webapp/migrations/Version20220220155814.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220220155814 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Add external source warning table';

--- a/webapp/migrations/Version20220311075658.php
+++ b/webapp/migrations/Version20220311075658.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220311075658 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Clarify difference between internal and external freeform fields.';

--- a/webapp/migrations/Version20220408071147.php
+++ b/webapp/migrations/Version20220408071147.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220408071147 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return 'Fix comment for team external ID.';

--- a/webapp/migrations/Version20220408073801.php
+++ b/webapp/migrations/Version20220408073801.php
@@ -12,6 +12,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20220408073801 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function getDescription(): string
     {
         return '';


### PR DESCRIPTION
Since the introduction of Sentry we got on some systems issues related to this:
https://github.com/getsentry/sentry-symfony/issues/488

This was fixed in doctrine but sentry changed the class so that fix didn't work, instead of reverting the sentry introduction I've now marked all migrations as non transactional to fix the issue.

After some discussion with @nickygerritsen we've decided to add the fix per migration instead of introducing another class to inherit from for the following reasons:
- The amount of lines actually gets higher with that class
- There is now duplication on generated code which is a lot less of an issue
- This is a lot easier to follow
- Future migrations don't need this fix but would for consistency get that same baseclass or there is a difference between migrations which makes it a lot harder to work and debug why something is an issu