### PR TITLE
Fix E2E, Datasource=2 default redirects to management page

### DIFF
--- a/gitlab/unit-tests.sh
+++ b/gitlab/unit-tests.sh
@@ -42,7 +42,7 @@ if [ $CODECOVERAGE -eq 1 ]; then
     CNT=$(sed -n '/Generating code coverage report/,$p' "$GITLABARTIFACTS"/phpunit.out | grep -v DoctrineTestBundle | grep -cv ^$)
     FILE=deprecation.txt
     sed -n '/Generating code coverage report/,$p' "$GITLABARTIFACTS"/phpunit.out > ${CI_PROJECT_DIR}/$FILE
-    if [ $CNT -le 21 ]; then
+    if [ $CNT -le 12 ]; then
         STATE=success
     else
         STATE=failure

--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -101,7 +101,11 @@ class ControllerRolesTraversalTest extends BaseTest
         if (($statusCode === 403 || $statusCode === 401) && $response->isRedirection()) {
             self::assertEquals($response->headers->get('location'), $this::$loginURL);
         } elseif (($response->getStatusCode() === 302 ) && $response->isRedirection()) {
-            self::assertTrue(strpos($response->headers->get('location'), '/public') !== false);
+            if (strpos($url, '/jury/external-contest') !== false) {
+                self::assertTrue(strpos($response->headers->get('location'), '/jury/external-contest/manage') !== false);
+            } else {
+                self::assertTrue(strpos($response->headers->get('location'), '/public') !== false);
+            }
         } else {
             self::assertEquals($statusCode, $response->getStatusCode(), $message);
         }


### PR DESCRIPTION
Other solutions would be to add a fixture or add this URL to $substrings.

I've added a commit to trigger the CI for this datasource, will revert that one after approval