### PR TITLE
chmod in busybox does not have --reference

### DIFF
--- a/paths.mk.in
+++ b/paths.mk.in
@@ -156,5 +156,5 @@ define substconfigvars
 	-e 's,@BASEURL[@],@BASEURL@,g' \
 	-e 's,@PHPVERSION[@],@PHPVERSION@,g' \
 	> $@
-@chmod --reference=$< $@
+@chmod $(shell stat -c '%a' $<) $@
 endef


### PR DESCRIPTION
This is needed to let domjudge configure/make on alpine linux (busybox like).