### PR TITLE
Fix CI after rename of variable & limiting parameter type

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -65,7 +65,7 @@ class ClarificationController extends AbstractRestController
      * Admin and api_reader get everything, anonymous gets only general clarifications,
      * team user gets general clarifications plus those sent from or to the team.
      * @throws NonUniqueResultException
-     * @Rest\Get("/{id<\d+>}")
+     * @Rest\Get("/{id}")
      * @OA\Response(
      *     response="200",
      *     description="Returns the given clarification for this contest",
@@ -82,7 +82,7 @@ class ClarificationController extends AbstractRestController
     /**
      * Add a clarification to this contest
      * @Rest\Post("")
-     * @Rest\Put("/{id<\d+>}")
+     * @Rest\Put("/{id}")
      * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a clarification")
      * @OA\RequestBody(
      *     required=true,

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -211,7 +211,7 @@ class ContestController extends AbstractRestController
      * @Rest\Delete("/{cid}/banner", name="delete_contest_banner")
      * @IsGranted("ROLE_ADMIN")
      * @OA\Response(response="204", description="Deleting banner succeeded")
-     * @OA\Parameter(ref="#/components/parameters/id")
+     * @OA\Parameter(ref="#/components/parameters/cid")
      */
     public function deleteBannerAction(Request $request, string $cid): Response
     {
@@ -261,7 +261,7 @@ class ContestController extends AbstractRestController
      * )
      * @IsGranted("ROLE_ADMIN")
      * @OA\Response(response="204", description="Setting banner succeeded")
-     * @OA\Parameter(ref="#/components/parameters/id")
+     * @OA\Parameter(ref="#/components/parameters/cid")
      */
     public function setBannerAction(Request $request, string $cid, ValidatorInterface $validator): Response
     {

--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -90,7 +90,7 @@ class SubmissionController extends AbstractRestController
     /**
      * Get the given submission for this contest.
      * @throws NonUniqueResultException
-     * @Rest\Get("submissions/{id<\d+>}")
+     * @Rest\Get("submissions/{id}")
      * @Rest\Get("contests/{cid}/submissions/{id}")
      * @OA\Response(
      *     response="200",
@@ -113,7 +113,7 @@ class SubmissionController extends AbstractRestController
     /**
      * Add a submission to this contest.
      * @Rest\Post("contests/{cid}/submissions")
-     * @Rest\Put("contests/{cid}/submissions/{id<\d+>}")
+     * @Rest\Put("contests/{cid}/submissions/{id}")
      * @Security("is_granted('ROLE_TEAM') or is_granted('ROLE_API_WRITER')", message="You need to have the Team Member role to add a submission")
      * @OA\RequestBody(
      *     required=true,
@@ -450,8 +450,8 @@ class SubmissionController extends AbstractRestController
 
     /**
      * Get the files for the given submission as a ZIP archive.
-     * @Rest\Get("contests/{cid}/submissions/{id<\d+>}/files", name="submission_files")
-     * @Rest\Get("submissions/{id<\d+>}/files", name="submission_files_root")
+     * @Rest\Get("contests/{cid}/submissions/{id}/files", name="submission_files")
+     * @Rest\Get("submissions/{id}/files", name="submission_files_root")
      * @IsGranted("ROLE_API_SOURCE_READER")
      * @throws NonUniqueResultException
      * @OA\Response(
@@ -493,7 +493,7 @@ class SubmissionController extends AbstractRestController
 
     /**
      * Get the source code of all the files for the given submission.
-     * @Rest\Get("contests/{cid}/submissions/{id<\d+>}/source-code")
+     * @Rest\Get("contests/{cid}/submissions/{id}/source-code")
      * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_JUDGEHOST')")
      * @throws NonUniqueResultException
      * @OA\Response(

--- a/webapp/src/Serializer/ContestVisitor.php
+++ b/webapp/src/Serializer/ContestVisitor.php
@@ -69,7 +69,7 @@ class ContestVisitor implements EventSubscriberInterface
             $extension = $parts[count($parts) - 1];
 
             $route = $this->dj->apiRelativeUrl(
-                'v4_contest_banner', ['id' => $id]
+                'v4_contest_banner', ['cid' => $id]
             );
             $property = new StaticPropertyMetadata(
                 Contest::class,


### PR DESCRIPTION
See [this commit ](https://github.com/DOMjudge/domjudge/blob/613d63b60032504c2dbd48ff8a80ba2849fd2edd/webapp/src/Controller/API/AbstractRestController.php#L257-L258) why we accept external Ids for clarifications & submissions.