### PR TITLE
Balloon status is non-restricted for any staff member

### DIFF
--- a/webapp/src/Controller/Jury/BalloonController.php
+++ b/webapp/src/Controller/Jury/BalloonController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route("/jury/balloons")
- * @Security("is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON')")
+ * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_BALLOON')")
  */
 class BalloonController extends AbstractController
 {

--- a/webapp/src/Controller/RootController.php
+++ b/webapp/src/Controller/RootController.php
@@ -38,6 +38,9 @@ class RootController extends BaseController
             if ($this->dj->checkrole('balloon')) {
                 return $this->redirectToRoute('jury_balloons');
             }
+            if ($this->dj->checkrole('clarification_rw')) {
+                return $this->redirectToRoute('jury_clarifications');
+            }
         }
         return $this->redirectToRoute('public_index');
     }

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -43,7 +43,9 @@
             </div>
             <div class="card-body">
                 <ul>
-                    <li><a href="{{ path('jury_balloons') }}">Balloon Status</a></li>
+                    {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_BALLOON') %}
+                        <li><a href="{{ path('jury_balloons') }}">Balloon Status</a></li>
+                    {% endif %}
                     {% if is_granted('ROLE_CLARIFICATION_RW') %}
                         <li><a href="{{ path('jury_clarifications') }}">Clarifications</a></li>
                     {% endif %}


### PR DESCRIPTION
Other alternatives is to add a check again in the template for the link or to add this specific role to the security firewall. This does add the balloons also to the menu but that makes sense for this user type.