### PR TITLE
Only allow balloon urls with integers

### DIFF
--- a/webapp/src/Controller/API/BalloonController.php
+++ b/webapp/src/Controller/API/BalloonController.php
@@ -53,7 +53,7 @@ class BalloonController extends AbstractRestController
 
     /**
      * Mark a specific balloon as done.
-     * @Rest\Post("/{balloonId}/done")
+     * @Rest\Post("/{balloonId<\d+>}/done")
      * @OA\Response(
      *     response="204",
      *     description="The balloon was now marked as done or already marked as such.",


### PR DESCRIPTION
This will make that urls with balloonId as non integer will get a 404 instead of a 500
(https://github.com/DOMjudge/domjudge/security/code-scanning/295)

Alternative would be to do something like:
https://github.com/zircote/swagger-php/issues/594 but I can't find a working annotation format for this and that might still return a 500 instead of the 404 or 400 which would steer the user towards the correct solution.