### PR TITLE
Initialize testcase runs as 0

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1716,7 +1716,7 @@ class ExternalContestSourceService
         }
 
         $time    = Utils::toEpochFloat($data['time']);
-        $runTime = $data['run_time'] ?? null;
+        $runTime = $data['run_time'] ?? 0.0;
 
         $judgementTypeId = $data['judgement_type_id'] ?? null;
         $verdictsFlipped = array_flip($this->verdicts);


### PR DESCRIPTION
The runobject should have the run_time according to (https://ccs-specs.icpc.io/2022-07/contest_api?highlight=event-feed#runs) but as the example does already not list it this might be ambigious.

We don't allow runs to be 0, so initializing as 0.0 as that is the most common mistake is a good backup IMO.