### PR TITLE
Change python2->3 migration to not be skipped.

### DIFF
--- a/webapp/migrations/Version20191031203138.php
+++ b/webapp/migrations/Version20191031203138.php
@@ -29,17 +29,19 @@ final class Version20191031203138 extends AbstractMigration implements Container
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $em = $this->container->get('doctrine')->getManager();
         /** @var Language $python2 */
         $python2 = $em->getRepository(Language::class)->find('py2');
         /** @var Language $python3 */
         $python3 = $em->getRepository(Language::class)->find('py3');
-        $this->skipIf($python2 === null || $python3 === null, 'Python 2 or 3 language not found');
-        $this->skipIf($python2->getAllowSubmit(), 'Python 2 language enabled');
-        $this->skipIf($python3->getAllowSubmit(), 'Python 3 language enabled');
-        $this->skipIf($python2->getExtensions() !== ['py2', 'py'], 'Python 2 extensions modified');
-        $this->skipIf($python3->getExtensions() !== ['py3'], 'Python 3 extensions modified');
+        if ($python2 === null ||
+            $python3 === null ||
+            $python2->getAllowSubmit() ||
+            $python3->getAllowSubmit() ||
+            $python2->getExtensions() !== ['py2', 'py'] ||
+            $python3->getExtensions() !== ['py3']) {
+            return;
+        }
 
         $this->addSql('UPDATE language SET extensions = \'["py3","py"]\' WHERE langid = \'py3\'');
         $this->addSql('UPDATE language SET extensions = \'["py2"]\' WHERE langid = \'py2\'');
@@ -53,11 +55,15 @@ final class Version20191031203138 extends AbstractMigration implements Container
         $python2 = $em->getRepository(Language::class)->find('py2');
         /** @var Language $python3 */
         $python3 = $em->getRepository(Language::class)->find('py3');
-        $this->skipIf($python2 === null || $python3 === null, 'Python 2 or 3 language not found');
-        $this->skipIf($python2->getAllowSubmit(), 'Python 2 language enabled');
-        $this->skipIf($python3->getAllowSubmit(), 'Python 3 language enabled');
-        $this->skipIf($python2->getExtensions() !== ['py2'], 'Python 2 extensions modified');
-        $this->skipIf($python3->getExtensions() !== ['py3', 'py'], 'Python 3 extensions modified');
+
+        if ($python2 === null ||
+            $python3 === null ||
+            $python2->getAllowSubmit() ||
+            $python3->getAllowSubmit() ||
+            $python2->getExtensions() !== ['py2', 'py'] ||
+            $python3->getExtensions() !== ['py3']) {
+            return;
+        }
 
         $this->addSql('UPDATE language SET extensions = \'["py2","py"]\' WHERE langid = \'py2\'');
         $this->addSql('UPDATE language SET extensions = \'["py"]\' WHERE langid = \'py3\'');


### PR DESCRIPTION
This makes it such that the migration will not be tried every time.

This is 'broken' since a Doctrine upgrade from last year.