### PR TITLE
Use a wrapper function dj_sleep around time_nanosleep.

### DIFF
--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -15,7 +15,7 @@ define('CREATE_WRITABLE_TEMP_DIR', getenv('DOMJUDGE_CREATE_WRITABLE_TEMP_DIR') ?
 // If any transient network error occurs on the nth trial,
 // the judgehost retries the HTTP request after pow(factor, trial - 1) + rand(0, jitter) sec.
 
-function define_backoff_params_from_env(string $var_name, int|float $default_value) {
+function define_backoff_params_from_env(string $var_name, $default_value) {
     if (defined($var_name)) {
         return;
     }
@@ -25,7 +25,7 @@ function define_backoff_params_from_env(string $var_name, int|float $default_val
             'min_range' => 0,
         ),
     );
-    $final_value = filter_var(getenv('DOMJUDGE_' . $var_name), FILTER_VALIDATE_INT, $options);
+    $final_value = filter_var(getenv('DOMJUDGE_' . $var_name), FILTER_VALIDATE_FLOAT, $options);
     define($var_name, $final_value);
 }
 

--- a/etc/judgehost-config.php
+++ b/etc/judgehost-config.php
@@ -13,9 +13,9 @@ define('CREATE_WRITABLE_TEMP_DIR', getenv('DOMJUDGE_CREATE_WRITABLE_TEMP_DIR') ?
 
 // These define HTTP request backoff related constants.
 // If any transient network error occurs on the nth trial,
-// the judgehost retries the HTTP request after (1000 * pow(factor, trial - 1) + rand(0, jitter)) ms.
+// the judgehost retries the HTTP request after pow(factor, trial - 1) + rand(0, jitter) sec.
 
-function define_backoff_params_from_env(string $var_name, int $default_value) {
+function define_backoff_params_from_env(string $var_name, int|float $default_value) {
     if (defined($var_name)) {
         return;
     }
@@ -29,7 +29,7 @@ function define_backoff_params_from_env(string $var_name, int $default_value) {
     define($var_name, $final_value);
 }
 
-define_backoff_params_from_env('BACKOFF_JITTER_MS', 200);
+define_backoff_params_from_env('BACKOFF_JITTER_SEC', 0.2);
 define_backoff_params_from_env('BACKOFF_FACTOR', 2);
 define_backoff_params_from_env('BACKOFF_STEPS', 3);
-define_backoff_params_from_env('BACKOFF_INITIAL_DELAY_MS', 1000);
+define_backoff_params_from_env('BACKOFF_INITIAL_DELAY_SEC', 1.0);

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -579,7 +579,8 @@ if (!empty($options['e'])) {
             break;
         }
         logmsg(LOG_WARNING, "Failed to report $judgeTaskId in attempt #" . ($i + 1) . ".");
-        dj_sleep(0.0001 * random_int(3, ($i+1)*10));
+        $sleep_ms = 100 + random_int(200, ($i+1)*1000);
+        dj_sleep(0.001 * $sleep_ms);
     }
     unlink($options['j']);
     exit(0);

--- a/lib/lib.wrappers.php
+++ b/lib/lib.wrappers.php
@@ -71,3 +71,25 @@ function dj_escapeshellarg(?string $arg) : string
     if (!isset($arg) || $arg==='') return "''";
     return escapeshellarg($arg);
 }
+
+/**
+ * A simple function that allows to sleep for fractional seconds. Note that
+ * usleep is documented to consume CPU cycles and may not work for times
+ * larger than a second.
+ * Returns a boolean value for success or if the delay was interrupted by a
+ * signal, returns a float with the time remaining, similar to time_nanosleep.
+ */
+const SECOND_IN_NANOSECONDS = 1_000_000_000;
+
+function dj_sleep(float $seconds) : bool
+{
+    $seconds_int = (int)$seconds;
+    $nanoseconds = (int)(SECOND_IN_NANOSECONDS*($seconds-$seconds_int));
+
+    $result = time_nanosleep($seconds_int, $nanoseconds);
+    if (is_array($result)) {
+        $result = $result['seconds'] + $result['nanoseconds'] / SECOND_IN_NANOSECONDS;
+    }
+
+    return $result;
+}


### PR DESCRIPTION
This instead of using usleep as it is not guaranteed to handle times larger than a second and may also consume CPU cycles.

Alternative fix for #1815