### PR TITLE
Also include filename and executable bit in immutable executable hash.

### DIFF
--- a/webapp/src/Entity/ImmutableExecutable.php
+++ b/webapp/src/Entity/ImmutableExecutable.php
@@ -89,7 +89,7 @@ class ImmutableExecutable
         $this->hash = md5(
             join(
                 array_map(
-                    fn(ExecutableFile $file) => $file->getHash(),
+                    fn(ExecutableFile $file) => $file->getHash() . $file->getFilename() . $file->isExecutable(),
                     $filesArray
                 )
             )


### PR DESCRIPTION
In a situation where we
- would previously have cached an executable locally on a judgehost,
- reloaded the DB with a slightly changed executable, but the same immutable executable ID
- and the slight changes did not touch the content, but just the file names or executable bits the judgedaemon would not have realized it needs to update the executable.

Now the hash includes these metadata and should change.