### PR TITLE
Extend access controller test with all properties

### DIFF
--- a/webapp/tests/Unit/Controller/API/AccessControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AccessControllerTest.php
@@ -4,6 +4,12 @@ namespace App\Tests\Unit\Controller\API;
 
 class AccessControllerTest extends BaseTest
 {
+    public function testAccessAsAnonymous(): void
+    {
+        $url = $this->helperGetEndpointURL('access');
+        $this->verifyApiJsonResponse('GET', $url, 401);
+    }
+
     public function testAccessAsDemo(): void
     {
         $url = $this->helperGetEndpointURL('access');
@@ -23,21 +29,32 @@ class AccessControllerTest extends BaseTest
         self::assertArrayHasKey('endpoints', $access);
 
         $expectedTypes = [
-            'contest',
-            'judgement-types',
-            'languages',
-            'problems',
-            'groups',
-            'organizations',
-            'teams',
-            'state',
-            'submissions',
-            'judgements',
-            'runs',
-            'awards',
+            'contest' => ['id', 'name', 'formal_name', 'start_time', 'duration', 'scoreboard_freeze_duration', 'penalty_time'],
+            'judgement-types' => ['id', 'name', 'penalty', 'solved'],
+            'languages' => ['id', 'name', 'entry_point_required', 'entry_point_name', 'extensions'],
+            'problems' => ['id', 'label', 'name', 'ordinal', 'rgb', 'color', 'time_limit', 'test_data_count', 'statement'],
+            'groups' => ['id', 'icpc_id', 'name', 'hidden'],
+            'organizations' => ['id', 'icpc_id', 'name', 'formal_name', 'country', 'country_flag'],
+            'teams' => ['id', 'icpc_id', 'name', 'display_name', 'organization_id', 'group_ids'],
+            'state' => ['started', 'frozen', 'ended', 'thawed', 'finalized', 'end_of_updates'],
+            'submissions' => ['id', 'language_id', 'problem_id', 'team_id', 'time', 'contest_time', 'entry_point', 'files'],
+            'judgements' => ['id', 'submission_id', 'judgement_type_id', 'start_time', 'start_contest_time', 'end_time', 'end_contest_time', 'max_run_time'],
+            'runs' => ['id', 'judgement_id', 'ordinal', 'judgement_type_id', 'time', 'contest_time', 'run_time'],
+            'awards' => ['id', 'citation', 'team_ids'],
         ];
 
         $actualTypes = array_map(fn(array $endpoint) => $endpoint['type'], $access['endpoints']);
-        self::assertSame($expectedTypes, $actualTypes);
+        self::assertSame(array_keys($expectedTypes), $actualTypes);
+
+        foreach ($expectedTypes as $type => $expectedProperties) {
+            $actualProperties = [];
+            foreach ($access['endpoints'] as $res) {
+                if ($res['type'] == $type) {
+                    $actualProperties = $res['properties'];
+                    break;
+                }
+            }
+            self::assertSame($expectedProperties, $actualProperties);
+        }
     }
 }


### PR DESCRIPTION
Also check for the anonymous access.
In the future we should also check for the team+jury role to make sure systems without admin access still get the correct information.