### PR TITLE
API reader has full access to all data

### DIFF
--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -151,14 +151,7 @@ class GeneralInfoController extends AbstractFOSRestController
      */
     public function getStatusAction(): array
     {
-        if ($this->dj->checkrole('jury')) {
-            $onlyOfTeam = null;
-        } elseif ($this->dj->checkrole('team') && $this->dj->getUser()->getTeam()) {
-            $onlyOfTeam = $this->dj->getUser()->getTeam();
-        } else {
-            $onlyOfTeam = -1;
-        }
-        $contests = $this->dj->getCurrentContests($onlyOfTeam);
+        $contests = $this->dj->getCurrentContests(null);
         if (empty($contests)) {
             throw new BadRequestHttpException('No active contest');
         }


### PR DESCRIPTION
I think we either have to choose to limit on all endpoints (and we discussed this already in https://github.com/DOMjudge/domjudge/issues/405 for the eventfeed which is part of the API in our case) or should just keep it simple, API access is full access.

When there are good usecases where we want to give out some of the info we can re-add this code again (and actually add tests for it).