### PR TITLE
contest option to change tiebreaker from penalty to runtime

### DIFF
--- a/webapp/migrations/Version20230209125636.php
+++ b/webapp/migrations/Version20230209125636.php
@@ -20,7 +20,7 @@ final class Version20230209125636 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE contest ADD order_by_runtime TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Is runtime used as tiebreaker instead of penalty?\'');
+        $this->addSql('ALTER TABLE contest ADD runtime_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Is runtime used as tiebreaker instead of penalty?\'');
         $this->addSql('DROP INDEX order_public ON rankcache');
         $this->addSql('DROP INDEX order_restricted ON rankcache');
         $this->addSql('ALTER TABLE rankcache ADD totalruntime_restricted INT DEFAULT 0 NOT NULL COMMENT \'Total runtime in milliseconds (restricted audience)\', ADD totalruntime_public INT DEFAULT 0 NOT NULL COMMENT \'Total runtime in milliseconds (public)\'');
@@ -32,7 +32,7 @@ final class Version20230209125636 extends AbstractMigration
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE contest DROP order_by_runtime');
+        $this->addSql('ALTER TABLE contest DROP runtime_as_score_tiebreaker');
         $this->addSql('ALTER TABLE scorecache DROP runtime_restricted, DROP runtime_public');
         $this->addSql('DROP INDEX order_restricted ON rankcache');
         $this->addSql('DROP INDEX order_public ON rankcache');

--- a/webapp/migrations/Version20230209125636.php
+++ b/webapp/migrations/Version20230209125636.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230209125636 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Prepare database for runtime tiebreaker.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest ADD order_by_runtime TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Is runtime used as tiebreaker instead of penalty?\'');
+        $this->addSql('DROP INDEX order_public ON rankcache');
+        $this->addSql('DROP INDEX order_restricted ON rankcache');
+        $this->addSql('ALTER TABLE rankcache ADD totalruntime_restricted INT DEFAULT 0 NOT NULL COMMENT \'Total runtime in milliseconds (restricted audience)\', ADD totalruntime_public INT DEFAULT 0 NOT NULL COMMENT \'Total runtime in milliseconds (public)\'');
+        $this->addSql('CREATE INDEX order_public ON rankcache (cid, points_public, totaltime_public, totalruntime_public)');
+        $this->addSql('CREATE INDEX order_restricted ON rankcache (cid, points_restricted, totaltime_restricted, totalruntime_restricted)');
+        $this->addSql('ALTER TABLE scorecache ADD runtime_restricted INT DEFAULT 0 NOT NULL COMMENT \'Runtime in milliseconds (restricted audience)\', ADD runtime_public INT DEFAULT 0 NOT NULL COMMENT \'Runtime in milliseconds (public)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest DROP order_by_runtime');
+        $this->addSql('ALTER TABLE scorecache DROP runtime_restricted, DROP runtime_public');
+        $this->addSql('DROP INDEX order_restricted ON rankcache');
+        $this->addSql('DROP INDEX order_public ON rankcache');
+        $this->addSql('ALTER TABLE rankcache DROP totalruntime_restricted, DROP totalruntime_public');
+        $this->addSql('CREATE INDEX order_restricted ON rankcache (cid, points_restricted, totaltime_restricted)');
+        $this->addSql('CREATE INDEX order_public ON rankcache (cid, points_public, totaltime_public)');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -185,7 +185,7 @@ class ScoreboardController extends AbstractRestController
                 ];
 
                 if ($contest->getRuntimeAsScoreTiebreaker()) {
-                    $problem['fastest_implementation'] = $matrixItem->isCorrect && $scoreboard->isFastestImplementation($teamScore->team, $contestProblem);
+                    $problem['fastest_submission'] = $matrixItem->isCorrect && $scoreboard->isFastestSubmission($teamScore->team, $contestProblem);
                     if ($matrixItem->isCorrect) {
                         $problem['runtime'] = $matrixItem->runtime;
                     }

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -164,10 +164,15 @@ class ScoreboardController extends AbstractRestController
                 'team_id' => $teamScore->team->getApiId($this->eventLogService),
                 'score' => [
                     'num_solved' => $teamScore->numPoints,
-                    'total_time' => $teamScore->totalTime,
                 ],
                 'problems' => [],
             ];
+
+            if ($contest->getRuntimeAsScoreTiebreaker()) {
+                $row['score']['total_runtime'] = $teamScore->totalRuntime;
+            } else {
+                $row['score']['total_time'] = $teamScore->totalTime;
+            }
 
             foreach ($scoreboard->getMatrix()[$teamScore->team->getTeamid()] as $problemId => $matrixItem) {
                 $contestProblem = $scoreboard->getProblems()[$problemId];
@@ -177,11 +182,18 @@ class ScoreboardController extends AbstractRestController
                     'num_judged' => $matrixItem->numSubmissions,
                     'num_pending' => $matrixItem->numSubmissionsPending,
                     'solved' => $matrixItem->isCorrect,
-                    'first_to_solve' => $matrixItem->isCorrect && $scoreboard->solvedFirst($teamScore->team, $contestProblem),
                 ];
 
