### PR TITLE
Use Psr6-namespaced DoctrineProvider

### DIFF
--- a/webapp/config/packages/prod/doctrine.yaml
+++ b/webapp/config/packages/prod/doctrine.yaml
@@ -13,12 +13,12 @@ doctrine:
 
 services:
     doctrine.result_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
         arguments:
             - '@doctrine.system_cache_pool'

--- a/webapp/config/packages/prod/doctrine.yaml
+++ b/webapp/config/packages/prod/doctrine.yaml
@@ -13,12 +13,12 @@ doctrine:
 
 services:
     doctrine.result_cache_provider:
-        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         public: false
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
-        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         public: false
         arguments:
             - '@doctrine.system_cache_pool'

--- a/webapp/config/packages/prod/doctrine.yaml
+++ b/webapp/config/packages/prod/doctrine.yaml
@@ -13,11 +13,13 @@ doctrine:
 
 services:
     doctrine.result_cache_provider:
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         public: false
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         public: false
         arguments:


### PR DESCRIPTION
`Symfony\Component\Cache\DoctrineProvider` is deprecated, change it to `Symfony\Component\Cache\Psr6\DoctrineProvider`.