### PR TITLE
Fix internal error in cases where the last judgetask of a judging fails.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -815,8 +815,10 @@ class JudgehostController extends AbstractFOSRestController
             ->setJudgehostlog($judgehostlog)
             ->setTime(Utils::now())
             ->setDisabled($disabled);
-
         $this->em->persist($error);
+        // Even if there are no remaining judge tasks for this judging open (which is covered by the transaction below),
+        // we need to mark this judging as internal error.
+        $judging->setInternalError($error);
         $this->em->flush();
 
         if ($field_name !== null) {


### PR DESCRIPTION
An example of this is when you break the `boolfind` problem which only has a single test case.

Then the errorid of the judging is never set, leading to issues when later trying to resolve the internal error since no judging is found with the errorid.