### PR TITLE
Fix wrong problem disabling when combined run/compare script crashes

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1339,9 +1339,15 @@ function judge(array $judgeTask): bool
     }
 
     if ($result === 'compare-error') {
-        logmsg(LOG_ERR, "comparing failed for compare script '" . $judgeTask['compare_script_id'] . "'");
-        $description = 'compare script ' . $judgeTask['compare_script_id'] . ' crashed';
-        disable('compare_script', 'compare_script_id', $judgeTask['compare_script_id'], $description, $judgeTask['judgetaskid']);
+        if ($combined_run_compare) {
+            logmsg(LOG_ERR, "comparing failed for combined run/compare script '" . $judgeTask['run_script_id'] . "'");
+            $description = 'combined run/compare script ' . $judgeTask['run_script_id'] . ' crashed';
+            disable('run_script', 'run_script_id', $judgeTask['run_script_id'], $description, $judgeTask['judgetaskid']);
+        } else {
+            logmsg(LOG_ERR, "comparing failed for compare script '" . $judgeTask['compare_script_id'] . "'");
+            $description = 'compare script ' . $judgeTask['compare_script_id'] . ' crashed';
+            disable('compare_script', 'compare_script_id', $judgeTask['compare_script_id'], $description, $judgeTask['judgetaskid']);
+        }
         return false;
     }
 


### PR DESCRIPTION
When a task with combined run and compare script crashes, the judgehost disables the compare script with id=1. That is not the correct executable though: when the problem has a combined run/compare script the only meaningful executable is the run script.

Fixes #1887

---

I'm not 100% convinced, but probably it makes sense to unset (nullify?) the id of the compare script when using combined run/compare. At the moment it seems that the `compare_script_id` is 1, even though that executable is not used.

The judge task sent to the judgedaemon in my case is:

```json
{
  "judgetaskid": 133,
  "type": "judging_run",
  "priority": 0,
  "jobid": "88",
  "uuid": "bd48ffdd-ab82-459d-85fc-012ffcad4170",
  "submitid": "84",
  "compile_script_id": "8",
  "run_script_id": "30",
  "compare_script_id": "1",
  "testcase_id": "25",
  "testcase_hash": "00d9c90eabe0eb7babed8e341052d082_58f001457802c6d02c69e960d05f052c",
  "compile_config": "{\"script_timelimit\":30,\"script_memory_limit\":2097152,\"script_filesize_limit\":2621440,\"language_extensions\":[\"c\"],\"filter_compiler_files\":true,\"hash\":\"ac6b2c3be82211958c91cde21f27fd26\"}",
  "run_config": "{\"time_limit\":5.0,\"memory_limit\":2097152,\"output_limit\":8192,\"process_limit\":64,\"entry_point\":null,\"hash\":\"6b86f8910436038383c205d881cf7276\"}",
  "compare_config": "{\"script_timelimit\":30,\"script_memory_limit\":2097152,\"script_filesize_limit\":2621440,\"compare_args\":\"\",\"combined_run_compare\":true,\"hash\":\"cf0a04ed136ac59cb9ee3296a5fe9bba\"}"
}
```