### PR TITLE
Add button, jury action and API action to download ZIP with all problem samples, attachments and statement.

### DIFF
--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -750,6 +750,15 @@ class ContestController extends AbstractRestController
         return $this->dj->getContestStats($this->getContestWithId($request, $cid));
     }
 
+    /**
+     * @Rest\Get("/{cid}/samples.zip", name="samples_data_zip")
+     */
+    public function samplesDataZipAction(Request $request, string $cid): Response
+    {
+        $contest = $this->getContestWithId($request, $cid);
+        return $this->dj->getSamplesZipForContest($contest);
+    }
+
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
         try {

--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -753,9 +753,21 @@ class ContestController extends AbstractRestController
     /**
      * @Rest\Get("/{cid}/samples.zip", name="samples_data_zip")
      */
-    public function samplesDataZipAction(Request $request, string $cid): Response
+    public function samplesDataZipAction(Request $request): Response
     {
-        $contest = $this->getContestWithId($request, $cid);
+        // getContestQueryBuilder add filters to only get the contests that the user
+        // has access to.
+        /** @var Contest|null $contest */
+        $contest = $this->getContestQueryBuilder()
+            ->andWhere('c.cid = :cid')
+            ->setParameter('cid', $this->getContestId($request))
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($contest === null) {
+            throw new NotFoundHttpException(sprintf('Object with ID \'%s\' not found', $id));
+        }
+
         return $this->dj->getSamplesZipForContest($contest);
     }
 

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -969,6 +969,20 @@ class ContestController extends BaseController
         return $this->doLock($contestId, false);
     }
 
+    /**
+     * @Route("/{contestId<\d+>}/samples.zip", name="jury_contest_samples_data_zip")
+     */
+    public function samplesDataZipAction(Request $request, int $contestId): Response
+    {
+        /** @var Contest $contest */
+        $contest = $this->em->getRepository(Contest::class)->find($contestId);
+        if (!$contest) {
+            throw new NotFoundHttpException(sprintf('Contest with ID %s not found', $contestId));
+        }
+
+        return $this->dj->getSamplesZipForContest($contest);
+    }
+
     private function doLock(int $contestId, bool $locked): Response
     {
         /** @var Contest $contest */

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -196,6 +196,18 @@
                         </a>
                     </td>
                 </tr>
+                <tr>
+                    <th>Sample data ZIP</th>
+                    <td>
+                        <a class="btn btn-sm btn-secondary" href="{{ path('jury_contest_samples_data_zip', {contestId: contest.cid}) }}">
+                            <i class="fas fa-download"></i> Download
+                        </a>
+                        <br/>
+                        <small class="text-muted">
+                            Contains samples, attachments and statement for all problems.
+                        </small>
+                    </td>
+                </tr>
                 {% set contestId = contest.cid %}
                 {% if showExternalId(contest) %}
                     {% set contestId = contest.externalid %}


### PR DESCRIPTION
Not sure if `samples.zip` (and the name of the action) makes the most sense? But it's mostly samples in there after all.