### PR TITLE
Mention the misc/jvm_overhead in docs

### DIFF
--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -180,6 +180,8 @@ Note that this service will automatically be started if you use the
 customize the script ``judge/create_cgroups`` as required and run it
 after each boot.
 
+The script `jvm_footprint` can be used to measure the memory overhead of the JVM for languages such as Kotlin and Java.
+
 
 REST API credentials
 --------------------


### PR DESCRIPTION
Currently this script is not mentioned in the documentation but seems to be useful for people using it for the first time. I'm not sure what is the correct location in the current documentation but to me it feels like this should be in something like tweaking the chroot which should also mention on how to create new languages. Because we don't have this yes I think this is the best location for now.