### PR TITLE
Only authenticated users can reach the page

### DIFF
--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -159,6 +159,7 @@ class GeneralInfoController extends AbstractFOSRestController
     /**
      * Get information about the currently logged in user.
      * @Rest\Get("/user")
+     * @IsGranted("IS_AUTHENTICATED_FULLY")
      * @OA\Response(
      *     response="200",
      *     description="Information about the logged in user",
@@ -167,12 +168,7 @@ class GeneralInfoController extends AbstractFOSRestController
      */
     public function getUserAction(): User
     {
-        $user = $this->dj->getUser();
-        if ($user === null) {
-            throw new HttpException(401, 'Permission denied');
-        }
-
-        return $user;
+        return $this->dj->getUser();
     }
 
     /**


### PR DESCRIPTION
The isGranted will now only allow authorized users so we can just return
the user info.

Based on: https://symfonycasts.com/screencast/symfony-security/is-auth

The original reason for this branch was that we return a 401 with a text which is not according to another PR I wanted to do.