### PR TITLE
Allow to call the API using CLI and use it to import the sample problems.

### DIFF
--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -1,14 +1,17 @@
 Adding contest data in bulk
 ===========================
 
-DOMjudge offers two ways to add or update contest data in bulk: using API
-endpoints and using the jury interface.
+DOMjudge offers three ways to add or update contest data in bulk: using API
+endpoints, using the CLI (which wraps the API) and using the jury interface.
 In general, we follow the `CCS specification`_ for all file formats involved.
 
 For using the API, the following examples require you to set up admin credentials
 in your `.netrc`_ file. You need to install `httpie`_ and replace the
 ``<API_URL>`` in the examples below with the API URL of your local DOMjudge
 installation.
+
+For using the CLI, you need to replace ``<WEBAPP_DIR>`` with the path to
+the ``webapp`` directory of the DOMserver.
 
 Importing team categories
 -------------------------
@@ -56,6 +59,10 @@ To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/groups" json@groups.json
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f json=groups.json users/groups
+
 Using the legacy TSV format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -83,6 +90,11 @@ To import the file using the jury interface, go to `Import / export`, select
 To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/groups" tsv@groups.tsv
+
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f tsv=groups.tsv users/groups
+
 
 Importing team affiliations
 ---------------------------
@@ -128,6 +140,10 @@ To import the file using the jury interface, go to `Import / export`, select
 To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/organizations" json@organizations.json
+
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f json=organizations.json users/organizations
 
 Importing teams
 ---------------
@@ -181,6 +197,11 @@ To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/teams" json@teams.json
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f json=teams.json users/teams
+
+
 Using the legacy TSV format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -216,6 +237,10 @@ To import the file using the jury interface, go to `Import / export`, select
 To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/teams" tsv@teams2.tsv
+
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f tsv=teams2.tsv users/teams
 
 Importing accounts
 ------------------
@@ -276,6 +301,11 @@ To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/accounts" yaml@accounts.yaml
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f yaml=accounts.yaml users/accounts
+
+
 Using the legacy TSV format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -303,6 +333,10 @@ To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/users/accounts" tsv@accounts.tsv
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f tsv=accounts.tsv users/accounts
+
 Importing contest metadata
 --------------------------
 
@@ -329,6 +363,10 @@ and click `Import`.
 To import the file using the API run the following commands::
 
     http --check-status -b -f POST "<API_URL>/contests" yaml@contest.yaml
+
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f yaml=contest.yaml contests
 
 This call returns the new contest ID, which you need to import problems.
 
@@ -366,6 +404,9 @@ To import the file using the API run the following commands::
 
     http --check-status -b -f POST "<API_URL>/contests/<CID>/problems" data@problems.yaml
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -f data=problems.yaml contests/<CID>/problems
 
 Replace ``<CID>`` with the contest ID that was returned when importing the
 contest metadata.
@@ -384,6 +425,10 @@ To import the file using the API run the following command::
 
     http --check-status -b -f POST "<API_URL>/contests/<CID>/problems" zip@problem.zip problem="<PROBID>"
 
+To import the file using the CLI run the following command::
+
+    <WEBAPP_DIR>/bin/console api:call -m POST -d problem=<PROBID> -f zip=problem.zip contest/<CID>/problems
+
 Replace ``<CID>`` with the contest ID that the previous command returns and
 ``<PROBID>`` with the problem ID (you can get that from the web interface or
 the API).
@@ -398,6 +443,12 @@ subsections, you can also use the script that we provide in
 Call it from your contest folder like this::
 
     misc-tools/import-contest <API_URL>
+
+to use the API, or::
+
+    misc-tools/import-contest <WEBAPP_DIR>
+
+to use the CLI.
 
 Importing from ICPC CMS API
 ---------------------------
@@ -423,14 +474,24 @@ Importing DOMjudge configuration
 DOMjudge exposes its configuration at the `<API_URL>/config` endpoint in JSON
 form and accepts a `PUT` request to load/update configuration.
 
-You can retrieve the current configuration via
+You can retrieve the current configuration using the API via::
 
     http --check-status --pretty=format "<API_URL>/config" > config.json
