### PR TITLE
Fix logic bug in edit and resubmit.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -908,7 +908,7 @@ class SubmissionController extends BaseController
                 unlink($file->getRealPath());
             }
 
-            if (!$submission) {
+            if (!$submittedSubmission) {
                 $this->addFlash('danger', $message);
                 return $this->redirectToRoute('jury_submission', ['submitId' => $submission->getSubmitid()]);
             }


### PR DESCRIPTION
`$submission` refers to the team submission, while `$submittedSubmission` is actually the attempt to resubmit it.