### PR TITLE
Use entity ID badges for team ID's everywhere so we can show the external as well as the internal ID and make it look better.

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -608,3 +608,7 @@ tr.ignore td, td.ignore, span.ignore {
 .problem-badge {
     font-size: 100%;
 }
+
+.tooltip .tooltip-inner {
+    max-width: 500px;
+}

--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -168,12 +168,12 @@ class ClarificationController extends AbstractController
 
             if ($fromteam = $clar->getSender()) {
                 $data['from_teamname'] = $fromteam->getEffectiveName();
-                $data['from_teamid'] = $fromteam->getTeamid();
+                $data['from_team'] = $fromteam;
                 $concernsteam = $fromteam->getTeamid();
             }
             if ($toteam = $clar->getRecipient()) {
                 $data['to_teamname'] = $toteam->getEffectiveName();
-                $data['to_teamid'] = $toteam->getTeamid();
+                $data['to_team'] = $toteam;
             }
 
             $contest = $clar->getContest();

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -77,6 +77,7 @@ class UserController extends BaseController
             'name'       => ['title' => 'name', 'sort' => true],
             'email'      => ['title' => 'email', 'sort' => true],
             'user_roles' => ['title' => 'roles', 'sort' => true],
+            'teamid'     => ['title' => '', 'sort' => false, 'render' => 'entity_id_badge'],
             'team'       => ['title' => 'team', 'sort' => true],
         ];
         if ( in_array('ipaddress', $this->config->get('auth_methods')) ) {
@@ -114,8 +115,12 @@ class UserController extends BaseController
             }
 
             if ($u->getTeam()) {
+                $userdata['teamid'] = [
+                    'value' => $u->getTeam(),
+                    'idPrefix' => 't',
+                ];
                 $userdata['team'] = [
-                    'value' => 't' . $u->getTeam()->getTeamid() . ' (' . $u->getTeamName() . ')',
+                    'value' => $u->getTeamName(),
                     'sortvalue' => $u->getTeam()->getTeamid(),
                     'link' => $this->generateUrl('jury_team', [
                         'teamId' => $u->getTeam()->getTeamid(),

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -168,7 +168,7 @@ $(function() {
             {% for t in teams %}
               {% set id=t.teamid %}
               <tr class="clickable-row" data-href="{{ path('analysis_team', {'teamid':id}) }}">
-                <th scope="row">{{ id }}</th>
+                <th scope="row" style="text-align: right;">{{ t | entityIdBadge('t') }}</th>
                 <td>{% if t.affiliation %}{{ t.affiliation.name }}{% else %}-{% endif %}</td>
                 <td class="truncate" style="max-width: 200px">{{ t.effectiveName }}</td>
                 <td>{{ misc.team_stats[id].total_submitted }} / {{ misc.team_stats[id].total_accepted }}</td>

--- a/webapp/templates/jury/clarification.html.twig
+++ b/webapp/templates/jury/clarification.html.twig
@@ -22,7 +22,7 @@
 
 {% for clar in list %}
 
-<div class="card mb-3 {% if clar.from_teamid is not defined %}border-primary{% endif %}">
+<div class="card mb-3 {% if clar.from_team is not defined %}border-primary{% endif %}">
 <div class="card-header"><div class="row">
 <div class="col-sm">
     Clarification {{ clar.clarid }}
@@ -37,8 +37,8 @@
 <div class="row">
 <div class="col-sm">
 From:
-{% if clar.from_teamid is defined %}
-<a href="{{ path('jury_team', {teamId: clar.from_teamid}) }}">{{ clar.from_teamname }} (t{{ clar.from_teamid }})</a>
+{% if clar.from_team is defined %}
+<a href="{{ path('jury_team', {teamId: clar.from_team.teamid}) }}">{{ clar.from_teamname }} {{ clar.from_team | entityIdBadge('t') }}</a>
 {% else %}
 Jury
     {% if clar.from_jurymember is defined %}
@@ -80,9 +80,9 @@ Jury
 
 <div class="row">
 <div class="col-sm">To:
-{% if clar.to_teamid is defined %}
-<a href="{{ path('jury_team', {teamId: clar.to_teamid}) }}">{{ clar.to_teamname }} (t{{ clar.to_teamid }})</a>
-{% elseif clar.from_teamid is defined %}
+{% if clar.to_team is defined %}
+<a href="{{ path('jury_team', {teamId: clar.to_team.teamid}) }}">{{ clar.to_teamname }} {{ clar.to_team | entityIdBadge('t') }}</a>
+{% elseif clar.from_team is defined %}
 Jury
 {% else %}
 <strong>All</strong>

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -168,7 +168,7 @@
                         {% else %}
                             {% for team in contest.teams %}
                                 <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">
-                                    {{ team.effectiveName }} (t{{ team.teamid }})
+                                    {{ team.effectiveName }} {{ team | entityIdBadge('t') }}
                                 </a>
                                 <br>
                             {% endfor %}

--- a/webapp/templates/jury/entity_id_badge.html.twig
+++ b/webapp/templates/jury/entity_id_badge.html.twig
@@ -1,4 +1,3 @@
-
 <span class="badge badge-secondary id-badge" data-toggle="tooltip" data-placement="top" title="{% if externalId is not null %}External ID: {{ externalId }}, {% endif %}Internal ID: {{ idPrefix }}{{ id }}">
     {% if externalId is not null %}
         {{ externalId }}

--- a/webapp/templates/jury/entity_id_badge.html.twig
+++ b/webapp/templates/jury/entity_id_badge.html.twig
@@ -1,0 +1,8 @@
+
+<span class="badge badge-secondary id-badge" data-toggle="tooltip" data-placement="top" title="{% if externalId is not null %}External ID: {{ externalId }}, {% endif %}Internal ID: {{ idPrefix }}{{ id }}">
+    {% if externalId is not null %}
+        {{ externalId }}
+    {% else %}
+        {{ idPrefix }}{{ id }}
+    {% endif %}
+</span>

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -114,7 +114,8 @@
                            class="{{ item.cssclass|default('') }}{% if key == "status" %} {{ item.value|statusClass() }}{% endif %}"
                                 {%- if item.title is defined %} title="{{ item.title }}"{% endif %}
                                 {%- if item.filterKey is defined and item.filterValue is defined %} data-{{ item.filterKey }}="{{ item.filterValue }}"{% endif %}
-                                {%- if item.sortvalue is defined %} data-sort="{{ item.sortvalue }}"{% endif %}>
+                                {%- if item.sortvalue is defined %} data-sort="{{ item.sortvalue }}"{% endif %}
+                                {% if (column.render | default('')) == "entity_id_badge" %}style="text-align: right;" {% endif %}>
                             {%- if item.link is defined %}<a href="{{ item.link }}">
                                 {%- elseif row.link is defined %}<a href="{{ row.link }}">{% endif %}
                                     {% if key == "status" %}
@@ -125,6 +126,8 @@
                                     {{- (item.value|default(item.default|default('')))|affiliationLogo(item.title) -}}
                                     {% elseif key == "warning_content" %}
                                     {{- item.value|printWarningContent -}}
+                                    {% elseif (column.render | default('')) == "entity_id_badge" %}
+                                    {% if item.value %}{{- item.value|entityIdBadge(item.idPrefix|default('')) -}}{% endif %}
                                     {% else %}
                                     {{- (item.value|default(item.default|default(''))) -}}
                                     {% endif %}

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -47,7 +47,7 @@
                     {%- set recipient = 'All' %}
                 {%- else %}
                     {%- set recipient = clarification.recipient.effectiveName ~ (clarification.recipient | entityIdBadge('t')) %}
-                    {%- set recipientBadge = clarification.sender | entityIdBadge('t') %}
+                    {%- set recipientBadge = clarification.recipient | entityIdBadge('t') %}
                 {%- endif %}
             {%- else %}
                 {%- set recipient = 'Jury' %}

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -12,8 +12,8 @@
         {%- endif %}
 
         <th scope="col">time</th>
-        <th scope="col">from</th>
-        <th scope="col">to</th>
+        <th scope="col" colspan="2">from</th>
+        <th scope="col" colspan="2">to</th>
         <th scope="col">subject</th>
 
         <th scope="col">text</th>
@@ -39,19 +39,25 @@
             {%- endif %}
 
             <td data-order="{{ clarification.submittime }}"><a href="{{ link }}">{{ clarification.submittime | printtime(null, clarification.contest) }}</a></td>
+            {%- set recipientBadge = '' %}
+            {%- set senderBadge = '' %}
             {%- if clarification.sender is null %}
                 {%- set sender = 'Jury' %}
                 {%- if clarification.recipient is null %}
                     {%- set recipient = 'All' %}
                 {%- else %}
-                    {%- set recipient = clarification.recipient.effectiveName %}
+                    {%- set recipient = clarification.recipient.effectiveName ~ (clarification.recipient | entityIdBadge('t')) %}
+                    {%- set recipientBadge = clarification.sender | entityIdBadge('t') %}
                 {%- endif %}
             {%- else %}
                 {%- set recipient = 'Jury' %}
                 {%- set sender = clarification.sender.effectiveName %}
+                {%- set senderBadge = clarification.sender | entityIdBadge('t') %}
             {%- endif %}
 
+            <td><a href="{{ link }}" title="{{ sender }}" style="text-align: right">{{ senderBadge | raw }}</a></td>
             <td><a href="{{ link }}" title="{{ sender }}">{{ sender | u.truncate(teamname_max_length, '…') }}</a></td>
+            <td><a href="{{ link }}" title="{{ recipient }}" style="text-align: right">{{ recipientBadge | raw }}</a></td>
             <td><a href="{{ link }}" title="{{ recipient }}">{{ recipient | u.truncate(teamname_max_length, '…') }}</a></td>
             <td><a href="{{ link }}">
                     {%- if clarification.problem -%}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -49,7 +49,7 @@
             {%- endif %}
 
             <th scope="col">time</th>
-            <th scope="col">team</th>
+            <th scope="col" colspan="2">team</th>
             <th scope="col">problem</th>
             <th scope="col">lang</th>
             {% if showExternalResult and showExternalTestcases %}
@@ -111,9 +111,15 @@
                 <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
                     <a href="{{ link }}">{{ submission.submittime | printtime(null, submission.contest) }}</a>
                 </td>
+                <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}" style="text-align: right;">
+                    <a href="{{ link }}">
+                        {{ submission.team | entityIdBadge('t') }}
+                    </a>
+                </td>
                 <td rowspan="{{ rowSpan }}" class="{{ tdExtraClass }}">
-                    <a href="{{ link }}"
-                       title="t{{ submission.team.teamid }}">{{ submission.team.name | u.truncate(teamname_max_length, '…') }}</a>
+                    <a href="{{ link }}">
+                        {{ submission.team.name | u.truncate(teamname_max_length, '…') }}
+                    </a>
                 </td>
                 <td class="probid{{ tdExtraClass }}" rowspan="{{ rowSpan }}">
                     <a href="{{ link }}"

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -95,7 +95,7 @@
         <span>
             <i class="fas fa-users" title="Team:"></i>
             <a href="{{ path('jury_team', {teamId: submission.team.teamid, cid: submission.contest.cid}) }}">
-                {{ submission.team.effectiveName }} (t{{ submission.team.teamid }})
+                {{ submission.team.effectiveName }} {{ submission.team | entityIdBadge('t') }}
             </a>
         </span>
 
@@ -103,7 +103,7 @@
             <span>
                 <i class="fas fa-user" title="User:"></i>
                 <a href="{{ path('jury_user', {userId: submission.user.userid, cid: submission.contest.cid}) }}">
-                    {{ submission.user.username }}
+                    {{ submission.user.username }} {{ submission.user | entityIdBadge('u') }}
                 </a>
             </span>
         {% endif %}
@@ -112,6 +112,7 @@
             <i class="fas fa-trophy" title="Contest:"></i>
             <a href="{{ path('jury_contest', {'contestId': submission.contest.cid}) }}">
                 {{ submission.contest.shortname }}
+                {{ submission.contest | entityIdBadge('c') }}
             </a>
         </span>
 
@@ -123,6 +124,7 @@
                 {% else %}
                     {{ submission.problem.name }}
                 {% endif %}
+                {{ submission.problem | entityIdBadge('p') }}
             </a>
         </span>
 
@@ -130,6 +132,7 @@
             <i class="fas fa-comments" title="Language:"></i>
             <a href="{{ path('jury_language', {'langId': submission.language.langid}) }}">
                 {{ submission.language.name }}
+                {{ submission.language | entityIdBadge }}
             </a>
         </span>
 

--- a/webapp/templates/jury/submissions.html.twig
+++ b/webapp/templates/jury/submissions.html.twig
@@ -107,6 +107,8 @@
                         })
                         .show();
                 }
+
+                $('table.submissions-table').find('[data-toggle="tooltip"]').tooltip();
             };
 
             $('select[data-filter-field]').on('change', process_submissions_filter);

--- a/webapp/templates/jury/team_affiliation.html.twig
+++ b/webapp/templates/jury/team_affiliation.html.twig
@@ -93,15 +93,15 @@
                 <table class="data-table table table-sm table-striped table-hover">
                     <thead>
                     <tr>
-                        <th>ID</th>
+                        <th style="text-align: right;">ID</th>
                         <th>Teamname</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for team in teamAffiliation.teams %}
                         <tr>
