### PR TITLE
Use a shared service for awards between the API and the scoreboard. Fixes #1792

### DIFF
--- a/webapp/src/Service/AwardService.php
+++ b/webapp/src/Service/AwardService.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Contest;
+use App\Entity\Team;
+use App\Utils\Scoreboard\Scoreboard;
+
+class AwardService
+{
+    // TODO: add tests for this service
+
+    protected EventLogService $eventLogService;
+
+    public function __construct(EventLogService $eventLogService)
+    {
+        $this->eventLogService = $eventLogService;
+    }
+
+    public function getAwards(Contest $contest, Scoreboard $scoreboard, string $requestedType = null): ?array
+    {
+        $group_winners = $problem_winners = $problem_shortname = [];
+        $groups = [];
+        foreach ($scoreboard->getTeams() as $team) {
+            $teamid = $team->getApiId($this->eventLogService);
+            if ($scoreboard->isBestInCategory($team)) {
+                $catId = $team->getCategory()->getApiId($this->eventLogService);
+                $group_winners[$catId][] = $teamid;
+                $groups[$catId] = $team->getCategory()->getName();
+            }
+            foreach ($scoreboard->getProblems() as $problem) {
+                $shortname = $problem->getShortname();
+                $probid = $problem->getApiId($this->eventLogService);
+                if ($scoreboard->solvedFirst($team, $problem)) {
+                    $problem_winners[$probid][] = $teamid;
+                    $problem_shortname[$probid] = $shortname;
+                }
+            }
+        }
+        $results = [];
+        foreach ($group_winners as $id => $team_ids) {
+            $type = 'group-winner-' . $id;
+            $result = [ 'id' => $type,
+                'citation' => 'Winner(s) of group ' . $groups[$id],
+                'team_ids' => $team_ids];
+            if ($requestedType === $type) {
+                return $result;
+            }
+            $results[] = $result;
+        }
+        foreach ($problem_winners as $id => $team_ids) {
+            $type = 'first-to-solve-' . $id;
+            $result = [ 'id' => $type,
+                'citation' => 'First to solve problem ' . $problem_shortname[$id],
+                'team_ids' => $team_ids];
+            if ($requestedType === $type) {
+                return $result;
+            }
+            $results[] = $result;
+        }
+        $overall_winners = $medal_winners = [];
+
+        $additionalBronzeMedals = $contest->getB() ?? 0;
+
+        // Can we assume this is ordered just walk the first 12+B entries?
+        foreach ($scoreboard->getScores() as $teamScore) {
+            if ($teamScore->numPoints == 0) {
+                continue;
+            }
+            $rank = $teamScore->rank;
+            $teamid = $teamScore->team->getApiId($this->eventLogService);
+            if ($rank === 1) {
+                $overall_winners[] = $teamid;
+            }
+            if ($contest->getMedalsEnabled() && $contest->getMedalCategories()->contains($teamScore->team->getCategory())) {
+                if ($rank <= $contest->getGoldMedals()) {
+                    $medal_winners['gold'][] = $teamid;
+                } elseif ($rank <= $contest->getGoldMedals() + $contest->getSilverMedals()) {
+                    $medal_winners['silver'][] = $teamid;
+                } elseif ($rank <= $contest->getGoldMedals() + $contest->getSilverMedals() + $contest->getBronzeMedals() + $additionalBronzeMedals) {
+                    $medal_winners['bronze'][] = $teamid;
+                }
+            }
+        }
+        if (count($overall_winners) > 0) {
+            $type = 'winner';
+            $result = [
+                'id' => $type,
+                'citation' => 'Contest winner',
+                'team_ids' => $overall_winners
+            ];
+            if ($requestedType === $type) {
+                return $result;
+            }
+            $results[] = $result;
+        }
+        foreach ($medal_winners as $metal => $team_ids) {
+            $type = $metal . '-medal';
+            $result = [
+                'id' => $metal . '-medal',
+                'citation' => ucfirst($metal) . ' medal winner',
+                'team_ids' => $team_ids
+            ];
+            if ($requestedType === $type) {
+                return $result;
+            }
+            $results[] = $result;
+        }
+
+        // Specific type was requested, but not found above.
+        if (!is_null($requestedType)) {
+            return null;
+        }
+
+        return $results;
+    }
+
+    public function medalType(Team $team, Contest $contest, Scoreboard $scoreboard): ?string
+    {
+        $teamid = $team->getApiId($this->eventLogService);
+        $awards = $this->getAwards($contest, $scoreboard);
+        $awardsById = [];
+        foreach ($awards as $award) {
+            $awardsById[$award['id']] = $award;
+        }
+        $medalNames = ['gold-medal', 'silver-medal', 'bronze-medal'];
+        foreach ($medalNames as $medalName) {
+            if (in_array($teamid, $awardsById[$medalName]['team_ids'] ?? [])) {
+                return $medalName;
+            }
+        }
+        return null;
+    }
+}

