### PR TITLE
Improve submission details UI.

### DIFF
--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -40,6 +40,10 @@ class SubmissionController extends BaseController
     protected ConfigurationService $config;
     protected FormFactoryInterface $formFactory;
 
+    const NEVER_SHOW_COMPILE_OUTPUT = 0;
+    const ONLY_SHOW_COMPILE_OUTPUT_ON_ERROR = 1;
+    const ALWAYS_SHOW_COMPILE_OUTPUT = 2;
+
     public function __construct(
         EntityManagerInterface $em,
         SubmissionService $submissionService,
@@ -191,14 +195,20 @@ class SubmissionController extends BaseController
                 ->getResult();
         }
 
+        $actuallyShowCompile = $showCompile == self::ALWAYS_SHOW_COMPILE_OUTPUT
+            || ($showCompile == self::ONLY_SHOW_COMPILE_OUTPUT_ON_ERROR && $judging->getResult() === 'compiler-error');
+
         $data = [
             'judging' => $judging,
             'verificationRequired' => $verificationRequired,
-            'showCompile' => $showCompile,
+            'showCompile' => $actuallyShowCompile,
             'allowDownload' => $allowDownload,
             'showSampleOutput' => $showSampleOutput,
             'runs' => $runs,
         ];
+        if ($actuallyShowCompile) {
+            $data['size'] = 'xl';
+        }
 
         if ($request->isXmlHttpRequest()) {
             return $this->render('team/submission_modal.html.twig', $data);

--- a/webapp/templates/partials/modal.html.twig
+++ b/webapp/templates/partials/modal.html.twig
@@ -1,5 +1,8 @@
 <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
+    {% if size is not defined %}
+        {% set size = 'lg' %}
+    {% endif %}
+    <div class="modal-dialog modal-{{size}}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -25,14 +25,16 @@
                 Language:
                 <b>{{ judging.submission.language.name }}</b>
             </div>
-            <div class="p-2">
-                Compilation:
-                {% if judging.result == 'compiler-error' %}
-                    <span class="badge badge-danger">failed</span>
-                {% else %}
-                    <span class="badge badge-success">successful</span>
-                {% endif %}
-            </div>
+            {% if not showCompile %}
+                <div class="p-2">
+                    Compilation:
+                    {% if judging.result == 'compiler-error' %}
+                        <span class="badge badge-danger">failed</span>
+                    {% else %}
+                        <span class="badge badge-success">successful</span>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
 
         {% if judging.result != 'compiler-error' %}
@@ -53,9 +55,17 @@
             </div>
         {% endif %}
 
-        {% if showCompile == 2 or (showCompile == 1 and judging.result == 'compiler-error') %}
+        {% if showCompile %}
             <hr/>
-            <h4 class="text-center">Compilation output</h4>
+            <h6 class="text-center">
+                Compilation
+                {% if judging.result == 'compiler-error' %}
+                    <span class="badge badge-danger">failed</span>
+                {% else %}
+                    <span class="badge badge-success">successful</span>
+                {% endif %}
+                with the following output
+            </h6>
             {% if judging.outputCompile(true) is not empty %}
                 <pre class="output_text pre-scrollable">{{ judging.outputCompile(true) }}</pre>
             {% else %}

--- a/webapp/templates/team/submission_modal.html.twig
+++ b/webapp/templates/team/submission_modal.html.twig
@@ -3,5 +3,5 @@
 {% block title %}Submission details{% endblock %}
 
 {% block content %}
-    {% include 'team/partials/submission.html.twig' with {size: 6} %}
+    {% include 'team/partials/submission.html.twig' %}
 {% endblock %}


### PR DESCRIPTION
- Increase width of modal dialog if we show compilation output. Fixes
  #1564.
- If we are showing compilation output, move the compilation result
  close to the output to reduce the likelihood for confusion. Related to
  #1579.