### PR TITLE
compare.cc (default validator): improve float WA message

### DIFF
--- a/sql/files/defaultdata/compare/compare.cc
+++ b/sql/files/defaultdata/compare/compare.cc
@@ -115,7 +115,7 @@ void compare_float(std::string judge, std::string team, flt jval, flt tval, flt 
 const char *USAGE = "Usage: %s judge_in judge_ans feedback_dir [options] < team_out";
 
 int main(int argc, char **argv) {
-	if(argc < 4) {
+	if (argc < 4) {
 		judge_error(USAGE, argv[0]);
 	}
 	judgemessage = openfeedback(argv[3], "judgemessage.txt", argv[0]);
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
 				wrong_answer("String tokens mismatch\nJudge: \"%s\"\nTeam: \"%s\"", judge.c_str(), team.c_str());
 			}
 		} else {
-			if(strcasecmp(judge.c_str(), team.c_str()) != 0) {
+			if (strcasecmp(judge.c_str(), team.c_str()) != 0) {
 				wrong_answer("String tokens mismatch\nJudge: \"%s\"\nTeam: \"%s\"", judge.c_str(), team.c_str());
 			}
 		}

--- a/sql/files/defaultdata/compare/compare.cc
+++ b/sql/files/defaultdata/compare/compare.cc
@@ -72,27 +72,44 @@ FILE *openfeedback(const char *feedbackdir, const char *feedback, const char *wh
 	return res;
 }
 
-/* Test two numbers for equality, accounting for +/-INF, NaN and
- * precision. Float f2 is considered the reference value for relative
- * error.
+/* Test two floating-point numbers for equality, accounting for +/-INF, NaN, and precision.
+ * Float `jval` is considered the reference value for relative error.
  */
-int equal(flt f1, flt f2, flt float_abs_tol, flt float_rel_tol)
-{
-	flt absdiff, reldiff;
+void compare_float(std::string judge, std::string team, flt jval, flt tval, flt float_abs_tol, flt float_rel_tol) {
 	/* Finite values are compared with some tolerance */
-	if ( std::isfinite(f1) && std::isfinite(f2) ) {
-		absdiff = fabsl(f1-f2);
-		reldiff = fabsl((f1-f2)/f2);
-		return !(absdiff > float_abs_tol && reldiff > float_rel_tol);
-	}
+	if (std::isfinite(tval) && std::isfinite(jval)) {
+		flt absdiff = fabsl(tval-jval);
+		flt reldiff = fabsl((tval-jval)/jval);
+		if (float_abs_tol >= 0 && float_rel_tol >= 0) {
+			if (absdiff > float_abs_tol || reldiff > float_rel_tol) {
+				wrong_answer("Too large difference.\n Judge: %s\n Team: %s\n Absolute difference: %Lg (tolerance: %Lg%s)\n Relative difference: %Lg (tolerance: %Lg%s)",
+							 judge.c_str(), team.c_str(),
+							 absdiff, float_abs_tol, absdiff > float_abs_tol ? ", exceeded" : "",
+							 reldiff, float_rel_tol, reldiff > float_rel_tol ? ", exceeded" : "");
+			}
+		} else if (float_abs_tol >= 0) {
+			if (absdiff > float_abs_tol) {
+				wrong_answer("Too large difference.\n Judge: %s\n Team: %s\n Absolute difference: %Lg (tolerance: %Lg, exceeded)",
+							 judge.c_str(), team.c_str(), absdiff, float_abs_tol);
+			}
+		} else if (float_rel_tol >= 0) {
+			if (reldiff > float_rel_tol) {
+				wrong_answer("Too large difference.\n Judge: %s\n Team: %s\n Relative difference: %Lg (tolerance: %Lg, exceeded)",
+							 judge.c_str(), team.c_str(), reldiff, float_rel_tol);
+			}
+		}
 	/* NaN is equal to NaN */
-	if ( std::isnan(f1) && std::isnan(f2) ) return 1;
+	} else if (std::isnan(jval) && std::isnan(tval)) {
+		return;
 	/* Infinite values are equal if their sign matches */
-	if ( std::isinf(f1) && std::isinf(f2) ) {
-		return std::signbit(f1) == std::signbit(f2);
-	}
+	} else if (std::isinf(jval) && std::isinf(tval)) {
+		if (std::signbit(jval) != std::signbit(tval)) {
+			wrong_answer("Expected float %s, got: %s", judge.c_str(), team.c_str());
+		}
 	/* Values in different classes are always different. */
-	return 0;
+	} else {
+		wrong_answer("Expected float %s, got: %s", judge.c_str(), team.c_str());
+	}
 }
 
 const char *USAGE = "Usage: %s judge_in judge_ans feedback_dir [options] < team_out";
@@ -176,10 +193,7 @@ int main(int argc, char **argv) {
 			if (!isfloat(team.c_str(), tval)) {
 				wrong_answer("Expected float, got: %s", team.c_str());
 			}
-			if (!equal(tval, jval, float_abs_tol, float_rel_tol)) {
-				wrong_answer("Too large difference.\n Judge: %s\n Team: %s\n Difference: %Lg\n (abs tol %Lg rel tol %Lg)",
-							 judge.c_str(), team.c_str(), fabsl(jval-tval), float_abs_tol, float_rel_tol);
-			}
+			compare_float(judge, team, jval, tval, float_abs_tol, float_rel_tol);
 		} else if (case_sensitive) {
 			if (strcmp(judge.c_str(), team.c_str()) != 0) {
 				wrong_answer("String tokens mismatch\nJudge: \"%s\"\nTeam: \"%s\"", judge.c_str(), team.c_str());


### PR DESCRIPTION
The WA message showed `-1` for undefined tolerance values, which was kind of confusing.
Additionally, it was not always clear whether it was the absolute and/or relative tolerance that was exceeded.
This PR adds some extra branches to show a more precise WA message.

The main reason for this change is that the output of this validator is not only visible to jury members, but also to participants for the sample cases, which caused some confusion. But also for jury members, the validator output should be more clear now :slightly_smiling_face: 

I couldn't find any tests for this default validator, but if there are any, I'll be happy to still add some more, to cover all the new branches.
For now, I've tested this validator manually, using some problems from [BAPC 2022](https://2022.bapc.eu/). Problem Failing Flagship has only an absolute tolerance, and problem Imperfect Imperial Units has only a relative tolerance.

@RagnarGrootKoerkamp you'll probably also like this :smile: 