### PR TITLE
Let scripts use the CLI to internally access the API by default.

### DIFF
--- a/doc/manual/import.rst
+++ b/doc/manual/import.rst
@@ -10,7 +10,7 @@ in your `.netrc`_ file. You need to install `httpie`_ and replace the
 ``<API_URL>`` in the examples below with the API URL of your local DOMjudge
 installation.
 
-For using the CLI, you need to replace ``<WEBAPP_DIR>`` with the path to
+To use the CLI, you need to replace ``<WEBAPP_DIR>`` with the path to
 the ``webapp`` directory of the DOMserver.
 
 Importing team categories
@@ -444,11 +444,11 @@ Call it from your contest folder like this::
 
     misc-tools/import-contest <API_URL>
 
-to use the API, or::
+to use the API, or simply::
 
-    misc-tools/import-contest <WEBAPP_DIR>
+    misc-tools/import-contest
 
-to use the CLI.
+to use the CLI. In this case you must run it from the DOMserver.
 
 Importing from ICPC CMS API
 ---------------------------
@@ -487,11 +487,11 @@ called `config.json` in your current directory::
 
     misc-tools/configure-domjudge <API_URL>
 
-to use the API or::
+to use the API, or simply::
 
-    misc-tools/configure-domjudge <WEBAPP_DIR>
+    misc-tools/configure-domjudge
 
-to use the CLI.
+to use the CLI. In this case you must run it from the DOMserver.
 
 .. _CCS specification: https://ccs-specs.icpc.io/2022-07/ccs_system_requirements#appendix-file-formats
 .. _.netrc: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html

--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -3,7 +3,7 @@
 '''
 configure-domjudge -- Convenience script to update DOMjudge configuration.
 
-Reads credentials from ~/.netrc.
+Reads credentials from ~/.netrc when using the API.
 
 See also https://www.domjudge.org/docs/manual/main/import.html
 (replace main with the DOMjudge major.minor version if you are running a
@@ -23,8 +23,10 @@ from typing import List, Set
 sys.path.append('@domserver_libdir@')
 import dj_utils
 
+webappdir = '@domserver_webappdir@'
+
 def usage():
-    print(f'Usage {sys.argv[0]} <domjudge-webapp-dir-or-api-url>')
+    print(f'Usage: {sys.argv[0]} [<domjudge-api-url>]')
     exit(1)
 
 
@@ -40,7 +42,7 @@ def compare_configs(expected_config: Set, actual_config: Set, num_spaces=4) -> (
                     diffs.extend(d)
             else:
                 diffs.append(f'{space_string}- {k}:\n   {space_string}is: {actual_config[k]}\n  {space_string}new: {expected_config[k]}')
-    
+
     new_keys = set(expected_config.keys()).difference(set(actual_config.keys()))
     missing_keys = set(actual_config.keys()).difference(set(expected_config.keys()))
     return (diffs, new_keys, missing_keys)
@@ -50,10 +52,12 @@ def _keyify_list(l: List) -> Set:
     return { elem['id']: elem for elem in l }
 
 
-if len(sys.argv) < 2:
+if len(sys.argv) == 1:
+    dj_utils.domjudge_webapp_folder_or_api_url = webappdir
+elif len(sys.argv) == 2:
+    dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
+else:
     usage()
-
-dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
 
 user_data = dj_utils.do_api_request('user')
 if 'admin' not in user_data['roles']:

--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -2,8 +2,8 @@
 
 '''
 import-contest -- Convenience script to import a contest (including metadata,
-teams and problems) via the command line to the DOMjudge API or to a DOMjudge
-installation using the CLI.
+teams and problems) from the command line. Defaults to using the CLI interface;
+Specify a DOMjudge API URL as to use that.
 
 Reads credentials from ~/.netrc when using the API.
 
@@ -27,10 +27,11 @@ sys.path.append('@domserver_libdir@')
 import dj_utils
 
 cid = None
+webappdir = '@domserver_webappdir@'
 
 
 def usage():
-    print(f'Usage {sys.argv[0]} <domjudge-webapp-dir-or-api-url>')
+    print(f'Usage: {sys.argv[0]} [<domjudge-api-url>]')
     exit(1)
 
 
@@ -92,11 +93,12 @@ def import_images(entity: str, property: str, filename_regexes: List[str]):
         else:
             print(f'Skipping {entity} {property} import.')
 
-
-if len(sys.argv) < 2:
+if len(sys.argv) == 1:
+    dj_utils.domjudge_webapp_folder_or_api_url = webappdir
+elif len(sys.argv) == 2:
+    dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
+else:
     usage()
-
-dj_utils.domjudge_webapp_folder_or_api_url = sys.argv[1]
 
 user_data = dj_utils.do_api_request('user')
 if 'admin' not in user_data['roles']:

--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -224,6 +224,13 @@ remove_db_users()
 	verbose "DOMjudge database and user(s) removed."
 }
 
+install_examples()
+{
+	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
+	"$EXAMPLEPROBDIR"/generate-contest-yaml
+	( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest )
+}
+
 ### Script starts here ###
 
 # Parse command-line options:
@@ -286,10 +293,7 @@ uninstall)
 
 install-examples)
 	read_dbpasswords
-
-	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
-	"$EXAMPLEPROBDIR"/generate-contest-yaml
-	( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${WEBAPPDIR}" )
+	install_examples
 	;;
 
 install-loadtest)
@@ -316,11 +320,7 @@ bare-install|install)
 	unset DB_FIRST_INSTALL
 	DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-default-data
 	if [ "$1" = "install" ]; then
-		DBUSER=$domjudge_DBUSER PASSWD=$domjudge_PASSWD symfony_console domjudge:load-example-data
-		"$EXAMPLEPROBDIR"/generate-contest-yaml
-		( cd "$EXAMPLEPROBDIR" && yes y | "$BINDIR"/import-contest "${WEBAPPDIR}" )
-	fi
-	if [ "$1" = "install" ]; then
+		install_examples
 		verbose "SQL structure and default/example data installed."
 	else
 		verbose "SQL structure and defaults installed (no sample data)."


### PR DESCRIPTION
This simplifies usage, and is typically what you want when you run these commands locally on the domserver.