### PR TITLE
Released DJ8.1 version is tested with PHP(7.4-8.2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,7 @@
 | DOMjudge Version | Supported          | PHP version supported |
 | ---------------- | ------------------ | --------------------- |
 | 8.x.x            | :warning:          | 7.4-8.2               |
+| 8.1.x            | :white_check_mark: | 7.4-8.2               |
 | 8.0.x            | :white_check_mark: | 7.2-8.0               |
 | 7.3.x            | :white_check_mark: | 7.2-7.4               |
 | < 7.3            | :x:                | :x:                   |


### PR DESCRIPTION
The CI tests for PHP8.2.

After release of DOMjudge 8.2 we should update this again but that is in the checklist now.