### PR TITLE
Add unittests for jury and admins about edit&delete buttons

### DIFF
--- a/webapp/tests/Unit/Controller/Jury/JudgehostControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/JudgehostControllerTest.php
@@ -15,4 +15,5 @@ class JudgehostControllerTest extends JuryControllerTest
     protected static string  $className                = Judgehost::class;
     protected static array   $DOM_elements             = ['h1' => ['Judgehosts']];
     protected static string  $add                      = '';
+    protected static string  $edit                     = '';
 }

--- a/webapp/tests/Unit/Controller/Jury/JuryControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/JuryControllerTest.php
@@ -348,6 +348,9 @@ abstract class JuryControllerTest extends BaseTest
                     self::assertSelectorExists('body:contains("' . $element . '")');
                 }
             }
+            // Check that the Edit button is visible on an entity page.
+            $this->verifyPageResponse('GET', substr($editLink, 0, strlen($editLink)-strlen(static::$edit)), 200);
+            self::assertSelectorExists('a:contains("' . $this->editButton . '")');
         }
     }
 
@@ -381,15 +384,20 @@ abstract class JuryControllerTest extends BaseTest
         $this->logOut();
         $this->logIn();
         $this->loadFixtures(static::$deleteFixtures);
-        $this->verifyPageResponse('GET', static::$baseUrl, 200);
         // Find a CID we can delete.
         $em = self::getContainer()->get('doctrine')->getManager();
         $ent = $em->getRepository(static::$className)->findOneBy([$identifier => $entityShortName]);
+        $entityUrl = static::$baseUrl . '/' . $ent->{static::$getIDFunc}();
+        // Check that the Delete button is visible on an entity page.
+        $this->verifyPageResponse('GET', $entityUrl, 200);
+        self::assertSelectorExists('a:contains("' . $this->deleteButton . '")');
+        // Follow the route via the overview page.
+        $this->verifyPageResponse('GET', static::$baseUrl, 200);
         self::assertSelectorExists('i[class*=fa-trash-alt]');
         self::assertSelectorExists('body:contains("' . $entityShortName . '")');
         $this->verifyPageResponse(
             'GET',
-            static::$baseUrl . '/' . $ent->{static::$getIDFunc}() . static::$delete,
+            $entityUrl . static::$delete,
             200
         );
         $this->client->submitForm('Delete', []);


### PR DESCRIPTION
These tests make sure that jury members cannot reach the edit/delete pages and also don't see the links or buttons for these cases. 
For the admin we now additionaly also check if the buttons exist on the single entity page as in the past we only checked the route directly via the main page (/contests -> /contest/1/delete) instead of /contests -> /contest/1 -> Delete button)