### PR TITLE
Do not reset color of contestproblem during problem import since it could've been set during problemset import already.

### DIFF
--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -213,7 +213,12 @@ class ImportProblemService
             }
         }
 
-        // Reset problem settings that might not appear in the ZIP back to default
+        // Reset problem settings that might not appear in the ZIP back to default.
+        // Note that we only reset settings here that make sense. In particular, we will
+        // not reset any settings that could also have been set while importing the problem set
+        // through problems.yaml/json or problemset.yaml. This means that we will not set the
+        // color and shortname properties on the contest problem unless explicitly specified.
+        // The same holds for the timelimit of the problem.
         if ($problem->getProbid()) {
             $problem
                 ->setCompareExecutable()
@@ -230,8 +235,6 @@ class ImportProblemService
                     ->setPoints(1)
                     ->setAllowSubmit(true)
                     ->setAllowJudge(true);
-                // TODO: we should decide how and what to reset
-                    // ->setColor(null);
             }
         }
 


### PR DESCRIPTION
Also add a comment as to why we do not (re)set specific properties.

After checking the logic here: https://github.com/DOMjudge/domjudge/blob/main/webapp/src/Service/ImportExportService.php#L227-L227, it seems indeed only the color was a property we DID (re)set during problem import but shouldn't. There are some more properties (shortname of the contestproblem or timelimit of the problem) that we should not reset since they can be set in the problemset import, so I added a comment to make sure we do not do that in the future.