-                if ($matrixItem->isCorrect) {
-                    $problem['time'] = Utils::scoretime($matrixItem->time, $scoreIsInSeconds);
+                if ($contest->getRuntimeAsScoreTiebreaker()) {
+                    $problem['fastest_implementation'] = $matrixItem->isCorrect && $scoreboard->isFastestImplementation($teamScore->team, $contestProblem);
+                    if ($matrixItem->isCorrect) {
+                        $problem['runtime'] = $matrixItem->runtime;
+                    }
+                } else {
+                    $problem['first_to_solve'] = $matrixItem->isCorrect && $scoreboard->solvedFirst($teamScore->team, $contestProblem);
+                    if ($matrixItem->isCorrect) {
+                        $problem['time'] = Utils::scoretime($matrixItem->time, $scoreIsInSeconds);
+                    }
                 }
 
                 $row['problems'][] = $problem;

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -295,12 +295,11 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     private bool $processBalloons = true;
 
     /**
-     * @ORM\Column(type="boolean", name="order_by_runtime",
+     * @ORM\Column(type="boolean", name="runtime_as_score_tiebreaker",
      *     options={"comment"="Is runtime used as tiebreaker instead of penalty?","default"=0},
      *     nullable=false)
-     * @Serializer\Exclude()
      */
-    private bool $order_by_runtime = false;
+    private bool $runtime_as_score_tiebreaker = false;
 
     /**
      * @ORM\Column(type="boolean", name="public",
@@ -730,15 +729,15 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
         return $this->processBalloons;
     }
 
-    public function setOrderByRuntime(bool $orderByRuntime): Contest
+    public function setRuntimeAsScoreTiebreaker(bool $runtimeAsScoreTiebreaker): Contest
     {
-        $this->order_by_runtime = $orderByRuntime;
+        $this->runtime_as_score_tiebreaker = $runtimeAsScoreTiebreaker;
         return $this;
     }
 
-    public function getOrderByRuntime(): bool
+    public function getRuntimeAsScoreTiebreaker(): bool
     {
-        return $this->order_by_runtime;
+        return $this->runtime_as_score_tiebreaker;
     }
 
     public function setMedalsEnabled(bool $medalsEnabled): Contest

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -295,6 +295,14 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     private bool $processBalloons = true;
 
     /**
+     * @ORM\Column(type="boolean", name="order_by_runtime",
+     *     options={"comment"="Is runtime used as tiebreaker instead of penalty?","default"=0},
+     *     nullable=false)
+     * @Serializer\Exclude()
+     */
+    private bool $order_by_runtime = false;
+
+    /**
      * @ORM\Column(type="boolean", name="public",
      *     options={"comment"="Is this contest visible for the public?",
      *              "default"=1},
@@ -720,6 +728,17 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     public function getProcessBalloons(): bool
     {
         return $this->processBalloons;
+    }
+
+    public function setOrderByRuntime(bool $orderByRuntime): Contest
+    {
+        $this->order_by_runtime = $orderByRuntime;
+        return $this;
+    }
+
+    public function getOrderByRuntime(): bool
+    {
+        return $this->order_by_runtime;
     }
 
     public function setMedalsEnabled(bool $medalsEnabled): Contest

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
  *     name="rankcache",
  *     options={"collation"="utf8mb4_unicode_ci", "charset"="utf8mb4", "comment"="Scoreboard rank cache"},
  *     indexes={
- *         @ORM\Index(name="order_restricted", columns={"cid","points_restricted","totaltime_restricted"}),
- *         @ORM\Index(name="order_public", columns={"cid","points_public","totaltime_public"}),
+ *         @ORM\Index(name="order_restricted", columns={"cid","points_restricted","totaltime_restricted", "totalruntime_restricted"}),
+ *         @ORM\Index(name="order_public", columns={"cid","points_public","totaltime_public", "totalruntime_public"}),
  *         @ORM\Index(name="cid", columns={"cid"}),
  *         @ORM\Index(name="teamid", columns={"teamid"})
  *     })
@@ -36,6 +36,14 @@ class RankCache
     private int $totaltime_restricted = 0;
 
     /**
+     * @ORM\Column(type="integer", name="totalruntime_restricted", length=4,
+     *     options={"comment"="Total runtime in milliseconds (restricted audience)",
+     *              "default"="0"},
+     *     nullable=false)
+     */
+    private $totalruntime_restricted = 0;
+
+    /**
      * @ORM\Column(type="integer", name="points_public", length=4,
      *     options={"comment"="Total correctness points (public)",
      *              "unsigned"=true,"default"="0"},
@@ -51,6 +59,13 @@ class RankCache
      */
     private int $totaltime_public = 0;
 
+    /**
+     * @ORM\Column(type="integer", name="totalruntime_public", length=4,
+     *     options={"comment"="Total runtime in milliseconds (public)",
+     *              "default"="0"},
+     *     nullable=false)
+     */
+    private $totalruntime_public = 0;
 
     /**
      * @ORM\Id
@@ -88,6 +103,17 @@ class RankCache
         return $this->totaltime_restricted;
     }
 
+    public function setTotalruntimeRestricted(int $totalruntimeRestricted): RankCache
+    {
+        $this->totalruntime_restricted = $totalruntimeRestricted;
+        return $this;
+    }
+
+    public function getTotalruntimeRestricted(): int
+    {
+        return $this->totalruntime_restricted;
+    }
+
     public function setPointsPublic(int $pointsPublic): RankCache
     {
         $this->points_public = $pointsPublic;
@@ -108,6 +134,17 @@ class RankCache
     public function getTotaltimePublic(): int
     {
         return $this->totaltime_public;
+    }
+
+    public function setTotalruntimePublic(int $totalruntimePublic): RankCache
+    {
+        $this->totalruntime_public = $totalruntimePublic;
+        return $this;
+    }
+
+    public function getTotalruntimePublic(): int
+    {
+        return $this->totalruntime_public;
     }
 
     public function setContest(?Contest $contest = null): RankCache

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -51,6 +51,13 @@ class ScoreCache
      */
     private $solvetime_restricted = 0;
 
+    /**
+     * @ORM\Column(type="integer", name="runtime_restricted", length=4,
+     *     options={"comment"="Runtime in milliseconds (restricted audience)",
+     *              "default"="0"},
+     *     nullable=false)
+     */
+    private $runtime_restricted = 0;
 
     /**
      * @ORM\Column(type="integer", name="submissions_public", length=4,
@@ -84,6 +91,14 @@ class ScoreCache
      *     nullable=false)
      */
     private $solvetime_public = 0;
+
+    /**
+     * @ORM\Column(type="integer", name="runtime_public", length=4,
+     *     options={"comment"="Runtime in milliseconds (public)",
+     *              "default"="0"},
+     *     nullable=false)
+     */
+    private $runtime_public = 0;
 
     /**
      * @ORM\Column(type="boolean", name="is_first_to_solve",
@@ -160,6 +175,17 @@ class ScoreCache
         return $this->solvetime_restricted;
     }
 
+    public function setRuntimeRestricted(int $runtimeRestricted): ScoreCache
+    {
+        $this->runtime_restricted = $runtimeRestricted;
+        return $this;
+    }
+
+    public function getRuntimeRestricted(): int
+    {
+        return $this->runtime_restricted;
+    }
+
     public function setSubmissionsPublic(int $submissionsPublic): ScoreCache
     {
         $this->submissions_public = $submissionsPublic;
@@ -204,6 +230,17 @@ class ScoreCache
     public function getSolvetimePublic()
     {
         return $this->solvetime_public;
+    }
+
+    public function setRuntimePublic(int $runtimePublic): ScoreCache
+    {
+        $this->runtime_public = $runtimePublic;
+        return $this;
+    }
+
+    public function getRuntimePublic(): int
+    {
+        return $this->runtime_public;
     }
 
     public function setIsFirstToSolve(bool $isFirstToSolve): ScoreCache
@@ -264,6 +301,11 @@ class ScoreCache
     public function getSolveTime(bool $restricted)
     {
         return $restricted ? $this->getSolvetimeRestricted() : $this->getSolvetimePublic();
+    }
+
+    public function getRuntime(bool $restricted): int
+    {
+        return $restricted ? $this->getRuntimeRestricted() : $this->getRuntimePublic();
     }
 
     public function getIsCorrect(bool $restricted): bool

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -94,6 +94,14 @@ class ContestType extends AbstractExternalIdEntityType
             ],
             'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
         ]);
+        $builder->add('orderByRuntime', ChoiceType::class, [
+            'expanded' => true,
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+            'help' => 'Enable this to show runtimes in milliseconds on scoreboard and use them as tiebreaker instead of penalty.',
+        ]);
         $builder->add('medalsEnabled', ChoiceType::class, [
             'expanded' => true,
             'choices' => [

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -100,7 +100,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Enable this to show runtimes in milliseconds on scoreboard and use them as tiebreaker instead of penalty. The runtime of a submission is the maximum over all testcases.',
+            'help' => 'Enable this to show runtimes in seconds on scoreboard and use them as tiebreaker instead of penalty. The runtime of a submission is the maximum over all testcases.',
         ]);
         $builder->add('medalsEnabled', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -100,7 +100,7 @@ class ContestType extends AbstractExternalIdEntityType
                 'Yes' => true,
                 'No' => false,
             ],
-            'help' => 'Enable this to show runtimes in milliseconds on scoreboard and use them as tiebreaker instead of penalty.',
+            'help' => 'Enable this to show runtimes in milliseconds on scoreboard and use them as tiebreaker instead of penalty. The runtime of a submission is the maximum over all testcases.',
         ]);
         $builder->add('medalsEnabled', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -94,7 +94,7 @@ class ContestType extends AbstractExternalIdEntityType
             ],
             'help' => 'Disable this to stop recording balloons. Usually you can just leave this enabled.',
         ]);
-        $builder->add('orderByRuntime', ChoiceType::class, [
+        $builder->add('runtimeAsScoreTiebreaker', ChoiceType::class, [
             'expanded' => true,
             'choices' => [
                 'Yes' => true,

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -359,7 +359,7 @@ class ScoreboardService
             // STEP 1:
             // runtime improvements should be possible for all correct submissions
             if (!is_null($judging) && $judging->getResult() == Judging::RESULT_CORRECT) {
-                $runtime = (int) round(1000*$judging->getMaxRuntime()); // round to milliseconds
+                $runtime = (int) floor(1000*$judging->getMaxRuntime()); // round to milliseconds
                 $runtimeJury = min($runtimeJury, $runtime);
                 if (!$submission->isAfterFreeze()) {
                     $runtimePubl = min($runtimePubl, $runtime);

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -148,7 +148,11 @@ class ScoreboardService
         $restricted = ($jury || $freezeData->showFinal(false));
         $variant    = $restricted ? 'restricted' : 'public';
         $points     = $rankCache ? $rankCache->getPointsRestricted() : 0;
-        $totalTime  = $rankCache ? $rankCache->getTotaltimeRestricted() : 0;
+        $totalTime  = 0;
+        if($rankCache) {
+            $totalTime  = $contest->getOrderByRuntime() ? $rankCache->getTotalruntimeRestricted() : $rankCache->getTotaltimeRestricted();
+        }
+        $timeType   = $contest->getOrderByRuntime() ? 'runtime' : 'time';
         $sortOrder  = $team->getCategory()->getSortorder();
 
         // Number of teams that definitely ranked higher.
@@ -161,8 +165,8 @@ class ScoreboardService
             ->andWhere('tc.sortorder = :sortorder')
             ->andWhere('t.enabled = 1')
             ->andWhere(sprintf('r.points_%s > :points OR '.
-                               '(r.points_%s = :points AND r.totaltime_%s < :totaltime)',
-                               $variant, $variant, $variant))
+                               '(r.points_%s = :points AND r.total%s_%s < :totaltime)',
+                               $variant, $variant, $timeType, $variant))
             ->setParameter('contest', $contest)
             ->setParameter('sortorder', $sortOrder)
             ->setParameter('points', $points)
@@ -185,8 +189,8 @@ class ScoreboardService
                 ->andWhere('r.contest = :contest')
                 ->andWhere('tc.sortorder = :sortorder')
                 ->andWhere('t.enabled = 1')
-                ->andWhere(sprintf('r.points_%s = :points AND r.totaltime_%s = :totaltime',
-                                   $variant, $variant))
+                ->andWhere(sprintf('r.points_%s = :points AND r.total%s_%s = :totaltime',
+                                   $variant, $timeType, $variant))
                 ->setParameter('contest', $contest)
                 ->setParameter('sortorder', $sortOrder)
                 ->setParameter('points', $points)
@@ -319,7 +323,8 @@ class ScoreboardService
         } else {
             $queryBuilder
                 ->addSelect('j')
-                ->leftJoin('s.judgings', 'j', Join::WITH, 'j.valid = 1');
+                ->leftJoin('s.judgings', 'j', Join::WITH, 'j.valid = 1')
+                ->leftJoin('j.runs', 'jr');
         }
 
         // Check if we need to count compile error as a penalty.
@@ -335,6 +340,34 @@ class ScoreboardService
         $submissionsPubl = $pendingPubl = $timePubl = 0;
         $correctJury     = false;
         $correctPubl     = false;
+        $runtimeJury     = PHP_INT_MAX;
+        $runtimePubl     = PHP_INT_MAX;
+
+        // do runtime separately to not interfere with break/continue logic in normal submission counting
+        // we want to allow runtime improvements even after first correct submission
+        foreach ($submissions as $submission) {
+            /** @var Judging|ExternalJudgement|null $judging */
+            if ($useExternalJudgements) {
+                $judging = $submission->getExternalJudgements()->first() ?: null;
+            } else {
+                $judging = $submission->getJudgings()->first() ?: null;
+            }
+
+            // Check if this submission has a publicly visible judging result:
+            if ($judging === null ||
+                (!$useExternalJudgements && $verificationRequired && !$judging->getVerified()) ||
+                empty($judging->getResult())) {
+                continue;
+            }
+
+            if ($judging->getResult() == Judging::RESULT_CORRECT) {
+                $runtime = (int) round(1000*$judging->getMaxRuntime()); // round to milliseconds
+                $runtimeJury = min($runtimeJury, $runtime);
+                if (!$submission->isAfterFreeze()) {
+                    $runtimePubl = min($runtimePubl, $runtime);
+                }
+            }
+        }
 
         foreach ($submissions as $submission) {
             /** @var Judging|ExternalJudgement|null $judging */
@@ -464,19 +497,21 @@ class ScoreboardService
             'submissionsRestricted' => $submissionsJury,
             'pendingRestricted' => $pendingJury,
             'solvetimeRestricted' => (int)$timeJury,
+            'runtimeRestricted' => $runtimeJury === PHP_INT_MAX ? 0 : $runtimeJury,
             'isCorrectRestricted' => (int)$correctJury,
             'submissionsPublic' => $submissionsPubl,
             'pendingPublic' => $pendingPubl,
             'solvetimePublic' => (int)$timePubl,
+            'runtimePublic' => $runtimePubl === PHP_INT_MAX ? 0 : $runtimePubl,
             'isCorrectPublic' => (int)$correctPubl,
             'isFirstToSolve' => (int)$firstToSolve,
         ];
         $this->em->getConnection()->executeQuery('REPLACE INTO scorecache
             (cid, teamid, probid,
-             submissions_restricted, pending_restricted, solvetime_restricted, is_correct_restricted,
-             submissions_public, pending_public, solvetime_public, is_correct_public, is_first_to_solve)
-            VALUES (:cid, :teamid, :probid, :submissionsRestricted, :pendingRestricted, :solvetimeRestricted, :isCorrectRestricted,
-            :submissionsPublic, :pendingPublic, :solvetimePublic, :isCorrectPublic, :isFirstToSolve)', $params);
+             submissions_restricted, pending_restricted, solvetime_restricted, runtime_restricted, is_correct_restricted,
+             submissions_public, pending_public, solvetime_public, runtime_public, is_correct_public, is_first_to_solve)
+            VALUES (:cid, :teamid, :probid, :submissionsRestricted, :pendingRestricted, :solvetimeRestricted, :runtimeRestricted, :isCorrectRestricted,
+            :submissionsPublic, :pendingPublic, :solvetimePublic, :runtimePublic, :isCorrectPublic, :isFirstToSolve)', $params);
 
         if ($this->em->getConnection()->fetchOne('SELECT RELEASE_LOCK(:lock)',
                                                     ['lock' => $lockString]) != 1) {
@@ -531,9 +566,11 @@ class ScoreboardService
         $variants  = ['public' => false, 'restricted' => true];
         $numPoints = [];
         $totalTime = [];
+        $totalRuntime = [];
         foreach ($variants as $variant => $isRestricted) {
             $numPoints[$variant] = 0;
             $totalTime[$variant] = $team->getPenalty();
+            $totalRuntime[$variant] = 0;
         }
 
         $penaltyTime      = (int) $this->config->get('penalty_time');
@@ -565,6 +602,7 @@ class ScoreboardService
                         (float)$scoreCache->getSolveTime($isRestricted),
                         $scoreIsInSeconds
                     ) + $penalty;
