### PR TITLE
Document possible outcomes for config check via API

### DIFF
--- a/.github/workflowscripts/baseinstall.sh
+++ b/.github/workflowscripts/baseinstall.sh
@@ -50,6 +50,7 @@ section_end
 
 section_start "Set simple admin password"
 echo "password" > ./etc/initial_admin_password.secret
+echo "machine localhost login admin password password" > ~/.netrc
 section_end
 
 section_start "Install domserver"

--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -257,7 +257,17 @@ class GeneralInfoController extends AbstractFOSRestController
      * @IsGranted("ROLE_ADMIN")
      * @OA\Response(
      *     response="200",
-     *     description="Result of the various checks performed",
+     *     description="Result of the various checks performed, no problems found",
+     *     @OA\JsonContent(type="object")
+     * )
+     * @OA\Response(
+     *     response="250",
+     *     description="Result of the various checks performed, warnings found",
+     *     @OA\JsonContent(type="object")
+     * )
+     * @OA\Response(
+     *     response="260",
+     *     description="Result of the various checks performed, errors found.",
      *     @OA\JsonContent(type="object")
      * )
      */
@@ -266,17 +276,17 @@ class GeneralInfoController extends AbstractFOSRestController
         $result = $this->checkConfigService->runAll();
 
         // Determine HTTP response code.
-        // If at least one test error: 500
-        // If at least one test warning: 300
+        // If at least one test error: 260
+        // If at least one test warning: 250
         // Otherwise 200
-        // We use max() here to make sure that if it is 300/500 it will never be 'lowered'
+        // We use max() here to make sure that if it is 250/260 it will never be 'lowered'
         $aggregate = 200;
         foreach ($result as &$cat) {
             foreach ($cat as &$test) {
                 if ($test['result'] == 'E') {
-                    $aggregate = max($aggregate, 500);
+                    $aggregate = max($aggregate, 260);
                 } elseif ($test['result'] == 'W') {
-                    $aggregate = max($aggregate, 300);
+                    $aggregate = max($aggregate, 250);
                 }
                 unset($test['escape']);
             }


### PR DESCRIPTION
The general advice for HTTP5xx is to repeat the request which would not help here. We now use unclaimed HTTP codes to stay within 2xx as the request worked, but now document the outcomes better so one doesn't need to check the code to know why these HTTP codes were returned.

Fixes: https://github.com/DOMjudge/domjudge/security/code-scanning/328