### PR TITLE
Fix result undefined

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -124,7 +124,7 @@ class UserController extends AbstractRestController
         /** @var UploadedFile $jsonFile */
         $jsonFile = $request->files->get('json') ?: [];
         $message = null;
-        if ($result = $this->importExportService->importJson('organizations', $jsonFile, $message) && $result >= 0) {
+        if (($result = $this->importExportService->importJson('organizations', $jsonFile, $message)) && $result >= 0) {
             // TODO: better return all organizations here
             return "$result new organization(s) successfully added.";
         } else {


### PR DESCRIPTION
The and binds stronger so we need to steer that the importJson is ran first and registered as  and the next theck is done only later. The other imports already had the brackets as we had 2 types to import both using result.

Fixes: https://github.com/DOMjudge/domjudge/security/code-scanning/218