### PR TITLE
Replace custom specialchars function with PHP default

### DIFF
--- a/webapp/src/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/Controller/Jury/InternalErrorController.php
@@ -171,7 +171,7 @@ class InternalErrorController extends BaseController
         if ($request->isXmlHttpRequest()) {
             $profiler?->disable();
             $progressReporter = function (int $progress, string $log, ?string $message = null) {
-                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => Utils::specialchars($log), 'message' => $message]);
+                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => htmlspecialchars($log), 'message' => $message]);
                 ob_flush();
                 flush();
             };

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -12,7 +12,6 @@ use App\Entity\Team;
 use App\Entity\TeamAffiliation;
 use App\Service\DOMJudgeService;
 use App\Service\ScoreboardService;
-use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
@@ -209,7 +208,7 @@ class JuryMiscController extends BaseController
 
         if ($request->isXmlHttpRequest() && $request->isMethod('POST')) {
             $progressReporter = function (int $progress, string $log, ?string $message = null) {
-                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => Utils::specialchars($log), 'message' => $message]);
+                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => htmlspecialchars($log), 'message' => $message]);
                 ob_flush();
                 flush();
             };

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -425,7 +425,7 @@ class RejudgingController extends BaseController
 
         if ($request->isXmlHttpRequest()) {
             $progressReporter = function (int $progress, string $log, ?string $message = null) {
-                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => Utils::specialchars($log), 'message' => Utils::specialchars($message ?? '')]);
+                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => htmlspecialchars($log), 'message' => htmlspecialchars($message ?? '')]);
                 ob_flush();
                 flush();
             };
@@ -514,7 +514,7 @@ class RejudgingController extends BaseController
         }
         if ($isCreateRejudgingAjax) {
             $progressReporter = function (int $progress, string $log, ?string $redirect = null) {
-                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => Utils::specialchars($log), 'redirect' => $redirect]);
+                echo $this->dj->jsonEncode(['progress' => $progress, 'log' => htmlspecialchars($log), 'redirect' => $redirect]);
                 ob_flush();
                 flush();
             };
@@ -700,7 +700,7 @@ class RejudgingController extends BaseController
         }
 
         $progressReporter = function (int $progress, string $log, ?string $redirect = null) {
-            echo $this->dj->jsonEncode(['progress' => $progress, 'log' => Utils::specialchars($log), 'redirect' => $redirect]);
+            echo $this->dj->jsonEncode(['progress' => $progress, 'log' => htmlspecialchars($log), 'redirect' => $redirect]);
             ob_flush();
             flush();
         };

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -828,7 +828,7 @@ class CheckConfigService
                 $description .= sprintf("<a href=\"%s\">%s %s</a> does not have an external ID\n",
                                         $this->router->generate($route, $routeParams),
                                         ucfirst(str_replace('_', ' ', $inflector->tableize($entityType))),
-                                        Utils::specialchars(implode(', ', $metadata->getIdentifierValues($entity)))
+                                        htmlspecialchars(implode(', ', $metadata->getIdentifierValues($entity)))
                 );
             }
         } else {

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -323,7 +323,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $assetFunction = $this->twig->getFunction('asset')->getCallable();
             $assetUrl      = call_user_func($assetFunction, $asset);
             return sprintf('<img src="%s" alt="%s" class="affiliation-logo">',
-                           Utils::specialchars($assetUrl), Utils::specialchars($shortName));
+                           htmlspecialchars($assetUrl), htmlspecialchars($shortName));
         }
 
         return '';
@@ -385,7 +385,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
 
             if (!empty($testcase['description'])) {
                 $title = sprintf('Run %d: %s', $key + 1,
-                                 Utils::specialchars($testcase['description']));
+                                 htmlspecialchars($testcase['description']));
             } else {
                 $title = sprintf('Run %d', $key + 1);
             }
@@ -563,10 +563,10 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         }
         $firstFile = $files[0]->getFilename();
         if (count($files) == 1) {
-            return sprintf('<span class="hostname">%s</span>', Utils::specialchars($firstFile));
+            return sprintf('<span class="hostname">%s</span>', htmlspecialchars($firstFile));
         }
         return sprintf('<span class="filename">%s</span> (and %d more)',
-                       Utils::specialchars($firstFile),
+                       htmlspecialchars($firstFile),
                        count($files) - 1
         );
     }
@@ -586,7 +586,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $hostname = array_shift($expl);
         }
 
