### PR TITLE
Extend with option to install additional repository lists

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -63,12 +63,16 @@ Options:
   -a <arch>    Machine architecture to use.
   -d <dir>     Directory where to build the chroot environment.
   -D <distro>  Linux distribution to use: 'Debian' or 'Ubuntu'.
-  -R <release> Release for the selected Linux distribution
+  -R <release> Release for the selected Linux distribution.
   -i <debs>    List of extra package names to install (comma separated).
   -r <debs>    List of extra package names to remove (comma separated).
   -l <debs>    List of local package files to install (comma separated).
-  -p <url>     HTTP(S) Proxy URL to use during package install
-  -m <url>     Debian or Ubuntu mirror URL to be used for package installation
+  -s <lists>   List of apt repository .list files that exist outside the chroot 
+               to add to the chroot (comma separated). Signing keys for the
+               repository will be imported if they exist as <filename>.gpg,
+               <filename>.asc or <filename>.arm.
+  -p <url>     HTTP(S) Proxy URL to use during package install.
+  -m <url>     Debian or Ubuntu mirror URL to be used for package installation.
   -y           Force overwriting the chroot dir and installing debootstrap.
   -f           Force the download of debootstrap even if it's already installed.
   -h           Display this help.
@@ -101,7 +105,7 @@ FORCEYES=0
 FORCEDOWNLOAD=0
 
 # Read command-line parameters:
-while getopts 'a:d:D:R:i:r:l:p:m:yfh' OPT ; do
+while getopts 'a:d:D:R:i:r:l:s:p:m:yfh' OPT ; do
     case $OPT in
         a) ARCH=$OPTARG ;;
         d) CHROOTDIR=$OPTARG ;;
@@ -110,6 +114,7 @@ while getopts 'a:d:D:R:i:r:l:p:m:yfh' OPT ; do
         i) INSTALLDEBS_EXTRA=$OPTARG ;;
         r) REMOVEDEBS_EXTRA=$OPTARG ;;
         l) LOCALDEBS=$OPTARG ;;
+        s) REPOLISTS=$OPTARG ;;
         p) DEBPROXY=$OPTARG ;;
         m) DEBMIRROR=$OPTARG ;;
         y) FORCEYES=1 ;;
@@ -394,6 +399,29 @@ if [ "$DISTRO" = 'Ubuntu' ]; then
     # Refer to: http://ubuntuforums.org/showthread.php?t=1326721
     in_chroot "dpkg-divert --local --rename --add /sbin/initctl"
     in_chroot "ln -s /bin/true /sbin/initctl"
+fi
+
+# Add additional repository lists to the chroot for upstream repos
+if [ -n "$REPOLISTS" ]; then
+    SPLIT_LIST=$(printf %s "$REPOLISTS" | tr ',' ' ')
+    for provided_repo in $SPLIT_LIST ; do
+        cat "$provided_repo" >> "$CHROOTDIR/etc/apt/sources.list.d/upstream_chroot.list"
+        for filetype in asc arm gpg; do
+            repo_sign_key="${provided_repo}.${filetype}"
+            if [ -f "${repo_sign_key}" ]; then
+                GPGFILENAME=$(mktemp -p "$CHROOTDIR/etc/apt/trusted.gpg.d" 'upstream_gpg_XXXXXX.gpg')
+                file_head=$(head -n1 "${repo_sign_key}")
+                if [ "-----BEGIN PGP ARMORED FILE-----" = "$file_head" ]; then
+                    gpg --dearmor "${repo_sign_key}"
+                    repo_sign_key="${repo_sign_key}.gpg"
+                fi
+                cp "${repo_sign_key}" "$GPGFILENAME"
+                chmod +r "$GPGFILENAME"
+            fi
+        done
+        # Show if we can read from this new upstream repo
+        in_chroot "apt-get update"
+    done
 fi
 
 # Upgrade the system, and install/remove packages as desired


### PR DESCRIPTION
- This will check for a gpg key and if its in armoured state
  - This will be trusted for all packes instead of only the single repo
- The repo will added as extra repository and packages can be installed from it
- Tests for this will be added in another PR

This is needed for the WFs to install the additional pypy repo.