### PR TITLE
Add direct button to public page for registering when enabled. Fixes #1780.

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -12,6 +12,7 @@ use App\Entity\JudgingRun;
 use App\Entity\Language;
 use App\Entity\Submission;
 use App\Entity\SubmissionFile;
+use App\Entity\TeamCategory;
 use App\Entity\Testcase;
 use App\Service\AwardService;
 use App\Service\ConfigurationService;
@@ -119,6 +120,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         $user = $this->dj->getUser();
         $team = $user?->getTeam();
 
+        $selfRegistrationCategoriesCount = $this->em->getRepository(TeamCategory::class)->count(['allow_self_registration' => 1]);
         // These variables mostly exist for the header template.
         return [
             'current_contest_id'            => $this->dj->getCurrentContestCookie(),
@@ -147,6 +149,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                                                $this->authorizationChecker->isGranted('ROLE_ADMIN') &&
                                                $this->config->get('data_source') === DOMJudgeService::DATA_SOURCE_CONFIGURATION_AND_LIVE_EXTERNAL,
             'doc_links'                     => $this->dj->getDocLinks(),
+            'allow_registration'            => $selfRegistrationCategoriesCount !== 0,
         ];
     }
 

--- a/webapp/templates/partials/menu_login_logout_button.html.twig
+++ b/webapp/templates/partials/menu_login_logout_button.html.twig
@@ -6,6 +6,11 @@
         <i class="fas fa-sign-out-alt"></i> Logout
     </a>
 {% else %}
+    {% if allow_registration %}
+        <a class="btn btn-info btn-sm justify-content-center mr-2" href="{{ path('register') }}">
+            <i class="fas fa-user-plus"></i> Register
+        </a>
+    {% endif %}
     <a class="btn btn-info btn-sm justify-content-center" href="{{ path('login') }}">
         <i class="fas fa-sign-in-alt"></i> Login
     </a>

--- a/webapp/templates/security/register.html.twig
+++ b/webapp/templates/security/register.html.twig
@@ -19,6 +19,10 @@
         </div>
         {# Form elements will be rendered automatically #}
         {{ form_end(registration_form) }}
+        <div class="mt-3">
+            Already have an account?<br/>
+            <a href="{{ path('login') }}">Login</a>.
+        </div>
     </div>
 {% endblock %}
 

--- a/webapp/tests/Unit/Controller/RegisterControllerTest.php
+++ b/webapp/tests/Unit/Controller/RegisterControllerTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\DataFixtures\Test\EnableSelfregisterFixture;
+use App\Tests\Unit\BaseTestCase;
+
+class RegisterControllerTest extends BaseTestCase
+{
+    public function testRegisterNotAllowed(): void
+    {
+        $this->verifyPageResponse('GET', '/public', 200);
+        self::assertSelectorNotExists('a.btn:contains("Register")');
+
+        $this->verifyPageResponse('GET', '/register', 403);
+        self::assertSelectorExists(':contains("Registration not enabled")');
+
+        $this->verifyPageResponse('GET', '/login', 200);
+        self::assertSelectorNotExists('a:contains("Register now")');
+    }
+
+    public function testRegisterAllowed(): void
+    {
+        $this->loadFixture(EnableSelfregisterFixture::class);
+
+        $this->verifyPageResponse('GET', '/public', 200);
+        self::assertSelectorExists('a.btn:contains("Register")');
+
+        $this->verifyPageResponse('GET', '/register', 200);
+        self::assertSelectorExists('a:contains("Login")');
+
+        $this->verifyPageResponse('GET', '/login', 200);
+        self::assertSelectorExists('a:contains("Register now")');
+    }
+}


### PR DESCRIPTION
Based on 2a69e59dd309beaa5328a249d7f208236223dca9.

Note that #1780 suggests to drop the `Don't have an account?` section because we don't test it often and we have no unit tests. Instead of doing that, I added some simple unit tests.

I also added a link to log in from the register page, of people land on that 'by accident'.