-        return sprintf('<span class="hostname">%s</span>', Utils::specialchars($hostname));
+        return sprintf('<span class="hostname">%s</span>', htmlspecialchars($hostname));
     }
 
     /**
@@ -668,7 +668,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     {
         $line = strtok($difftext, "\n"); //first line
         if ($line === false || sscanf($line, "### DIFFERENCES FROM LINE %d ###\n", $firstdiff) != 1) {
-            return Utils::specialchars($difftext);
+            return htmlspecialchars($difftext);
         }
         $return = $line . "\n";
 
@@ -687,11 +687,11 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             $diffline  = mb_substr($line, $linenowidth + 1);
             $mid       = mb_substr($diffline, $midloc - 1, 3);
             $formdiffline = match ($mid) {
-                ' = ' => "<span class='correct'>" . Utils::specialchars($diffline) . "</span>",
-                ' ! ' => "<span class='differ'>" . Utils::specialchars($diffline) . "</span>",
-                ' $ ' => "<span class='endline'>" . Utils::specialchars($diffline) . "</span>",
-                ' > ', ' < ' => "<span class='extra'>" . Utils::specialchars($diffline) . "</span>",
-                default => Utils::specialchars($diffline),
+                ' = ' => "<span class='correct'>" . htmlspecialchars($diffline) . "</span>",
+                ' ! ' => "<span class='differ'>" . htmlspecialchars($diffline) . "</span>",
+                ' $ ' => "<span class='endline'>" . htmlspecialchars($diffline) . "</span>",
+                ' > ', ' < ' => "<span class='extra'>" . htmlspecialchars($diffline) . "</span>",
+                default => htmlspecialchars($diffline),
             };
             $return = $return . $linenostr . " " . $formdiffline . "\n";
             $line   = strtok("\n");
@@ -738,7 +738,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             if (empty($content)) {
                 break;
             }
-            $content   = Utils::specialchars($content);
+            $content   = htmlspecialchars($content);
             $content   = '<td class="output_text">'
                          . str_replace("\n", "\u{21B5}<br/>", $content)
                          . '</td>';
@@ -822,7 +822,7 @@ document.getElementById("__EDITOR__").editor = __EDITOR__;
 HTML;
         $rank   = $index;
         $id     = sprintf('editor%s', $rank);
-        $code   = Utils::specialchars($code);
+        $code   = htmlspecialchars($code);
         if ($elementToUpdate) {
             $extraForEdit = <<<JS
 __EDITOR__.getSession().on('change', function() {
@@ -843,7 +843,7 @@ var filePath = "%s";
 var mode = modelist.getModeForPath(filePath).mode;
 __EDITOR__.getSession().setMode(mode);
 JS;
-            $mode         = sprintf($modeTemplate, Utils::specialchars($filename));
+            $mode         = sprintf($modeTemplate, htmlspecialchars($filename));
         } else {
             $mode = '';
         }
@@ -860,9 +860,9 @@ JS;
             // Strip any additional DOS/MAC newline characters:
             $line = trim($line, "\r\n");
             $formdiffline = match (substr($line, 0, 1)) {
-                '-' => "<span class='diff-del'>" . Utils::specialchars($line) . "</span>",
-                '+' => "<span class='diff-add'>" . Utils::specialchars($line) . "</span>",
-                default => Utils::specialchars($line),
+                '-' => "<span class='diff-del'>" . htmlspecialchars($line) . "</span>",
+                '+' => "<span class='diff-add'>" . htmlspecialchars($line) . "</span>",
+                default => htmlspecialchars($line),
             };
             $return .= $formdiffline . "\n";
             $line   = strtok("\n");
@@ -961,8 +961,8 @@ JS;
             return implode('<br>', $descriptionLines);
         } else {
             $default         = implode('<br>', array_slice($descriptionLines, 0, 3));
-            $defaultEscaped  = Utils::specialchars($default);
-            $expandedEscaped = Utils::specialchars(implode('<br>', $descriptionLines));
+            $defaultEscaped  = htmlspecialchars($default);
+            $expandedEscaped = htmlspecialchars(implode('<br>', $descriptionLines));
             return <<<EOF
 <span>
     <span data-expanded="$expandedEscaped" data-collapsed="$defaultEscaped">

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -182,7 +182,7 @@ class Utils
         if ($epoch === null) {
             return null;
         }
-        $millis = Utils::getMillis((float) $epoch);
+        $millis = self::getMillis((float) $epoch);
         return date("Y-m-d\TH:i:s", (int) $epoch)
             . ($floored ? '' : $millis)
             . date("P", (int) $epoch);
@@ -198,7 +198,7 @@ class Utils
         $seconds = abs($seconds);
         $hours = (int)($seconds / 3600);
         $minutes = (int)(($seconds - $hours*3600)/60);
-        $millis = Utils::getMillis($seconds);
+        $millis = self::getMillis($seconds);
         $seconds = $seconds - $hours*3600 - $minutes*60;
         return $sign . sprintf("%d:%02d:%02d", $hours, $minutes, $seconds)
             . ($floored ? '' : $millis);
@@ -456,7 +456,7 @@ class Utils
         if (empty($datetime)) {
             return '';
         }
-        return Utils::specialchars(date($format, (int)$datetime));
+        return htmlspecialchars(date($format, (int)$datetime));
     }
 
     /**
@@ -488,23 +488,6 @@ class Utils
         $ret  .= sprintf('%02d', $diff);
 
         return $ret;
-    }
-
-    /**
-     * Wrapper around PHP's htmlspecialchars() to set desired options globally:
-     *
-     * - ENT_QUOTES: Also convert single quotes, in case string is contained
-     *   in a single quoted context.
-     * - ENT_HTML5: Display those single quotes as the HTML5 entity &apos;.
-     * - ENT_SUBSTITUTE: Replace any invalid Unicode characters with the
-     *   Unicode replacement character.
-     */
-    public static function specialchars(string $string): string
-    {
-        return htmlspecialchars(
-            $string,
-            ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE
-        );
     }
 
     /**
@@ -546,7 +529,7 @@ class Utils
         }
 
         if ($n1 == $n2 && $n1 == $dp[$n1][$n2]) {
-            return [false, Utils::specialchars($line1) . "\n"];
+            return [false, htmlspecialchars($line1) . "\n"];
         }
 
         // reconstruct lcs
@@ -573,11 +556,11 @@ class Utils
         $j = 0;
         for ($k = 0; $k < $l; $k++) {
             while ($i < $n1 && $tokens1[$i] != $lcs[$k]) {
-                $diff .= "<del>" . Utils::specialchars($tokens1[$i]) . "</del> ";
+                $diff .= "<del>" . htmlspecialchars($tokens1[$i]) . "</del> ";
                 $i++;
             }
             while ($j < $n2 && $tokens2[$j] != $lcs[$k]) {
-                $diff .= "<ins>" . Utils::specialchars($tokens2[$j]) . "</ins> ";
+                $diff .= "<ins>" . htmlspecialchars($tokens2[$j]) . "</ins> ";
                 $j++;
             }
             $diff .= $lcs[$k] . " ";
@@ -585,11 +568,11 @@ class Utils
             $j++;
         }
         while ($i < $n1 && ($k >= $l || $tokens1[$i] != $lcs[$k])) {
-            $diff .= "<del>" . Utils::specialchars($tokens1[$i]) . "</del> ";
+            $diff .= "<del>" . htmlspecialchars($tokens1[$i]) . "</del> ";
             $i++;
         }
         while ($j < $n2 && ($k >= $l || $tokens2[$j] != $lcs[$k])) {
-            $diff .= "<ins>" . Utils::specialchars($tokens2[$j]) . "</ins> ";
+            $diff .= "<ins>" . htmlspecialchars($tokens2[$j]) . "</ins> ";
             $j++;
         }
 

--- a/webapp/tests/Unit/Utils/UtilsTest.php
+++ b/webapp/tests/Unit/Utils/UtilsTest.php
@@ -565,26 +565,6 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Test that the specialchars function returns the correct result
-     */
-    public function testSpecialchars(): void
-    {
-        $plain = "Example string to test";
-        self::assertEquals($plain, Utils::specialchars($plain));
-
-        $html = 'Example <a href="aap">string</a> to test';
-        $htmlenc = 'Example &lt;a href=&quot;aap&quot;&gt;string&lt;/a&gt; to test';
-        self::assertEquals($htmlenc, Utils::specialchars($html));
-
-        $validutf = "Test Thĳs ⛪⚖";
-        self::assertEquals($validutf, Utils::specialchars($validutf));
-
-        $invalidutf = "Test \xc3\x28 example";
-        $replacedutf = "Test �( example";
-        self::assertEquals($replacedutf, Utils::specialchars($invalidutf));
-    }
-
-    /**
      * Test that string is not cut when shorter or one longer than requested maximum
      */
     public function testCutStringNoop(): void
@@ -740,7 +720,7 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Test that the specialchars function returns the correct result with a
+     * Test that the wrapUnquoted function returns the correct result with a
      * long line
      */
     public function testWrapUnquotedLongLineUnquoted(): void
@@ -753,7 +733,7 @@ text.";
     }
 
     /**
-     * Test that the specialchars function returns the correct result with a
+     * Test that the wrapUnquoted function returns the correct result with a
      * long quoted line
      */
     public function testWrapUnquotedLongLineWithQuoted(): void
@@ -790,7 +770,7 @@ you know";
     }
 
     /**
-     * Test that the specialchars function returns the correct result with a
+     * Test that the wrapUnquoted function returns the correct result with a
      * long quoted line with a custom quote character
      */
     public function testWrapUnquotedLongLineWithQuotedCustomQuoteCharacter(): void


### PR DESCRIPTION
Since PHP 8.1 the default flags are ENT_SUBSTITUTE and ENT_QUOTES. There seems no real value to keep the custom function for just the ENT_HTML5 switch and reverting back to defaults makes things simpler and might mean we benefit from future defaults changes.