### PR TITLE
Re-set the table width of the submissions table to auto.

### DIFF
--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -184,3 +184,7 @@ div.submission-summary > span {
 .button-row {
     margin-bottom: 1rem;
 }
+
+table.submissions-table {
+    width: auto;
+}


### PR DESCRIPTION
The bootstrap default is 100% which looks weird if you have large screen, especially since we made the team column two columns.

![image](https://user-images.githubusercontent.com/418721/199008739-e5877107-bdc5-44f4-98a9-58c2bbb0a306.png)

![image (1)](https://user-images.githubusercontent.com/418721/199008803-466ff486-ccfe-4608-b847-89bd6df0f619.png)
