### PR TITLE
Add support for importing submissions as shadow that we don't accept, add custom verdicts and update unverified badge

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -301,6 +301,13 @@
                 1: configuration data external
                 2: configuration and live data external
             docdescription: See :doc:`the chapter on running DOMjudge as a shadow system<shadow>` for more information.
+        -   name: external_judgement_types
+            type: array_keyval
+            key_placeholder: ID
+            value_placeholder: Name
+            default_value: []
+            public: true
+            description: List of additional judgement types as reported by the external CCS. All assumed to give a penalty.
         -   name: external_ccs_submission_url
             type: string
             default_value: ""

--- a/webapp/migrations/Version20230507124955.php
+++ b/webapp/migrations/Version20230507124955.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230507124955 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add import error to submissions';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submission ADD import_error TINYINT(1) NOT NULL COMMENT \'Whether this submission was imported during shadowing but had an error while doing so.\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submission DROP import_error');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20230508095605.php
+++ b/webapp/migrations/Version20230508095605.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20230507124955 extends AbstractMigration
+final class Version20230508095605 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -20,7 +20,7 @@ final class Version20230507124955 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE submission ADD import_error TINYINT(1) NOT NULL COMMENT \'Whether this submission was imported during shadowing but had an error while doing so.\'');
+        $this->addSql('ALTER TABLE submission ADD import_error VARCHAR(255) DEFAULT NULL COMMENT \'If this submission was imported during shadowing but had an error while doing so, the error message.\'');
     }
 
     public function down(Schema $schema): void

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -41,8 +41,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
     ) {
         parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts = include $verdictsConfig;
+        $verdicts = $this->dj->getVerdicts();
         $verdicts['aborted'] = 'JE'; /* happens for aborted judgings */
         $this->verdicts = $verdicts;
     }

--- a/webapp/src/Controller/API/JudgementTypeController.php
+++ b/webapp/src/Controller/API/JudgementTypeController.php
@@ -80,8 +80,7 @@ class JudgementTypeController extends AbstractRestController
      */
     protected function getJudgementTypes(array $filteredOn = null): array
     {
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts       = include $verdictsConfig;
+        $verdicts = $this->dj->getVerdicts(mergeExternal: true);
 
         $result = [];
         foreach ($verdicts as $name => $label) {

--- a/webapp/src/Controller/API/RunController.php
+++ b/webapp/src/Controller/API/RunController.php
@@ -43,8 +43,7 @@ class RunController extends AbstractRestController implements QueryObjectTransfo
         parent::__construct($entityManager, $DOMJudgeService, $config,
             $eventLogService);
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $this->verdicts = include $verdictsConfig;
+        $this->verdicts = $this->dj->getVerdicts();
     }
 
     /**

--- a/webapp/src/Controller/Jury/ConfigController.php
+++ b/webapp/src/Controller/Jury/ConfigController.php
@@ -92,6 +92,8 @@ class ConfigController extends AbstractController
                     'options' => $spec['options'] ?? null,
                     'key_options' => $spec['key_options'] ?? null,
                     'value_options' => $spec['value_options'] ?? null,
+                    'key_placeholder' => $spec['key_placeholder'] ?? '',
+                    'value_placeholder' => $spec['value_placeholder'] ?? '',
                 ];
             }
             $allData[] = [

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -210,8 +210,7 @@ class RejudgingController extends BaseController
         }
         $todo = $this->rejudgingService->calculateTodo($rejudging)['todo'];
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts       = include $verdictsConfig;
+        $verdicts = $this->dj->getVerdicts();
         $verdicts[''] = 'JE'; /* happens for aborted judgings */
         $verdicts['aborted'] = 'JE'; /* happens for aborted judgings */
 

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -64,6 +64,8 @@ class ShadowDifferencesController extends BaseController
             return $this->render('jury/shadow_differences.html.twig');
         }
 
+        $verdicts['import-error'] = 'IE';
+
         $used         = [];
         $verdictTable = [];
         // Pre-fill $verdictTable to get a consistent ordering.
