### PR TITLE
Consistently use (de)activate_time in contest.yaml.

### DIFF
--- a/doc/manual/config-basic.rst
+++ b/doc/manual/config-basic.rst
@@ -57,13 +57,13 @@ from the main page.
 Besides the name the most important configuration about a contest
 are the various time milestones.
 
-A contest can be selected for viewing after its *activation time*, but
+A contest can be selected for viewing after its *activate time*, but
 the scoreboard will only become visible to public and teams once the
 contest *starts*. Thus no data such as problems and teams is revealed
 before then.
 
 When the contest *ends*, the scores will remain displayed until the
-*deactivation time* passes.
+*deactivate time* passes.
 
 DOMjudge has the option to 'freeze' the public and team scoreboards
 at some point during the contest. This means that scores are no longer

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -55,7 +55,7 @@ class ImportExportService
             'end_time' => Utils::absTime($contest->getEndtime(), true),
             'duration' => Utils::relTime($contest->getContestTime((float)$contest->getEndtime())),
             'penalty_time' => $this->config->get('penalty_time'),
-            'activation_time' => Utils::absTime($contest->getActivatetime(), true),
+            'activate_time' => Utils::absTime($contest->getActivatetime(), true),
         ];
         if ($warnMsg = $contest->getWarningMessage()) {
             $data['warning_message'] = $warnMsg;
@@ -143,7 +143,7 @@ class ImportExportService
             return false;
         }
 
-        $activateTimeFields = ['activation_time','activate_time','activation-time', 'activate-time'];
+        $activateTimeFields = ['activate_time', 'activation_time', 'activate-time', 'activation-time'];
         $deactivateTimeFields = preg_filter('/^/', 'de', $activateTimeFields);
         $startTimeFields = ['start_time', 'start-time'];
         $requiredFields = [$startTimeFields, ['name', 'formal_name'], ['id', 'short_name', 'short-name'], 'duration'];

--- a/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
@@ -55,7 +55,7 @@ EOF;
 id: practice
 formal_name: NWERC 2020 Practice Session
 name: practice
-activation_time: '2021-03-27T09:00:00+00:00'
+activate_time: '2021-03-27T09:00:00+00:00'
 start_time: '2021-03-27T09:00:00+00:00'
 end_time: '2021-03-27T11:00:00+00:00'
 duration: 2:00:00.000
@@ -244,9 +244,9 @@ EOF;
     /**
      * @dataProvider provideNewContest
      */
-    public function testActivationTimeContestYaml(
-        string $activationTime, string $startTime, ?string $deactivationTime,
-        bool $setActivation, bool $setDeactivation
+    public function testActivateTimeContestYaml(
+        string $activateTime, string $startTime, ?string $deactivateTime,
+        bool $setActivate, bool $setDeactivate
     ): void {
         $yaml = <<<EOF
 duration: 2:00:00
@@ -262,11 +262,11 @@ problems:
     id: anothereruption
 EOF;
 
-        if ($setActivation) {
-            $yaml = "activation_time: ".$activationTime."\n".$yaml;
+        if ($setActivate) {
+            $yaml = "activate_time: ".$activateTime."\n".$yaml;
         }
-        if ($setDeactivation) {
-            $yaml = "deactivation_time: ".$deactivationTime."\n".$yaml;
+        if ($setDeactivate) {
+            $yaml = "deactivate_time: ".$deactivateTime."\n".$yaml;
         }
         $url = $this->helperGetEndpointURL($this->apiEndpoint);
         $tempYamlFile = tempnam(sys_get_temp_dir(), "/contest-yaml-");
@@ -278,16 +278,16 @@ EOF;
 
         $now = Utils::now();
         $nowTime = Utils::printtime($now, 'Y-m-d H:i:s');
-        $activation = Utils::toEpochFloat($activationTime);
+        $activate = Utils::toEpochFloat($activateTime);
         $start = Utils::toEpochFloat($startTime);
-        
+
         self::assertIsString($cid);
         self::assertSame('New Contest to check Activation', $this->getContest($cid)->getName());
         self::assertSame($start, $this->getContest($cid)->getStarttime());
 
-        if ($setActivation) {
-            self::assertSame($activationTime, Utils::printtime($this->getContest($cid)->getActivatetime(), 'Y-m-d H:i:s'));
-            self::assertSame($activation, $this->getContest($cid)->getActivatetime());
+        if ($setActivate) {
+            self::assertSame($activateTime, Utils::printtime($this->getContest($cid)->getActivatetime(), 'Y-m-d H:i:s'));
+            self::assertSame($activate, $this->getContest($cid)->getActivatetime());
         } else {
             // Contest uploaded starts in the past
             if (Utils::printtime(Utils::now(), 'Y-m-d H:i:s')>=$startTime) {
@@ -296,8 +296,8 @@ EOF;
                 self::assertTrue($this->getContest($cid)->getActivatetime() <= $now);
             }
         }
-        if ($deactivationTime) {
-            self::assertSame($deactivationTime, Utils::printtime($this->getContest($cid)->getDeactivatetime(), 'Y-m-d H:i:s'));
+        if ($deactivateTime) {
+            self::assertSame($deactivateTime, Utils::printtime($this->getContest($cid)->getDeactivatetime(), 'Y-m-d H:i:s'));
         } else {
             self::assertNull($this->getContest($cid)->getDeactivatetime());
         }

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -100,7 +100,7 @@ start_time: '{$year}-01-01T08:00:00+00:00'
 end_time: '{$year}-01-01T13:00:00+00:00'
 duration: '5:00:00.000'
 penalty_time: 20
-activation_time: '{$pastYear}-01-01T08:00:00+00:00'
+activate_time: '{$pastYear}-01-01T08:00:00+00:00'
 scoreboard_freeze_time: '{$year}-01-01T12:00:00+00:00'
 scoreboard_freeze_duration: '1:00:00'
 problems:


### PR DESCRIPTION
Related to #1807