### PR TITLE
Upgrade the component to development version

### DIFF
--- a/.github/jobs/fix_pipelinecomponents_image.sh
+++ b/.github/jobs/fix_pipelinecomponents_image.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eux
+
+echo "Set plugin config for version detection"
+phpcs --config-set installed_paths /app/vendor/phpcompatibility/php-compatibility
+      
+# Current released version does not know enums
+echo "Upgrade the compatibility for PHP versions"
+mydir=$(pwd)
+sed -i 's/"phpcompatibility\/php-compatibility": "9.3.5"/"phpcompatibility\/php-compatibility": "dev-develop"/g' /app/composer.json
+cd /app; composer update
+cd $mydir

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,7 +14,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Rewrite Changelog to find new mistakes
         run: awk '1;/Version 7.2.1 - 6 May 2020/{exit}' ChangeLog > latest_Changelog
       - name: Get dirs to skip

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,14 +15,14 @@ jobs:
     container:
       image: domjudge/gitlabci:2.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run the syntax checks
         run: .github/jobs/syntax.sh
 
   detect-dump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Search for leftover dump( statements"
         run: .github/jobs/detect_dump.sh
 
@@ -31,7 +31,7 @@ jobs:
     container:
       image: pipelinecomponents/php-linter:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Detect PHP linting issues
         run: >
           parallel-lint --colors
@@ -52,7 +52,7 @@ jobs:
         PHPVERSION: ["8.1", "8.2"]
     steps:
       - run: apk add git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Various fixes to this image
         run: .github/jobs/fix_pipelinecomponents_image.sh
       - name: Detect compatibility with supported PHP version

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -51,6 +51,7 @@ jobs:
       matrix:
         PHPVERSION: ["8.1", "8.2"]
     steps:
+      - run: apk add git
       - uses: actions/checkout@v2
       - name: Various fixes to this image
         run: .github/jobs/fix_pipelinecomponents_image.sh

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -52,8 +52,8 @@ jobs:
         PHPVERSION: ["8.1", "8.2"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set plugin config for version detection
-        run: phpcs --config-set installed_paths /app/vendor/phpcompatibility/php-compatibility
+      - name: Various fixes to this image
+        run: .github/jobs/fix_pipelinecomponents_image.sh
       - name: Detect compatibility with supported PHP version
         run: >
           phpcs -s -p --colors

--- a/.github/workflows/mayhem-api-template.yml
+++ b/.github/workflows/mayhem-api-template.yml
@@ -23,7 +23,7 @@ jobs:
       DB_USER: user
       DB_PASSWORD: password
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh ${{ inputs.version }}

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -14,7 +14,7 @@ jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # important!
       - name: Install PHP_CodeSniffer

--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -7,7 +7,7 @@ jobs:
   Scan-Build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
   check-static-codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download latest codecov upload script
         run: wget https://codecov.io/bash -O newcodecov
       - name: Detect changes to manually verify

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -851,7 +851,7 @@ while (true) {
 
         // Either the file didn't exist or we deleted it above.
         if (!file_exists($success_file)) {
-            $oldworkdir = $workdir . '-old-' . getmypid() . '-' . strftime('%Y-%m-%d_%H:%M');
+            $oldworkdir = $workdir . '-old-' . getmypid() . '-' . date('Y-m-d_H:i');
             if (!rename($workdir, $oldworkdir)) {
                 error("Could not rename stale working directory to '$oldworkdir'.");
             }


### PR DESCRIPTION
The current version does not understand enum in combination with $this. See: https://github.com/PHPCompatibility/PHPCompatibility/issues/1343

Normally we wouldn't like having to run a pre-release version but this is for a very minor component (check if code is acceptable in this PHP version) and the image is only used for this test so shouldn't have an effect on other tests.