### PR TITLE
Ignore EPIPE in runguard while running splice

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -898,6 +898,12 @@ void pump_pipes(fd_set* readfds, size_t data_read[], size_t data_passed[])
 						/* Setting errno here to repeat the copy. */
 						errno = EAGAIN;
 					}
+					if ( nread==-1 && errno==EPIPE ) {
+						/* This happens when the child process has
+						   exited and the pipe is closed. */
+						nread = 0;
+						errno = 0;
+					}
 				} else {
 					nread = read(child_pipefd[i][PIPE_OUT], buf, to_read);
 					if ( nread>0 ) {


### PR DESCRIPTION
It is possible that when pumping the pipes in runguard using splice the pipes get closed. This can happen when a interactor/solution pair is executed with runpipe without the proxy running: when the interactor exits stdin/stdout are closed and splice fails to move that data around.

The problem happens only with splice because it seems that splice(closed pipe -> closed pipe) fails with EPIPE, while read(closed pipe) returns 0 (EOF) and write is never called.

This patch ignores EPIPE when running in splice mode.

## How to reproduce

It's easy to reproduce the problem even outside DOMjudge. You need `runpipe`, `runguard` and the following files: [test.zip](https://github.com/DOMjudge/domjudge/files/10366839/test.zip)

- Inside `domjudge/judge` extract test.zip and enter `domjudge/judge/test`
- Compile the interactor with `g++ interactor.cpp -Wall -o runjury`
- Run `./run.sh` (you may need to fix the sudoers configuration or update run.sh to use another user)

Without this patch the interactor fails with an output similar to:

<details>
<summary>Details</summary>

```
++ whoami
+ ../runpipe -v -M meta.txt ./runjury /dev/null /dev/null feedback = sudo -n ../runguard -u edomora97 --outmeta=program.meta -- ./solution.py
[Jan 07 18:39:39.026] ../runpipe[141348]: verbose mode enabled
[Jan 07 18:39:39.026] ../runpipe[141348]: writing metadata to 'meta.txt'
[Jan 07 18:39:39.026] ../runpipe[141348]: Processes:
[Jan 07 18:39:39.026] ../runpipe[141348]:   #0: ./runjury /dev/null /dev/null feedback
[Jan 07 18:39:39.026] ../runpipe[141348]:   #1: sudo -n ../runguard -u edomora97 --outmeta=program.meta -- ./solution.py
[Jan 07 18:39:39.026] ../runpipe[141348]: installing SIGTERM handler
[Jan 07 18:39:39.026] ../runpipe[141348]: exit handler will send event using 4 -> 3
[Jan 07 18:39:39.026] ../runpipe[141348]: set pipe fd 5 to size 1048576
[Jan 07 18:39:39.026] ../runpipe[141348]: set pipe fd 6 to size 1048576
[Jan 07 18:39:39.026] ../runpipe[141348]: setting up pipe #0 (fd 6) -> #1 (fd 5)
[Jan 07 18:39:39.026] ../runpipe[141348]: set pipe fd 7 to size 1048576
[Jan 07 18:39:39.026] ../runpipe[141348]: set pipe fd 8 to size 1048576
[Jan 07 18:39:39.026] ../runpipe[141348]: setting up pipe #1 (fd 8) -> #0 (fd 7)
[Jan 07 18:39:39.026] ../runpipe[141348]: started #0, pid 141349
[Jan 07 18:39:39.026] ../runpipe[141348]: started #1, pid 141350
[Jan 07 18:39:39.026] ../runpipe[141348]: epoll will listen for fd 3
[Jan 07 18:39:39.050] ../runpipe[141348]: child with pid 141349 exited
../runguard: copying data fd 1: Broken pipe
Try `../runguard --help' for more information.
[Jan 07 18:39:39.153] ../runpipe[141348]: child with pid 141350 exited
[Jan 07 18:39:39.153] ../runpipe[141348]: all processes exited
[Jan 07 18:39:39.153] ../runpipe[141348]: Exit statuses:
[Jan 07 18:39:39.153] ../runpipe[141348]:   #0: exited with status 42
[Jan 07 18:39:39.153] ../runpipe[141348]:   #1: exited with status 255
+ set +x
----- program.meta -----
internal-error: ../runguard: copying data fd 1: Broken pipe
----- meta.txt -----
exitcode: 42
bytes-transferred: 0
total-duration-us: 127309
validator-exited-first: true
```

</details>

Note the **`../runguard: copying data fd 1: Broken pipe`**.

With the patch in place the output is something like:

<details>
<summary>Details</summary>

```
++ whoami
+ ../runpipe -v -M meta.txt ./runjury /dev/null /dev/null feedback = sudo -n ../runguard -u edomora97 --outmeta=program.meta -- ./solution.py
[Jan 07 18:40:55.958] ../runpipe[141558]: verbose mode enabled
[Jan 07 18:40:55.959] ../runpipe[141558]: writing metadata to 'meta.txt'
[Jan 07 18:40:55.959] ../runpipe[141558]: Processes:
[Jan 07 18:40:55.959] ../runpipe[141558]:   #0: ./runjury /dev/null /dev/null feedback
[Jan 07 18:40:55.959] ../runpipe[141558]:   #1: sudo -n ../runguard -u edomora97 --outmeta=program.meta -- ./solution.py
[Jan 07 18:40:55.959] ../runpipe[141558]: installing SIGTERM handler
[Jan 07 18:40:55.959] ../runpipe[141558]: exit handler will send event using 4 -> 3
[Jan 07 18:40:55.959] ../runpipe[141558]: set pipe fd 5 to size 1048576
[Jan 07 18:40:55.959] ../runpipe[141558]: set pipe fd 6 to size 1048576
[Jan 07 18:40:55.959] ../runpipe[141558]: setting up pipe #0 (fd 6) -> #1 (fd 5)
[Jan 07 18:40:55.959] ../runpipe[141558]: set pipe fd 7 to size 1048576
[Jan 07 18:40:55.959] ../runpipe[141558]: set pipe fd 8 to size 1048576
[Jan 07 18:40:55.959] ../runpipe[141558]: setting up pipe #1 (fd 8) -> #0 (fd 7)
[Jan 07 18:40:55.959] ../runpipe[141558]: started #0, pid 141559
[Jan 07 18:40:55.959] ../runpipe[141558]: started #1, pid 141560
[Jan 07 18:40:55.959] ../runpipe[141558]: epoll will listen for fd 3
[Jan 07 18:40:55.985] ../runpipe[141558]: child with pid 141559 exited
[Jan 07 18:40:55.988] ../runpipe[141558]: child with pid 141560 exited
[Jan 07 18:40:55.988] ../runpipe[141558]: all processes exited
[Jan 07 18:40:55.988] ../runpipe[141558]: Exit statuses:
[Jan 07 18:40:55.988] ../runpipe[141558]:   #0: exited with status 42
[Jan 07 18:40:55.988] ../runpipe[141558]:   #1: exited with status 0
+ set +x
----- program.meta -----
exitcode: 0
wall-time: 0.016
user-time: 0.010
sys-time: 0.000
cpu-time: -1.000
time-used: cpu-time
time-result:
stdin-bytes: 0
stdout-bytes: 3
stderr-bytes: 0
----- meta.txt -----
exitcode: 42
bytes-transferred: 0
total-duration-us: 29435
validator-exited-first: true
```

</details>

Note that there is no `internal-error`.

Attached there is also `test.c` that tries to stress that peculiar behavior of splice. Running it shows that `splice(closed -> closed)` fails with EPIPE, even though `read(closed)` is 0 (EOF) and `write(closed, 0)` is 0 (no EPIPE).

## Further notes

Note that this behavior is quite hard to encounter in the wild, because runpipe's proxy (which is enabled by default) closes the pipes differently, and it seems to not trigger this.
However, I'd like to see an option to disable the proxy for a specific task to increase the speed of the communication at the cost of losing the ability to inspect the stream.