### PR TITLE
Mayhem nullable property

### DIFF
--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -76,7 +76,6 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
      *                            nullable=false)
      * @Serializer\Groups({"Nonstrict"})
      * @Identifier()
-     * @Assert\NotBlank()
      */
     private string $shortname = '';
 

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -5,6 +5,7 @@ use App\Validator\Constraints\Identifier;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use OpenApi\Annotations as OA;
 use JMS\Serializer\Annotation as Serializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -109,6 +110,7 @@ class Language extends BaseApiEntity
      *     options={"comment"="The description used in the UI for the entry point field."},
      *     nullable=true)
      * @Serializer\SerializedName("entry_point_name")
+     * @OA\Property(nullable=true)
      */
     private ?string $entry_point_description = null;
 

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
+use OpenApi\Annotations as OA;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -55,6 +56,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
      * @ORM\Column(type="string", name="icpcid", length=255, options={"comment"="Team ID in the ICPC system",
      *                            "collation"="utf8mb4_bin"}, nullable=true)
      * @Serializer\SerializedName("icpc_id")
+     * @OA\Property(nullable=true)
      */
     protected ?string $icpcid;
 
@@ -67,6 +69,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
     /**
      * @ORM\Column(type="string", name="display_name", length=255, options={"comment"="Team display name", "collation"="utf8mb4_bin"},
      *                            nullable=true)
+     * @OA\Property(nullable=true)
      */
     private ?string $display_name = null;
 
@@ -83,6 +86,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
      * @ORM\Column(type="text", length=4294967295, name="publicdescription", options={"comment"="Public team definition; for example: Team member names (freeform)"},
      *                          nullable=true)
      * @Serializer\Groups({"Nonstrict"})
+     * @OA\Property(nullable=true)
      */
     private ?string $publicDescription;
 

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
+use OpenApi\Annotations as OA;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -55,6 +56,7 @@ class TeamAffiliation extends BaseApiEntity implements AssetEntityInterface
      *              "collation"="utf8mb4_bin"},
      *     nullable=true)
      * @Serializer\SerializedName("icpc_id")
+     * @OA\Property(nullable=true)
      */
     protected ?string $icpcid = null;
 

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -5,6 +5,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
+use OpenApi\Annotations as OA;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -53,6 +54,7 @@ class TeamCategory extends BaseApiEntity
      *              "collation"="utf8mb4_bin"},
      *     nullable=true)
      * @Serializer\SerializedName("icpc_id")
+     * @OA\Property(nullable=true)
      */
     protected ?string $icpcid = null;
 
@@ -78,6 +80,7 @@ class TeamCategory extends BaseApiEntity
      *     options={"comment"="Background colour on the scoreboard"},
      *     nullable=true)
      * @Serializer\Groups({"Nonstrict"})
+     * @OA\Property(nullable=true)
      */
     private ?string $color;
 


### PR DESCRIPTION
Currently we had some properties which according to the api doc are always a string. But when these have no value they were rendered as null. This PR makes this explicit so a client can first check if something is null and base its rendering on that instead of having to check if a string is empty which could be an actual choice.

Looking at https://github.com/DOMjudge/domjudge/commit/7f0b5a479a20e2870029f92d5b0482c718ca3de2 I'm not sure if the AssertNotBlank had another use but it seems to work this way.