### PR TITLE
Test POST of new groups via API

### DIFF
--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -436,6 +436,28 @@ nelmio_api_doc:
                         lazy_eval_results:
                             type: boolean
                             description: Whether to use lazy evaluation for this problem. Defaults to the global setting
-
+                TeamCategoryPost:
+                    type: object
+                    required: [name]
+                    properties:
+                        hidden:
+                            type: boolean
+                            description: Show this group on the scoreboard?
+                            nullable: true
+                        icpc_id:
+                            type: string
+                            description: The ID in the ICPC CMS for this group
+                            nullable: true
+                        name:
+                            type: string
+                            description: How to name this group on the scoreboard
+                        sortorder:
+                            type: integer
+                            minimum: 0
+                            description: Bundle groups with the same sortorder, create different scoreboards per sortorder
+                        color:
+                            type: string
+                            nullable: true
+                            description: Color to use for teams in this group on the scoreboard
     areas:
         path_patterns: [ ^/api/v4 ]

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -76,11 +76,11 @@ class GroupController extends AbstractRestController
         content: [
             new OA\MediaType(
                 mediaType: 'multipart/form-data',
-                schema: new OA\Schema(ref: '#/components/schemas/TeamCategory')
+                schema: new OA\Schema(ref: '#/components/schemas/TeamCategoryPost')
             ),
             new OA\MediaType(
                 mediaType: 'application/json',
-                schema: new OA\Schema(ref: '#/components/schemas/TeamCategory')
+                schema: new OA\Schema(ref: '#/components/schemas/TeamCategoryPost')
             ),
         ]
     )]
@@ -92,7 +92,11 @@ class GroupController extends AbstractRestController
     public function addAction(Request $request, ImportExportService $importExport): Response
     {
         $saved = [];
-        $importExport->importGroupsJson([$request->request->all()], $message, $saved);
+        $postedData = $request->request->all();
+        if (array_key_exists('id', $postedData)) {
+            throw new BadRequestHttpException("Cannot add group with ID");
+        }
+        $importExport->importGroupsJson([$postedData], $message, $saved);
         if (!empty($message)) {
             throw new BadRequestHttpException("Error while adding group: $message");
         }

--- a/webapp/tests/Unit/Controller/API/GroupControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GroupControllerTest.php
@@ -33,7 +33,43 @@ class GroupControllerTest extends BaseTestCase
         ]
     ];
 
+    protected array $newGroupPostData = [
+        'name' => 'newGroup',
+        'icpc_id' => 'icpc100',
+        'hidden' => false,
+        'sortorder' => 1,
+        'color' => '#0077B3'
+    ];
+
     // We test explicitly for groups 1 and 5 here, which are hidden groups and
     // should not be returned for non-admin users.
     protected array $expectedAbsent = ['4242', 'nonexistent', '1', '5'];
+
+    public function testNewAddedGroup(): void
+    {
+        $url = $this->helperGetEndpointURL($this->apiEndpoint);
+        $objectsBeforeTest = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
+
+        $returnedObject = $this->verifyApiJsonResponse('POST', $url, 201, 'admin', $this->newGroupPostData);
+        foreach ($this->newGroupPostData as $key => $value) {
+            self::assertEquals($value, $returnedObject[$key]);
+        }
+
+        $objectsAfterTest  = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
+        $newItems = array_map('unserialize', array_diff(array_map('serialize', $objectsAfterTest), array_map('serialize', $objectsBeforeTest)));
+        self::assertEquals(1, count($newItems));
+        $listKey = array_keys($newItems)[0];
+        foreach ($this->newGroupPostData as $key => $value) {
+            self::assertEquals($value, $newItems[$listKey][$key]);
+        }
+    }
+
+    public function testNewAddedGroupPostWithId(): void
+    {
+        $url = $this->helperGetEndpointURL($this->apiEndpoint);
+        $postWithId = $this->newGroupPostData;
+        $postWithId['id'] = '1';
+        // CLICS does not allow POST to set the id value
+        $this->verifyApiJsonResponse('POST', $url, 400, 'admin', $postWithId);
+    }
 }


### PR DESCRIPTION
After discussion with @nickygerritsen we agreed that POST should not set the ID to stay in line with the wording in the CLICS spec.

This does cost duplication for the API doc as we now need to stop mentioning the id field in the doc.