### PR TITLE
Show stacktrace for queries in debug bar.

### DIFF
--- a/webapp/config/packages/doctrine.yaml
+++ b/webapp/config/packages/doctrine.yaml
@@ -8,6 +8,7 @@ doctrine:
             collate: utf8mb4_unicode_ci
 
         url: '%env(resolve:DATABASE_URL)%'
+        profiling_collect_backtrace: '%kernel.debug%'
         types:
             tinyint: App\Doctrine\DBAL\Types\TinyIntType
             blobtext: App\Doctrine\DBAL\Types\BlobTextType


### PR DESCRIPTION
People in the Symfony Slack told me about this. I think it's useful.
There is a "minor" performance impact in dev mode and 0 in production, and I think it's worth it.