### PR TITLE
Display timelimits at time of running in runtime graph.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -209,9 +209,27 @@ class SubmissionController extends BaseController
             ->getQuery()
             ->getResult();
 
+        // These three arrays are indexed by judgingid
         /** @var Judging[] $judgings */
         $judgings    = array_map(fn($data) => $data[0], $judgingData);
         $maxRunTimes = array_map(fn($data) => $data['max_runtime'], $judgingData);
+        $timelimits  = [];
+
+        if ($judgings) {
+            $judgeTasks = $this->em->createQueryBuilder()
+                ->from(JudgeTask::class, 'jt', 'jt.jobid')
+                ->select('jt')
+                ->andWhere('jt.jobid IN (:jobIds)')
+                ->setParameter(
+                    'jobIds',
+                    array_map(static fn(Judging $judging) => $judging->getJudgingid(), $judgings)
+                )
+                ->getQuery()
+                ->getResult();
+            $timelimits = array_map(function (JudgeTask $task) {
+                return $this->dj->jsonDecode($task->getRunConfig())['time_limit'];
+            }, $judgeTasks);
+        }
 
         $selectedJudging = null;
         // Find the selected judging.
@@ -468,6 +486,7 @@ class SubmissionController extends BaseController
             'lastSubmission' => $lastSubmission,
             'judgings' => $judgings,
             'maxRunTimes' => $maxRunTimes,
+            'timelimits' => $timelimits,
             'selectedJudging' => $selectedJudging,
             'lastJudging' => $lastJudging,
             'runs' => $runs,

--- a/webapp/templates/jury/partials/submission_graph.html.twig
+++ b/webapp/templates/jury/partials/submission_graph.html.twig
@@ -93,15 +93,25 @@
                 .datum(run_max_times)
                 .call(chart);
             var svgsize = chart.container.clientWidth || chart.container.parentNode.clientWidth;
-            var line = d3.select('#maxruntime svg')
+            var chartStart = chart.margin().left;
+            var chartEnd = +svgsize - chart.margin().right;
+            var chartWidth = chartEnd - chartStart;
+            var barWidth = chartWidth / {{ judgings | filter(judging => judging.result and judging.result != 'aborted') | length }};
+            {% for judging in judgings | filter(judging => judging.result and judging.result != 'aborted') %}
+            d3.select('#maxruntime svg')
                 .append('line')
                 .attr({
-                    x1: chart.margin().left,
-                    y1: chart.yAxis.scale()({{ timelimit }}) + chart.margin().top,
-                    x2: +svgsize - chart.margin().right,
-                    y2: chart.yAxis.scale()({{ timelimit }}) + chart.margin().top,
+                    x1: chartStart + {{ loop.index0 }} * barWidth,
+                    y1: chart.yAxis.scale()({{ timelimits[judging.judgingid] }}) + chart.margin().top,
+                    x2: chartStart + (1 + {{ loop.index0 }}) * barWidth,
+                    y2: chart.yAxis.scale()({{ timelimits[judging.judgingid] }}) + chart.margin().top,
                 })
-                .style("stroke", "#F00");
+                .style("stroke", "#F00")
+            {% if timelimits[judging.judgingid] != timelimit %}
+                .style("stroke-dasharray", "3 3")
+            {% endif %}
+                .style("stroke-width", "2px");
+            {% endfor %}
             nv.utils.windowResize(chart.update);
             return chart;
         });
@@ -142,7 +152,8 @@
                     x2: +svgsize - chart.margin().right,
                     y2: chart.yAxis.scale()({{ timelimit }}) + chart.margin().top,
                 })
-                .style("stroke", "#F00");
+                .style("stroke", "#F00")
+                .style("stroke-width", "2px");
             nv.utils.windowResize(chart.update);
             return chart;
         });
@@ -184,7 +195,8 @@
                     x2: +svgsize - chart.margin().right,
                     y2: chart.yAxis.scale()({{ timelimit }}) + chart.margin().top,
                 })
-                .style("stroke", "#F00");
+                .style("stroke", "#F00")
+                .style("stroke-width", "2px");
             nv.utils.windowResize(chart.update);
             return chart;
         });


### PR DESCRIPTION
Fixes #1859

We decided to not show the current timelimit as a separate line, but just dasherize / not dasherize the line. Also no vertical bars, since it seems to look better.

Screenshot:
<img width="516" alt="Screenshot 2023-05-07 at 20 45 52" src="https://user-images.githubusercontent.com/550145/236696929-1181f795-2d0b-41ce-bfe3-77af69168eef.png">

cc @mpsijm 