@@ -111,6 +113,10 @@ class ShadowDifferencesController extends BaseController
                 $localResult = $localJudging->getResult();
             } else {
                 $localResult = 'judging';
+            }
+
+            if ($submission->isImportError()) {
+                $localResult = 'import-error';
             }
 
             if ($externalJudgement && $externalJudgement->getResult()) {

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -56,9 +56,8 @@ class ShadowDifferencesController extends BaseController
         // Close the session, as this might take a while and we don't need the session below.
         $this->requestStack->getSession()->save();
 
-        $contest        = $this->dj->getCurrentContest();
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts       = array_merge(['judging' => 'JU'], include $verdictsConfig);
+        $contest  = $this->dj->getCurrentContest();
+        $verdicts = array_merge(['judging' => 'JU'], $this->dj->getVerdicts(mergeExternal: true));
 
         if (!$contest) {
             return $this->render('jury/shadow_differences.html.twig');

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -186,7 +186,8 @@ class ShadowDifferencesController extends BaseController
         [$submissions, $submissionCounts] = $this->submissions->getSubmissionList(
             $contests,
             $restrictions,
-            0
+            limit: 0,
+            showShadowUnverified: true
         );
 
         $data = [

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -181,7 +181,7 @@ class SubmissionController extends BaseController
             ->join('s.problem', 'p')
             ->join('s.language', 'l')
             ->join('s.contest', 'c')
-            ->join('s.files', 'f')
+            ->leftJoin('s.files', 'f')
             ->leftJoin('s.external_judgements', 'ej', Join::WITH, 'ej.valid = 1')
             ->leftJoin('s.contest_problem', 'cp')
             ->select('s', 't', 'p', 'l', 'c', 'partial f.{submitfileid, filename}', 'cp', 'ej')

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -109,10 +109,9 @@ class SubmissionController extends BaseController
             $this->submissionService->getSubmissionList($contests, $restrictions, $limit);
 
         // Load preselected filters
-        $filters          = $this->dj->jsonDecode((string)$this->dj->getCookie('domjudge_submissionsfilter') ?: '[]');
+        $filters = $this->dj->jsonDecode((string)$this->dj->getCookie('domjudge_submissionsfilter') ?: '[]');
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $results = array_keys(include $verdictsConfig);
+        $results = array_keys($this->dj->getVerdicts());
         $results[] = 'judging';
         $results[] = 'queued';
 

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -268,7 +268,7 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         return $this;
     }
 
-    public function isImportError(): string
+    public function isImportError(): ?string
     {
         return $this->importError;
     }

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -90,11 +90,13 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     private ?string $entry_point = null;
 
     #[ORM\Column(
-        nullable: false,
-        options: ['comment' => 'Whether this submission was imported during shadowing but had an error while doing so.']
+        nullable: true,
+        options: ['comment' => 'If this submission was imported during shadowing but had an error while doing so, the error message.']
     )]
+    #[OA\Property(nullable: true)]
+    #[Serializer\Expose(if: "context.getAttribute('domjudge_service').checkrole('jury')")]
     #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
-    private bool $importError = false;
+    private ?string $importError = null;
 
     #[ORM\ManyToOne(inversedBy: 'submissions')]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
@@ -260,13 +262,13 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
         return $this->entry_point;
     }
 
-    public function setImportError(bool $importError): Submission
+    public function setImportError(?string $importError): Submission
     {
         $this->importError = $importError;
         return $this;
     }
 
-    public function isImportError(): bool
+    public function isImportError(): string
     {
         return $this->importError;
     }

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -91,7 +91,7 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
 
     #[ORM\Column(
         nullable: true,
-        options: ['comment' => 'If this submission was imported during shadowing but had an error while doing so, the error message.']
+        options: ['comment' => 'The error message for submissions which got an error during shadow importing.']
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\Expose(if: "context.getAttribute('domjudge_service').checkrole('jury')")]

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -89,6 +89,13 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     #[Serializer\Expose(if: "context.getAttribute('domjudge_service').checkrole('jury')")]
     private ?string $entry_point = null;
 
+    #[ORM\Column(
+        nullable: false,
+        options: ['comment' => 'Whether this submission was imported during shadowing but had an error while doing so.']
+    )]
+    #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
+    private bool $importError = false;
+
     #[ORM\ManyToOne(inversedBy: 'submissions')]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
     #[Serializer\Exclude]
