### PR TITLE
Disable the use of #pramga

### DIFF
--- a/sql/files/defaultdata/c/run
+++ b/sql/files/defaultdata/c/run
@@ -6,6 +6,9 @@
 DEST="$1" ; shift
 MEMLIMIT="$1" ; shift
 
+# Disable the use of #pramga to tell the compiler to change compile flags
+sed -i 's/^#pragma/\/\/ #pragma/i' "$@"
+
 # Add -DONLINE_JUDGE or -DDOMJUDGE below if you want it make easier for teams
 # to do local debugging.
 

--- a/sql/files/defaultdata/cpp/run
+++ b/sql/files/defaultdata/cpp/run
@@ -6,6 +6,9 @@
 DEST="$1" ; shift
 MEMLIMIT="$1" ; shift
 
+# Disable the use of #pramga to tell the compiler to change compile flags
+sed -i 's/^#pragma/\/\/ #pragma/i' "$@"
+
 # Add -DONLINE_JUDGE or -DDOMJUDGE below if you want it make easier for teams
 # to do local debugging.
 


### PR DESCRIPTION
### Disable the use of #pramga to tell the compiler to change compile flags.

The following directive will override `-O2`, which I think should be disabled.
`#pragma GCC optimize ("Ofast")`