### PR TITLE
Show a message when viewing the scoreboard as balloon runner.

### DIFF
--- a/webapp/templates/jury/scoreboard.html.twig
+++ b/webapp/templates/jury/scoreboard.html.twig
@@ -11,7 +11,7 @@
 {% block content %}
 
     <div data-ajax-refresh-target data-ajax-refresh-after="pinScoreheader">
-        {% include 'partials/scoreboard.html.twig' with {jury: is_granted('ROLE_JURY'), public: not is_granted('ROLE_JURY')} %}
+        {% include 'partials/scoreboard.html.twig' with {jury: is_granted('ROLE_JURY'), public: not is_granted('ROLE_JURY'), show_balloon_public_message: not is_granted('ROLE_JURY')} %}
     </div>
 
 {% endblock %}

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -84,6 +84,12 @@
         {% endfor %}
     {% else %}
 
+        {% if show_balloon_public_message is defined and show_balloon_public_message %}
+            <div class="alert alert-warning" role="alert" style="font-size: 80%;">
+                You are seeing the public scoreboard, since you are a balloon runner.
+            </div>
+        {% endif %}
+
         {% if scoreboard.freezeData.showFrozen(false) %}
             <div class="alert alert-warning" role="alert" style="font-size: 80%;">
                 {% if jury %}


### PR DESCRIPTION
Fixes #1289.

It seems @vmcj already fixed the logic itself, this just adds a message to not confuse balloon runners.