### PR TITLE
Allow setting activation time in contest.yaml

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -138,7 +138,7 @@ class ImportExportService
         $activateTimeFields = ['activation_time','activate_time','activation-time', 'activate-time'];
         $deactivateTimeFields = preg_filter('/^/', 'de', $activateTimeFields);
         $startTimeFields = ['start_time', 'start-time'];
-        $requiredFields = [$startTimeFields, 'formal_name', ['id', 'name', 'short-name', 'short_name'], 'duration'];
+        $requiredFields = [$startTimeFields, ['name', 'formal_name'], ['id', 'short_name', 'short-name'], 'duration'];
         $missingFields = [];
         foreach ($requiredFields as $field) {
             if (is_array($field)) {
@@ -188,7 +188,7 @@ class ImportExportService
 
         $contest = new Contest();
         $contest
-            ->setName($data['formal_name'])
+            ->setName($data['name'] ?? $data['formal_name'] )
             ->setShortname(preg_replace(
                                $invalid_regex,
                                '_',

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -47,19 +47,34 @@ class ImportExportService
         // We expect contest.yaml and problemset.yaml combined into one file here.
 
         $data = [
+            'id' => $contest->getExternalid(),
             'formal_name' => $contest->getName(),
             'name' => $contest->getShortname(),
             'start_time' => Utils::absTime($contest->getStarttime(), true),
+            'end_time' => Utils::absTime($contest->getEndtime(), true),
             'duration' => Utils::relTime($contest->getContestTime((float)$contest->getEndtime())),
             'penalty_time' => $this->config->get('penalty_time'),
+            'activation_time' => Utils::absTime($contest->getActivatetime(), true),
         ];
         if ($warnMsg = $contest->getWarningMessage()) {
             $data['warning_message'] = $warnMsg;
         }
         if ($contest->getFreezetime() !== null) {
+            $data['scoreboard_freeze_time'] = Utils::absTime($contest->getFreezetime(), true);
             $data['scoreboard_freeze_duration'] = Utils::relTime(
                 $contest->getContestTime((float)$contest->getEndtime()) - $contest->getContestTime((float)$contest->getFreezetime()),
-                true);
+                true,
+            );
+            if ($contest->getUnfreezetime() !== null) {
+                $data['scoreboard_thaw_time'] = Utils::absTime($contest->getUnfreezetime(), true);
+            }
+        }
+        if ($contest->getFinalizetime() !== null) {
+            $data['finalize_time'] = Utils::absTime($contest->getFinalizetime(), true);
+        }
+
+        if ($contest->getDeactivatetime() !== null) {
+            $data['deactivate_time'] = Utils::absTime($contest->getDeactivatetime(), true);
         }
 
         if ($includeProblems) {

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -110,11 +110,12 @@ class ImportExportService
         $timeValue = null;
         $usedField = null;
         foreach ($fields as $field) {
-            if ($timeValue) {
-                continue;
-            }
             $timeValue = $data[$field] ?? null;
             $usedField = $field;
+            // We need to check as the value for the key can be null
+            if ($timeValue) {
+                break;
+            }
         }
 
         if (is_string($timeValue)) {

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -136,10 +136,10 @@ class ImportExportService
         return $time instanceof DateTime ? DateTimeImmutable::createFromMutable($time) : $time;
     }
 
-    public function importContestData($data, ?string &$message = null, string &$cid = null): bool
+    public function importContestData($data, ?string &$errorMessage = null, string &$cid = null): bool
     {
         if (empty($data) || !is_array($data)) {
-            $message = 'Error parsing YAML file.';
+            $errorMessage = 'Error parsing YAML file.';
             return false;
         }
 
@@ -167,20 +167,20 @@ class ImportExportService
         }
 
         if (!empty($missingFields)) {
-            $message = sprintf('Missing fields: %s', implode(', ', $missingFields));
+            $errorMessage = sprintf('Missing fields: %s', implode(', ', $missingFields));
             return false;
         }
 
         $invalid_regex = str_replace(['/^[', '+$/'], ['/[^', '/'], DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX);
 
-        $startTime = $this->convertImportedTime($startTimeFields, $data, $message);
-        if ($message) {
+        $startTime = $this->convertImportedTime($startTimeFields, $data, $errorMessage);
+        if ($errorMessage) {
             return false;
         }
 
         // Activate time is special, it can return non empty message for parsing error or null if no field was provided
-        $activateTime = $this->convertImportedTime($activateTimeFields, $data, $message);
-        if ($message) {
+        $activateTime = $this->convertImportedTime($activateTimeFields, $data, $errorMessage);
+        if ($errorMessage) {
             return false;
         } elseif (!$activateTime) {
             $activateTime = new DateTime();
@@ -189,8 +189,8 @@ class ImportExportService
             }
         }
 
-        $deactivateTime = $this->convertImportedTime($deactivateTimeFields, $data, $message);
-        if ($message) {
+        $deactivateTime = $this->convertImportedTime($deactivateTimeFields, $data, $errorMessage);
+        if ($errorMessage) {
             return false;
         }
 
@@ -230,7 +230,7 @@ class ImportExportService
         if ($freezeDuration !== null) {
             $freezeDurationDiff = Utils::timeStringDiff($data['duration'], $freezeDuration);
             if (str_starts_with($freezeDurationDiff, '-')) {
-                $message = 'Freeze duration is longer than contest length';
+                $errorMessage = 'Freeze duration is longer than contest length';
                 return false;
             }
             $contest->setFreezetimeString(sprintf('+%s', $freezeDurationDiff));
@@ -246,7 +246,7 @@ class ImportExportService
                 $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
             }
 
-            $message = sprintf("Contest has errors:\n\n%s", implode("\n", $messages));
+            $errorMessage = sprintf("Contest has errors:\n\n%s", implode("\n", $messages));
             return false;
         }
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -135,8 +135,8 @@ class ImportExportService
             return false;
         }
 
-        $starttimeFields = ['start_time', 'start-time'];
-        $requiredFields = [$starttimeFields, 'name', ['id', 'short-name'], 'duration'];
+        $startTimeFields = ['start_time', 'start-time'];
+        $requiredFields = [$startTimeFields, 'name', ['id', 'short-name'], 'duration'];
         $missingFields = [];
         foreach ($requiredFields as $field) {
             if (is_array($field)) {
@@ -163,14 +163,14 @@ class ImportExportService
 
         $invalid_regex = str_replace(['/^[', '+$/'], ['/[^', '/'], DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX);
 
-        $starttime = $this->convertImportedTime($starttimeFields, $data, $message);
+        $startTime = $this->convertImportedTime($startTimeFields, $data, $message);
         if ($message) {
             return false;
         }
 
         $activateTime = new DateTime();
-        if ($activateTime > $starttime) {
-            $activateTime = $starttime;
+        if ($activateTime > $startTime) {
+            $activateTime = $startTime;
         }
         $contest = new Contest();
         $contest
@@ -182,7 +182,7 @@ class ImportExportService
                            ))
             ->setExternalid($contest->getShortname())
             ->setWarningMessage($data['warning-message'] ?? null)
-            ->setStarttimeString(date_format($starttime, 'Y-m-d H:i:s e'))
+            ->setStarttimeString(date_format($startTime, 'Y-m-d H:i:s e'))
             ->setActivatetimeString(date_format($activateTime, 'Y-m-d H:i:s e'))
             ->setEndtimeString(sprintf('+%s', $data['duration']));
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -99,7 +99,13 @@ class ImportExportService
         return $data;
     }
 
-    protected function convertImportedTime(array $fields, array $data, ?string &$message = null): ?DateTimeImmutable
+    /**
+     * Finds the first set field from $fields in $data and parse it as a date.
+     *
+     * To verify that everything works as expected the $errorMessage needs to be checked
+     * for parsing errors.
+     */
+    protected function convertImportedTime(array $fields, array $data, ?string &$errorMessage = null): ?DateTimeImmutable
     {
         $timeValue = null;
         $usedField = null;
@@ -119,8 +125,9 @@ class ImportExportService
             /** @var DateTime $time */
             $time = $timeValue;
         }
+        // If/When parsing fails we get a false instead of a null
         if ($time === false) {
-            $message = 'Can not parse '.$usedField;
+            $errorMessage = 'Can not parse '.$usedField;
             return null;
         } elseif ($time) {
             $time = $time->setTimezone(new DateTimeZone(date_default_timezone_get()));

--- a/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
@@ -52,12 +52,16 @@ problems:
     short-name: cheating
 EOF;
         $expectedYaml = <<<EOF
-duration: 2:00:00.000
+id: practice
 formal_name: NWERC 2020 Practice Session
-penalty_time: 20
-scoreboard_freeze_duration: 0:30:00
 name: practice
+activation_time: '2021-03-27T09:00:00+00:00'
 start_time: '2021-03-27T09:00:00+00:00'
+end_time: '2021-03-27T11:00:00+00:00'
+duration: 2:00:00.000
+penalty_time: 20
+scoreboard_freeze_time: '2021-03-27T10:30:00+00:00'
+scoreboard_freeze_duration: 0:30:00
 EOF;
 
         $url = $this->helperGetEndpointURL($this->apiEndpoint);

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -91,12 +91,17 @@ class ImportExportControllerTest extends BaseTestCase
     public function provideContestYamlContents(): Generator
     {
         $year = date('Y')+1;
+        $pastYear = date('Y');
         $yaml =<<<HEREDOC
+id: demo
 formal_name: 'Demo contest'
 name: demo
 start_time: '{$year}-01-01T08:00:00+00:00'
+end_time: '{$year}-01-01T13:00:00+00:00'
 duration: '5:00:00.000'
 penalty_time: 20
+activation_time: '{$pastYear}-01-01T08:00:00+00:00'
+scoreboard_freeze_time: '{$year}-01-01T12:00:00+00:00'
 scoreboard_freeze_duration: '1:00:00'
 problems:
     -

--- a/webapp/tests/Unit/Service/ImportExportServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportExportServiceTest.php
@@ -37,8 +37,8 @@ class ImportExportServiceTest extends KernelTestCase
     public function provideImportContestDataErrors(): Generator
     {
         yield [[], 'Error parsing YAML file.'];
-        yield [['name' => 'Some name'], 'Missing fields: one of (start_time, start-time), one of (id, short-name), duration'];
-        yield [['short-name' => 'somename', 'start-time' => '2020-01-01 12:34:56'], 'Missing fields: name, duration'];
+        yield [['name' => 'Some name'], 'Missing fields: one of (start_time, start-time), one of (id, short_name, short-name), duration'];
+        yield [['short-name' => 'somename', 'start-time' => '2020-01-01 12:34:56'], 'Missing fields: one of (name, formal_name), duration'];
         yield [
             [
                 'name'       => 'Test contest',

--- a/webapp/tests/Unit/Service/ImportExportServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportExportServiceTest.php
@@ -46,7 +46,7 @@ class ImportExportServiceTest extends KernelTestCase
                 'duration'   => '5:00:00',
                 'start-time' => 'Invalid start time here',
             ],
-            'Can not parse start time'
+            'Can not parse start-time'
         ];
         yield [
             [
@@ -55,7 +55,7 @@ class ImportExportServiceTest extends KernelTestCase
                 'duration'   => '5:00:00',
                 'start_time' => 'Invalid start time here',
             ],
-            'Can not parse start time'
+            'Can not parse start_time'
         ];
         yield [
             [


### PR DESCRIPTION
Closes https://github.com/DOMjudge/domjudge/issues/1719

I've added some more times to the contest which might be useful. If we can expose a property but currently it's null, should we display as null or do we omit it from the                                response? I've now chosen to omit as that is also easier to parse for downstream clients. It's easy to crash an a missing key and fix it, but finding why you get a strange time when converting null to something else is slightly harder IMO.