### PR TITLE
Re-enable the upload of code coverage

### DIFF
--- a/gitlab/unit-tests.sh
+++ b/gitlab/unit-tests.sh
@@ -69,3 +69,12 @@ curl https://api.github.com/repos/domjudge/domjudge/statuses/$CI_COMMIT_SHA \
 if [ $UNITSUCCESS -ne 0 ]; then
     exit 1
 fi
+
+if [ $CODECOVERAGE -eq 1 ]; then
+    section_start_collap uploadcoverage "Upload code coverage"
+    # Only upload when we got working unit-tests.
+    set +u # Uses some variables which are not set
+    # shellcheck disable=SC1090
+    . $DIR/.github/jobs/uploadcodecov.sh 1>/dev/zero 2>/dev/zero
+    section_end uploadcoverage
+fi


### PR DESCRIPTION
This reverts commit 8c21d86b3bca37e75cefe0a1a4993e1c8317d4c1.

The needed script was moved but not updated in the script.