### PR TITLE
Add support for a contest-wide scoreboard warning message

### DIFF
--- a/webapp/migrations/Version20221104143647.php
+++ b/webapp/migrations/Version20221104143647.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221104143647 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add new warning_message column to contest';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE contest ADD warning_message TEXT DEFAULT NULL COMMENT \'Warning message for this contest shown on the scoreboards\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE contest DROP warning_message');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -324,6 +324,15 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     private bool $openToAllTeams = true;
 
     /**
+     * @ORM\Column(type="text", length=65535, name="warning_message",
+     *     options={"comment"="Warning message for this contest shown on the scoreboards"},
+     *                          nullable=true)
+     * @Serializer\Groups({"Nonstrict"})
+     * @OA\Property(nullable=true)
+     */
+    private ?string $warningMessage = null;
+
+    /**
      * @ORM\Column(type="boolean", name="is_locked",
      *     options={"comment"="Is this contest locked for modifications?",
      *              "default"=0},
@@ -689,6 +698,17 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     public function getAllowSubmit(): bool
     {
         return $this->allowSubmit;
+    }
+
+    public function getWarningMessage(): ?string
+    {
+        return $this->warningMessage;
+    }
+
+    public function setWarningMessage(?string $warningMessage): Contest
+    {
+        $this->warningMessage = (empty($warningMessage) ? null : $warningMessage);
+        return $this;
     }
 
     public function setProcessBalloons(bool $processBalloons): Contest

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -168,6 +168,11 @@ class ContestType extends AbstractExternalIdEntityType
             'label' => 'Delete banner',
             'required' => false,
         ]);
+        $builder->add('warningMessage', TextType::class, [
+            'required' => false,
+            'label' => 'Scoreboard warning message',
+            'help' => 'When set, a warning message displayed above all scoreboards for this contest.',
+        ]);
         $builder->add('problems', CollectionType::class, [
             'entry_type' => ContestProblemType::class,
             'prototype' => true,

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -66,6 +66,9 @@ class ImportExportService
             'start-time' => Utils::absTime($contest->getStarttime(), true),
             'duration' => Utils::relTime($contest->getContestTime((float)$contest->getEndtime())),
         ];
+        if ($warnMsg = $contest->getWarningMessage()) {
+            $data['warningMessage'] = $warnMsg;
+        }
         if ($contest->getFreezetime() !== null) {
             $data['scoreboard-freeze-duration'] = Utils::relTime(
                 $contest->getContestTime((float)$contest->getEndtime()) - $contest->getContestTime((float)$contest->getFreezetime()),
@@ -157,6 +160,7 @@ class ImportExportService
                                $data['shortname'] ?? $data['short-name'] ?? $data['id']
                            ))
             ->setExternalid($contest->getShortname())
+            ->setWarningMessage($data['warningMessage'] ?? null)
             ->setStarttimeString(date_format($starttime, 'Y-m-d H:i:s e'))
             ->setActivatetimeString(date_format($activateTime, 'Y-m-d H:i:s e'))
             ->setEndtimeString(sprintf('+%s', $data['duration']));

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -67,7 +67,7 @@ class ImportExportService
             'duration' => Utils::relTime($contest->getContestTime((float)$contest->getEndtime())),
         ];
         if ($warnMsg = $contest->getWarningMessage()) {
-            $data['warningMessage'] = $warnMsg;
+            $data['warning-message'] = $warnMsg;
         }
         if ($contest->getFreezetime() !== null) {
             $data['scoreboard-freeze-duration'] = Utils::relTime(
@@ -160,7 +160,7 @@ class ImportExportService
                                $data['shortname'] ?? $data['short-name'] ?? $data['id']
                            ))
             ->setExternalid($contest->getShortname())
-            ->setWarningMessage($data['warningMessage'] ?? null)
+            ->setWarningMessage($data['warning-message'] ?? null)
             ->setStarttimeString(date_format($starttime, 'Y-m-d H:i:s e'))
             ->setActivatetimeString(date_format($activateTime, 'Y-m-d H:i:s e'))
             ->setEndtimeString(sprintf('+%s', $data['duration']));

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -213,6 +213,10 @@
                         <th>Banner</th>
                         <td><img style="max-width: 300px;" src="{{ asset(banner) }}" title="{{ contest.name }}" /></td>
                 {% endif %}
+                <tr>
+                    <th>Warning message</th>
+                    <td>{{ contest.warningMessage }}</td>
+                </tr>
             </table>
         </div>
     </div>

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -37,6 +37,7 @@
         {% if form.offsetExists('clearBanner') %}
             {{ form_row(form.clearBanner) }}
         {% endif %}
+        {{ form_row(form.warningMessage) }}
     </div>
     <div class="col-lg-6">
         <h5>Specification of contest times</h5>

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -11,6 +11,12 @@
 {% if current_contest is null %}
     <p class="nodata">No active contest</p>
 {% else %}
+    {% if current_contest.warningMessage %}
+        <div class="alert alert-danger" role="alert">
+            {{ current_contest.warningMessage }}
+        </div>
+    {% endif %}
+
     <div class="card">
         <div class="card-header" style="font-family: Roboto, sans-serif; display: flex;">
             <span style="font-weight: bold;">{{ current_contest.name }}</span>

--- a/webapp/tests/Unit/Controller/PublicControllerTest.php
+++ b/webapp/tests/Unit/Controller/PublicControllerTest.php
@@ -42,6 +42,23 @@ class PublicControllerTest extends BaseTest
         self::assertSelectorExists('p.nodata:contains("No active contest")');
     }
 
+    public function testScoreboardWarningMessage(): void
+    {
+        $this->verifyPageResponse('GET', '/public', 200);
+        self::assertSelectorNotExists('div.alert-danger');
+
+        $msg = 'This is a test contest';
+
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        /** @var Contest $contest */
+        $contest = $em->getRepository(Contest::class)->findOneBy(['externalid' => 'demo']);
+        $contest->setWarningMessage($msg);
+        $em->flush();
+
+        $this->verifyPageResponse('GET', '/public', 200);
+        self::assertSelectorTextContains('div.alert-danger', $msg);
+    }
+
     public function testNoSelfRegister(): void
     {
         $this->verifyPageResponse('GET', static::$urlRegister, 403);


### PR DESCRIPTION
Useful when specific contests are used for testing and to avoid any confusion about their officialdom.