--- a/webapp/src/Service/AwardService.php
+++ b/webapp/src/Service/AwardService.php
@@ -8,8 +8,6 @@ use App\Utils\Scoreboard\Scoreboard;
 
 class AwardService
 {
-    // TODO: add tests for this service
-
     protected EventLogService $eventLogService;
 
     public function __construct(EventLogService $eventLogService)

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -13,6 +13,7 @@ use App\Entity\Language;
 use App\Entity\Submission;
 use App\Entity\SubmissionFile;
 use App\Entity\Testcase;
+use App\Service\AwardService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -40,6 +41,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     protected EntityManagerInterface $em;
     protected SubmissionService $submissionService;
     protected EventLogService $eventLogService;
+    protected AwardService $awards;
     protected TokenStorageInterface $tokenStorage;
     protected AuthorizationCheckerInterface $authorizationChecker;
     protected string $projectDir;
@@ -51,6 +53,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         EntityManagerInterface        $em,
         SubmissionService             $submissionService,
         EventLogService               $eventLogService,
+        AwardService                  $awards,
         TokenStorageInterface         $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
         string                        $projectDir
@@ -61,6 +64,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         $this->em                   = $em;
         $this->submissionService    = $submissionService;
         $this->eventLogService      = $eventLogService;
+        $this->awards               = $awards;
         $this->tokenStorage         = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->projectDir           = $projectDir;
@@ -122,6 +126,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('printMetadata', [$this, 'printMetadata'], ['is_safe' => ['html']]),
             new TwigFilter('printWarningContent', [$this, 'printWarningContent'], ['is_safe' => ['html']]),
             new TwigFilter('entityIdBadge', [$this, 'entityIdBadge'], ['is_safe' => ['html']]),
+            new TwigFilter('medalType', [$this->awards, 'medalType']),
         ];
     }
 

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -19,10 +19,6 @@
 {% set scores = scoreboard.scores | filter(score => limitToTeams is null or score.team.teamid in limitToTeamIds) %}
 {% set problems = scoreboard.problems %}
 {% set medalsEnabled = contest.medalsEnabled %}
-{% if scoreFilter and scoreFilter.filteredOn is not empty %}
-    {% set medalsEnabled = false %}
-{% endif %}
-{% set medalCategories = contest.medalCategories %}
 
 {% if maxWidth > 0 %}
     <style>