+
+or via the CLI using::
+
+    <WEBAPP_DIR>/bin/console api:call config > config.json
 
 For your convenience, we added a script to update configuration from a file
 called `config.json` in your current directory::
 
     misc-tools/configure-domjudge <API_URL>
+
+to use the API or::
+
+    misc-tools/configure-domjudge <WEBAPP_DIR>
+
+to use the CLI.
 
 .. _CCS specification: https://ccs-specs.icpc.io/2022-07/ccs_system_requirements#appendix-file-formats
 .. _.netrc: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html

--- a/gitlab/base.sh
+++ b/gitlab/base.sh
@@ -76,7 +76,7 @@ php_version="${version:-}"
 sudo cp /opt/domjudge/domserver/etc/domjudge-fpm.conf "/etc/php/$php_version/fpm/pool.d/domjudge-fpm.conf"
 echo "php_admin_value[date.timezone] = Europe/Amsterdam" | sudo tee -a "/etc/php/$php_version/fpm/pool.d/domjudge-fpm.conf"
 sudo /usr/sbin/php-fpm${php_version}
-
+echo "date.timezone = Europe/Amsterdam" | sudo tee -a "/etc/php/$php_version/cli/php.ini"
 
 passwd=$(cat etc/initial_admin_password.secret)
 echo "machine localhost login admin password $passwd" >> ~www-data/.netrc

--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -24,7 +24,7 @@ sys.path.append('@domserver_libdir@')
 import dj_utils
 
 def usage():
-    print(f'Usage {sys.argv[0]} <domjudge-api-url>')
+    print(f'Usage {sys.argv[0]} <domjudge-webapp-dir-or-api-url>')
     exit(1)
 
 
@@ -53,7 +53,7 @@ def _keyify_list(l: List) -> Set:
 if len(sys.argv) < 2:
     usage()
 
-dj_utils.api_url = sys.argv[1]
+dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
 
 user_data = dj_utils.do_api_request('user')
 if 'admin' not in user_data['roles']:

--- a/misc-tools/dj_utils.py
+++ b/misc-tools/dj_utils.py
@@ -5,16 +5,19 @@ Part of the DOMjudge Programming Contest Jury System and licensed
 under the GNU GPL. See README and COPYING for details.
 '''
 
+import itertools
 import json
 import os
 import requests
 import requests.utils
+import shlex
+import subprocess
 import sys
 
 _myself = os.path.basename(sys.argv[0])
 _default_user_agent = requests.utils.default_user_agent()
 headers = {'user-agent': f'dj_utils/{_myself} ({_default_user_agent})'}
-api_url = 'unset'
+domjudge_webapp_folder_or_api_url = 'unset'
 ca_check = True
 
 
@@ -49,6 +52,9 @@ def parse_api_response(name: str, response: requests.Response):
 def do_api_request(name: str):
     '''Perform an API call to the given endpoint and return its data.
 
+    Based on whether `domjudge_webapp_folder_or_api_url` is a folder or URL this
+    will use the DOMjudge CLI or HTTP API.
+
     Parameters:
         name (str): the endpoint to call
 
@@ -59,25 +65,32 @@ def do_api_request(name: str):
         RuntimeError when the response is not JSON or the HTTP status code is non 2xx.
     '''
 
-    global ca_check
-    url = f'{api_url}/{name}'
+    if os.path.isdir(domjudge_webapp_folder_or_api_url):
+        return api_via_cli(name)
+    else:
+        global ca_check
+        url = f'{domjudge_webapp_folder_or_api_url}/{name}'
 
-    try:
-        response = requests.get(url, headers=headers, verify=ca_check)
-    except requests.exceptions.SSLError as e:
-        ca_check = not confirm("Can not verify certificate, ignore certificate check?", False)
-        if ca_check:
-            print('Can not verify certificate chain for DOMserver.')
-            exit(1)
-        else:
-            return do_api_request(name)
-    except requests.exceptions.RequestException as e:
-        raise RuntimeError(e)
+        try:
+            response = requests.get(url, headers=headers, verify=ca_check)
+        except requests.exceptions.SSLError as e:
+            ca_check = not confirm(
+                "Can not verify certificate, ignore certificate check?", False)
+            if ca_check:
+                print('Can not verify certificate chain for DOMserver.')
+                exit(1)
+            else:
+                return do_api_request(name)
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(e)
     return parse_api_response(name, response)
 
 
 def upload_file(name: str, apifilename: str, file: str, data: dict = {}):
     '''Upload the given file to the API at the given path with the given name.