-                            <td>
-                                <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team.teamid }}</a>
+                            <td style="text-align: right;">
+                                <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team | entityIdBadge('t') }}</a>
                             </td>
                             <td>
                                 <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team.effectiveName }}</a>

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -78,15 +78,15 @@
                 <table class="data-table table table-sm table-striped table-hover">
                     <thead>
                     <tr>
-                        <th>ID</th>
+                        <th style="text-align: right;">ID</th>
                         <th>Teamname</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for team in teamCategory.teams %}
                         <tr>
-                            <td>
-                                <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team.teamid }}</a>
+                            <td style="text-align: right">
+                                <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team | entityIdBadge('t') }}</a>
                             </td>
                             <td>
                                 <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">{{ team.effectiveName }}</a>

--- a/webapp/templates/jury/user.html.twig
+++ b/webapp/templates/jury/user.html.twig
@@ -84,7 +84,7 @@
                     {% if user.team %}
                         <td class="teamid">
                             <a href="{{ path('jury_team', {'teamId': user.team.teamid}) }}">
-                                {{ user.team.effectiveName }} (t{{ user.team.teamid }})
+                                {{ user.team.effectiveName }} {{ user.team | entityIdBadge('t') }}
                             </a>
                         </td>
                     {% else %}

--- a/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
@@ -70,7 +70,7 @@ class ClarificationControllerTest extends BaseTest
         self::assertEquals("> Can you tell me how to solve this problem?\r\n\r\nNo, read the problem statement.",
                            $clarificationText[1]);
 
-        $this->verifyLinkToURL('Example teamname (t2)',
+        $this->verifyLinkToURL('Example teamname',
                                'http://localhost/jury/teams/2');
     }
 


### PR DESCRIPTION
Also use the badges on the submission detail page for user, contest, problem and language.

With thanks to @meisterT .

Screenshots on request in Slack since data is officially still secret.