### PR TITLE
CONTRIBUTORS.md: fix link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,7 +64,7 @@ Many people have contributed over the years. Many thanks:
 Some code has been ported from the ETH Zurich fork by Christoph
 Krautz, Thomas Rast et al.
 
-The file (CONTRIBUTING.md)[CONTRIBUTING.md] has instructions on
+The file [CONTRIBUTING.md](CONTRIBUTING.md) has instructions on
 how to best contribute.
 
 ## Special thanks


### PR DESCRIPTION
Turns out the square brackets and parentheses were the other way around :stuck_out_tongue: 