### PR TITLE
fix: handle transient network errors with exponential backoff

### DIFF
--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -26,7 +26,6 @@ function define_backoff_params_from_env(string $var_name, int $default_value) {
         ),
     );
     $final_value = filter_var(getenv('DOMJUDGE_' . $var_name), FILTER_VALIDATE_INT, $options);
-    echo $var_name . ": " . $final_value;
     define($var_name, $final_value);
 }
 

--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -25,7 +25,7 @@ function define_backoff_params_from_env(string $var_name, int $default_value) {
             'min_range' => 0,
         ),
     );
-    $final_value = filter_var(getenv('DOMJUDGE_' . $envvar_name), FILTER_VALIDATE_INT, $options);
+    $final_value = filter_var(getenv('DOMJUDGE_' . $var_name), FILTER_VALIDATE_INT, $options);
     echo $var_name . ": " . $final_value;
     define($var_name, $final_value);
 }

--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -12,8 +12,8 @@ define('SYSLOG', LOG_LOCAL0);
 define('CREATE_WRITABLE_TEMP_DIR', getenv('DOMJUDGE_CREATE_WRITABLE_TEMP_DIR') ? true : false);
 
 // These define HTTP request backoff related constants.
-// If any transient network error occurs on nth trial,
-// judgehost retries HTTP request after (1000 * pow(factor, trial - 1) + rand(0, jitter)) ms.
+// If any transient network error occurs on the nth trial,
+// the judgehost retries the HTTP request after (1000 * pow(factor, trial - 1) + rand(0, jitter)) ms.
 
 function define_backoff_params_from_env(string $var_name, int $default_value) {
     if (defined($var_name)) {
@@ -32,3 +32,4 @@ function define_backoff_params_from_env(string $var_name, int $default_value) {
 define_backoff_params_from_env('BACKOFF_JITTER_MS', 200);
 define_backoff_params_from_env('BACKOFF_FACTOR', 2);
 define_backoff_params_from_env('BACKOFF_STEPS', 3);
+define_backoff_params_from_env('BACKOFF_INITIAL_DELAY_MS', 1000);

--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -10,3 +10,26 @@ define('SYSLOG', LOG_LOCAL0);
 // the submission can write to. Also the environment variable TMPDIR will
 // be set to this directory
 define('CREATE_WRITABLE_TEMP_DIR', getenv('DOMJUDGE_CREATE_WRITABLE_TEMP_DIR') ? true : false);
+
+// These define HTTP request backoff related constants.
+// If any transient network error occurs on nth trial,
+// judgehost retries HTTP request after (1000 * pow(factor, trial - 1) + rand(0, jitter)) ms.
+
+function define_backoff_params_from_env(string $var_name, int $default_value) {
+    if (defined($var_name)) {
+        return;
+    }
+    $options = array(
+        'options' => array(
+            'default' => $default_value,
+            'min_range' => 0,
+        ),
+    );
+    $final_value = filter_var(getenv('DOMJUDGE_' . $envvar_name), FILTER_VALIDATE_INT, $options);
+    echo $var_name . ": " . $final_value;
+    define($var_name, $final_value);
+}
+
+define_backoff_params_from_env('BACKOFF_JITTER_MS', 200);
+define_backoff_params_from_env('BACKOFF_FACTOR', 2);
+define_backoff_params_from_env('BACKOFF_STEPS', 3);

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -62,7 +62,7 @@ function read_credentials(): void
 }
 
 /**
- * @return resource|false
+ * @return CurlHandle|false
  */
 function setup_curl_handle(string $restuser, string $restpass)
 {
@@ -92,9 +92,14 @@ function close_curl_handles(): void
  * $data is the urlencoded data passed as GET or POST parameters.
  * When $failonerror is set to false, any error will be turned into a
  * warning and null is returned.
+ * This function retries request on transient network errors.
+ * To deal with the transient errors while avoiding overloads,
+ * this function uses exponential backoff algorithm.
+ * Every error except HTTP 401, 500 is considered transient.
  */
 $lastrequest = '';
-function request(string $url, string $verb = 'GET', $data = '', bool $failonerror = true)
+function request(
+    string $url, string $verb = 'GET', $data = '', bool $failonerror = true, int $jitter = 200, $factor = 2, $steps = 3)
 {
     global $endpoints, $endpointID, $lastrequest;
 
@@ -133,32 +138,49 @@ function request(string $url, string $verb = 'GET', $data = '', bool $failonerro
         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, null);
     }
 
-    $response = curl_exec($curl_handle);
-    if ($response === false) {
-        $errstr = "Error while executing curl $verb to url " . $url . ": " . curl_error($curl_handle);
-        if ($failonerror) {
-            error($errstr);
+    $delay_in_ms = 1000;
+    $succeeded = false;
+    $response = null;
+    $errstr = null;
+
+    for ($trial = 1; $trial <= $steps; $trial++) {
+        $response = curl_exec($curl_handle);
+        if ($response === false) {
+            $errstr = "Error while executing curl $verb to url " . $url . ": " . curl_error($curl_handle);
         } else {
-            warning($errstr);
-            $endpoints[$endpointID]['errorred'] = true;
-            return null;
+            $status = curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
+            if ($status == 401) {
+                $errstr = "Authentication failed (error $status) while contacting $url. " .
+                    "Check credentials in restapi.secret.";
+                break;
+            } else if ($status != 200) {
+                $json = dj_json_try_decode($response);
+                if ($json !== null) {
+                    $response = var_export($json, true);
+                }
+                $errstr = "Error while executing curl $verb to url " . $url .
+                    ": http status code: " . $status .
+                    ", request size = " . strlen(print_r($data, true)) .
+                    ", response: " . $response;
+                if ($status == 500) {
+                    break;
+                }
+            } else {
+                $succeeded = true;
+                break;
+            }
+        }
+        if ($trial == $steps) {
+            $errstr = $errstr . " Retry limit reached.";
+        } else {
+            $warnstr = $errstr . " This request will be retried after about " .
+                $delay_in_ms . "ms... (" . $trial . "/" . $steps . ")";
+            warning($warnstr);
+            usleep($delay_in_ms + random_int(0, $jitter));
+            $delay_in_ms = $delay_in_ms * $factor;
         }
     }
-    $status = curl_getinfo($curl_handle, CURLINFO_HTTP_CODE);
-    if ($status < 200 || $status >= 300) {
-        if ($status == 401) {
-            $errstr = "Authentication failed (error $status) while contacting $url. " .
-                "Check credentials in restapi.secret.";
-        } else {
-            $json = dj_json_decode($response);
-            if ($json !== null) {
-                $response = var_export($json, true);
-            }
-            $errstr = "Error while executing curl $verb to url " . $url .
-                ": http status code: " . $status .
-                ", request size = " . strlen(print_r($data, true)) .
-                ", response: " . $response;
-        }
+    if (!$succeeded) {
         if ($failonerror) {
             error($errstr);
         } else {

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -137,7 +137,7 @@ function request(string $url, string $verb = 'GET', $data = '', bool $failonerro
         curl_setopt($curl_handle, CURLOPT_POSTFIELDS, null);
     }
 
-    $delay_in_ms = 1000;
+    $delay_in_ms = BACKOFF_INITIAL_DELAY_MS;
     $succeeded = false;
     $response = null;
     $errstr = null;

--- a/lib/lib.wrappers.php
+++ b/lib/lib.wrappers.php
@@ -15,6 +15,15 @@ function dj_json_decode(string $str)
 }
 
 /**
+ * Try decode a JSON string with our preferred settings.
+ * Does not throw error, but errors can be obtained via json_last_error().
+ */
+function dj_json_try_decode(string $str)
+{
+    return json_decode($str, true, 512);
+}
+
+/**
  * Encode data to JSON with our preferred settings.
  */
 function dj_json_encode($data) : string

--- a/lib/lib.wrappers.php
+++ b/lib/lib.wrappers.php
@@ -20,7 +20,7 @@ function dj_json_decode(string $str)
  */
 function dj_json_try_decode(string $str)
 {
-    return json_decode($str, true, 512);
+    return json_decode($str, true);
 }
 
 /**

--- a/lib/lib.wrappers.php
+++ b/lib/lib.wrappers.php
@@ -15,7 +15,7 @@ function dj_json_decode(string $str)
 }
 
 /**
- * Try decode a JSON string with our preferred settings.
+ * Try to decode a JSON string with our preferred settings.
  * Does not throw error, but errors can be obtained via json_last_error().
  */
 function dj_json_try_decode(string $str)


### PR DESCRIPTION
Implemented two enhancements.
1. Retries curl_exec on transient errors (e.g. temporary network error or temporary HTTP error from a proxy in front of DOMservers)
2. Does not throw error on non-JSON error response. This fixes #1673.