+
+    Based on whether `domjudge_webapp_folder_or_api_url` is a folder or URL this
+    will use the DOMjudge CLI or HTTP API.
 
     Parameters:
         name (str): the endpoint to call
@@ -91,19 +104,64 @@ def upload_file(name: str, apifilename: str, file: str, data: dict = {}):
         RuntimeError when the HTTP status code is non 2xx.
     '''
 
-    global ca_check
-    files = [(apifilename, open(file, 'rb'))]
+    if os.path.isdir(domjudge_webapp_folder_or_api_url):
+        return api_via_cli(name, 'POST', data, {apifilename: file})
+    else:
+        global ca_check
+        files = [(apifilename, open(file, 'rb'))]
 
-    url = f'{api_url}/{name}'
+        url = f'{domjudge_webapp_folder_or_api_url}/{name}'
 
-    try:
-        response = requests.post(url, files=files, headers=headers, data=data, verify=ca_check)
-    except requests.exceptions.SSLError as e:
-        ca_check = not confirm("Can not verify certificate, ignore certificate check?", False)
-        if ca_check:
-            print('Can not verify certificate chain for DOMserver.')
-            exit(1)
-        else:
-            response = requests.post(url, files=files, headers=headers, data=data, verify=ca_check)
+        try:
+            response = requests.post(
+                url, files=files, headers=headers, data=data, verify=ca_check)
+        except requests.exceptions.SSLError as e:
+            ca_check = not confirm(
+                "Can not verify certificate, ignore certificate check?", False)
+            if ca_check:
+                print('Can not verify certificate chain for DOMserver.')
+                exit(1)
+            else:
+                response = requests.post(
+                    url, files=files, headers=headers, data=data, verify=ca_check)
 
     return parse_api_response(name, response)
+
+
+def api_via_cli(name: str, method: str = 'GET', data: dict = {}, files: dict = {}):
+    '''Perform the given API request using the CLI
+
+    Parameters:
+        name (str): the endpoint to call
+        method (str): the method to use. Either GET or POST
+        data (dict): the POST data to use. Only used when method is POST
+        files (dict): the files to use. Only used when method is POST
+
+    Returns:
+        The parsed endpoint contents.
+
+    Raises:
+        RuntimeError when the command exit code is not 0.
+    '''
+
+    command = [
+        f'{domjudge_webapp_folder_or_api_url}/bin/console',
+        'api:call',
+        '-m',
+        shlex.quote(method),
+    ] + list(itertools.chain(*[
+        ['-d', f'{shlex.quote(item)}={shlex.quote(data[item])}'] for item in data
+    ])) + list(itertools.chain(*[
+        ['-f', f'{shlex.quote(item)}={shlex.quote(files[item])}'] for item in files
+    ])) + [
+        shlex.quote(name)
+    ]
+
+    result = subprocess.run(command, capture_output=True)
+    response = result.stdout.decode('ascii')
+
+    if result.returncode != 0:
+        print(response)
+        raise RuntimeError(f'API request {name} failed')
+
+    return json.loads(response)

--- a/misc-tools/dj_utils.py
+++ b/misc-tools/dj_utils.py
@@ -5,12 +5,10 @@ Part of the DOMjudge Programming Contest Jury System and licensed
 under the GNU GPL. See README and COPYING for details.
 '''
 
-import itertools
 import json
 import os
 import requests
 import requests.utils
-import shlex
 import subprocess
 import sys
 
