### PR TITLE
Fix error when adding a team with a user without username. Fixes #1847.

### DIFF
--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -133,7 +133,7 @@ class Team extends BaseApiEntity implements ExternalRelationshipEntityInterface,
      * @Assert\Regex("/^[a-z0-9@._-]+$/i", message="Only alphanumeric characters and _-@. are allowed")
      * @Serializer\Exclude
      */
-    private ?string $newUsername;
+    private ?string $newUsername = null;
 
     /**
      * @Serializer\Exclude

--- a/webapp/src/Form/Type/TeamType.php
+++ b/webapp/src/Form/Type/TeamType.php
@@ -134,7 +134,7 @@ class TeamType extends AbstractExternalIdEntityType
         ]);
         $builder->add('newUsername', TextType::class, [
             'label'    => 'Username',
-            'required' => false,
+            'required' => true,
         ]);
 
         $builder->add('save', SubmitType::class);

--- a/webapp/templates/jury/partials/team_form.html.twig
+++ b/webapp/templates/jury/partials/team_form.html.twig
@@ -38,14 +38,17 @@
                 case 'dont-add-user':
                     $existingUserField.hide();
                     $newUsernameField.hide();
+                    $newUsernameField.find('input').attr('required', false);
                     break;
                 case 'create-new-user':
                     $existingUserField.hide();
                     $newUsernameField.show();
+                    $newUsernameField.find('input').attr('required', true);
                     break;
                 case 'add-existing-user':
                     $existingUserField.show();
                     $newUsernameField.hide();
+                    $newUsernameField.find('input').attr('required', false);
                     break;
             }
         };


### PR DESCRIPTION
I decided to not change the UI itself, but this does both clientside checking (with the nice tooltip) as well as proper server checking (the `empty()` failed if you don't initialise the field).