### PR TITLE
Test with latest PHP82 version

### DIFF
--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -51,7 +51,7 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["7.4","8.0","8.1"]
+      - PHPVERSION: ["7.4","8.0","8.1","8.2"]
         TEST: ["E2E","Unit"]
         CRAWL_DATASOURCES: ["0","1","2"]
 
@@ -60,6 +60,6 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["8.1"]
+      - PHPVERSION: ["8.2"]
         TEST: ["E2E","Unit"]
         CRAWL_DATASOURCES: ["0"]


### PR DESCRIPTION
Codecoverage is still done on the PHP81 for now as it makes more sense to do this when something is merged to main.