### PR TITLE
Add label for empty default value for <option> config keys

### DIFF
--- a/gitlab/webstandard.sh
+++ b/gitlab/webstandard.sh
@@ -84,12 +84,7 @@ if [ "$TEST" = "w3cval" ]; then
     wget https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
     unzip -q vnu.linux.zip
     section_end test_suite
-    FLTRALL='--filterpattern .*autocomplete.*|.*style.*'
-    if [ "$ROLE" = admin ]; then
-        FLTR="$FLTRALL|.*option.*"
-    else
-        FLTR="$FLTRALL"
-    fi
+    FLTR='--filterpattern .*autocomplete.*|.*style.*'
     for typ in html css svg
     do
         $DIR/vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-$typ --format json $FLTR $URL 2> result.json

--- a/webapp/templates/jury/config.html.twig
+++ b/webapp/templates/jury/config.html.twig
@@ -89,7 +89,7 @@
                                                                     style="width:10em;text-align:right;display:inline-block;"
                                                                     name="config_{{ option.name }}[{{ counter }}][key]">
                                                                 {% for value, label in option.key_options %}
-                                                                    <option {% if key == value %}selected{% endif %} value="{{ value }}">{{ label }}</option>
+                                                                    <option {% if key == value %}selected{% endif %} value="{{ value }}" label="{{ label | default('empty option') }}">{{ label }}</option>
                                                                 {% endfor %}
                                                             </select>
                                                         {% else %}


### PR DESCRIPTION
W3C wants a label with a non empty content when the value is empty. Another benefit is that when using an alternative text-only browser the website can still be used.