### PR TITLE
Fix phpcs annotation

### DIFF
--- a/.github/jobs/data/phpruleset.xml
+++ b/.github/jobs/data/phpruleset.xml
@@ -2,16 +2,43 @@
 <ruleset name="DOMjudge">
     <description>Project specific exclusions.</description>
     <rule ref="PSR2" />
-    <rule ref="PSR1.Files.SideEffects">
+    <!-- Keep indentation up to the author -->
+    <rule ref="PSR2.Methods.FunctionCallSignature.Indent">
         <severity>0</severity>
     </rule>
+    <!-- We have multiple lines of +120 where splitting is not trivial -->
     <rule ref="Generic.Files.LineLength">
         <severity>0</severity>
     </rule>
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing">
+    <!-- We use this for empty constructors, empty try/catch -->
+    <rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
         <severity>0</severity>
     </rule>
-    <rule ref="PSR2.Methods.FunctionCallSignature">
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore">
+        <severity>0</severity>
+    </rule>
+    <!-- The judgedaemon does this to keep it selfcontained -->
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>judge/judgedaemon\.main\.php</exclude-pattern>
+    </rule>
+    <!-- We use this to have a newline for such cases to keep it readable -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.OneParamPerLine">
+        <exclude-pattern>webapp/tests/Unit/Controller/API/ScoreboardControllerTest.php</exclude-pattern>
+    </rule>
+    <!-- This will annotate a lot of files now -->
+    <rule ref="PSR2.Methods.FunctionCallSignature.MultipleArguments">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.CloseBracketLine">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket">
         <severity>0</severity>
     </rule>
 </ruleset>

--- a/webapp/src/Controller/API/MetricsController.php
+++ b/webapp/src/Controller/API/MetricsController.php
@@ -235,7 +235,7 @@ class MetricsController extends AbstractFOSRestController
             foreach ($balloons_waiting as $b) {
                 $t = $b->getSubmission()->getSubmittime();
                 $t2 = $n-$t;
-                $balloons_longest_waitingtime = max($t2,$balloons_longest_waitingtime);
+                $balloons_longest_waitingtime = max($t2, $balloons_longest_waitingtime);
             }
             $m['balloons_longest_waitingtime']->set($balloons_longest_waitingtime, $labels);
         }

--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -123,7 +123,7 @@ class ExecutableController extends BaseController
                 $zip         = $this->dj->openZipFile($archive->getRealPath());
                 $filename    = $archive->getClientOriginalName();
                 $id          = substr($filename, 0, strlen($filename) - strlen(".zip"));
-                if (! preg_match ('#^[a-z0-9_-]+$#i', $id)) {
+                if (! preg_match('#^[a-z0-9_-]+$#i', $id)) {
                     throw new InvalidArgumentException(sprintf("File base name '%s' must contain only alphanumerics", $id));
                 }
                 $description = $id;

--- a/webapp/tests/Unit/Command/ResetUserPasswordCommandTest.php
+++ b/webapp/tests/Unit/Command/ResetUserPasswordCommandTest.php
@@ -90,7 +90,8 @@ class ResetUserPasswordCommandTest extends BaseTestCase
         self::assertThat(
             $statusCode,
             $this->logicalNot($this->equalTo(new CommandIsSuccessful())),
-            'Command should fail with missing parameters.');
+            'Command should fail with missing parameters.'
+        );
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('[ERROR] Can not find user with username '.$user, $output);
     }

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -204,7 +204,7 @@ EOF;
         foreach (['9999','nan','nonexistent'] as $nonExpectedObjectId) {
             $url = $this->helperGetEndpointURL($this->apiEndpoint)."?team=".$nonExpectedObjectId;
             $objects = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
-            self::assertEquals([],$objects);
+            self::assertEquals([], $objects);
         }
         foreach ($this->expectedObjects as $expectedObject) {
             if (!isset($expectedObject['team_id'])) {
@@ -222,7 +222,7 @@ EOF;
                     }
                 }
             }
-            self::assertEquals(true,$found);
+            self::assertEquals(true, $found);
         }
     }
 }


### PR DESCRIPTION
I've disabled some rules which I think we should enable again. PHPCBF did not pick them up correctly so another tool should do that.