### PR TITLE
Split languages overview into enabled and disabled languages.

### DIFF
--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -65,7 +65,6 @@ class LanguageController extends BaseController
             'langid' => ['title' => 'ID/ext', 'sort' => true],
             'name' => ['title' => 'name', 'sort' => true, 'default_sort' => true],
             'entrypoint' => ['title' => 'entry point', 'sort' => true],
-            'allowsubmit' => ['title' => 'allow submit', 'sort' => true],
             'allowjudge' => ['title' => 'allow judge', 'sort' => true],
             'timefactor' => ['title' => 'timefactor', 'sort' => true],
             'extensions' => ['title' => 'extensions', 'sort' => true],
@@ -79,7 +78,8 @@ class LanguageController extends BaseController
         }
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $languages_table  = [];
+        $enabled_languages  = [];
+        $disabled_languages  = [];
         foreach ($languages as $lang) {
             $langdata    = [];
             $langactions = [];
@@ -112,19 +112,28 @@ class LanguageController extends BaseController
             $langdata = array_merge($langdata, [
                 'entrypoint' => ['value' => $lang->getRequireEntryPoint() ? 'yes' : 'no'],
                 'extensions' => ['value' => implode(', ', $lang->getExtensions())],
-                'allowsubmit' => ['value' => $lang->getAllowSubmit() ? 'yes' : 'no'],
                 'allowjudge' => ['value' => $lang->getAllowJudge() ? 'yes' : 'no'],
             ]);
 
-            $languages_table[] = [
-                'data' => $langdata,
-                'actions' => $langactions,
-                'link' => $this->generateUrl('jury_language', ['langId' => $lang->getLangid()]),
-                'cssclass' => $lang->getAllowSubmit() ? '' : 'disabled',
-            ];
+            if ($lang->getAllowSubmit()) {
+                $enabled_languages[] = [
+                    'data' => $langdata,
+                    'actions' => $langactions,
+                    'link' => $this->generateUrl('jury_language', ['langId' => $lang->getLangid()]),
+                    'cssclass' => '',
+                ];
+            } else {
+                $disabled_languages[] = [
+                    'data' => $langdata,
+                    'actions' => $langactions,
+                    'link' => $this->generateUrl('jury_language', ['langId' => $lang->getLangid()]),
+                    'cssclass' => 'disabled',
+                ];
+            }
         }
         return $this->render('jury/languages.html.twig', [
-            'languages' => $languages_table,
+            'enabled_languages' => $enabled_languages,
+            'disabled_languages' => $disabled_languages,
             'table_fields' => $table_fields,
             'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
         ]);

--- a/webapp/templates/jury/languages.html.twig
+++ b/webapp/templates/jury/languages.html.twig
@@ -10,9 +10,16 @@
 
 {% block content %}
 
-    <h1>Languages</h1>
+    <h1>Enabled languages</h1>
 
-    {{ macros.table(languages, table_fields, num_actions) }}
+    {{ macros.table(enabled_languages, table_fields, num_actions) }}
+
+    <br/>
+    <br/>
+
+    <h1>Disabled languages</h1>
+
+    {{ macros.table(disabled_languages, table_fields, num_actions) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>


### PR DESCRIPTION
Typically only a few languages are enabled and they are drowned in the long list of configured languages.

before:
![image](https://user-images.githubusercontent.com/418721/219601834-5771185a-1a43-4b83-b52f-6ce6a3d518e0.png)

after:
![image](https://user-images.githubusercontent.com/418721/219601920-b8d5ab0b-e63c-4d3d-9892-ecd423932022.png)
