### PR TITLE
Allow test-fork-parent-exit.c to be a timelimit as well.

### DIFF
--- a/example_problems/hello/submissions/multiple/test-fork-parent-exit.c
+++ b/example_problems/hello/submissions/multiple/test-fork-parent-exit.c
@@ -7,7 +7,7 @@
  * processes killed. Without cgroup support, this will crash the
  * judgedaemon because the child processes are found still running.
  *
- * @EXPECTED_RESULTS@: WRONG-ANSWER
+ * @EXPECTED_RESULTS@: WRONG-ANSWER, TIMELIMIT
  */
 
 #include <unistd.h>


### PR DESCRIPTION
Whether this is actually time limit or wrong answer depends on the gitlab runner or its host.