### PR TITLE
Add roles needed to setup a contest like SWERC

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -358,6 +358,9 @@ class UserController extends AbstractRestController
         }
 
         $roles = $request->request->all('roles');
+        if (in_array('cds', $roles)) {
+            $roles = array_merge(['api_source_reader', 'api_writer', 'api_reader'], array_diff($roles, ['cds']));
+        }
         foreach ($roles as $djRole) {
             if ($djRole === '') {
                 continue;

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -362,6 +362,9 @@ class UserController extends AbstractRestController
             if ($djRole === '') {
                 continue;
             }
+            if ($djRole === 'judge') {
+                $djRole = 'jury';
+            }
             $role = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => $djRole]);
             if ($role === null) {
                 throw new BadRequestHttpException(sprintf("Role %s not found", $djRole));

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -363,7 +363,7 @@ class UserController extends AbstractRestController
             $roles = ['cds'];
         }
         if (in_array('cds', $roles)) {
-            $roles = array_merge(['api_source_reader', 'api_writer', 'api_reader'], array_diff($roles, ['cds']));
+            $roles = ['api_source_reader', 'api_writer', 'api_reader', ...array_diff($roles, ['cds'])];
         }
         foreach ($roles as $djRole) {
             if ($djRole === '') {

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -358,6 +358,10 @@ class UserController extends AbstractRestController
         }
 
         $roles = $request->request->all('roles');
+        // For the file import we change a CDS user to the roles needed for ICPC CDS.
+        if ($user->getUsername() === 'cds') {
+            $roles = ['cds'];
+        }
         if (in_array('cds', $roles)) {
             $roles = array_merge(['api_source_reader', 'api_writer', 'api_reader'], array_diff($roles, ['cds']));
         }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -460,7 +460,9 @@ class User extends BaseApiEntity implements UserInterface, PasswordAuthenticated
         // Types allowed by the CCS Specs Contest API in order of most permissions to least
         // Either key=>value where key is the DOMjudge role and value is the API type or
         // only value, where both the DOMjudge role and API type are the same
-        $allowedTypes = ['admin', 'jury' => 'judge', 'api_reader' => 'admin', 'team'];
+        $allowedTypes = ['admin', 'api_writer' => 'admin', 'jury' => 'judge',
+                         'api_reader' => 'admin', 'api_writer' => 'admin', 'api_source_reader' => 'judge',
+                         'team'];
         foreach ($allowedTypes as $role => $allowedType) {
             if (is_numeric($role)) {
                 $role = $allowedType;

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -847,6 +847,9 @@ class ImportExportService
                 case 'api_writer':
                     $roles[] = $apiWriteRole;
                     break;
+                case 'cds':
+                    $roles += [$apiReadRole, $apiSourceRole, $apiWriteRole];
+                    break;
                 case 'analyst':
                 case 'staff':
                     // Ignore type analyst and staff for now. We don't have a useful mapping yet.
@@ -1180,6 +1183,9 @@ class ImportExportService
                     break;
                 case 'api_source_reader':
                     $roles[] = $apiSourceRole;
+                    break;
+                case 'cds':
+                    $roles += [$apiReadRole, $apiSourceRole, $apiWriteRole];
                     break;
                 case 'analyst':
                     // Ignore type analyst for now. We don't have a useful mapping yet.

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -790,14 +790,15 @@ class ImportExportService
      */
     public function importAccountsJson(array $data, ?string &$message = null, ?array &$saved = null): int
     {
-        $teamRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
-        $juryRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
-        $adminRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
-        $balloonRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
-        $clarRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
-        $apiReadRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
-        $apiWriteRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
-        $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
+        $teamRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
+        $juryRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
+        $adminRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
+        $balloonRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
+        $clarRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
+        $apiReadRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
+        $apiWriteRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
+        $apiSourceRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_source_reader']);
+        $juryCategory  = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
             $juryCategory = new TeamCategory();
             $juryCategory
@@ -839,6 +840,9 @@ class ImportExportService
                     $roles[] = $clarRole;
                 case 'api_reader':
                     $roles[] = $apiReadRole;
+                    break;
+                case 'api_source_reader':
+                    $roles[] = $apiSourceRole;
                     break;
                 case 'api_writer':
                     $roles[] = $apiWriteRole;
@@ -1098,15 +1102,16 @@ class ImportExportService
      */
     protected function importAccountsTsv(array $content, ?string &$message = null): int
     {
-        $accountData = [];
-        $l           = 1;
-        $teamRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
-        $juryRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
-        $adminRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
-        $balloonRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
-        $clarRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
-        $apiReadRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
-        $apiWriteRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
+        $accountData   = [];
+        $l             = 1;
+        $teamRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
+        $juryRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
+        $adminRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
+        $balloonRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
+        $clarRole      = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
+        $apiReadRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
+        $apiWriteRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
+        $apiSourceRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_source_reader']);
 
         $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
@@ -1172,6 +1177,9 @@ class ImportExportService
                     break;
                 case 'api_writer':
                     $roles[] = $apiWriteRole;
+                    break;
+                case 'api_source_reader':
+                    $roles[] = $apiSourceRole;
                     break;
                 case 'analyst':
                     // Ignore type analyst for now. We don't have a useful mapping yet.

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -813,6 +813,9 @@ class ImportExportService
         foreach ($data as $idx => $account) {
             $juryTeam = null;
             $roles    = [];
+            if (isset($account['username']) && $account['username'] === 'cds') {
+                $account['type'] = 'cds';
+            }
             switch ($account['type']) {
                 case 'admin':
                     $roles[] = $adminRole;
@@ -1135,6 +1138,9 @@ class ImportExportService
 
             $team  = $juryTeam = null;
             $roles = [];
+            if ($line[2] === 'cds') {
+                $line[0] = 'cds';
+            }
             switch ($line[0]) {
                 case 'admin':
                     $roles[] = $adminRole;

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -838,6 +838,7 @@ class ImportExportService
                     break;
                 case 'clarification_rw':
                     $roles[] = $clarRole;
+                    break;
                 case 'api_reader':
                     $roles[] = $apiReadRole;
                     break;

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -813,6 +813,8 @@ class ImportExportService
         foreach ($data as $idx => $account) {
             $juryTeam = null;
             $roles    = [];
+            // Special case for the World Finals, if the username is CDS we limit the access.
+            // The user can see what every admin can see, but can not login via the UI.
             if (isset($account['username']) && $account['username'] === 'cds') {
                 $account['type'] = 'cds';
             }

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -795,6 +795,8 @@ class ImportExportService
         $adminRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
         $balloonRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
         $clarRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
+        $apiReadRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
+        $apiWriteRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
         $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
             $juryCategory = new TeamCategory();
@@ -835,6 +837,11 @@ class ImportExportService
                     break;
                 case 'clarification_rw':
                     $roles[] = $clarRole;
+                case 'api_reader':
+                    $roles[] = $apiReadRole;
+                    break;
+                case 'api_writer':
+                    $roles[] = $apiWriteRole;
                     break;
                 case 'analyst':
                 case 'staff':
@@ -1097,7 +1104,9 @@ class ImportExportService
         $juryRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
         $adminRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
         $balloonRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
-        $clarRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
+        $clarRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
+        $apiReadRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_reader']);
+        $apiWriteRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'api_writer']);
 
         $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
@@ -1157,6 +1166,12 @@ class ImportExportService
                     break;
                 case 'clarification_rw':
                     $roles[] = $clarRole;
+                    break;
+                case 'api_reader':
+                    $roles[] = $apiReadRole;
+                    break;
+                case 'api_writer':
+                    $roles[] = $apiWriteRole;
                     break;
                 case 'analyst':
                     // Ignore type analyst for now. We don't have a useful mapping yet.

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -794,6 +794,7 @@ class ImportExportService
         $juryRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
         $adminRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
         $balloonRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
+        $clarRole     = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
         $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
             $juryCategory = new TeamCategory();
@@ -831,6 +832,9 @@ class ImportExportService
                     break;
                 case 'balloon':
                     $roles[] = $balloonRole;
+                    break;
+                case 'clarification_rw':
+                    $roles[] = $clarRole;
                     break;
                 case 'analyst':
                 case 'staff':
@@ -1092,7 +1096,8 @@ class ImportExportService
         $teamRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
         $juryRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'jury']);
         $adminRole   = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'admin']);
-        $balloonRole  = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
+        $balloonRole = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'balloon']);
+        $clarRole    = $this->em->getRepository(Role::class)->findOneBy(['dj_role' => 'clarification_rw']);
 
         $juryCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['name' => 'Jury']);
         if (!$juryCategory) {
@@ -1149,6 +1154,9 @@ class ImportExportService
                     break;
                 case 'balloon':
                     $roles[] = $balloonRole;
+                    break;
+                case 'clarification_rw':
+                    $roles[] = $clarRole;
                     break;
                 case 'analyst':
                     // Ignore type analyst for now. We don't have a useful mapping yet.

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -86,6 +86,15 @@ abstract class AccountBaseTestCase extends BaseTestCase
                               'roles' => ['api_writer']]],
                             [['username' => 'grafana',
                               'roles' => ['api_reader']]],
