### PR TITLE
Use chroot arch in mirror selection for ubuntu

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -202,9 +202,10 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
 
     # Ubuntu mirror, modify to match closest mirror
     if [ -z "$DEBMIRROR" ]; then
-        # x86_64 can use the main Ubuntu repo's, other
+        # x86(_64) can use the main Ubuntu repo's, other
         # architectures need to use a mirror from ubuntu-ports.
-        if [ "$(uname -m)" = "x86_64" ]; then
+        MAINSTREAM="amd64 i386"
+        if [ -z "${MAINSTREAM##*$ARCH*}" ]; then
             DEBMIRROR="http://us.archive.ubuntu.com/ubuntu/"
         else
             DEBMIRROR="http://ports.ubuntu.com/ubuntu-ports/"


### PR DESCRIPTION
It's already explained in the comment but:
- Ubuntu has only i386 & amd64 in the archive mirrors and the other
archs are in ports.ubuntu, when selecting where to download packages for
the chroot we should pick the mirror selected for the chroot arch
instead of the host arch as we might install a arm64 chroot in a amd64
machine (why is another question but the script allowes for this).