### PR TITLE
Possible GHA fix - Add missing mapi config version

### DIFF
--- a/.github/workflowscripts/mapi.config
+++ b/.github/workflowscripts/mapi.config
@@ -1,3 +1,5 @@
+version: "1.0"
+
 suppressed:
 - reason: "414 will not be encountered by normal users"
   response: "Request-URI Too Large"


### PR DESCRIPTION
See:
https://mayhem4api.forallsecure.com/docs/ch02-02-suppress-issues.html
for a full example file.

Locally the mapi config doesn't run without the version in the config
file. It might also fix the issue for:
https://github.com/DOMjudge/domjudge/runs/7223110542?check_suite_focus=true