### PR TITLE
Improve jury clarification list overview.

### DIFF
--- a/webapp/templates/jury/clarifications.html.twig
+++ b/webapp/templates/jury/clarifications.html.twig
@@ -77,7 +77,7 @@
             {%- if newClarifications | length == 0 %}
                 <p class="nodata">No new clarification requests.</p>
             {%- else %}
-                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: newClarifications} %}
+                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: newClarifications, direction: 'from'} %}
             {%- endif %}
         {% endif %}
 
@@ -86,7 +86,7 @@
             {%- if oldClarifications | length == 0 %}
                 <p class="nodata">No old clarification requests.</p>
             {%- else %}
-                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: oldClarifications} %}
+                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: oldClarifications, direction: 'from'} %}
             {%- endif %}
         {% endif %}
 
@@ -95,7 +95,7 @@
             {%- if generalClarifications | length == 0 %}
                 <p class="nodata">No general clarifications.</p>
             {%- else %}
-                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: generalClarifications} %}
+                {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: generalClarifications, direction: 'to'} %}
             {%- endif %}
         {% endif %}
     {%- endif %}

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -7,13 +7,11 @@
             <th scope="col">external ID</th>
         {% endif %}
         {%- if current_contests | length > 1 %}
-
             <th scope="col">contest</th>
         {%- endif %}
 
         <th scope="col">time</th>
-        <th scope="col">from</th>
-        <th scope="col">to</th>
+        <th scope="col" colspan="2">{{ direction }}<th>
         <th scope="col">subject</th>
 
         <th scope="col">text</th>
@@ -34,31 +32,43 @@
                 <td><a href="{{ link }}">{{ clarification.externalid }}</a></td>
             {% endif %}
             {%- if current_contests | length > 1 %}
-
                 <td><a href="{{ link }}">{{ clarification.contest.shortname }}</a></td>
             {%- endif %}
 
             <td data-order="{{ clarification.submittime }}"><a href="{{ link }}">{{ clarification.submittime | printtime(null, clarification.contest) }}</a></td>
-            {%- set recipientBadge = '' %}
-            {%- set senderBadge = '' %}
             {%- if clarification.sender is null %}
-                {%- set sender = 'Jury' %}
+                {%- set recipientBadge = '' %}
                 {%- if clarification.recipient is null %}
                     {%- set recipient = 'All' %}
                 {%- else %}
                     {%- set recipient = clarification.recipient.effectiveName %}
                     {%- set recipientBadge = clarification.recipient | entityIdBadge('t') %}
                 {%- endif %}
+                <td style="text-align: right;">
+                    <a href="{{ link }}" title="{{ recipient }}">
+                        {{ recipientBadge | raw }}
+                    </a>
+                </td>
+                <td>
+                    <a href="{{ link }}" title="{{ recipient }}">
+                        {{ recipient | u.truncate(teamname_max_length, '…') }}
+                    </a>
+                </td>
             {%- else %}
-                {%- set recipient = 'Jury' %}
                 {%- set sender = clarification.sender.effectiveName %}
                 {%- set senderBadge = clarification.sender | entityIdBadge('t') %}
+                <td style="text-align: right;">
+                    <a href="{{ link }}" title="{{ sender }}">
+                        {{ senderBadge | raw }}
+                    </a>
+                </td>
+                <td>
+                    <a href="{{ link }}" title="{{ sender }}">
+                        {{ sender | u.truncate(teamname_max_length, '…') }}
+                    </a>
+                </td>
             {%- endif %}
 
-            <td><a href="{{ link }}" title="{{ sender }}">{{ senderBadge | raw }}</a>&nbsp;
-                <a href="{{ link }}" title="{{ sender }}">{{ sender | u.truncate(teamname_max_length, '…') }}</a></td>
-            <td><a href="{{ link }}" title="{{ recipient }}">{{ recipientBadge | raw }}</a>&nbsp;
-                <a href="{{ link }}" title="{{ recipient }}">{{ recipient | u.truncate(teamname_max_length, '…') }}</a></td>
             <td><a href="{{ link }}">
                     {%- if clarification.problem -%}
                         problem {{ clarification.problem.contestProblems.first | problemBadge -}}


### PR DESCRIPTION
- stop repeating the word jury all over the page
- only have either from or to column, not both, in each sublist
- align team badges as we do for the submission list (and with that fix ugly line breaks in the table, an alternative would have been to fix the `&nbsp;`).

before:
![before](https://user-images.githubusercontent.com/418721/220444984-e1b4bc39-78c9-4dd6-8fbe-9639c906911b.png)

after:
![after](https://user-images.githubusercontent.com/418721/220445014-69e35df6-3d5d-4276-8b0a-50f98aa7d151.png)
