### PR TITLE
Fix incorrect counts on award render due to non-award participants.

### DIFF
--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -104,6 +104,7 @@
     {% set previousSortOrder = -1 %}
     {% set previousTeam = null %}
     {% set backgroundColors = {"#FFFFFF": 1} %}
+    {% set medalCount = 0 %}
     {% for score in scores %}
         {% set classes = [] %}
         {% if score.team.category.sortorder != previousSortOrder %}
@@ -119,11 +120,12 @@
         {# process medal color #}
         {% set medalColor = '' %}
         {% if showLegends and medalsEnabled and score.team.category in medalCategories and score.numPoints > 0 %}
-            {% if score.rank <= contest.goldMedals %}
+            {% set medalCount = medalCount + 1 %}
+            {% if medalCount <= contest.goldMedals %}
                 {% set medalColor = 'gold-medal' %}
-            {% elseif score.rank <= contest.goldMedals + contest.silverMedals %}
+            {% elseif medalCount <= contest.goldMedals + contest.silverMedals %}
                 {% set medalColor = 'silver-medal' %}
-            {% elseif score.rank <= contest.goldMedals + contest.silverMedals + contest.bronzeMedals + contest.b %}
+            {% elseif medalCount <= contest.goldMedals + contest.silverMedals + contest.bronzeMedals + contest.b %}
                 {% set medalColor = 'bronze-medal' %}
             {% endif %}
         {% endif %}


### PR DESCRIPTION
I found a bug while using awards, as shown below. We set 52 gold medals, however, since there are 2 teams were non-award participants, they also in the top 52, so the gold medal should be sent to the top 54, but it isn't!

![a](https://user-images.githubusercontent.com/29372915/198890903-0b25e60b-7f66-41e7-90b7-21b5a94528a3.png)

![b](https://user-images.githubusercontent.com/29372915/198891025-d8e79755-e0fe-4456-b8a9-201b5ffedbc9.png)

![c](https://user-images.githubusercontent.com/29372915/198891032-8a5a9936-4742-487e-b5b3-128dba04ce66.png)

After reading the code, I think I need to use an additional award counter as a variable instead of using `score.rank` directly in `scoreboard_table.html.twig`.