### PR TITLE
Mention EXPECTED_RESULTS in the docs

### DIFF
--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -12,13 +12,13 @@ On top, DOMjudge defines a few extensions:
    distributed to participants. The file extension determines any of
    three supported formats. If multiple files matching this pattern are
    available, any one of those will be used.
- * Annotation with ``@EXPECTED_RESULTS@: `` for jury solutions.
+ * Annotation with ``@EXPECTED_RESULTS@:`` for jury solutions.
    Use this to annotate the possible outcomes that a submission can have,
    that will be accepted by the Judging verifier.
    This extension is in consideration to be added to the ICPC specification,
    see https://github.com/Kattis/problem-package-format/pull/4.
    Note that, to match with the current ICPC specification,
-   the ``@EXPECTED_RESULTS@: `` tag is ignored in
+   the ``@EXPECTED_RESULTS@:`` tag is ignored in
    the four official submission subdirectories,
    but it will work if the tagged solution is in, e.g.,
    ``submissions/mixed/`` or ``submissions/rejected/``.

--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -12,6 +12,9 @@ On top, DOMjudge defines a few extensions:
    distributed to participants. The file extension determines any of
    three supported formats. If multiple files matching this pattern are
    available, any one of those will be used.
+ * Annotation with ``EXPECTED_RESULTS`` for jury solutions. The ICPC
+   problem package specification always has precedence. Use this to annotate
+   possible outcomes a submission can have to use together with the Judging verifier. 
 
 The file ``domjudge-problem.ini`` contains key-value pairs, one
 pair per line, of the form ``key = value``. The ``=`` can

--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -25,7 +25,8 @@ On top, DOMjudge defines a few extensions:
 
    .. literalinclude:: ../../example_problems/boolfind/submissions/mixed-verdicts/boolfind-test-random.py
       :language: python
-      :caption: *Example jury solution with multiple outcomes*
+      :caption: *Example jury solution with multiple outcomes (Shortened)*
+      :lines: -10
 
 The file ``domjudge-problem.ini`` contains key-value pairs, one
 pair per line, of the form ``key = value``. The ``=`` can

--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -12,9 +12,16 @@ On top, DOMjudge defines a few extensions:
    distributed to participants. The file extension determines any of
    three supported formats. If multiple files matching this pattern are
    available, any one of those will be used.
- * Annotation with ``EXPECTED_RESULTS`` for jury solutions. The ICPC
-   problem package specification always has precedence. Use this to annotate
-   possible outcomes a submission can have to use together with the Judging verifier. 
+ * Annotation with ``@EXPECTED_RESULTS@: `` for jury solutions.
+   Use this to annotate the possible outcomes that a submission can have,
+   that will be accepted by the Judging verifier.
+   This extension is in consideration to be added to the ICPC specification,
+   see https://github.com/Kattis/problem-package-format/pull/4.
+   Note that, to match with the current ICPC specification,
+   the ``@EXPECTED_RESULTS@: `` tag is ignored in
+   the four official submission subdirectories,
+   but it will work if the tagged solution is in, e.g.,
+   ``submissions/mixed/`` or ``submissions/rejected/``.
 
 The file ``domjudge-problem.ini`` contains key-value pairs, one
 pair per line, of the form ``key = value``. The ``=`` can

--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -21,7 +21,11 @@ On top, DOMjudge defines a few extensions:
    the ``@EXPECTED_RESULTS@:`` tag is ignored in
    the four official submission subdirectories,
    but it will work if the tagged solution is in, e.g.,
-   ``submissions/mixed/`` or ``submissions/rejected/``.
+   ``submissions/mixed-verdicts``, ``submissions/mixed/`` or ``submissions/rejected/``.
+
+   .. literalinclude:: ../../example_problems/boolfind/submissions/mixed-verdicts/boolfind-test-random.py
+      :language: python
+      :caption: *Example jury solution with multiple outcomes*
 
 The file ``domjudge-problem.ini`` contains key-value pairs, one
 pair per line, of the form ``key = value``. The ``=`` can


### PR DESCRIPTION
Closes: https://github.com/DOMjudge/domjudge/issues/1861

Currently the EXPECTED_RESULTS are not part of the ICPC problem package and I'm not sure if they will be soon. We mention the EXPECTED_RESULTS in the README of the example problems but not in the doc. This PR tries to fix this.

I'm not sure how much we want to mention here as it will become part of the spec?

~~Still need to link to the Judging verifier also but that is hard to do in a PR via GitHub itself. If we agree on the wording I'll also make that link so the functionality is bundled together with its primary usage in the docs.~~ We already link from the Judging Verifier to this page which is most likely the better route.