@@ -251,6 +258,17 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     public function getEntryPoint(): ?string
     {
         return $this->entry_point;
+    }
+
+    public function setImportError(bool $importError): Submission
+    {
+        $this->importError = $importError;
+        return $this;
+    }
+
+    public function isImportError(): bool
+    {
+        return $this->importError;
     }
 
     public function setTeam(?Team $team = null): Submission

--- a/webapp/src/Form/Type/RejudgingType.php
+++ b/webapp/src/Form/Type/RejudgingType.php
@@ -107,8 +107,7 @@ class RejudgingType extends AbstractType
                 ->orderBy('j.hostname'),
         ]);
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts = array_keys(include $verdictsConfig);
+        $verdicts = array_keys($this->dj->getVerdicts());
         $builder->add('verdicts', ChoiceType::class, [
             'label' => 'Verdict',
             'multiple' => true,

--- a/webapp/src/Form/Type/SubmissionsFilterType.php
+++ b/webapp/src/Form/Type/SubmissionsFilterType.php
@@ -103,8 +103,7 @@ class SubmissionsFilterType extends AbstractType
             "attr" => ["data-filter-field" => "team-id"],
         ]);
 
-        $verdictsConfig = $this->dj->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts = array_keys(include $verdictsConfig);
+        $verdicts = array_keys($this->dj->getVerdicts());
         $verdicts[] = "judging";
         $verdicts[] = "queued";
         $verdicts[] = "import-error";

--- a/webapp/src/Form/Type/SubmissionsFilterType.php
+++ b/webapp/src/Form/Type/SubmissionsFilterType.php
@@ -107,6 +107,7 @@ class SubmissionsFilterType extends AbstractType
         $verdicts = array_keys(include $verdictsConfig);
         $verdicts[] = "judging";
         $verdicts[] = "queued";
+        $verdicts[] = "import-error";
         $builder->add("result", ChoiceType::class, [
             "label" => "Filter on result(s)",
             "multiple" => true,

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1079,6 +1079,10 @@ class DOMJudgeService
         $problem    = $submission->getContestProblem();
         $language   = $submission->getLanguage();
 
+        if ($submission->isImportError()) {
+            return;
+        }
+
         $evalOnDemand = false;
         // We have 2 cases, the problem picks the global value or the value is set.
         if (((int)$problem->getLazyEvalResults() === (int)DOMJudgeService::EVAL_DEFAULT && $this->config->get('lazy_eval_results') === static::EVAL_DEMAND)

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1470,4 +1470,18 @@ class DOMJudgeService
             ]
         );
     }