+                            [['username' => 'cds',
+                              'roles' => ['admin']],
+                             ['roles' => ['api_reader','api_writer','api_source_reader']]],
+                            [['username' => 'icpc-tool',
+                              'roles' => ['cds']],
+                             ['roles' => ['api_reader','api_writer','api_source_reader']]],
+                            [['username' => 'double-role',
+                              'roles' => ['cds','api_reader'], 'skipTsv' => true],
+                             ['roles' => ['api_reader','api_writer','api_source_reader']]],
                             [['username' => 'plagiarism',
                               'roles' => ['api_source_reader']]],
                             [['roles' => ['clarification_rw','balloon'], 'skipTsv' => true]],
@@ -129,7 +138,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
             $tempData = ['id'=>$user, 'username'=> $user, 'name'=>$name, 'password'=>$pass, 'type'=>$role];
             // Handle TSV file
             if (count($testUser['roles']) !== 1 && !$testUser['skipTsv']) {
-                static::markTestFailed("TSV can not have more than 1 role.");
+                $this->fail("TSV can not have more than 1 role.");
             } elseif (isset($testUser['skipTsv'])) {
                 unset($testUser['skipTsv']);
             }

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -82,6 +82,10 @@ abstract class AccountBaseTestCase extends BaseTestCase
                             [['roles' => ['judge']],['roles' => ['jury']]],
                             [['roles' => ['balloon']]],
                             [['roles' => ['clarification_rw']]],