+                    $totalRuntime[$variant] += $scoreCache->getRuntime($isRestricted);
                 }
             }
         }
@@ -575,13 +613,15 @@ class ScoreboardService
             'teamid' => $team->getTeamid(),
             'pointsRestricted' => $numPoints['restricted'],
             'totalTimeRestricted' => $totalTime['restricted'],
+            'totalRuntimeRestricted' => $totalRuntime['restricted'],
             'pointsPublic' => $numPoints['public'],
             'totalTimePublic' => $totalTime['public'],
+            'totalRuntimePublic' => $totalRuntime['public'],
         ];
         $this->em->getConnection()->executeQuery('REPLACE INTO rankcache (cid, teamid,
-            points_restricted, totaltime_restricted,
-            points_public, totaltime_public)
-            VALUES (:cid, :teamid, :pointsRestricted, :totalTimeRestricted, :pointsPublic, :totalTimePublic)', $params);
+            points_restricted, totaltime_restricted, totalruntime_restricted,
+            points_public, totaltime_public, totalruntime_public)
+            VALUES (:cid, :teamid, :pointsRestricted, :totalTimeRestricted, :totalRuntimeRestricted, :pointsPublic, :totalTimePublic, :totalRuntimePublic)', $params);
 
         if ($this->em->getConnection()->fetchOne('SELECT RELEASE_LOCK(:lock)',
                                                     ['lock' => $lockString]) != 1) {

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -149,10 +149,10 @@ class ScoreboardService
         $variant    = $restricted ? 'restricted' : 'public';
         $points     = $rankCache ? $rankCache->getPointsRestricted() : 0;
         $totalTime  = 0;
-        if($rankCache) {
-            $totalTime  = $contest->getOrderByRuntime() ? $rankCache->getTotalruntimeRestricted() : $rankCache->getTotaltimeRestricted();
+        if ($rankCache) {
+            $totalTime  = $contest->getRuntimeAsScoreTiebreaker() ? $rankCache->getTotalruntimeRestricted() : $rankCache->getTotaltimeRestricted();
         }
-        $timeType   = $contest->getOrderByRuntime() ? 'runtime' : 'time';
+        $timeType   = $contest->getRuntimeAsScoreTiebreaker() ? 'runtime' : 'time';
         $sortOrder  = $team->getCategory()->getSortorder();
 
         // Number of teams that definitely ranked higher.

--- a/webapp/src/Utils/Scoreboard/ProblemSummary.php
+++ b/webapp/src/Utils/Scoreboard/ProblemSummary.php
@@ -16,6 +16,9 @@ class ProblemSummary
     /** @var float[] */
     public array $bestTimes = [];
 
+    /** @var int[] */
+    public array $bestRuntimes = [];
+
     public function addSubmissionCounts(
         int $sortorder,
         int $numSubmissions,
@@ -53,5 +56,23 @@ class ProblemSummary
     public function updateBestTime(int $sortorder, $bestTime)
     {
         $this->bestTimes[$sortorder] = $bestTime;
+    }
+
+    /**
+     * Get the best runtime in milliseconds for the given sortorder.
+     */
+    public function getBestRuntime(int $sortorder): int
+    {
+        return $this->bestRuntimes[$sortorder] ?? PHP_INT_MAX;
+    }
+
+    /**
+     * update fastest runtime if given time is a new record for this problem/sortorder
+     */
+    public function updateBestRuntime(int $sortorder, int $runtime)
+    {
+        if ($runtime < $this->getBestRuntime($sortorder)) {
+            $this->bestRuntimes[$sortorder] = $runtime;
+        }
     }
 }

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -455,7 +455,7 @@ class Scoreboard
     /**
      * Determine whether this team has the fastest correct implementation for this problem
      */
-    public function isFastestImplementation(Team $team, ContestProblem $problem): bool
+    public function isFastestSubmission(Team $team, ContestProblem $problem): bool
     {
         $item = $this->matrix[$team->getTeamid()][$problem->getProbid()];
         if (!$item->isCorrect) {

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -308,7 +308,7 @@ class Scoreboard
             return $b->numPoints <=> $a->numPoints;
         }
         // Else, less time spent means higher rank.
-        if($this->getOrderByRuntime()) { // runtime ordering
+        if ($this->getRuntimeAsScoreTiebreaker()) { // runtime ordering
             if ($a->totalRuntime != $b->totalRuntime) {
                 return $a->totalRuntime <=> $b->totalRuntime;
             }
@@ -470,8 +470,8 @@ class Scoreboard
      * Determine whether to order by runtime instead of solvetime
      * @return bool
      */
-    public function getOrderByRuntime(): bool
+    public function getRuntimeAsScoreTiebreaker(): bool
     {
-        return $this->contest->getOrderByRuntime();
+        return $this->contest->getRuntimeAsScoreTiebreaker();
     }
 }

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -179,7 +179,8 @@ class Scoreboard
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
-                $penalty
+                $penalty,
+                $scoreRow->getRuntime($this->restricted)
             );
 
             if ($scoreRow->getIsCorrect($this->restricted)) {
@@ -189,11 +190,12 @@ class Scoreboard
                 $this->scores[$teamId]->numPoints += $contestProblem->getPoints();
                 $this->scores[$teamId]->solveTimes[] = $solveTime;
                 $this->scores[$teamId]->totalTime += $solveTime + $penalty;
+                $this->scores[$teamId]->totalRuntime += $scoreRow->getRuntime($this->restricted);
             }
         }
 
         // Now sort the scores using the scoreboard sort function.
-        uasort($this->scores, [static::class, 'scoreboardCompare']);
+        uasort($this->scores, [$this, 'scoreboardCompare']);
 
         // Loop over all teams to calculate ranks and totals.
         $prevSortOrder  = -1;
@@ -236,7 +238,7 @@ class Scoreboard
                 $problemId = $contestProblem->getProbid();
                 // Provide default scores when nothing submitted for this team + problem yet
                 if (!isset($this->matrix[$teamId][$problemId])) {
-                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0);
+                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
                 }
 
                 $problemMatrixItem = $this->matrix[$teamId][$problemId];
@@ -251,6 +253,10 @@ class Scoreboard
                 if ($problemMatrixItem->isFirst) {
                     $problemSummary->updateBestTime($sortOrder, $problemMatrixItem->time);
                 }
+                // aggregate minimum runtime of correct submissions for each problem
+                if ($problemMatrixItem->isCorrect) {
+                    $problemSummary->updateBestRuntime($sortOrder, $problemMatrixItem->runtime);
+                }
             }
         }
     }
