### PR TITLE
Use default value to prevent unexisting variable for logging

### DIFF
--- a/webapp/src/Logger/VarargsLogMessageProcessor.php
+++ b/webapp/src/Logger/VarargsLogMessageProcessor.php
@@ -22,6 +22,7 @@ class VarargsLogMessageProcessor implements ProcessorInterface
             return $record;
         }
 
+        $res = false;
         try {
             $res = vsprintf($record['message'], $record['context']);
         } catch (ValueError $e) {}


### PR DESCRIPTION
Fixes: https://mayhem4api.forallsecure.com/issues/23036/1250975

We log an error when we get something like:
reply_to_id:"<nIDm!pqH!C7:}nt%C"

We cant format it, so should just print with the normal value (or maybe replace it to not pass it further?)