+
+    public function getVerdicts(bool $mergeExternal = false): array
+    {
+        $verdictsConfig = $this->getDomjudgeEtcDir() . '/verdicts.php';
+        $verdicts       = include $verdictsConfig;
+
+        if ($mergeExternal) {
+            foreach ($this->config->get('external_judgement_types') as $id => $name) {
+                $verdicts[$name] = $id;
+            }
+        }
+
+        return $verdicts;
+    }
 }

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -76,8 +76,12 @@ class SubmissionService
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    public function getSubmissionList(array $contests, array $restrictions, int $limit = 0): array
-    {
+    public function getSubmissionList(
+        array $contests,
+        array $restrictions,
+        int $limit = 0,
+        bool $showShadowUnverified = false
+    ): array {
         if (empty($contests)) {
             return [[], []];
         }
@@ -266,6 +270,10 @@ class SubmissionService
             'queued' => 'j.result IS NULL AND j.starttime IS NULL',
             'judging' => 'j.starttime IS NOT NULL AND j.endtime IS NULL'
         ];
+        if ($showShadowUnverified) {
+            $countQueryExtras['shadowUnverified'] = 'ej.verified = 0 AND ej.result IS NOT NULL AND (ej.result != j.result OR j.result IS NULL)';
+            unset($countQueryExtras['unverified']);
+        }
         foreach ($countQueryExtras as $count => $countQueryExtra) {
             $countQueryBuilder = (clone $queryBuilder)->select('COUNT(s.submitid) AS cnt');
             if (!empty($countQueryExtra)) {

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -501,6 +501,11 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
 
     public function printValidJurySubmissionResult(Submission $submission, bool $forDisplay = true): string
     {
+        if ($submission->isImportError()) {
+            $result = 'import-error';
+            return $forDisplay ? $this->printValidJuryResult($result) : $result;
+        }
+
         /** @var Judging|null $firstJudging */
         $firstJudging  = $submission->getJudgings()->first();
         $judgingResult = '';

--- a/webapp/templates/jury/config.html.twig
+++ b/webapp/templates/jury/config.html.twig
@@ -96,6 +96,7 @@
                                                             <input class="form-control form-control-sm"
                                                                    style="width:10em;text-align:right;display:inline-block;" type="text"
                                                                    value="{{ key }}"
+                                                                   placeholder="{{ option.key_placeholder }}"
                                                                    name="config_{{ option.name }}[{{ counter }}][key]"
                                                                    id="config_{{ option.name }}_{{ counter }}__key_">
                                                         {% endif %}
@@ -111,6 +112,7 @@
                                                             <input class="form-control form-control-sm"
                                                                    style="width:30em;display:inline-block;" type="text"
                                                                    value="{{ val }}"
+                                                                   placeholder="{{ option.value_placeholder }}"
                                                                    name="config_{{ option.name }}[{{ counter }}][val]"
                                                                    id="config_{{ option.name }}_{{ counter }}__val">
                                                             {% endif %}
@@ -130,6 +132,7 @@
                                                         {% else %}
                                                             <input class="form-control form-control-sm"
                                                                    style="width:10em;text-align:right;display:inline-block;" type="text"
+                                                                   placeholder="{{ option.key_placeholder }}"
                                                                    name="config_{{ option.name }}[__idx__][key]"
                                                                    id="config_{{ option.name }}___idx____key_">
                                                         {% endif %}
@@ -144,6 +147,7 @@
                                                         {% else %}
                                                             <input class="form-control form-control-sm"
                                                                    style="width:30em;display:inline-block;" type="text"
+                                                                   placeholder="{{ option.value_placeholder }}"
                                                                    name="config_{{ option.name }}[__idx__][val]"
                                                                    id="config_{{ option.name }}___idx____val">
                                                         {% endif %}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -22,8 +22,12 @@
         <span class="badge text-bg-info">{{ submissionCounts.total }} submitted</span>
         <span class="badge text-bg-success">{{ submissionCounts.correct }} correct</span>
 
-        {% if submissionCounts.unverified > 0 %}
+        {% if submissionCounts.unverified is defined and submissionCounts.unverified > 0 %}
             <span class="badge text-bg-warning">{{ submissionCounts.unverified }} unverified</span>
+        {% endif %}
+
+        {% if submissionCounts.shadowUnverified is defined and submissionCounts.shadowUnverified > 0 %}
+            <span class="badge text-bg-warning">{{ submissionCounts.shadowUnverified }} shadow differences unverified</span>
         {% endif %}
 
         {% if submissionCounts.ignored > 0 %}
@@ -262,7 +266,7 @@
                 </tr>
                 <tr>
                     <td colspan="3" class="inline-verify-form">
-                        {% if externalJudgement is not null %}
+                        {% if externalJudgement is not null and (not submission.judgings.first or submission.judgings.first.result != externalJudgement.result) %}
                             {% include 'jury/partials/verify_form.html.twig' with {
                                 label: 'Shadow difference verified',
                                 judging: externalJudgement,

--- a/webapp/templates/jury/shadow_differences.html.twig
+++ b/webapp/templates/jury/shadow_differences.html.twig
@@ -106,7 +106,9 @@
                     var $matrixData = $('[data-new-shadow-matrix]');
                     var $matrix = $('[data-shadow-matrix]');
                     $matrix.html($matrixData.children());
-                }
+                };
+
+                $('table.submissions-table').find('[data-bs-toggle="tooltip"]').tooltip();
             });
         </script>
     {% endif %}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -87,7 +87,10 @@
     {% endif %}
 
     {% if submission.importError %}
-        <div class="alert alert-danger">This submission could not be imported into DOMjudge and thus will only show external data.</div>
+        <div class="alert alert-danger">
+            <div>This submission could not be imported into DOMjudge and thus will only show external data.</div>
+            <div>The error during import was: <code>{{ submission.importError }}</code></div>
+        </div>
     {% endif %}
 
     {% if not submission.contestProblem %}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -62,26 +62,32 @@
                 (ignored)
             {% endif %}
         </h1>
-        {% if is_granted('ROLE_ADMIN') %}
-            {% if submission.valid %}
-                {% set action = 'ignore' %}
-            {% else %}
-                {% set action = 'unignore' %}
+        {% if not submission.importError %}
+            {% if is_granted('ROLE_ADMIN') %}
+                {% if submission.valid %}
+                    {% set action = 'ignore' %}
+                {% else %}
+                    {% set action = 'unignore' %}
+                {% endif %}
+                <form action="{{ path('jury_submission_update_status', {'submitId': submission.submitid}) }}" method="post"
+                      style="display: inline; ">
+                    <input type="hidden" name="valid" value="{% if submission.valid %}0{% else %}1{% endif %}"/>
+                    <input type="submit" class="btn btn-outline-secondary btn-sm"
+                           value="{{ action | upper }} this submission"
+                           onclick="return confirm('Really {{ action }} submission s{{ submission.submitid }}?');"/>
+                </form>
             {% endif %}
-            <form action="{{ path('jury_submission_update_status', {'submitId': submission.submitid}) }}" method="post"
-                  style="display: inline; ">
-                <input type="hidden" name="valid" value="{% if submission.valid %}0{% else %}1{% endif %}"/>
-                <input type="submit" class="btn btn-outline-secondary btn-sm"
-                       value="{{ action | upper }} this submission"
-                       onclick="return confirm('Really {{ action }} submission s{{ submission.submitid }}?');"/>
-            </form>
-        {% endif %}
 
-        {% include 'jury/partials/rejudge_form.html.twig' with {table: 'submission', id: submission.submitid} %}
+            {% include 'jury/partials/rejudge_form.html.twig' with {table: 'submission', id: submission.submitid} %}
+        {% endif %}
     </div>
 
     {% if not submission.valid %}
         <div class="alert alert-danger">This submission is not used during scoreboard calculations.</div>
+    {% endif %}
+
+    {% if submission.importError %}
+        <div class="alert alert-danger">This submission could not be imported into DOMjudge and thus will only show external data.</div>
     {% endif %}
 
     {% if not submission.contestProblem %}
@@ -184,7 +190,9 @@
         </div>
     {% endif %}
 
-    {% if externalJudgement is not null and externalJudgement.result is not empty and selectedJudging is not null and selectedJudging.result is not empty and externalJudgement.result != selectedJudging.result %}
+    {% if externalJudgement is not null and externalJudgement.result is not empty and (
+        (selectedJudging is not null and selectedJudging.result is not empty and externalJudgement.result != selectedJudging.result)
+        or submission.importError) %}
         <div class="alert alert-danger">
             <strong>Results differ!</strong>
             <hr>
@@ -197,7 +205,12 @@
                         {{ externalJudgement.result | printValidJuryResult }} by the external CCS
                     </a>
                 {% endif -%}
-                , but as {{ selectedJudging.result | printValidJuryResult }}
+                , but as
+                {% if submission.importError %}
+                    {{ 'import-error' | printValidJuryResult }}
+                {% else %}
+                    {{ selectedJudging.result | printValidJuryResult }}
+                {% endif %}
                 by DOMjudge.
             </p>
 
@@ -351,19 +364,21 @@
 
         <div class="mb-2">
             <div>
-                Result:
-                {% if selectedJudging is null or selectedJudging.result is empty %}
-                    {%- if selectedJudging and selectedJudging.started %}
-                        {{- '' | printValidJuryResult -}}
+                {% if not submission.importError %}
+                    Result:
+                    {% if selectedJudging is null or selectedJudging.result is empty %}
+                        {%- if selectedJudging and selectedJudging.started %}
+                            {{- '' | printValidJuryResult -}}
+                        {%- else %}
+                            {{- 'queued' | printValidJuryResult -}}
+                        {%- endif %}
                     {%- else %}
-                        {{- 'queued' | printValidJuryResult -}}
+                        {{- selectedJudging.result | printValidJuryResult -}}
                     {%- endif %}
-                {%- else %}
-                    {{- selectedJudging.result | printValidJuryResult -}}
-                {%- endif %}
-                {%- if submission.stillBusy -%}
-                    (&hellip;)
-                {%- endif -%}
+                    {%- if submission.stillBusy -%}
+                        (&hellip;)
+                    {%- endif -%}
+                {% endif %}
                 {%- if lastJudging is not null -%}
                     {% set lastSubmissionLink = path('jury_submission', {submitId: lastSubmission.submitid}) %}{#-
                 -#}<span class="lastresult">
@@ -371,7 +386,11 @@
                 -#}</span>
                 {%- endif -%}
                 {%- if externalJudgement is not null %}
-                    (external: {{ externalJudgement.result | printValidJuryResult }})
+                    {% if submission.importError %}
+                        External result: {{ externalJudgement.result | printValidJuryResult }}
+                    {% else %}
+                        (external: {{ externalJudgement.result | printValidJuryResult }})
+                    {% endif %}
                 {%- endif %}
                 {%- if selectedJudging is not null and judgehosts is not empty -%}
                     , Judgehost(s):
@@ -418,27 +437,29 @@
             {# Display testcase results #}
             {% if externalJudgement is not null or (selectedJudging is not null and selectedJudging.result != 'compiler-error') %}
                 <table>
-                    <tr>
-                        <td>testcase runs:</td>
-                        <td>
-                            {% if selectedJudging is null %}
-                                {% set judgingDone = false %}
-                            {% else %}
-                                {% set judgingDone = selectedJudging.endtime is not empty %}
-                            {% endif %}
-                            {{ runs | displayTestcaseResults(judgingDone) }}
-                            {% if selectedJudging is not null and runsOutstanding %}
-                                {% if selectedJudging.judgeCompletely %}
-                                    <i class="fas fa-balance-scale" title="remaining test cases requested to be judged"></i>
-                                {% elseif selectedJudging.result is not null %}
-                                    <form action="{{ path('jury_submission_request_remaining', {'judgingId': selectedJudging.judgingid}) }}" method="post"
-                                          style="display: inline; ">
-                                        <input type="submit" class="btn btn-outline-secondary btn-sm" value="judge remaining" />
-                                    </form>
+                    {% if not submission.importError %}
+                        <tr>
+                            <td>testcase runs:</td>
+                            <td>
+                                {% if selectedJudging is null %}
+                                    {% set judgingDone = false %}
+                                {% else %}
+                                    {% set judgingDone = selectedJudging.endtime is not empty %}
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                    </tr>
+                                {{ runs | displayTestcaseResults(judgingDone) }}
+                                {% if selectedJudging is not null and runsOutstanding %}
+                                    {% if selectedJudging.judgeCompletely %}
+                                        <i class="fas fa-balance-scale" title="remaining test cases requested to be judged"></i>
+                                    {% elseif selectedJudging.result is not null %}
+                                        <form action="{{ path('jury_submission_request_remaining', {'judgingId': selectedJudging.judgingid}) }}" method="post"
+                                              style="display: inline; ">
+                                            <input type="submit" class="btn btn-outline-secondary btn-sm" value="judge remaining" />
+                                        </form>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
                     {% if lastJudging is not null %}
                         <tr class="lasttcruns">
                             <td>


### PR DESCRIPTION
Fixes #1849, fixes #272, fixes #1848

So this does a couple of things:
* It adds a flag to `submitSolution` to allow to import a submission that is not valid according to us. This will not create a judging or judgetasks, but will import the submission and show it as `import-error`. This allows us to import submissions (and their sourcecode if available) so we can still compare the shadow data.
* Add a config setting for custom judgement types and use this to import unknown judgement types as shadow. For this I refactored out the logic to get verdicts from verdicts.php, so it is less duplicated code. This now has a flag to also add external verdicts, which is used in a few places (shadow diff, the API).
* Replace the `x unverified` badge with a badge showing how many unverified shadow differences there are. Also only show the verify mark form when there is a difference.