@@ -264,7 +270,7 @@ class Scoreboard
      *   based on number of problems solved and the time it took;
      * - If still equal, order on team name alphabetically.
      */
-    protected static function scoreboardCompare(TeamScore $a, TeamScore $b): int
+    protected function scoreboardCompare(TeamScore $a, TeamScore $b): int
     {
         // First order by our predefined sortorder based on category.
         $a_sortorder = $a->team->getCategory()->getSortorder();
@@ -274,7 +280,7 @@ class Scoreboard
         }
 
         // Then compare scores.
-        $scoreCompare = static::scoreCompare($a, $b);
+        $scoreCompare = $this->scoreCompare($a, $b);
         if ($scoreCompare != 0) {
             return $scoreCompare;
         }
@@ -292,18 +298,24 @@ class Scoreboard
      * Main score comparison function, called from the 'scoreboardCompare' wrapper
      * above. Scores based on the following criteria:
      * - highest points from correct solutions;
-     * - least amount of total time spent on these solutions;
+     * - least amount of total time spent on these solutions; (or lowest total runtime)
      * - the tie-breaker function below.
      */
-    protected static function scoreCompare(TeamScore $a, TeamScore $b): int
+    protected function scoreCompare(TeamScore $a, TeamScore $b): int
     {
         // More correctness points than someone else means higher rank.
         if ($a->numPoints != $b->numPoints) {
             return $b->numPoints <=> $a->numPoints;
         }
         // Else, less time spent means higher rank.
-        if ($a->totalTime != $b->totalTime) {
-            return $a->totalTime <=> $b->totalTime;
+        if($this->getOrderByRuntime()) { // runtime ordering
+            if ($a->totalRuntime != $b->totalRuntime) {
+                return $a->totalRuntime <=> $b->totalRuntime;
+            }
+        } else { // solvetime ordering
+            if ($a->totalTime != $b->totalTime) {
+                return $a->totalTime <=> $b->totalTime;
+            }
         }
         // Else tie-breaker rule.
         return static::scoreTiebreaker($a, $b);
@@ -437,5 +449,29 @@ class Scoreboard
     public function solvedFirst(Team $team, ContestProblem $problem): bool
     {
         return $this->matrix[$team->getTeamid()][$problem->getProbid()]->isFirst;
+    }
+
+
+    /**
+     * Determine whether this team has the fastest correct implementation for this problem
+     */
+    public function isFastestImplementation(Team $team, ContestProblem $problem): bool
+    {
+        $item = $this->matrix[$team->getTeamid()][$problem->getProbid()];
+        if (!$item->isCorrect) {
+            return false;
+        }
+        $sortorder = $team->getCategory()->getSortorder();
+        $bestTime = $this->summary->getProblem($problem->getProbid())->getBestRuntime($sortorder);
+        return $item->runtime == $bestTime;
+    }
+
+    /**
+     * Determine whether to order by runtime instead of solvetime
+     * @return bool
+     */
+    public function getOrderByRuntime(): bool
+    {
+        return $this->contest->getOrderByRuntime();
     }
 }

--- a/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -12,6 +12,7 @@ class ScoreboardMatrixItem
     /** @var float|string */
     public $time;
     public int $penaltyTime;
+    public int $runtime;
 
     public function __construct(
         bool $isCorrect,
@@ -19,7 +20,8 @@ class ScoreboardMatrixItem
         int $numSubmissions,
         int $numSubmissionsPending,
         $time,
-        int $penaltyTime
+        int $penaltyTime,
+        int $runtime
     ) {
         $this->isCorrect             = $isCorrect;
         $this->isFirst               = $isFirst;
@@ -27,5 +29,6 @@ class ScoreboardMatrixItem
         $this->numSubmissionsPending = $numSubmissionsPending;
         $this->time                  = $time;
         $this->penaltyTime           = $penaltyTime;
+        $this->runtime               = $runtime;
     }
 }

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -55,6 +55,7 @@ class SingleTeamScoreboard extends Scoreboard
         if ($this->rankCache !== null) {
             $teamScore->numPoints += $this->rankCache->getPointsRestricted();
             $teamScore->totalTime += $this->rankCache->getTotaltimeRestricted();
+            $teamScore->totalRuntime += $this->rankCache->getTotalruntimeRestricted(); 
         }
         $teamScore->rank = $this->teamRank;
 
