### PR TITLE
Fix problem stats showing a submission both as correct and incorrect when there is no freeze or a box 'overlaps' the freeze start time. Fixes #1599.

### DIFF
--- a/webapp/src/DataFixtures/Test/SampleSubmissionsInBucketsFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleSubmissionsInBucketsFixture.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleSubmissionsInBucketsFixture extends AbstractTestDataFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // First, set the demo contest to have normal timing. We also set (un)freeze time,
+        // but the test will unset them for specific cases
+        $demoContest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $demoContest
+            ->setStarttimeString('2022-01-01 00:00:00 Europe/Amsterdam')
+            ->setFreezetimeString('2022-01-01 04:05:00 Europe/Amsterdam')
+            ->setEndtimeString('2022-01-01 05:00:00 Europe/Amsterdam')
+            ->setUnfreezetime(sprintf('%d-01-01 05:00:00 Europe/Amsterdam', date('Y') + 1));
+        $manager->flush();
+
+        // Now add some submissions:
+        // * One correct and one incorrect one before the freeze
+        // * One correct and one incorrect one just before the freeze
+        // * One correct and one incorrect at the end of the freeze
+
+        $submissionData = [
+            ['2022-01-01 02:00:00 Europe/Amsterdam', true],
+            ['2022-01-01 03:00:00 Europe/Amsterdam', false],
+            ['2022-01-01 04:03:00 Europe/Amsterdam', true],
+            ['2022-01-01 04:03:00 Europe/Amsterdam', false],
+            ['2022-01-01 04:40:00 Europe/Amsterdam', true],
+            ['2022-01-01 04:50:00 Europe/Amsterdam', false],
+        ];
+        foreach ($submissionData as [$time, $correct]) {
+            $problem    = $demoContest->getProblems()->first();
+            $submission = (new Submission())
+                ->setContest($demoContest)
+                ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => 'Example teamname']))
+                ->setContestProblem($problem)
+                ->setLanguage($manager->getRepository(Language::class)->find('cpp'))
+                ->setSubmittime(Utils::toEpochFloat($time));
+            $judging    = (new Judging())
+                ->setContest($demoContest)
+                ->setStarttime(Utils::toEpochFloat($time))
+                ->setEndtime(Utils::toEpochFloat($time) + 5)
+                ->setValid(true)
+                ->setSubmission($submission)
+                ->setResult($correct ? 'correct' : 'timelimit');
+            $submission->addJudging($judging);
+            $manager->persist($submission);
+            $manager->persist($judging);
+            $manager->flush();
+        }
+    }
+}

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -901,10 +901,11 @@ class DOMJudgeService
 
         if ($contest && $this->config->get('show_public_stats')) {
             $freezeData = new FreezeData($contest);
+            $showVerdictsInFreeze = $freezeData->showFinal(false) || $contest->getFreezetime() === null;
             $data['stats'] = $statistics->getGroupedProblemsStats(
                 $contest,
                 array_map(fn(ContestProblem $problem) => $problem->getProblem(), $problems),
-                $freezeData->showFinal(false),
+                $showVerdictsInFreeze,
                 (bool)$this->config->get('verification_required')
             );
         }

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -420,7 +420,7 @@ class StatisticsService
     public function getGroupedProblemsStats(
         Contest $contest,
         array $problems,
-        bool $showFrozen,
+        bool $showVerdictsInFreeze,
         bool $verificationRequired
     ): array {
         $stats = [
@@ -465,7 +465,7 @@ class StatisticsService
                 $queryBuilder = clone $judgingsQueryBuilder;
                 $queryBuilder->andWhere('s.submittime >= :starttime');
                 $queryBuilder->andWhere('s.submittime < :endtime');
-                if ($showFrozen || $end->getTimestamp() <= $contest->getFreezetime()) {
+                if ($showVerdictsInFreeze || $end->getTimestamp() <= $contest->getFreezetime()) {
                     // When we don't want to show frozen correct/incorrect submissions,
                     // get the same data for both correct and incorrect.
                     // This logic assumes the freeze matches with the start of a bucket.

--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -60,7 +60,7 @@
                                                             {% else %}
                                                                 {% set submissionText = 'submissions' %}
                                                             {% endif %}
-                                                            {% if not current_contest.freezeData.showFinal and current_contest.freezetime and stat.start.timestamp >= current_contest.freezetime %}
+                                                            {% if not current_contest.freezeData.showFinal and current_contest.freezetime and stat.end.timestamp >= current_contest.freezetime %}
                                                                 {% set maxBucketSize = max(1, stats.maxBucketSizeCorrect, stats.maxBucketSizeIncorrect) %}
                                                                 {% set bucket = (count / maxBucketSize * 9) | round(0, 'ceil') %}
                                                                 {% set itemClass = 'frozen' ~ '-' ~ bucket %}


### PR DESCRIPTION
This fixes two things:

* If there is no freeze, we treated the whole contest as freeze when getting the data for the boxes (hence it appears in both rows) but then when rendering the boxes we (correctly) didn't render them as during the freeze. We now do not treat the whole contest as frozen anymore.
* If there is a box that starts before the freeze but ends after it, we treated the box as frozen when getting the data but as not frozen when rendering, thus again showing both a green and red box. We now treat the whole box as frozen in both places.