### PR TITLE
Remove unused diff function and improve diff of source newline changes

### DIFF
--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -70,6 +70,7 @@ a.collapse { color: black; text-decoration: none; }
 .diff-add        { color: green; }
 .diff-del        { color: red; }
 .diff-changed    { color: darkorange; }
+.diff-endline    { font-weight: bold; }
 .file-diff-table { width: auto; }
 .file-diff-table tr th { padding-right: 10px; }
 

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -828,12 +828,15 @@ JS;
         $return = '';
         while ($line !== false && strlen($line) != 0) {
             // Strip any additional DOS/MAC newline characters:
-            $line = trim($line, "\r\n");
+            $line = str_replace("\r", "↵", $line);
             $formdiffline = match (substr($line, 0, 1)) {
                 '-' => "<span class='diff-del'>" . htmlspecialchars($line) . "</span>",
                 '+' => "<span class='diff-add'>" . htmlspecialchars($line) . "</span>",
                 default => htmlspecialchars($line),
             };
+            if (str_contains($formdiffline, '#Warning: Strings contain different line endings')) {
+                $formdiffline = "<span class='diff-endline'>$formdiffline</span>";
+            }
             $return .= $formdiffline . "\n";
             $line   = strtok("\n");
         }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -87,7 +87,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('lineCount', $this->lineCount(...)),
             new TwigFilter('base64', 'base64_encode'),
             new TwigFilter('base64_decode', 'base64_decode'),
-            new TwigFilter('parseRunDiff', $this->parseRunDiff(...), ['is_safe' => ['html']]),
             new TwigFilter('runDiff', $this->runDiff(...), ['is_safe' => ['html']]),
             new TwigFilter('interactiveLog', $this->interactiveLog(...), ['is_safe' => ['html']]),
             new TwigFilter('codeEditor', $this->codeEditor(...), ['is_safe' => ['html']]),
@@ -668,41 +667,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     public function lineCount(string $input): int
     {
         return mb_substr_count($input, "\n");
-    }
-
-    public function parseRunDiff(string $difftext): string
-    {
-        $line = strtok($difftext, "\n"); //first line
-        if ($line === false || sscanf($line, "### DIFFERENCES FROM LINE %d ###\n", $firstdiff) != 1) {
-            return htmlspecialchars($difftext);
-        }
-        $return = $line . "\n";
-
-        // Add second line 'team ? reference'.
-        $line   = strtok("\n");
-        $return .= $line . "\n";
-
-        // We determine the line number width from the '_' characters and
-        // the separator position from the character '?' on the second line.
-        $linenowidth = mb_strrpos($line, '_') + 1;
-        $midloc      = mb_strpos($line, '?') - ($linenowidth + 1);
-
-        $line = strtok("\n");
-        while (mb_strlen($line) != 0) {
-            $linenostr = mb_substr($line, 0, $linenowidth);
-            $diffline  = mb_substr($line, $linenowidth + 1);
-            $mid       = mb_substr($diffline, $midloc - 1, 3);
-            $formdiffline = match ($mid) {
-                ' = ' => "<span class='correct'>" . htmlspecialchars($diffline) . "</span>",
-                ' ! ' => "<span class='differ'>" . htmlspecialchars($diffline) . "</span>",
-                ' $ ' => "<span class='endline'>" . htmlspecialchars($diffline) . "</span>",
-                ' > ', ' < ' => "<span class='extra'>" . htmlspecialchars($diffline) . "</span>",
-                default => htmlspecialchars($diffline),
-            };
-            $return = $return . $linenostr . " " . $formdiffline . "\n";
-            $line   = strtok("\n");
-        }
-        return $return;
     }
 
     public function interactiveLog(string $log, bool $forTeam = false): string

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -710,16 +710,14 @@
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no validator output.</p>
                                 {% else %}
-                                    <pre class="output_text">
-{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
+                                    <pre class="output_text">{{ runsOutput[runIdx].output_diff }}</pre>
                                 {% endif %}
                             {% else %}
                                 <h5>Diff output</h5>
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no diff output.</p>
                                 {% else %}
-                                    <pre class="output_text">
-{{ runsOutput[runIdx].output_diff | parseRunDiff }}</pre>
+                                    <pre class="output_text">{{ runsOutput[runIdx].output_diff }}</pre>
                                 {% endif %}
 
                                 {% if run.firstJudgingRun.runresult != 'correct' %}
@@ -739,8 +737,7 @@
                                 {% if runsOutput[runIdx].output_run is empty %}
                                     <p class="nodata">There was no program output.</p>
                                 {% else %}
-                                    <pre class="output_text">
-{{ runsOutput[runIdx].output_run | parseRunDiff }}</pre>
+                                    <pre class="output_text">{{ runsOutput[runIdx].output_run }}</pre>
                                 {% endif %}
                             {% endif %}
 
@@ -748,14 +745,14 @@
                             {% if runsOutput[runIdx].output_error is empty %}
                                 <p class="nodata">There was no stderr output.</p>
                             {% else %}
-                                <pre class="output_text">{{ runsOutput[runIdx].output_error | parseRunDiff }}</pre>
+                                <pre class="output_text">{{ runsOutput[runIdx].output_error }}</pre>
                             {% endif %}
 
                             <h5>Judging system output (info/debug/errors)</h5>
                             {% if runsOutput[runIdx].output_system is empty %}
                                 <p class="nodata">There was no judging system output.</p>
                             {% else %}
-                                <pre class="output_text">{{ runsOutput[runIdx].output_system | parseRunDiff }}</pre>
+                                <pre class="output_text">{{ runsOutput[runIdx].output_system }}</pre>
                             {% endif %}
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
The diff now looks like:
![image](https://user-images.githubusercontent.com/4692022/236685414-993a348f-faba-4d66-9311-124feb2608e4.png)
