### PR TITLE
Cleanup PHP annotations

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -82,7 +82,6 @@ class ClarificationController extends AbstractRestController
     /**
      * Add a clarification to this contest
      * @Rest\Post("")
-     * @Rest\Post("/")
      * @Rest\Put("/{id}")
      * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a clarification")
      * @OA\RequestBody(

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -84,8 +84,6 @@ class ClarificationController extends AbstractRestController
      * @Rest\Post("")
      * @Rest\Post("/")
      * @Rest\Put("/{id}")
-     * @OA\Post()
-     * @OA\Put()
      * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a clarification")
      * @OA\RequestBody(
      *     required=true,

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -65,7 +65,6 @@ class ContestController extends AbstractRestController
      * Add a new contest.
      * @Rest\Post("")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -438,7 +437,6 @@ class ContestController extends AbstractRestController
     /**
      * Get the event feed for the given contest.
      * @Rest\Get("/{cid}/event-feed")
-     * @OA\Get()
      * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_API_READER')")
      * @throws NonUniqueResultException
      * @OA\Parameter(ref="#/components/parameters/cid")

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -330,7 +330,6 @@ class GeneralInfoController extends AbstractFOSRestController
      * Add a problem without linking it to a contest.
      * @Rest\Post("/problems")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\Tag(name="Problems")
      * @OA\RequestBody(
      *     required=true,

--- a/webapp/src/Controller/API/ProblemController.php
+++ b/webapp/src/Controller/API/ProblemController.php
@@ -56,7 +56,6 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
      * Add one or more problems.
      * @Rest\Post("/add-data")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -164,7 +163,6 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
      * Add a problem to this contest.
      * @Rest\Post("")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -113,8 +113,6 @@ class SubmissionController extends AbstractRestController
      * @Rest\Post("")
      * @Rest\Post("/")
      * @Rest\Put("/{id}")
-     * @OA\Post()
-     * @OA\Put()
      * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a submission")
      * @OA\RequestBody(
      *     required=true,

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -49,7 +49,6 @@ class UserController extends AbstractRestController
      * Add one or more groups.
      * @Rest\Post("/groups")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -101,7 +100,6 @@ class UserController extends AbstractRestController
      *
      * @Rest\Post("/organizations")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -139,7 +137,6 @@ class UserController extends AbstractRestController
      * Add one or more teams.
      * @Rest\Post("/teams")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(
@@ -190,7 +187,6 @@ class UserController extends AbstractRestController
      * Add accounts to teams.
      * @Rest\Post("/accounts")
      * @IsGranted("ROLE_ADMIN")
-     * @OA\Post()
      * @OA\RequestBody(
      *     required=true,
      *     @OA\MediaType(


### PR DESCRIPTION
One commit to fix https://github.com/DOMjudge/domjudge/security/code-scanning/377, the other to remove annotations which can be derived from another annotation for example OA removal because Rest is already enough to infer we have a Get endpoint.