@@ -119,15 +115,8 @@
 
         {# process medal color #}
         {% set medalColor = '' %}
-        {% if showLegends and medalsEnabled and score.team.category in medalCategories and score.numPoints > 0 %}
-            {% set medalCount = medalCount + 1 %}
-            {% if medalCount <= contest.goldMedals %}
-                {% set medalColor = 'gold-medal' %}
-            {% elseif medalCount <= contest.goldMedals + contest.silverMedals %}
-                {% set medalColor = 'silver-medal' %}
-            {% elseif medalCount <= contest.goldMedals + contest.silverMedals + contest.bronzeMedals + contest.b %}
-                {% set medalColor = 'bronze-medal' %}
-            {% endif %}
+        {% if showLegends %}
+            {% set medalColor = score.team | medalType(contest, scoreboard) %}
         {% endif %}
 
         {# check whether this is us, otherwise use category colour #}

--- a/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
@@ -2,11 +2,19 @@
 
 namespace App\Tests\Unit\Controller\API;
 
+use App\DataFixtures\Test\SampleSubmissionsThreeTriesCorrectFixture;
+use App\Entity\Contest;
+use App\Service\ScoreboardService;
+use Doctrine\ORM\EntityManagerInterface;
+
 class AwardsControllerTest extends BaseTest
 {
     protected ?string $apiEndpoint = 'awards';
 
     protected static string $skipMessageIDs = "Filtering on IDs not implemented in this endpoint.";
+
+    // We add a submission since we are not handing out any awards without it
+    protected static array $fixtures = [SampleSubmissionsThreeTriesCorrectFixture::class];
 
     /**
      * In the default test setup there are no judgings yet and one team.
@@ -17,6 +25,20 @@ class AwardsControllerTest extends BaseTest
     ];
 
     protected array $expectedAbsent = ['bronze-medal', 'first-to-solve'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // We need to refersh the scoreboard cache since we have added a submission
+        /** @var EntityManagerInterface $manager */
+        $manager = static::getContainer()->get(EntityManagerInterface::class);
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        /** @var ScoreboardService $scoreboardService */
+        $scoreboardService = static::getContainer()->get(ScoreboardService::class);
+        $scoreboardService->refreshCache($contest);
+    }
 
     public function testListWithIds(): void
     {

--- a/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AwardsControllerTest.php
@@ -30,7 +30,7 @@ class AwardsControllerTest extends BaseTest
     {
         parent::setUp();
 
-        // We need to refersh the scoreboard cache since we have added a submission
+        // We need to refresh the scoreboard cache since we added a submission
         /** @var EntityManagerInterface $manager */
         $manager = static::getContainer()->get(EntityManagerInterface::class);
         /** @var Contest $contest */

--- a/webapp/tests/Unit/Service/AwardServiceTest.php
+++ b/webapp/tests/Unit/Service/AwardServiceTest.php
@@ -21,7 +21,7 @@ class AwardServiceTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        // THe contest with have 1 gold, 1 silver and 2 bronze medals
+        // The contest with have 1 gold, 1 silver and 2 bronze medals
         $this->contest = (new Contest())
             ->setMedalsEnabled(true)
             ->setGoldMedals(1)

--- a/webapp/tests/Unit/Service/AwardServiceTest.php
+++ b/webapp/tests/Unit/Service/AwardServiceTest.php
@@ -21,7 +21,7 @@ class AwardServiceTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        // The contest with have 1 gold, 1 silver and 2 bronze medals
+        // The contest will have 1 gold, 1 silver and 2 bronze medals
         $this->contest = (new Contest())
             ->setMedalsEnabled(true)
             ->setGoldMedals(1)

--- a/webapp/tests/Unit/Service/AwardServiceTest.php
+++ b/webapp/tests/Unit/Service/AwardServiceTest.php
@@ -1,0 +1,223 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Problem;
+use App\Entity\ScoreCache;
+use App\Entity\Team;
+use App\Entity\TeamCategory;
+use App\Service\AwardService;
+use App\Service\EventLogService;
+use App\Utils\Scoreboard\Scoreboard;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AwardServiceTest extends KernelTestCase
+{
+    protected Contest $contest;
+    protected Scoreboard $scoreboard;
+
+    protected function setUp(): void
+    {
+        // THe contest with have 1 gold, 1 silver and 2 bronze medals
+        $this->contest = (new Contest())
+            ->setMedalsEnabled(true)
+            ->setGoldMedals(1)
+            ->setSilverMedals(1)
+            ->setBronzeMedals(1);
+        $categoryA = (new TeamCategory())
+            ->setName('Category A')
+            ->setExternalid('cat_A');
+        $categoryB = (new TeamCategory())
+            ->setName('Category B')
+            ->setExternalid('cat_B');
+        $this->contest
+            ->addMedalCategory($categoryA)
+            ->addMedalCategory($categoryB);
+        $reflectedProblem = new ReflectionClass(TeamCategory::class);
+        $teamIdProperty = $reflectedProblem->getProperty('categoryid');
+        $teamIdProperty->setValue($categoryA, 1);
+        $teamIdProperty->setValue($categoryB, 2);
+        $categories = [$categoryA, $categoryB];
+        // Create 4 teams, each belonging to a category
+        $teams = [];
+        foreach (['A', 'B', 'C', 'D'] as $teamLetter) {
+            $team = (new Team())
+                ->setName('Team ' . $teamLetter)
+                ->setExternalid('team_' . $teamLetter)
+                ->setCategory(in_array($teamLetter, ['A', 'B']) ? $categoryA : $categoryB)
+                ->setAffiliation(); // No affiliation needed
+            $reflectedProblem = new ReflectionClass(Team::class);
+            $teamIdProperty = $reflectedProblem->getProperty('teamid');
+            $teamIdProperty->setValue($team, count($teams));
+            $teams[] = $team;
+        }
+        // Create 4 problems
+        $problems = [];
+        foreach (['A', 'B', 'C', 'D'] as $problemLabel) {
+            $problem = (new ContestProblem())
+                ->setProblem(
+                    (new Problem())
+                        ->setName('Problem ' . $problemLabel)
+                        ->setExternalid('problem_' . $problemLabel)
+                )
+                ->setContest($this->contest)
+                ->setShortname($problemLabel);
+            $reflectedProblem = new ReflectionClass(Problem::class);
+            $probIdProperty = $reflectedProblem->getProperty('probid');
+            $probIdProperty->setValue($problem->getProblem(), count($problems));
+            $problems[] = $problem;
+        }
+
+        // Now generate some scores. We will create the following solves:
+        // (a numbers is the solve time or an x means not solved)
+        //
+        // Team | A  B  C  D
+        // -----+-----------
+        // A    | 1  5  10 20
+        // B    | x  2  3  x
+        // C    | x  x  x  4
+        // D    | x  x  x  x
+        //
+        // THis means A is the overall winner, will get a gold medal and is the winner
+        // of category A. It is also first to solve problem A.
+        // B is second, so it gets a silver medal. It is also first to solve problem B and C
+        // C is the first to solve problem D, gets a bronze medal and is winner of category B.
+        // D didn't solve anything, so it will not get any medals at all
+
+        $minute = 60;
+        // Indexed first by team, then by problem
+        $scores = [
+            'A' => [
+                'A' => 1,
+                'B' => 5,
+                'C' => 10,
+                'D' => 20,
+            ],
+            'B' => [
+                'B' => 2,
+                'C' => 3,
+            ],
+            'C' => [
+                'D' => 4,
+            ],
+        ];
+        $scoreCache = [];
+        foreach ($scores as $teamLabel => $scoresForTeam) {
+            foreach ($scoresForTeam as $problemLabel => $minute) {
+                $firstToSolve = in_array(
+                    $teamLabel . $problemLabel,
+                    ['AA', 'BB', 'BC', 'CD']
+                );
+                $scoreCache[] = (new ScoreCache())
+                    ->setContest($this->contest)
+                    ->setTeam($teams[ord($teamLabel) - ord('A')])
+                    ->setProblem($problems[ord($problemLabel) - ord('A')]->getProblem())
+                    ->setSubmissionsRestricted(1)
+                    ->setSolvetimeRestricted(60 * $minute)
+                    ->setIsCorrectRestricted(true)
+                    ->setIsFirstToSolve($firstToSolve);
+            }
+        }
+
+        $this->scoreboard = new Scoreboard(
+            $this->contest,
+            $teams,
+            $categories,
+            $problems,
+            $scoreCache,
+            $this->contest->getFreezeData(),
+            true,
+            20,
+            false
+        );
+    }
+
+    protected function getAwardService(): AwardService
+    {
+        // Always use external IDs so we also test that those are used in the correct spot
+        $eventLogService = $this->createMock(EventLogService::class);
+        $eventLogService->expects(self::any())
+            ->method('apiIdFieldForEntity')
+            ->willReturn('externalId');
+        return new AwardService($eventLogService);
+    }
+
+    protected function getAward(string $label): ?array
+    {
+        return $this->getAwardService()->getAwards($this->contest, $this->scoreboard, $label);
+    }
+
+    public function testWinner(): void
+    {
+        $winner = $this->getAward('winner');
+        static::assertNotNull($winner);
+        static::assertEquals('Contest winner', $winner['citation']);
+        static::assertEquals(['team_A'], $winner['team_ids']);
+    }
+
+    public function testMedals(): void
+    {
+        $medals = [
+            'gold' => 'team_A',
+            'silver' => 'team_B',
+            'bronze' => 'team_C',
+        ];
+        foreach ($medals as $medal => $team) {
+            $medalAward = $this->getAward($medal . '-medal');
+            static::assertNotNull($medalAward);
+            static::assertEquals(ucfirst($medal) . ' medal winner', $medalAward['citation']);
+            static::assertEquals([$team], $medalAward['team_ids']);
+        }
+    }
+
+    public function testGroupWinners(): void
+    {
+        $groupAWinner = $this->getAward('group-winner-cat_A');
+        static::assertNotNull($groupAWinner);
+        static::assertEquals('Winner(s) of group Category A', $groupAWinner['citation']);
+        static::assertEquals(['team_A'], $groupAWinner['team_ids']);
+
+        $a = $this->getAwardService()->getAwards($this->contest, $this->scoreboard);
+        $groupBWinner = $this->getAward('group-winner-cat_B');
+        static::assertNotNull($groupBWinner);
+        static::assertEquals('Winner(s) of group Category B', $groupBWinner['citation']);
+        static::assertEquals(['team_C'], $groupBWinner['team_ids']);
+    }
+
+    public function testFirstToSolve(): void
+    {
+        $fts = [
+            'A' => 'A',
+            'B' => 'B',
+            'C' => 'B',
+            'D' => 'C',
+        ];
+        foreach ($fts as $problem => $team) {
+            $firstToSolve = $this->getAward('first-to-solve-problem_' . $problem);
+            static::assertNotNull($firstToSolve);
+            static::assertEquals('First to solve problem ' . $problem, $firstToSolve['citation']);
+            static::assertEquals(['team_' . $team], $firstToSolve['team_ids']);
+        }
+    }
+
+    /**
+     * @dataProvider provideMedalType
+     */
+    public function testMedalType(int $teamIndex, ?string $expectedMedalType)
+    {
+        $awardsService = $this->getAwardService();
+        $team = $this->scoreboard->getTeams()[$teamIndex];
+        static::assertEquals($expectedMedalType, $awardsService->medalType($team, $this->contest, $this->scoreboard));
+    }
+
+    public function provideMedalType(): \Generator
+    {
+        yield [0, 'gold-medal'];
+        yield [1, 'silver-medal'];
+        yield [2, 'bronze-medal'];
+        yield [3, null];
+    }
+}


### PR DESCRIPTION
Also do not hand out any (medal) winner awards for teams who did not score.

Note: at a later point I want to add tests for the service, but for now we have the ones from the API (which are limited).