### PR TITLE
Dont return null as judgehost when judgehost is unknown

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -241,9 +241,9 @@ class JudgehostController extends AbstractFOSRestController
         if ($judgehost) {
             $judgehost->setEnabled($request->request->getBoolean('enabled'));
             $this->em->flush();
+            return [$judgehost];
         }
-
-        return [$judgehost];
+        throw new NotFoundHttpException(sprintf('Judgehost with hostname \'%s\' not found', $hostname));
     }
 
     /**


### PR DESCRIPTION
As this is not a fix to the docs but to the logic done in another PR.

Fixes: https://github.com/DOMjudge/domjudge/security/code-scanning/435