### PR TITLE
Disallow changes to immutable executables or files in them. Fixes #1796.

### DIFF
--- a/webapp/src/Entity/ExecutableFile.php
+++ b/webapp/src/Entity/ExecutableFile.php
@@ -16,6 +16,7 @@ use JMS\Serializer\Annotation as Serializer;
  *         @ORM\UniqueConstraint(name="rankindex", columns={"immutable_execid", "ranknumber"}),
  *         @ORM\UniqueConstraint(name="filename", columns={"immutable_execid", "filename"}, options={"lengths": {NULL, 190}})
  *     })
+ * @ORM\HasLifecycleCallbacks()
  */
 class ExecutableFile
 {
@@ -137,5 +138,13 @@ class ExecutableFile
     public function isExecutable(): bool
     {
         return $this->isExecutable;
+    }
+
+    /**
+     * @ORM\PreRemove()
+     */
+    public function disallowDelete(): void
+    {
+        throw new \RuntimeException('An executable file cannot be deleted');
     }
 }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -924,9 +924,8 @@ class DOMJudgeService
     public function createImmutableExecutable(ZipArchive $zip): ImmutableExecutable
     {
         $propertyFile = 'domjudge-executable.ini';
-        $immutableExecutable = new ImmutableExecutable();
-        $this->em->persist($immutableExecutable);
         $rank = 0;
+        $files = [];
         for ($idx = 0; $idx < $zip->numFiles; $idx++) {
             $filename = basename($zip->getNameIndex($idx));
             if ($filename === $propertyFile) {
@@ -951,13 +950,13 @@ class DOMJudgeService
                 ->setRank($rank)
                 ->setFilename($filename)
                 ->setFileContent($zip->getFromIndex($idx))
-                ->setImmutableExecutable($immutableExecutable)
                 ->setIsExecutable($executableBit);
             $this->em->persist($executableFile);
-            $immutableExecutable->addFile($executableFile);
+            $files[] = $executableFile;
             $rank++;
         }
-        $immutableExecutable->updateHash();
+        $immutableExecutable = new ImmutableExecutable($files);
+        $this->em->persist($immutableExecutable);
         $this->em->flush();
         return $immutableExecutable;
     }

--- a/webapp/templates/jury/executable_edit_content.html.twig
+++ b/webapp/templates/jury/executable_edit_content.html.twig
@@ -37,7 +37,7 @@
                         {% if is_granted('ROLE_ADMIN') %}
                             <a class="btn btn-secondary btn-sm"
                                data-ajax-modal
-                               href="{{ path('jury_executable_delete_single', {execId: executable.execid, rank: ranks[idx]}) }}">
+                               href="{{ path('jury_executable_delete_single', {execId: executable.execid, rankToDelete: ranks[idx]}) }}">
                                 <i class="fas fa-trash"></i> Delete
                             </a>
                         {% endif %}


### PR DESCRIPTION
I did the thing Jaap suggested and removed all writable methods on the immutable executable entity.

However, we removed executable files from the DB directly, so I also forbid that.