### PR TITLE
Do not force hours in time diff to be at least two digits.

### DIFF
--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -259,7 +259,7 @@ class Utils
         $m = floor($s / 60);
         $s -= $m * 60;
 
-        return sprintf('%02d:%02d:%02d', $h, $m, $s);
+        return sprintf('%d:%02d:%02d', $h, $m, $s);
     }
 
     /**

--- a/webapp/tests/Unit/Utils/UtilsTest.php
+++ b/webapp/tests/Unit/Utils/UtilsTest.php
@@ -255,12 +255,13 @@ class UtilsTest extends TestCase
      */
     public function testTimeStringDiff(): void
     {
-        self::assertEquals("01:00:00", Utils::timeStringDiff("16:00:00", "15:00:00"));
-        self::assertEquals("00:00:03", Utils::timeStringDiff("16:00:00", "15:59:57"));
-        self::assertEquals("00:00:00", Utils::timeStringDiff("16:43:12", "16:43:12"));
-        self::assertEquals("00:14:55", Utils::timeStringDiff("01:50:50", "01:35:55"));
-        self::assertEquals("01:14:55", Utils::timeStringDiff("01:50:50", "00:35:55"));
-        self::assertEquals("01:14:55", Utils::timeStringDiff("01:50:50", "35:55"));
+        self::assertEquals("1:00:00", Utils::timeStringDiff("16:00:00", "15:00:00"));
+        self::assertEquals("0:00:03", Utils::timeStringDiff("16:00:00", "15:59:57"));
+        self::assertEquals("0:00:00", Utils::timeStringDiff("16:43:12", "16:43:12"));
+        self::assertEquals("0:14:55", Utils::timeStringDiff("01:50:50", "01:35:55"));
+        self::assertEquals("1:14:55", Utils::timeStringDiff("01:50:50", "00:35:55"));
+        self::assertEquals("1:14:55", Utils::timeStringDiff("01:50:50", "35:55"));
+        self::assertEquals("11:47:47", Utils::timeStringDiff("12:23:42", "35:55"));
     }
 
     /**


### PR DESCRIPTION
Previously, this caused ugly scoreboard free times such as +04:00:00.

Reported by @jsannemo