### PR TITLE
Add option to use new event feed format. Part of #1631.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -281,6 +281,15 @@
             public: true
             description: If set, enable teams and jury to send source code to this command. See admin manual for allowed arguments.
             docdescription: See :ref:`printing` for more information.
+        -   name: event_feed_format
+            type: int
+            default_value: 0
+            public: false
+            description: "Format of the event feed to use"
+            options:
+                0: New format in use since the `2022-07` version # TODO: when spec is finalized, update version
+                1: Legacy format in use until the `2020-03` version
+                # Note: there is also a `2021-11` version of the event feed, but this has never been used so we will not implement it
         -   name: data_source
             type: int
             default_value: 0

--- a/webapp/migrations/Version20220726184436.php
+++ b/webapp/migrations/Version20220726184436.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220726184436 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make external_source_warning.last_event_id nullable.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE external_source_warning CHANGE last_event_id last_event_id VARCHAR(255) DEFAULT NULL COMMENT \'Last event ID this warning happened at\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE external_source_warning CHANGE last_event_id last_event_id VARCHAR(255) NOT NULL COMMENT \'Last event ID this warning happened at\'');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/ExternalSourceWarning.php
+++ b/webapp/src/Entity/ExternalSourceWarning.php
@@ -37,9 +37,9 @@ class ExternalSourceWarning
     /**
      * @ORM\Column(type="string", name="last_event_id", length=255,
      *     options={"comment"="Last event ID this warning happened at"},
-     *     nullable=false)
+     *     nullable=true)
      */
-    private string $lastEventId;
+    private ?string $lastEventId;
 
     /**
      * @ORM\Column(type="decimal", precision=32, scale=9, name="time",
@@ -94,12 +94,12 @@ class ExternalSourceWarning
         return $this->extwarningid;
     }
 
-    public function getLastEventId(): string
+    public function getLastEventId(): ?string
     {
         return $this->lastEventId;
     }
 
-    public function setLastEventId(string $lastEventId): ExternalSourceWarning
+    public function setLastEventId(?string $lastEventId): ExternalSourceWarning
     {
         $this->lastEventId = $lastEventId;
         return $this;

--- a/webapp/src/Form/Type/ExternalContestSourceType.php
+++ b/webapp/src/Form/Type/ExternalContestSourceType.php
@@ -47,7 +47,9 @@ class ExternalContestSourceType extends AbstractType
         $builder->add('username', TextType::class, [
             'required' => false,
         ]);
-        $builder->add('password', TextType::class);
+        $builder->add('password', TextType::class, [
+            'required' => false,
+        ]);
         $builder->add('save', SubmitType::class);
     }
 


### PR DESCRIPTION
CI will fail until we merge domjudge/domjudge-scripts#56, but this will add the new event feed:
* It adds an option to switch between the old and new format.
* It adds reconnection tokens as described in icpc/ccs-specs#108 which should soon be merged.
* It supports reading both versions of the feed as shadow.

This last thing required quite some changes to the reading of the feed, because we need to separate the event data from the event metadata (operation, optional event ID and endpoint type). But in the end I think this makes it better, since it is now a better separation.