### PR TITLE
Revert from using Symfony debug as autoloading fails

### DIFF
--- a/.github/workflows/mayhem-api.yml
+++ b/.github/workflows/mayhem-api.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Dump the OpenAPI
         run: .github/workflowscripts/getapi.sh
 
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.version == 'guest' }}
+        with:
+          name: all-apispec
+          path: |
+            /home/runner/work/domjudge/domjudge/openapi.json
+
       - name: Mayhem for API
         uses: ForAllSecure/mapi-action@v1
         if: ${{ matrix.version == 'guest' }}
@@ -77,4 +84,4 @@ jobs:
           name: ${{ matrix.version }}-logs
           path: |
             /var/log/nginx
-            /home/runner/work/domjudge/domjudge/webapp/var/log/*.log
+            /opt/domjudge/domserver/webapp/var/log/*.log

--- a/.github/workflowscripts/nginx_extra
+++ b/.github/workflowscripts/nginx_extra
@@ -5,5 +5,5 @@ server {
   ssl_session_timeout 5m;
   ssl_prefer_server_ciphers on;
   add_header Strict-Transport-Security max-age=31556952;
-  include /home/runner/work/domjudge/domjudge/etc/nginx-conf-inner;
+  include /opt/domjudge/domserver/etc/nginx-conf-inner;
 }


### PR DESCRIPTION
The idea was to display the stacktrace to enrich the issue in mayhem4api. This seems to fail as the application does not work after autowiring for the development bar. Instead we now upload the logs which should have the same information to make debugging possible.