### PR TITLE
In the scoreboard view, display `started` instead of `starts` after c…

### DIFF
--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -35,7 +35,12 @@
                     {% set now = 'now'|date('U') %}
                     {{ now | printremainingminutes(current_contest.endtime) }}
                 {% else %}
-                    starts: {{ current_contest.starttime | printtime }} - ends: {{ current_contest.endtime | printtime }}
+                    {% if current_contest.freezeData.started %}
+                        started:
+                    {% else %}
+                        starts:
+                    {% endif %}
+                    {{ current_contest.starttime | printtime }} - ends: {{ current_contest.endtime | printtime }}
                 {% endif %}
             </span>
         </div>


### PR DESCRIPTION
…ontest start.