### PR TITLE
Make it obvious when you are in dev mode.

### DIFF
--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -188,3 +188,7 @@ div.submission-summary > span {
 table.submissions-table {
     width: auto;
 }
+
+.devmode {
+    background-color: #295D8A !important;
+}

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -45,6 +45,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     protected TokenStorageInterface $tokenStorage;
     protected AuthorizationCheckerInterface $authorizationChecker;
     protected string $projectDir;
+    protected bool $debug;
 
     public function __construct(
         DOMJudgeService               $dj,
@@ -56,7 +57,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         AwardService                  $awards,
         TokenStorageInterface         $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
-        string                        $projectDir
+        string                        $projectDir,
+        bool                          $debug
     ) {
         $this->dj                   = $dj;
         $this->config               = $config;
@@ -68,6 +70,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         $this->tokenStorage         = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->projectDir           = $projectDir;
+        $this->debug                = $debug;
     }
 
     public function getFunctions(): array
@@ -167,6 +170,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                                                $this->authorizationChecker->isGranted('ROLE_ADMIN') &&
                                                $this->config->get('data_source') === DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'doc_links'                     => $this->dj->getDocLinks(),
+            'debug'                         => $this->debug,
         ];
     }
 

--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+<nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top {% if debug %} devmode {% endif %}">
     <a class="navbar-brand hidden-sm-down" href="{{ path('jury_index') }}">DOMjudge</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#menuDefault" aria-controls="menuDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -84,7 +84,16 @@
             {% endif %}
         </ul>
 
+        {% if debug %}
+            <ul class="navbar-nav ml-auto">
+                <li class="nav-item">
+                    <i class="fa-brands fa-dev fa-2x" style="color: white;"></i>
+                </li>
+            </ul>
+        {% endif %}
+
         <ul class="navbar-nav ml-auto">
+
             {# Render user information + logout button #}
             {% if is_granted('IS_AUTHENTICATED_FULLY') %}
                 <li class="nav-item dropdown">


### PR DESCRIPTION
This is only done in the jury interface, so no change for the teams.

It will also help in cases where you have a local maintainer install (which is typically in dev mode) and you don't want to confuse it with a production instance.

Example:
![image](https://user-images.githubusercontent.com/418721/219858218-e8e4daea-2d0e-480a-824f-5ceb42f8666e.png)