+                            [['username' => 'config_pusher',
+                              'roles' => ['api_writer']]],
+                            [['username' => 'grafana',
+                              'roles' => ['api_reader']]],
                             [['roles' => ['clarification_rw','balloon'], 'skipTsv' => true]],
                             [['roles' => ['jury','balloon'], 'skipTsv' => true]],
                         ];

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -15,7 +15,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
     public function helperVerifyApiUsers(string $myURL, array $objectsBeforeTest, array $newUserPostData): void
     {
         $objectsAfterTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
-        $newItems = array_map('unserialize', array_diff(array_map('serialize', $objectsAfterTest), array_map('serialize', $objectsBeforeTest)));
+        $newItems = array_map(unserialize(...), array_diff(array_map(serialize(...), $objectsAfterTest), array_map(serialize(...), $objectsBeforeTest)));
         // Because we login again with the admin user we might see that one also
         if (count($newItems)===2) {
             self::assertContains('admin', array_column($newItems,'username'), "Found unexpected new/changed user");

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -1,0 +1,164 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+use Generator;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Yaml\Yaml;
+
+abstract class AccountBaseTestCase extends BaseTestCase
+{
+    protected ?string $apiUser = 'admin';
+
+    protected array $expectedAbsent = ['4242', 'nonexistent'];
+
+    public function helperVerifyApiUsers(string $myURL, array $objectsBeforeTest, array $newUserPostData): void
+    {
+        $objectsAfterTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
+        $newItems = array_map('unserialize', array_diff(array_map('serialize', $objectsAfterTest), array_map('serialize', $objectsBeforeTest)));
+        // Because we login again with the admin user we might see that one also
+        if (count($newItems)===2) {
+            self::assertContains('admin', array_column($newItems,'username'), "Found unexpected new/changed user");
+            foreach ($newItems as $key=>$user) {
+                // Ignore the admin user for the tests.
+                if ($user['username'] === 'admin') {
+                    unset($newItems[$key]);
+                    break;
+                }
+            }
+        } else {
+            self::assertEquals(1, count($newItems));
+        }
+        $listKey = array_keys($newItems)[0];
+        foreach ($newUserPostData as $key => $expectedValue) {
+            if ($key !== 'password') {
+                // For security we don't output the password in the API
+                self::assertEquals($newItems[$listKey][$key], $expectedValue);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider provideNewAccount
+     */
+    public function testCreateUser(array $newUserPostData): void
+    {
+        $usersURL = $this->helperGetEndpointURL('users');
+        $myURL = $this->helperGetEndpointURL($this->apiEndpoint);
+        $objectsBeforeTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
+        $this->verifyApiJsonResponse('POST', $usersURL, 201, 'admin', $newUserPostData);
+        $objectsAfterTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
+        $this->helperVerifyApiUsers($myURL, $objectsBeforeTest, $newUserPostData);
+    }
+
+    public function provideNewAccount(): Generator
+    {
+        yield [['username' => 'newUser-001',
+                'name' => 'newUserWithName',
+                'password' => 'xkcd-password-style-password',
+                'roles' => ['team']]];
+    }
+
+    /**
+     * @dataProvider provideNewAccountFile
+     */
+    public function testCreateUserFileImport(string $newUsersFile, string $type, array $newUserPostData): void
+    {
+        $usersURL = $this->helperGetEndpointURL('users').'/accounts';
+        $myURL = $this->helperGetEndpointURL($this->apiEndpoint);
+        $objectsBeforeTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
+        $tempFile = tempnam(sys_get_temp_dir(), "/accounts-upload-test-");
+        file_put_contents($tempFile, $newUsersFile);
+        $tempUploadFile = new UploadedFile($tempFile, 'accounts.'.$type);
+        
+        $result = $this->verifyApiJsonResponse('POST', $usersURL, 200, 'admin', null, [$type => $tempUploadFile]);
+        unlink($tempFile);
+
+        self::assertEquals($result, "1 new account(s) successfully added.");
+        $this->helperVerifyApiUsers($myURL, $objectsBeforeTest, $newUserPostData);
+    }
+
+    public function provideNewAccountFile(): Generator
+    {
+        foreach ($this->provideNewAccount() as $index=>$testUser) {
+            $testUser = $testUser[0];
+            $user = $testUser['username'];
+            $name = $testUser['name'];
+            $pass = $testUser['password'];
+            $role = $testUser['roles'][0];
+            $tempData = ['id'=>$user, 'username'=> $user, 'name'=>$name, 'password'=>$pass, 'type'=>$role];
+            // Handle TSV file
+            if (count($testUser['roles']) !== 1) {
+                static::markTestFailed("TSV can not have more than 1 role.");
+            }
+            $fileVersions = ['accounts'];
+            if ($index === 0) {
+                $fileVersions[] = 'File_Version';
+            }
+            foreach ($fileVersions as $fileVersion) {
+                $file = $fileVersion."\t1";
+                $file .= "\n$role\t$name\t$user\t$pass";
+                yield [$file, 'tsv', $testUser];
+            }
+            // Handle YAML file
+            $file = <<<EOF
+- id: $user
+  username: $user
+  name: $name
+  password: $pass
+  type: $role
+EOF;
+            yield [$file, 'yaml', $testUser];
+            $file = <<<EOF
+- "id": $user
+  "username": $user
+  "name": $name
+  "password": $pass
+  "type": $role
+EOF;
+            yield [$file, 'yaml', $testUser];
+            yield [Yaml::dump([$tempData], 1), 'yaml', $testUser];
+            yield [Yaml::dump([$tempData], 1, 3), 'yaml', $testUser];
+            yield [Yaml::dump([$tempData], 2, 2), 'yaml', $testUser];
+            // Handle JSON file
+            $file = <<<EOF
+[{  id: $user,
+    username: $user,
+    name: $name,
+    password: $pass,
+    type: $role
+}]
+EOF;
+            yield [$file, 'json', $testUser];
+            $file = "[{id: \t$user,\tusername: $user, name:     $name,password: $pass, type: $role}]";
+            yield [$file, 'json', $testUser];
+        }
+    }
+
+    public function testListFilterTeam(): void
+    {
+        foreach (['9999','nan','nonexistent'] as $nonExpectedObjectId) {
+            $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$nonExpectedObjectId;
+            $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
+            self::assertEquals([],$objects);
+        }
+        foreach ($this->expectedObjects as $expectedObject) {
+            if (!isset($expectedObject['team_id'])) {
+                continue;
+            }
+            $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$expectedObject['team_id'];
+            $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
+            $found = False;
+            foreach ($objects as $possibleObject) {
+                if ($possibleObject['username'] == $expectedObject['username']) {
+                    $found = True;
+                    foreach ($expectedObject as $key => $value) {
+                        // Null values can also be absent.
+                        static::assertEquals($value, $possibleObject[$key] ?? null, $key . ' has correct value.');
+                    }
+                }
+            }
+            self::assertEquals(True,$found);
+        }
+    }
+}

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -69,7 +69,9 @@ abstract class AccountBaseTestCase extends BaseTestCase
         $otherVariations = [[['username' => 'newUser-001',
                               'roles' => ['team']]],
                             [['roles' => ['jury']]],
-                            [['roles' => ['judge']],['roles' => ['jury']]]
+                            [['roles' => ['judge']],['roles' => ['jury']]],
+                            [['roles' => ['balloon']]],
+                            [['roles' => ['clarification_rw']]],
                         ];
         yield [$defaultData];
         foreach ($otherVariations as $variation) {

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -85,6 +85,8 @@ abstract class AccountBaseTestCase extends BaseTestCase
             [['type' => 'api_writer'], ['type' => 'admin']],
             [['type' => 'api_reader'], ['type' => 'admin']],
             [['type' => 'api_source_reader'], ['type' => 'judge']],
+            [['type' => 'balloon'], ['roles' => ['balloon'], 'type' => null]],
+            [['type' => 'clarification_rw'], ['roles' => ['clarification_rw'], 'type' => null]],
         ];
         foreach ($accountCombinations as $combination) {
             $newUpload = array_merge($defaultData, $combination[0]);

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -58,14 +58,16 @@ abstract class AccountBaseTestCase extends BaseTestCase
 
     public function provideNewAccount(): Generator
     {
-        yield [['username' => 'newUser-001',
+        $defaultData = ['username' => 'newUser-001',
                 'name' => 'newUserWithName',
                 'password' => 'xkcd-password-style-password',
-                'roles' => ['team']]];
-        yield [['username' => 'newAdmin',
-                'name' => 'newUserWithName',
-                'password' => 'xkcd-password-style-password',
-                'roles' => ['admin']]];
+                'roles' => ['team']];
+        $otherVariations = [['username' => 'newAdmin',
+                             'roles' => ['admin']]];
+        yield [$defaultData];
+        foreach ($otherVariations as $variation) {
+            yield [array_merge($defaultData, $variation)];
+        }
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -48,7 +48,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
                 if (is_array($expectedValue)) {
                     sort($expectedValue);
                 }
-                self::assertEquals($newItemValue, $expectedValue);
+                self::assertEquals($expectedValue, $newItemValue);
             }
         }
     }

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -33,7 +33,12 @@ abstract class AccountBaseTestCase extends BaseTestCase
         foreach ($newUserPostData as $key => $expectedValue) {
             if ($key !== 'password') {
                 // For security we don't output the password in the API
-                self::assertEquals($newItems[$listKey][$key], $expectedValue);
+                $newItemValue = $newItems[$listKey][$key];
+                if ($key === 'roles' && in_array('admin', $newItemValue) && self::getContainer()->getParameter('kernel.debug')) {
+                    $newItemValue = array_diff($newItemValue, ['team']);
+                    // In development mode we add a team role to admin users for some API endpoints.
+                };
+                self::assertEquals($newItemValue, $expectedValue);
             }
         }
     }
@@ -57,6 +62,10 @@ abstract class AccountBaseTestCase extends BaseTestCase
                 'name' => 'newUserWithName',
                 'password' => 'xkcd-password-style-password',
                 'roles' => ['team']]];
+        yield [['username' => 'newAdmin',
+                'name' => 'newUserWithName',
+                'password' => 'xkcd-password-style-password',
+                'roles' => ['admin']]];
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -110,10 +110,10 @@ abstract class AccountBaseTestCase extends BaseTestCase
         $tempUploadFile = new UploadedFile($tempFile, 'accounts.'.$type);
         
         $result = $this->verifyApiJsonResponse('POST', $usersURL, 200, 'admin', null, [$type => $tempUploadFile]);
-        unlink($tempFile);
 
         self::assertEquals($result, "1 new account(s) successfully added.");
         $this->helperVerifyApiUsers($myURL, $objectsBeforeTest, $newUserPostData, $overwritten);
+        unlink($tempFile);
     }
 
     public function provideNewAccountFile(): Generator

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -87,6 +87,9 @@ abstract class AccountBaseTestCase extends BaseTestCase
             [['type' => 'api_source_reader'], ['type' => 'judge']],
             [['type' => 'balloon'], ['roles' => ['balloon'], 'type' => null]],
             [['type' => 'clarification_rw'], ['roles' => ['clarification_rw'], 'type' => null]],
