### PR TITLE
Add example Kotlin solution to team manual.

### DIFF
--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -402,7 +402,7 @@ contest ID to use, and the IDs of the team categories you want to include
 .. _clear-cache:
 
 Clearing the PHP/Symfony cache
----------------------------
+------------------------------
 
 Some operations require you to clear the PHP/Symfony cache. To do this, execute
 the `webapp/bin/console` (see the Config checker in the admin interfae for the

--- a/doc/manual/team.rst
+++ b/doc/manual/team.rst
@@ -375,17 +375,21 @@ for different programming languages.
    :language: c
    :caption: *A solution in C*
 
+.. raw:: latex
+
+   \clearpage
+
 .. literalinclude:: ../examples/example.cc
    :language: cpp
    :caption: *A solution in C++*
 
-.. raw:: pdf
-
-   PageBreak
-
 .. literalinclude:: ../examples/example.java
    :language: java
    :caption: *A solution in Java*
+
+.. literalinclude:: ../examples/example.kt
+   :language: kotlin
+   :caption: *A solution in Kotlin*
 
 .. literalinclude:: ../examples/example.py
    :language: python
@@ -398,10 +402,6 @@ for different programming languages.
 .. literalinclude:: ../examples/example.pas
    :language: pas
    :caption: *A solution in Pascal*
-
-.. raw:: pdf
-
-   PageBreak
 
 .. literalinclude:: ../examples/example.hs
    :language: hs


### PR DESCRIPTION
Also replace raw PDF pagebreak by LaTeX \clearpage as the first doesn't work. Note that clearpage also flushes all floats (in this case code listings) to the current page.