### PR TITLE
Remove cache on failure

### DIFF
--- a/gitlab/base.sh
+++ b/gitlab/base.sh
@@ -48,6 +48,11 @@ parameters:
     domjudge.baseurl: http://localhost/domjudge
 EOF
 
+# install check if the cache might be dirty
+set +e
+composer install --no-scripts || rm -rf lib/vendor
+set -e
+
 # install all php dependencies
 export APP_ENV="prod"
 composer install --no-scripts


### PR DESCRIPTION
When the CI cache has been updated by another branch/PR which touches composer other pipelines fail. We have this problem between released version branches but also when someone updates composer for a PR.