### PR TITLE
Link to main documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If you are interested in starting to contribute to DOMjudge, you are
 most welcome. The following are some pointers.
 
 First, install and configure the development version of DOMjudge.
-Either directly from the git repository, see the [developer information](https://www.domjudge.org/snapshot/manual/develop.html)
+Either directly from the git repository, see the [developer information](https://www.domjudge.org/docs/manual/main/develop.html)
 section in the admin manual, or via the [contributor docker image](https://github.com/DOMjudge/domjudge-packaging/tree/main/docker-contributor).
 If you follow the admin manual for installation, this is also a great
 way to verify that the documentation is clear and complete, and to


### PR DESCRIPTION
Snapshot is less often in sync than the main documentation.

@nickygerritsen fixed the docs generation so this URL works again.