### PR TITLE
Re-add warning about binary files to editing executables.

### DIFF
--- a/webapp/templates/jury/executable_edit_content.html.twig
+++ b/webapp/templates/jury/executable_edit_content.html.twig
@@ -12,6 +12,17 @@
 
     <h1>Content of executable <code>{{ executable.execid }}</code></h1>
 
+    {% if skippedBinary is not empty %}
+        <div class="alert alert-warning">
+            We exclude these files from editing since we could not detect their encoding (e.g. they are binary files):
+            <ul>
+                {% for file in skippedBinary %}
+                    <li><code>{{ file }}</code></li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
     {{ form_start(form) }}
 
     {% if not filenames %}


### PR DESCRIPTION
It was removed accidentally in b39e2d068486d6f1bfb71b88ade1148d690a1993.

Part of #1841.

![image](https://user-images.githubusercontent.com/418721/206867907-075b7690-f424-47fd-b9e5-e5de9310fa00.png)
