### PR TITLE
Add csafe and cppsafe executables with sanitizers support

### DIFF
--- a/sql/files/defaultdata/cppsafe/build
+++ b/sql/files/defaultdata/cppsafe/build
@@ -1,0 +1,2 @@
+#!/bin/sh
+# nothing to compile

--- a/sql/files/defaultdata/cppsafe/run
+++ b/sql/files/defaultdata/cppsafe/run
@@ -13,7 +13,7 @@ MEMLIMIT="$1" ; shift
 #           other languages autodetected by extension)
 # -Wall:    Report all warnings
 # -fsanitize: Enable the specified Sanitizers, see https://github.com/google/sanitizers for the full documentation
-# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: Make code position independant and disable optimizations that may obfuscate the info provided by the 
+# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: Make code position independent and disable optimizations that may obfuscate the info provided by the 
 sanitizers
 # -g: Include debugging/symbol information in the executable, improves sanitizers output if an error is detected
 # -O2:      Level 2 optimizations (default for speed)

--- a/sql/files/defaultdata/cppsafe/run
+++ b/sql/files/defaultdata/cppsafe/run
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# C++ compile wrapper-script for 'compile.sh'.
+# See that script for syntax and more info.
+
+DEST="$1" ; shift
+MEMLIMIT="$1" ; shift
+
+# Add -DONLINE_JUDGE or -DDOMJUDGE below if you want it make easier for teams
+# to do local debugging.
+
+# -x c++:   Explicitly set compile language to C++ (no object files or
+#           other languages autodetected by extension)
+# -Wall:    Report all warnings
+# -fsanitize: Enable the specified Sanitizers, see https://github.com/google/sanitizers for the full documentation
+# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: Make code position independant and disable optimizations that may obfuscate the info provided by the 
+sanitizers
+# -g: Include debugging/symbol information in the executable, improves sanitizers output if an error is detected
+# -O2:      Level 2 optimizations (default for speed)
+# -pipe:    Use pipes for communication between stages of compilation
+g++ -x c++ -Wall -fsanitize=address,undefined -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls -g -O2 -pipe -o "$DEST" "$@"
+exit $?

--- a/sql/files/defaultdata/csafe/build
+++ b/sql/files/defaultdata/csafe/build
@@ -1,0 +1,2 @@
+#!/bin/sh
+# nothing to compile

--- a/sql/files/defaultdata/csafe/run
+++ b/sql/files/defaultdata/csafe/run
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# C compile wrapper-script for 'compile.sh'.
+# See that script for syntax and more info.
+
+DEST="$1" ; shift
+MEMLIMIT="$1" ; shift
+
+# Add -DONLINE_JUDGE or -DDOMJUDGE below if you want it make easier for teams
+# to do local debugging.
+
+# -x c:     Explicitly set compile language to C (no C++ nor object files
+#           autodetected by extension)
+# -Wall:    Report all warnings
+# -fsanitize: Enable the specified Sanitizers, see https://github.com/google/sanitizers for the full documentation
+# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: Make code position independant and disable optimizations that may obfuscate the info provided by the
+sanitizers
+# -g: Include debugging/symbol information in the executable, improves sanitizers output if an error is detected
+# -O2:      Level 2 optimizations (default for speed)
+# -g        have file names and line numbers included in warning messages
+# -pipe:    Use pipes for communication between stages of compilation
+# -lm:      Link with math-library (has to be last argument!)
+export ASAN_OPTIONS=detect_leaks=1
+gcc -x c -Wall -fsanitize=address,undefined -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls -g -O2 -pipe -o "$DEST" "$@" -lm
+exit $?

--- a/sql/files/defaultdata/csafe/run
+++ b/sql/files/defaultdata/csafe/run
@@ -13,13 +13,12 @@ MEMLIMIT="$1" ; shift
 #           autodetected by extension)
 # -Wall:    Report all warnings
 # -fsanitize: Enable the specified Sanitizers, see https://github.com/google/sanitizers for the full documentation
-# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: Make code position independant and disable optimizations that may obfuscate the info provided by the
+# -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls: make code position independent and disable optimizations that may obfuscate the info provided by the
 sanitizers
 # -g: Include debugging/symbol information in the executable, improves sanitizers output if an error is detected
 # -O2:      Level 2 optimizations (default for speed)
 # -g        have file names and line numbers included in warning messages
 # -pipe:    Use pipes for communication between stages of compilation
 # -lm:      Link with math-library (has to be last argument!)
-export ASAN_OPTIONS=detect_leaks=1
 gcc -x c -Wall -fsanitize=address,undefined -fPIE -pie -fno-omit-frame-pointer -fno-optimize-sibling-calls -g -O2 -pipe -o "$DEST" "$@" -lm
 exit $?


### PR DESCRIPTION
We are using a modified version of the C executable in our introductory programming course. In contrast to other programming languages, C has a lot of behavior that is undefined but does not throw an immediate error. For example, it does not check if memory accesses are valid, as it is considered the responsibility of the user. Consider the following C code:

```c
#include<stdio.h>
#define max(a,b)	(a<b? b:a)
long long int a[100001]={0},n,i,c=0,d=0,t,x;
int main(){
	scanf("%I64d",&n);
	for(i=0;i<n;i++){
		scanf("%I64d",&x);
		a[x]+=x;
	}
	for(i=1;i<=100001;i++){
		t=c;
		c=max(c,d+a[i]),d=t;
	}
	printf("%I64d",c);
	return 0;
}
```

While it may be fit for purpose in a competitive programming context, it clearly contains an out of bounds access to the array, due to looping `i<=100001` instead of `i<100001`. The instructor may want to automatically detect and consider this kind of mistakes as not correct, and may want to force the user to fix the bug. Example in our Domjudge instance changing the C executable for the Csafe version, changes the veredict from correct to runtime error, and prints the line where the invalid access was produced.

![image](https://user-images.githubusercontent.com/55482385/213302201-e5314624-c8fb-4761-aecb-c447d0fdec71.png)

Additional notes:
- We do not want to replace the current C and cpp executables, we would like to allow Domjudge administrators to decide which behavior is preferable for their needs.
`-static ` flag was removed from the script as it was incompatible with some sanitizer checks and I am not sure why it is necessary. 
- As we have manually configured it in our Domjudge instance as an executable, we do not know if the changes included in this PR are enough to make it work by default for new Domjudge instances, or even if the folder structure is correct. Do not hesitate to correct us
- An idea for further improvement may be creating custom error codes for different sanitizer failures: right now all fall under Runtime Error

Any suggestion or feedback is welcome. Thanks @isaaclo97 for the help testing and validating the idea.