### PR TITLE
Fix maintainer-install on Ubuntu22.04

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -45,7 +45,8 @@ already listed under
 On Debian 11 (Bullseye) and above, instead install::
 
   sudo apt install autoconf automake bats \
-    python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml latexmk
+    python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
+    latexmk texlive-latex-recommended texlive-latex-extra tex-gyre
 
 When this software is present, bootstrapping can be done by running
 ``make dist``, which creates the ``configure`` script,


### PR DESCRIPTION
This was removed in 7db919726b527fbf4fae9c44b4fc26078d4361eb but I need this for cmap.sty on 22.04 after an upgrade from 20.04.