### PR TITLE
Add a badge for how many submissions are judging in submissions list.

### DIFF
--- a/webapp/src/Controller/API/MetricsController.php
+++ b/webapp/src/Controller/API/MetricsController.php
@@ -64,6 +64,7 @@ class MetricsController extends AbstractFOSRestController
         $m['submissions_unverified'] = $registry->getOrRegisterGauge('domjudge', 'submissions_unverified', "Number of unverified submissions", ['contest']);
         $m['submissions_queued']     = $registry->getOrRegisterGauge('domjudge', 'submissions_queued', "Number of queued submissions", ['contest']);
         $m['submissions_perteam']    = $registry->getOrRegisterGauge('domjudge', 'submissions_perteam', "Number of teams that have a queued submission", ['contest']);
+        $m['submissions_judging']    = $registry->getOrRegisterGauge('domjudge', 'submissions_judging', 'Number of submissions that are actively judged', ['contest']);
 
         // Get global team login metrics.
         $m['teams']           = $registry->getOrRegisterGauge('domjudge', 'teams', "Total number of teams", ['contest']);

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -276,7 +276,8 @@ class SubmissionService
             'correct' => 'j.result LIKE \'correct\'',
             'ignored' => 's.valid = 0',
             'unverified' => 'j.verified = 0 AND j.result IS NOT NULL',
-            'queued' => 'j.result IS NULL'
+            'queued' => 'j.result IS NULL AND j.starttime IS NULL',
+            'judging' => 'j.starttime IS NOT NULL AND j.endtime IS NULL'
         ];
         foreach ($countQueryExtras as $count => $countQueryExtra) {
             $countQueryBuilder = (clone $queryBuilder)->select('COUNT(s.submitid) AS cnt');

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -30,8 +30,12 @@
             <span class="badge badge-dark">{{ submissionCounts.ignored }} ignored</span>
         {% endif %}
 
+        {% if submissionCounts.judging > 0 %}
+            <span class="badge badge-primary">{{ submissionCounts.judging }} judging</span>
+        {% endif %}
+
         {% if submissionCounts.queued > 0 %}
-            <span class="badge badge-primary">{{ submissionCounts.queued }} queued (from {{submissionCounts.perteam}} teams)</span>
+            <span class="badge badge-danger">{{ submissionCounts.queued }} queued (from {{submissionCounts.perteam}} teams)</span>
         {% endif %}
     </div>
 

--- a/webapp/tests/Unit/Controller/API/MetricsControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/MetricsControllerTest.php
@@ -30,6 +30,9 @@ domjudge_submissions_correct{contest="demo"} 0
 # HELP domjudge_submissions_ignored Number of ignored submissions
 # TYPE domjudge_submissions_ignored gauge
 domjudge_submissions_ignored{contest="demo"} 0
+# HELP domjudge_submissions_judging Number of submissions that are actively judged
+# TYPE domjudge_submissions_judging gauge
+domjudge_submissions_judging{contest="demo"} 0
 # HELP domjudge_submissions_perteam Number of teams that have a queued submission
 # TYPE domjudge_submissions_perteam gauge
 domjudge_submissions_perteam{contest="demo"} 1


### PR DESCRIPTION
This should be useful info in general and would have been helpful today when we were debugging network issues.

Also change color of queued to red since this is now showing that there is something that needs to be picked up.

Example:
![image](https://user-images.githubusercontent.com/418721/204099564-a5719792-f506-499d-b528-8431b6e379bd.png)
