### PR TITLE
Test PHP8.2 as we haven't released a new DOMjudge version yet

### DIFF
--- a/gitlab/ci/misc.yml
+++ b/gitlab/ci/misc.yml
@@ -18,7 +18,7 @@ phpcs_compatibility:
   image: pipelinecomponents/php-codesniffer:latest
   parallel:
     matrix:
-      - PHPVERSION: ["7.4","8.0","8.1"]
+      - PHPVERSION: ["7.4","8.0","8.1","8.2"]
   script:
     - >
       phpcs -s -p --colors

--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -51,6 +51,6 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["7.4","8.0","8.1"]
+      - PHPVERSION: ["7.4","8.0","8.1","8.2"]
         TEST: ["E2E","Unit"]
         CRAWL_DATASOURCES: ["0","1","2"]


### PR DESCRIPTION
This to prevent the same issues as last year where some people already used a new PHP version with the current stable DOMjudge version.