### PR TITLE
Check remaining processes in cgroups, not with `ps`.

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -454,6 +454,25 @@ int use_cgroup()
 	    ( cpuset!=NULL && strlen(cpuset)>0 );
 }
 
+void check_remaining_procs()
+{
+    char path[1024];
+
+    if ( !use_cgroup() ) return;
+
+    snprintf(path, 1023, "/sys/fs/cgroup/cpu%scgroup.procs", cgroupname);
+    FILE *file = fopen(path, "r");
+    if (file == NULL) {
+        error(0, "Error opening cgroups file: %s", path);
+        return;
+    }
+
+    fseek(file, 0L, SEEK_END);
+    if (ftell(file) > 0) {
+        error(0, "Left-over processes in cgroup controller, please check!");
+    }
+}
+
 void output_cgroup_stats(double *cputime)
 {
 	int ret;
@@ -1409,6 +1428,8 @@ int main(int argc, char **argv)
 		} else {
 			exitcode = WEXITSTATUS(status);
 		}
+
+        check_remaining_procs();
 
 		double cputime = -1;
 		output_cgroup_stats(&cputime);

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -212,12 +212,6 @@ runcheck "$RUN_SCRIPT" $RUNARGS \
 	--stderr=program.err --outmeta=program.meta -- \
 	"$PREFIX/$PROGRAM" 2>runguard.err
 
-# Check for still running processes:
-output=$(ps -u "$RUNUSER" -o pid= -o comm= || true)
-if [ -n "$output" ] ; then
-	error "found processes still running as '$RUNUSER', check manually:\\n$output"
-fi
-
 if [ $COMBINED_RUN_COMPARE -eq 0 ]; then
 	# We first compare the output, so that even if the submission gets a
 	# timelimit exceeded or runtime error verdict later, the jury can


### PR DESCRIPTION
`ps` is relatively slow, so this change speeds up a trivial program with ~150 test cases by ~15% (from ~29s to ~24.5s).