### PR TITLE
Fix syntax test running as root

### DIFF
--- a/gitlab/syntax.sh
+++ b/gitlab/syntax.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 tests/syntax
 
 make configure
-./configure --with-baseurl='http://localhost/domjudge/'
+./configure --with-baseurl='http://localhost/domjudge/' --with-domjudge-user=root
 make install-docs
 make clean
 


### PR DESCRIPTION
Alternative is to specify to run as domjudge as we do in other tests but
it makes sense to also test this discouraged setup as root in this small
test.