### PR TITLE
Don't break on URLencoded logging entries

### DIFF
--- a/webapp/src/Logger/VarargsLogMessageProcessor.php
+++ b/webapp/src/Logger/VarargsLogMessageProcessor.php
@@ -7,6 +7,7 @@
 
 namespace App\Logger;
 
+use ValueError;
 use Monolog\Processor\ProcessorInterface;
 
 class VarargsLogMessageProcessor implements ProcessorInterface
@@ -21,10 +22,14 @@ class VarargsLogMessageProcessor implements ProcessorInterface
             return $record;
         }
 
-        $res = vsprintf($record['message'], $record['context']);
-        if ($res !== false) {
-            $record['message'] = $res;
-            $record['context'] = [];
+        try {
+            $res = vsprintf($record['message'], $record['context']);
+            if ($res !== false) {
+                $record['message'] = $res;
+                $record['context'] = [];
+            }
+        } catch (ValueError $e) {
+            return $record;
         }
 
         return $record;


### PR DESCRIPTION
Probably this should also be fixed in the calling function to check if there are not more % symbols being injected. Normally we would need to verify the actual tried fileaccess (Mayhem tries to read etc/passwd) but as this printf is only used for logging we seem to be safe.

Fixes: https://github.com/DOMjudge/domjudge/security/code-scanning/451