@@ -77,7 +78,8 @@ class SingleTeamScoreboard extends Scoreboard
                 $scoreRow->getSubmissions($this->restricted),
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
-                $penalty
+                $penalty,
+                $scoreRow->getRuntime($this->restricted)
             );
         }
 
@@ -87,7 +89,7 @@ class SingleTeamScoreboard extends Scoreboard
             $teamId    = $this->team->getTeamid();
             $problemId = $contestProblem->getProbid();
             if (!isset($this->matrix[$teamId][$problemId])) {
-                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0);
+                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
             }
         }
     }

--- a/webapp/src/Utils/Scoreboard/TeamScore.php
+++ b/webapp/src/Utils/Scoreboard/TeamScore.php
@@ -13,6 +13,7 @@ class TeamScore
     public array $solveTimes = [];
     public int $rank = 0;
     public int $totalTime;
+    public int $totalRuntime = 0;
 
     public function __construct(Team $team)
     {

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -122,6 +122,10 @@
                     <td>{{ contest.processBalloons | printYesNo }}</td>
                 </tr>
                 <tr>
+                    <th>Order by runtime</th>
+                    <td>{{ contest.orderByRuntime | printYesNo }}</td>
+                </tr>
+                <tr>
                     <th>Process medals</th>
                     <td>{{ contest.medalsEnabled | printYesNo }}</td>
                 </tr>

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -122,8 +122,8 @@
                     <td>{{ contest.processBalloons | printYesNo }}</td>
                 </tr>
                 <tr>
-                    <th>Order by runtime</th>
-                    <td>{{ contest.orderByRuntime | printYesNo }}</td>
+                    <th>Runtime as tiebreaker</th>
+                    <td>{{ contest.runtimeAsScoreTiebreaker | printYesNo }}</td>
                 </tr>
                 <tr>
                     <th>Process medals</th>

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -19,6 +19,7 @@
         {{ form_row(form.deactivatetimeString) }}
         {{ form_row(form.allowSubmit) }}
         {{ form_row(form.processBalloons) }}
+        {{ form_row(form.orderByRuntime) }}
         {{ form_row(form.medalsEnabled) }}
         <div data-medals-field>
             {{ form_row(form.medalCategories) }}

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -19,7 +19,7 @@
         {{ form_row(form.deactivatetimeString) }}
         {{ form_row(form.allowSubmit) }}
         {{ form_row(form.processBalloons) }}
-        {{ form_row(form.orderByRuntime) }}
+        {{ form_row(form.runtimeAsScoreTiebreaker) }}
         {{ form_row(form.medalsEnabled) }}
         <div data-medals-field>
             {{ form_row(form.medalCategories) }}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -235,7 +235,7 @@
                         {% if not scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.solvedFirst(score.team, problem) %}
                                 {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %}
-                        {% if scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.isFastestImplementation(score.team, problem) %}
+                        {% if scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.isFastestSubmission(score.team, problem) %}
                                 {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %} 
                     {% elseif showPending and matrixItem.numSubmissionsPending > 0 %}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -219,7 +219,7 @@
             {% endif %}
             {% set totalPoints = score.numPoints %}
             <td class="scorenc">{{ totalPoints }}</td>
-            {% if scoreboard.getOrderByRuntime() %}
+            {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
                 <td class="scorett">{{ score.totalRuntime }} ms</td>
             {% else %}
                 <td class="scorett">{{ totalTime }}</td>
@@ -232,10 +232,10 @@
                     {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
                     {% if matrixItem.isCorrect %}
                         {% set scoreCssClass = 'score_correct' %}
-                        {% if not scoreboard.getOrderByRuntime() and scoreboard.solvedFirst(score.team, problem) %}
+                        {% if not scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.solvedFirst(score.team, problem) %}
                                 {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %}
-                        {% if scoreboard.getOrderByRuntime() and scoreboard.isFastestImplementation(score.team, problem) %}
+                        {% if scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.isFastestImplementation(score.team, problem) %}
                                 {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %} 
                     {% elseif showPending and matrixItem.numSubmissionsPending > 0 %}
@@ -253,7 +253,7 @@
                     {% set time = '' %}
                     {% if matrixItem.isCorrect %}
                         {% set time = matrixItem.time %}
-                        {% if scoreboard.getOrderByRuntime() %}
+                        {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
                             {% set time = matrixItem.runtime ~ ' ms' %}
                         {% elseif scoreInSeconds %}
                             {% set time = time | scoreTime | printTimeRelative %}
@@ -331,7 +331,7 @@
     {% endif %}
 
     {% if showTeamSubmissions or jury %}
-        {% if scoreboard.getOrderByRuntime() %}
+        {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
             {% set cellColors = {first: 'Solved, fastest', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
         {% else %}
             {% set cellColors = {first: 'Solved first', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -219,7 +219,11 @@
             {% endif %}
             {% set totalPoints = score.numPoints %}
             <td class="scorenc">{{ totalPoints }}</td>
-            <td class="scorett">{{ totalTime }}</td>
+            {% if scoreboard.getOrderByRuntime() %}
+                <td class="scorett">{{ score.totalRuntime }} ms</td>
+            {% else %}
+                <td class="scorett">{{ totalTime }}</td>
+            {% endif %} 
 
             {% if showTeamSubmissions or jury %}
                 {% for problem in problems %}
@@ -228,9 +232,12 @@
                     {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
                     {% if matrixItem.isCorrect %}
                         {% set scoreCssClass = 'score_correct' %}
-                        {% if scoreboard.solvedFirst(score.team, problem) %}
-                            {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
+                        {% if not scoreboard.getOrderByRuntime() and scoreboard.solvedFirst(score.team, problem) %}
+                                {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                         {% endif %}
+                        {% if scoreboard.getOrderByRuntime() and scoreboard.isFastestImplementation(score.team, problem) %}
+                                {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
+                        {% endif %} 
                     {% elseif showPending and matrixItem.numSubmissionsPending > 0 %}
                         {% set scoreCssClass = 'score_pending' %}
                     {% elseif matrixItem.numSubmissions > 0 %}
@@ -246,7 +253,9 @@
                     {% set time = '' %}
                     {% if matrixItem.isCorrect %}
                         {% set time = matrixItem.time %}
-                        {% if scoreInSeconds %}
+                        {% if scoreboard.getOrderByRuntime() %}
+                            {% set time = matrixItem.runtime ~ ' ms' %}
+                        {% elseif scoreInSeconds %}
                             {% set time = time | scoreTime | printTimeRelative %}
                             {% if matrixItem.numSubmissions > 1 %}
                                 {% set time = time ~ ' + ' ~ (calculatePenaltyTime(true, matrixItem.numSubmissions) | printTimeRelative) %}
@@ -322,7 +331,11 @@
     {% endif %}
 
     {% if showTeamSubmissions or jury %}
-        {% set cellColors = {first: 'Solved first', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
+        {% if scoreboard.getOrderByRuntime() %}
+            {% set cellColors = {first: 'Solved, fastest', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
+        {% else %}
+            {% set cellColors = {first: 'Solved first', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
+        {% endif %} 
         <table id="cell_legend" class="scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
             <thead>
             <tr>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -220,7 +220,7 @@
             {% set totalPoints = score.numPoints %}
             <td class="scorenc">{{ totalPoints }}</td>
             {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
-                <td class="scorett">{{ score.totalRuntime }} ms</td>
+                <td class="scorett">{{ "%0.3f s" | format(score.totalRuntime/1000.0) }}</td>
             {% else %}
                 <td class="scorett">{{ totalTime }}</td>
             {% endif %} 
@@ -254,7 +254,7 @@
                     {% if matrixItem.isCorrect %}
                         {% set time = matrixItem.time %}
                         {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
-                            {% set time = matrixItem.runtime ~ ' ms' %}
+                            {% set time = "%0.3f s" | format(matrixItem.runtime / 1000.0) %}
                         {% elseif scoreInSeconds %}
                             {% set time = time | scoreTime | printTimeRelative %}
                             {% if matrixItem.numSubmissions > 1 %}

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -44,7 +44,7 @@
                 </div>
                 {% if judging.result == 'correct' and judging.submission.contest.getRuntimeAsScoreTiebreaker() %}
                     <div class="p-2">
-                        Runtime: <b>{{ 1000*judging.getMaxRuntime() }} ms</b>
+                        Max. Runtime: <b>{{ "%0.3f s" | format(judging.getMaxRuntime()) }}</b>
                     </div>
                 {% endif %}
             </div>

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -42,6 +42,11 @@
                 <div class="p-2">
                     Result: {{ judging.result | printResult }}
                 </div>
+                {% if judging.result == 'correct' %}
+                    <div class="p-2">
+                        Runtime: <b>{{ 1000*judging.getMaxRuntime() }} ms</b>
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
 

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -42,7 +42,7 @@
                 <div class="p-2">
                     Result: {{ judging.result | printResult }}
                 </div>
-                {% if judging.result == 'correct' %}
+                {% if judging.result == 'correct' and judging.submission.contest.getRuntimeAsScoreTiebreaker() %}
                     <div class="p-2">
                         Runtime: <b>{{ 1000*judging.getMaxRuntime() }} ms</b>
                     </div>

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -11,6 +11,7 @@
             <th scope="col">problem</th>
             <th scope="col">lang</th>
             <th scope="col">result</th>
+            <th scope="col">runtime</th>
             {% if allowDownload %}
                 <th scope="col"></th>
             {% endif %}
@@ -57,6 +58,15 @@
                         {%- else %}
                             {{- submission.judgings.first.result | printResult -}}
                         {%- endif %}
+                    </a>
+                </td>
+                <td>
+                    <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
+                        {% if link and submission.getResult()=='correct' %}
+                            {{ 1000*submission.judgings.first.getMaxRuntime() }} ms
+                        {% else %}
+                            -
+                        {% endif %}
                     </a>
                 </td>
         {% if allowDownload %}

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -11,7 +11,9 @@
             <th scope="col">problem</th>
             <th scope="col">lang</th>
             <th scope="col">result</th>
-            <th scope="col">runtime</th>
+            {% if contest.getRuntimeAsScoreTiebreaker() %}
+                <th scope="col">runtime</th>
+            {% endif %}
             {% if allowDownload %}
                 <th scope="col"></th>
             {% endif %}
@@ -60,6 +62,7 @@
                         {%- endif %}
                     </a>
                 </td>
+        {% if contest.getRuntimeAsScoreTiebreaker() %}
                 <td>
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
                         {% if link and submission.getResult()=='correct' %}
@@ -69,6 +72,7 @@
                         {% endif %}
                     </a>
                 </td>
+        {% endif %}
         {% if allowDownload %}
                 <td>
                     <a title="Download submission ZIP" aria-label="download submission zip" class="btn btn-light" href="{{ path('team_submission_download', {'submitId': submission.submitid}) }}">

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -66,7 +66,7 @@
                 <td>
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
                         {% if link and submission.getResult()=='correct' %}
-                            {{ 1000*submission.judgings.first.getMaxRuntime() }} ms
+                            {{ "%0.3f s" | format(submission.judgings.first.getMaxRuntime()) }}
                         {% else %}
                             -
                         {% endif %}


### PR DESCRIPTION
Hi. We have been using domjudge for 6 years now in our ICPC lectures.
However, we usually have weekly tasks for the student to solve and the penalty tiebreaker by domjudge doesn't fit well with this. That's why we show the runtime of correct submissions on the scoreboard and rank by summed time.
We found it a great tool to teach the students how practical runtime differs from asymptotics and how much of a performance impact different changes can have. 

We have been maintaining these changes on our own fork for some time but I decided to clean it up and submit a PR.
I would appreciate any feedback or help since this is the first PHP project I'm working on.