@@ -148,14 +146,16 @@ def api_via_cli(name: str, method: str = 'GET', data: dict = {}, files: dict = {
         f'{domjudge_webapp_folder_or_api_url}/bin/console',
         'api:call',
         '-m',
-        shlex.quote(method),
-    ] + list(itertools.chain(*[
-        ['-d', f'{shlex.quote(item)}={shlex.quote(data[item])}'] for item in data
-    ])) + list(itertools.chain(*[
-        ['-f', f'{shlex.quote(item)}={shlex.quote(files[item])}'] for item in files
-    ])) + [
-        shlex.quote(name)
+        method
     ]
+
+    for item in data:
+        command.extend(['-d', f'{item}={data[item]}'])
+
+    for item in files:
+        command.extend(['-f', f'{item}={files[item]}'])
+
+    command.append(name)
 
     result = subprocess.run(command, capture_output=True)
     response = result.stdout.decode('ascii')

--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -2,9 +2,10 @@
 
 '''
 import-contest -- Convenience script to import a contest (including metadata,
-teams and problems) via the command line.
+teams and problems) via the command line to the DOMjudge API or to a DOMjudge
+installation using the CLI.
 
-Reads credentials from ~/.netrc.
+Reads credentials from ~/.netrc when using the API.
 
 See also https://www.domjudge.org/docs/manual/main/import.html
 (replace main with the DOMjudge major.minor version if you are running a
@@ -29,7 +30,7 @@ cid = None
 
 
 def usage():
-    print(f'Usage {sys.argv[0]} <domjudge-api-url>')
+    print(f'Usage {sys.argv[0]} <domjudge-webapp-dir-or-api-url>')
     exit(1)
 
 
@@ -95,7 +96,7 @@ def import_images(entity: str, property: str, filename_regexes: List[str]):
 if len(sys.argv) < 2:
     usage()
 
-dj_utils.api_url = sys.argv[1]
+dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
 
 user_data = dj_utils.do_api_request('user')
 if 'admin' not in user_data['roles']:

--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -10,7 +10,6 @@ BINDIR="@domserver_bindir@"
 ETCDIR="@domserver_etcdir@"
 WEBAPPDIR="@domserver_webappdir@"
 EXAMPLEPROBDIR="@domserver_exampleprobdir@"
-BASEURL="@BASEURL@"
 
 PASSWDFILE="$ETCDIR/dbpasswords.secret"
 
@@ -225,23 +224,6 @@ remove_db_users()
 	verbose "DOMjudge database and user(s) removed."
 }
 
-check_netrc()
-{
-	if [ ! -f ~/.netrc ] && [ -f "$ETCDIR/initial_admin_password.secret" ]; then
-		echo "No ~/.netrc found, loading example data might fail. Create one (Y/n)?"
-		read -r createnetrc
-		if [ "$createnetrc" = "" ] || [ "$createnetrc" = "y" ] || [ "$createnetrc" = "Y" ]; then
-			initial_admin_password=$(cat $ETCDIR/initial_admin_password.secret)
-			machine=$(echo $BASEURL | cut -d '/' -f 3)
-			cat > ~/.netrc <<EOF
-machine $machine
-login admin
-password $initial_admin_password
-EOF
-		fi
-	fi
-}
-
 ### Script starts here ###
 
 # Parse command-line options:
@@ -306,9 +288,8 @@ install-examples)
 	read_dbpasswords
 
 	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
-	check_netrc
 	"$EXAMPLEPROBDIR"/generate-contest-yaml
-	( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${BASEURL}api" )
+	( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${WEBAPPDIR}" )
 	;;
 
 install-loadtest)
@@ -336,9 +317,8 @@ bare-install|install)
 	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-default-data
 	if [ "$1" = "install" ]; then
 		DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
-		check_netrc
 		"$EXAMPLEPROBDIR"/generate-contest-yaml
-		( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${BASEURL}api" )
+		( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${WEBAPPDIR}" )
 	fi
 	if [ "$1" = "install" ]; then
 		verbose "SQL structure and default/example data installed."

--- a/webapp/src/Command/CallApiActionCommand.php
+++ b/webapp/src/Command/CallApiActionCommand.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Service\DOMJudgeService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class CallApiActionCommand extends Command
+{
+    protected DOMJudgeService $dj;
+    protected EntityManagerInterface $em;
+
+    public function __construct(DOMJudgeService $dj, EntityManagerInterface $em)
+    {
+        parent::__construct();
+        $this->dj = $dj;
+        $this->em = $em;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('api:call')
+            ->setDescription('Call the DOMjudge API directly. Note: this will use admin credentials')
+            ->addArgument(
+                'endpoint',
+                InputArgument::REQUIRED,
+                'The API endpoint to call. For example `contests/3/teams`'
+            )
+            ->addOption(
+                'method',
+                'm',
+                InputOption::VALUE_REQUIRED,
+                'The HTTP method to use',
+                Request::METHOD_GET
+            )
+            ->addOption(
+                'data',
+                'd',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'POST data to use as key=value. Only allowed when the method is POST'
+            )
+            ->addOption(
+                'file',
+                'f',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Files to use as field=filename. Only allowed when the method is POST'
+            )
+            ->addOption(
+                'user',
+                'u',
+                InputOption::VALUE_REQUIRED,
+                'User to use for API requests. If not given, the first admin user will be used'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!in_array($input->getOption('method'), [Request::METHOD_GET, Request::METHOD_POST], true)) {
+            $output->writeln('Error: only GET and POST methods are supported');
+            return self::FAILURE;
+        }
+
+        if ($input->getOption('user')) {
+            $user = $this->em
+                ->getRepository(User::class)
+                ->findOneBy(['username' => $input->getOption('user')]);
+            if (!$user) {
+                $output->writeln('Error: Provided user not found');
+                return self::FAILURE;
+            }
+        } else {
+            // Find an admin user as we need one to make sure we can read all events.
+            /** @var User $user */
+            $user = $this->em->createQueryBuilder()
+                ->from(User::class, 'u')
+                ->select('u')
+                ->join('u.user_roles', 'r')
+                ->andWhere('r.dj_role = :role')
+                ->setParameter('role', 'admin')
+                ->setMaxResults(1)
+                ->getQuery()
+                ->getOneOrNullResult();
+            if (!$user) {
+                $output->writeln('Error: No admin user found. Please create at least one');
+                return self::FAILURE;
+            }
+        }
+
+        $data = [];
+        $files = [];
+        if ($input->getOption('method') === Request::METHOD_POST) {
+            foreach ($input->getOption('data') as $dataItem) {
+                $parts = explode('=', $dataItem, 2);
+                if (count($parts) !== 2) {
+                    $output->writeln(sprintf('Error: data item %s is not in key=value format', $dataItem));
+                    return self::FAILURE;
+                }
+
+                $data[$parts[0]] = $parts[1];
+            }
+
+            foreach ($input->getOption('file') as $fileItem) {
+                $parts = explode('=', $fileItem, 2);
+                if (count($parts) !== 2) {
+                    $output->writeln(sprintf('Error: file item %s is not in key=value format', $fileItem));
+                    return self::FAILURE;
+                }
+
+                if (!file_exists($parts[1])) {
+                    $output->writeln(sprintf('Error: file %s does not exist', $parts[1]));
+                    return self::FAILURE;
+                }
+
+                $files[$parts[0]] = new UploadedFile($parts[1], basename($parts[1]), mime_content_type($parts[1]), null, true);
+            }
+        } else {
+            if ($input->getOption('data')) {
+                $output->writeln('Error: data not allowed for GET methods.');
+                return self::FAILURE;
+            }
+            if ($input->getOption('file')) {
+                $output->writeln('Error: files not allowed for GET methods.');
+                return self::FAILURE;
+            }
+        }
+
+        try {
+            $response = null;
+            $this->dj->withAllRoles(function () use ($input, $data, $files, &$response) {
+                $response = $this->dj->internalApiRequest('/' . $input->getArgument('endpoint'), $input->getOption('method'), $data, $files, true);
+            }, $user);
+        } catch (HttpException $e) {
+            $output->writeln($e->getMessage());
+            // Return the HTTP status code as error code
+            return self::FAILURE;
+        }
+
+        $output->writeln(json_encode($response, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
This allows us to import these without having a webserver or a .netrc.

I think the Python code can probably be nicer, but I'm not sure how, so hoping @meisterT can assist.

I verified this works by stopping my webserver and importing.

When this is merged, we can re-enable running `install` instead of `bare-install` again in the contributor Docker image again as well 😄 .