### PR TITLE
setsid() failure is not an error

### DIFF
--- a/judge/runpipe.cc
+++ b/judge/runpipe.cc
@@ -887,7 +887,7 @@ int main(int argc, char **argv) {
 
   // Enter a new session since we are dealing with signals.
   if (setsid() < 0) {
-    error(errno, "failed to create a new session");
+    warning(errno, "failed to create a new session");
   }
   // The processes may close their pipes, so we need to ignore "broken pipe"
   // errors.


### PR DESCRIPTION
The setsid() syscall can fail only with EPERM, which means that the process is already the process group leader. This is not an error since we are trying to become the leader.

See `man 2 setsid`.

---

In particular `setsid()` fails when I try to run runpipe from the terminal. Probably bash sets the group leader before exec-ing. While running inside DJ the runpipe process is not the leader so it doesn't fail to setsid.