### PR TITLE
Test scoreboard filtering via API

### DIFF
--- a/webapp/tests/Unit/Controller/API/ScoreboardControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ScoreboardControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Unit\Controller\API;
 
-use App\DataFixtures\Test\ExtendDemoPracticeSessionTimeFixture;
+use App\DataFixtures\Test\DemoNonPublicContestFixture;
 use App\DataFixtures\Test\RemoveTeamFromDemoUserFixture;
 use App\DataFixtures\Test\SampleEventsFixture;
 use App\Entity\Contest;
@@ -17,10 +17,14 @@ class ScoreboardControllerTest extends BaseTest
      *
      * @dataProvider provideScoreboardAccess
      */
-    public function testScoreboardAccess(?string $user, int $contestId, bool $removeTeamFromDemoUser, bool $expectedAllowedAccess): void
-    {
+    public function testScoreboardAccess(
+        ?string $user, int $contestId, bool $removeTeamFromDemoUser, bool $expectedAllowedAccess, bool $publicContest
+    ): void {
         if ($removeTeamFromDemoUser) {
             $this->loadFixture(RemoveTeamFromDemoUserFixture::class);
+        }
+        if (!$publicContest) {
+            $this->loadFixture(DemoNonPublicContestFixture::class);
         }
         $contestId = $this->resolveEntityId(Contest::class, (string)$contestId);
         $url = "/contests/$contestId/scoreboard";
@@ -31,16 +35,53 @@ class ScoreboardControllerTest extends BaseTest
     public function provideScoreboardAccess(): Generator
     {
         // Contest 1 is a public contest, everyone should have access.
-        yield [null, 1, false, true];
-        yield ['demo', 1, false, true];
-        yield ['demo', 1, true, true];
-        yield ['admin', 1, false, true];
+        yield [null, 1, false, true, true];
+        yield ['demo', 1, false, true, true];
+        yield ['demo', 1, true, true, true];
+        yield ['admin', 1, false, true, true];
 
-        // TODO: Re-add this later.
-        // Contest 1 is not public, but the team demo belongs to was granted access explicitly.
-        // yield [null, 1, false, false];
-        // yield ['demo', 1, false, true];
-        // yield ['demo', 1, true, false]; // If we remove the team from the demo user, it should not be able to access the contest anymore.
-        // yield ['admin', 1, false, true];
+        // Contest 1 will be set to non public, not everyone will have access
+        yield [null, 1, false, false, false];
+        yield ['demo', 1, false, true, false];
+        yield ['demo', 1, true, false, false];
+        yield ['admin', 1, false, true, false];
+    }
+
+    /**
+     * Test that filtering works on the demo scoreboard
+     *
+     * @dataProvider provideFilters
+     */
+    public function testFilteredScoreboard(array $filters, int $expectedCount): void
+    {
+        $contestId = $this->resolveEntityId(Contest::class, '1');
+        $filter = '?'.implode('&', $filters);
+        $url = "/contests/$contestId/scoreboard";
+        $scoreboard = $this->verifyApiJsonResponse('GET', $url.$filter, 200, 'admin');
+        self::assertNotEmpty($scoreboard);
+        self::assertEquals($expectedCount, count($scoreboard['rows']));
+    }
+
+    public function provideFilters(): Generator
+    {
+        yield [['category=3'], 1];
+        yield [['category=1', 'sortorder=9', 'allteams=true'], 1];
+        yield [['category=1', 'sortorder=9'], 0];
+        yield [['affiliation=1'], 1];
+        yield [['affiliation=Not an University'], 0];
+        yield [['public=true'], 1]; // Scoreboard is frozen but has no results so those are the same
+        yield [['public=false'], 1];
+        yield [['sortorder=0'], 1];
+        yield [['sortorder=9','allteams=false'], 0];
+        yield [['sortorder=9','allteams=true'], 1];
+        yield [['sortorder=1','allteams=true'], 0];
+        yield [['sortorder=999'], 0];
+        yield [['allteams=false'], 1];
+        yield [['allteams=true'], 1]; // Sortorder has default 0 -> hidden category system has 9
+        yield [['country=NLD'], 1];
+        yield [['country=AAA'], 0];
+        yield [['country=USA'], 0];
+        yield [['category=2'], 0];
+        yield [['category=Not a category'], 0];
     }
 }


### PR DESCRIPTION
Also did the TODO by altering the demo contest to be non public. Those tests can be further improved by actually checking against the different contest states (before start, before freeze, frozen, ended, unfrozen) and with submissions in those states.