### PR TITLE
Mayhem conteststate null

### DIFF
--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -245,21 +245,27 @@ nelmio_api_doc:
                     properties:
                         started:
                             type: string
+                            nullable: true
                             format: date-time
                         ended:
                             type: string
+                            nullable: true
                             format: date-time
                         frozen:
                             type: string
+                            nullable: true
                             format: date-time
                         thawed:
                             type: string
+                            nullable: true
                             format: date-time
                         finalized:
                             type: string
+                            nullable: true
                             format: date-time
                         end_of_updates:
                             type: string
+                            nullable: true
                             format: date-time
                 Award:
                     type: object


### PR DESCRIPTION
This might still need to be altered to an empty string in the future for consistency.

Somehow we don't return the nullable property for Models (in other endpoints) but I think fixing that is better than returning an empty string everywhere (as the alternative solution to the Model problem).