+            [['type' => 'cds'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
+            [['username' => 'cds', 'type' => 'admin'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
+            [['username' => 'cds', 'type' => 'jury'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
         ];
         foreach ($accountCombinations as $combination) {
             $newUpload = array_merge($defaultData, $combination[0]);

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -86,6 +86,8 @@ abstract class AccountBaseTestCase extends BaseTestCase
                               'roles' => ['api_writer']]],
                             [['username' => 'grafana',
                               'roles' => ['api_reader']]],
+                            [['username' => 'plagiarism',
+                              'roles' => ['api_source_reader']]],
                             [['roles' => ['clarification_rw','balloon'], 'skipTsv' => true]],
                             [['roles' => ['jury','balloon'], 'skipTsv' => true]],
                         ];

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -17,9 +17,9 @@ abstract class AccountBaseTestCase extends BaseTestCase
         $objectsAfterTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
         $newItems = array_map(unserialize(...), array_diff(array_map(serialize(...), $objectsAfterTest), array_map(serialize(...), $objectsBeforeTest)));
         // Because we login again with the admin user we might see that one also
-        if (count($newItems)===2) {
-            self::assertContains('admin', array_column($newItems,'username'), "Found unexpected new/changed user");
-            foreach ($newItems as $key=>$user) {
+        if (count($newItems) === 2) {
+            self::assertContains('admin', array_column($newItems, 'username'), "Found unexpected new/changed user");
+            foreach ($newItems as $key => $user) {
                 // Ignore the admin user for the tests.
                 if ($user['username'] === 'admin') {
                     unset($newItems[$key]);
@@ -36,7 +36,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
                 // For security we don't output the password in the API
                 $newItemValue = $newItems[$listKey][$key];
                 if ($key === 'roles' &&
-                    (in_array('admin', $newItemValue) || in_array('jury', $newItemValue)) && 
+                    (in_array('admin', $newItemValue) || in_array('jury', $newItemValue)) &&
                     self::getContainer()->getParameter('kernel.debug')
                 ) {
                     $newItemValue = array_diff($newItemValue, ['team']);
@@ -56,7 +56,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
     /**
      * @dataProvider provideNewAccount
      */
-    public function testCreateUser(array $newUserPostData, ?array $overwritten=null): void
+    public function testCreateUser(array $newUserPostData, ?array $overwritten = null): void
     {
         // This is only relevant for another test
         if (isset($newUserPostData['skipImportFile'])) {
@@ -123,7 +123,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
     /**
      * @dataProvider provideNewAccountFile
      */
-    public function testCreateUserFileImport(string $newUsersFile, string $type, array $newUserPostData, ?array $overwritten=null): void
+    public function testCreateUserFileImport(string $newUsersFile, string $type, array $newUserPostData, ?array $overwritten = null): void
     {
         $usersURL = $this->helperGetEndpointURL('users').'/accounts';
         $myURL = $this->helperGetEndpointURL($this->apiEndpoint);
@@ -141,7 +141,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
 
     public function provideNewAccountFile(): Generator
     {
-        foreach ($this->provideNewAccount() as $index=>$testUser) {
+        foreach ($this->provideNewAccount() as $index => $testUser) {
             if (isset($testUser[0]['skipImportFile'])) {
                 // Not all properties which we can set via the API account endpoint can also
                 // be imported via the API file import.
@@ -153,7 +153,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
             $name = $testUser['name'];
             $pass = $testUser['password'];
             $role = $testUser['type'];
-            $tempData = ['id'=>$user, 'username'=> $user, 'name'=>$name, 'password'=>$pass, 'type'=>$role];
+            $tempData = ['id' => $user,  'username' => $user, 'name' => $name, 'password' => $pass, 'type' => $role];
             // Handle TSV file
             $fileVersions = ['accounts'];
             if ($index === 0) {
@@ -212,17 +212,17 @@ EOF;
             }
             $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$expectedObject['team_id'];
             $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
-            $found = False;
+            $found = false;
             foreach ($objects as $possibleObject) {
                 if ($possibleObject['username'] == $expectedObject['username']) {
-                    $found = True;
+                    $found = true;
                     foreach ($expectedObject as $key => $value) {
                         // Null values can also be absent.
                         static::assertEquals($value, $possibleObject[$key] ?? null, $key . ' has correct value.');
                     }
                 }
             }
-            self::assertEquals(True,$found);
+            self::assertEquals(true,$found);
         }
     }
 }

--- a/webapp/tests/Unit/Controller/API/AccountControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AccountControllerTest.php
@@ -4,7 +4,7 @@ namespace App\Tests\Unit\Controller\API;
 
 use Generator;
 
-class AccountControllerTest extends BaseTestCase
+class AccountControllerTest extends AccountBaseTestCase
 {
     protected ?string $apiEndpoint = 'accounts';
 
@@ -34,8 +34,6 @@ class AccountControllerTest extends BaseTestCase
         ],
     ];
 
-    protected array $expectedAbsent = ['4242', 'nonexistent'];
-
     /**
      * @dataProvider provideCurrentAccount
      */
@@ -60,56 +58,5 @@ class AccountControllerTest extends BaseTestCase
     {
         yield ['admin', ['id' => '1', 'team_id' => '1', 'username' => 'admin', 'type' => 'admin']];
         yield ['demo', ['id' => '3', 'team_id' => '2', 'username' => 'demo', 'type' => 'team']];
-    }
-
-    public function testNewAddedAccount(): void
-    {
-        $myURL = $this->helperGetEndpointURL($this->apiEndpoint);
-        $objectsBeforeTest = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
-
-        $newUserPostData = ['username' => 'newUser',
-                            'name' => 'newUserWithName',
-                            'password' => 'xkcd-password-style-password',
-                            'roles' => ['team']];
-        $url = $this->helperGetEndpointURL('users');
-        $this->verifyApiJsonResponse('POST', $url, 201, 'admin', $newUserPostData);
-
-        $objectsAfterTest  = $this->verifyApiJsonResponse('GET', $myURL, 200, $this->apiUser);
-        $newItems = array_map('unserialize', array_diff(array_map('serialize', $objectsAfterTest), array_map('serialize', $objectsBeforeTest)));
-        self::assertEquals(1, count($newItems));
-        $listKey = array_keys($newItems)[0];
-        foreach ($newUserPostData as $key => $value) {
-            if ($key !== 'password') {
-                // For security we don't output the password in the API
-                self::assertEquals($newItems[$listKey][$key], $value);
-            }
-        }
-    }
-
-    public function testListFilterTeam(): void
-    {
-        foreach (['9999','nan','nonexistent'] as $nonExpectedObjectId) {
-            $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$nonExpectedObjectId;
-            $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
-            self::assertEquals([],$objects);    
-        }
-        foreach ($this->expectedObjects as $expectedObject) {
-            if ($expectedObject['team_id'] === null) {
-                continue;
-            }
-            $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$expectedObject['team_id'];
-            $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
-            $found = False;
-            foreach ($objects as $possibleObject) {
-                if ($possibleObject['username'] == $expectedObject['username']) {
-                    $found = True;
-                    foreach ($expectedObject as $key => $value) {
-                        // Null values can also be absent.
-                        static::assertEquals($value, $possibleObject[$key] ?? null, $key . ' has correct value.');
-                    }
-                }
-            }
-            self::assertEquals(True,$found);
-        }
     }
 }

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -2,11 +2,9 @@
 
 namespace App\Tests\Unit\Controller\API;
 
-class UserControllerTest extends BaseTestCase
+class UserControllerTest extends AccountBaseTestCase
 {
     protected ?string $apiEndpoint = 'users';
-
-    protected ?string $apiUser = 'admin';
 
     protected array $expectedObjects = [
         1 => [
@@ -47,17 +45,4 @@ class UserControllerTest extends BaseTestCase
             "enabled" => true
         ],
     ];
-
-    protected array $expectedAbsent = ['4242', 'nonexistent'];
-
-    public function testCreateUser(): void
-    {
-        $newUserPostData = ['username' => 'newUser',
-                            'name' => 'newUserWithName',
-                            'password' => 'xkcd-password-style-password',
-                            'roles' => ['team']];
-
-        $url = $this->helperGetEndpointURL($this->apiEndpoint);
-        $this->verifyApiJsonResponse('POST', $url, 201, 'admin', $newUserPostData);
-    }
 }


### PR DESCRIPTION
Given that we use ADMIN in grafana and this was disabled for SWERC it makes sense to allow import for the API users. This way we can import all accounts in one go instead of having to add these extra users later.

If this gets approved I'll make some tests before merging (8.3+)