### PR TITLE
organization_id is not required

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1012,7 +1012,7 @@ class ExternalContestSourceService
             'externalid'             => $data['id'],
             'name'                   => $data['formal_name'] ?? $data['name'],
             'display_name'           => $data['display_name'] ?? null,
-            'affiliation.externalid' => $data['organization_id'],
+            'affiliation.externalid' => $data['organization_id'] ?? null,
             'category.externalid'    => $data['group_ids'][0] ?? null,
             'icpcid'                 => $data['icpc_id'] ?? null,
         ];


### PR DESCRIPTION
I think it is required according to https://ccs-specs.icpc.io/2022-07/ccs_system_requirements#contest-api (teams endpoint)
The team we failed on is the default DOMjudge team, which has no affiliation in the primary, the CDS removes all fields with a null value and we expected this to be there.