### PR TITLE
Don't use sometimes unset variable

### DIFF
--- a/gitlab/base.sh
+++ b/gitlab/base.sh
@@ -6,7 +6,7 @@ lsb_release -a
 
 cat > ~/.my.cnf <<EOF
 [client]
-host=${MARIADB_PORT_3306_TCP_ADDR}
+host=sqlserver
 user=root
 password=${MYSQL_ROOT_PASSWORD}
 EOF
@@ -26,7 +26,7 @@ if [ -n "${MYSQL_REQUIRE_PRIMARY_KEY:-}" ]; then
 fi
 
 # Generate a dbpasswords file
-echo "unused:${MARIADB_PORT_3306_TCP_ADDR}:domjudge:domjudge:domjudge:3306" > etc/dbpasswords.secret
+echo "unused:sqlserver:domjudge:domjudge:domjudge:3306" > etc/dbpasswords.secret
 
 # Generate APP_SECRET for symfony
 # shellcheck disable=SC2164


### PR DESCRIPTION
We already set this variable to a name set by us. CI seems to sometimes not be started with this variable, I see no issues in the CI log that the SQL server failed to start but it might start to late to actually fill this variable. This solution should not hurt more but in best case might fix some of the failing CI jobs.

See for example: https://gitlab.com/DOMjudge/domjudge/-/jobs/3867397560