### PR TITLE
Raise error when import via API failed

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -124,7 +124,7 @@ class UserController extends AbstractRestController
         /** @var UploadedFile $jsonFile */
         $jsonFile = $request->files->get('json') ?: [];
         $message = null;
-        if ($result = $this->importExportService->importJson('organizations', $jsonFile, $message)) {
+        if ($result = $this->importExportService->importJson('organizations', $jsonFile, $message) && $result >= 0) {
             // TODO: better return all organizations here
             return "$result new organization(s) successfully added.";
         } else {
@@ -171,10 +171,9 @@ class UserController extends AbstractRestController
             throw new BadRequestHttpException('Supply exactly one of \'json\' or \'tsv\'');
         }
         $message = null;
-        if ($tsvFile && ($result = $this->importExportService->importTsv('teams', $tsvFile, $message))) {
-            // TODO: better return all teams here?
-            return "$result new team(s) successfully added.";
-        } elseif ($jsonFile && ($result = $this->importExportService->importJson('teams', $jsonFile, $message))) {
+        if ((($tsvFile && ($result = $this->importExportService->importTsv('teams', $tsvFile, $message))) ||
+             ($jsonFile && ($result = $this->importExportService->importJson('teams', $jsonFile, $message)))) &&
+            $result >= 0) {
             // TODO: better return all teams here?
             return "$result new team(s) successfully added.";
         } else {
@@ -238,10 +237,9 @@ class UserController extends AbstractRestController
         }
 
         $message = null;
-        if ($tsvFile && ($result = $this->importExportService->importTsv('accounts', $tsvFile, $message))) {
-            // TODO: better return all accounts here?
-            return "$result new account(s) successfully added.";
-        } elseif ($jsonFile && ($result = $this->importExportService->importJson('accounts', $jsonFile, $message))) {
+        if ((($tsvFile && ($result = $this->importExportService->importTsv('accounts', $tsvFile, $message))) ||
+             ($jsonFile && ($result = $this->importExportService->importJson('accounts', $jsonFile, $message)))) &&
+            $result >= 0) {
             // TODO: better return all accounts here?
             return "$result new account(s) successfully added.";
         } else {


### PR DESCRIPTION
This was already done for 1 endpoint but not for the other ones. We don't want to raise the error in the service as the logic is shared for the import via UI where we want to use a flash card instead of returning a HTTP400.

This should fix:
https://github.com/DOMjudge/domjudge/security/code-scanning/218
https://github.com/DOMjudge/domjudge/security/code-scanning/294
https://github.com/DOMjudge/domjudge/security/code-scanning/375