### PR TITLE
Force that the build and run scripts are executable.

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -921,6 +921,8 @@ class DOMJudgeService
         for ($idx = 0; $idx < $zip->numFiles; $idx++) {
             $filename = basename($zip->getNameIndex($idx));
             if ($filename === $propertyFile) {
+                // This file is only for setting metadata of the executable,
+                // see webapp/src/Controller/Jury/ExecutableController.php.
                 continue;
             }
 
@@ -930,6 +932,10 @@ class DOMJudgeService
                 && $opsys==ZipArchive::OPSYS_UNIX
                 && (($attr >> 16) & 0100) === 0) {
                 $executableBit = false;
+            }
+            // As a special case force these files to be executable.
+            if ($filename==='build' || $filename==='run') {
+                $executableBit = true;
             }
             $executableFile = new ExecutableFile();
             $executableFile


### PR DESCRIPTION
Note that we only do this special case for these, not for
any other script that could be called from them, since only
for these we know the file names and that they should be
executable.

Also add a comment to clarify why `domjudge-executable.ini` is skipped.

Closes #1628