### PR TITLE
Add a preview of clarifications for teams and jury.

### DIFF
--- a/webapp/config/packages/security.yaml
+++ b/webapp/config/packages/security.yaml
@@ -74,7 +74,8 @@ security:
                 target: /public
 
     access_control:
-        - { path: ^/$, roles: PUBLIC_ACCESS }
+        - { path: ^/$, roles: IS_AUTHENTICATED_FULLY }
+        - { path: ^/markdown-preview, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/register, roles: PUBLIC_ACCESS }
         - { path: ^/public, roles: PUBLIC_ACCESS }

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -415,6 +415,7 @@ function clarificationAppendAnswer() {
     var textbox = $('#bodytext');
     textbox.val(textbox.val().replace(/\n$/, "") + '\n' + selected);
     textbox.scrollTop(textbox[0].scrollHeight);
+    previewClarification($('#bodytext') , $('#messagepreview'));
 }
 
 function confirmLogout() {
@@ -762,6 +763,28 @@ function humanReadableBytes(bytes) {
         }
     }
     return Math.floor(bytes) + 'B';
+}
+
+function previewClarification($input, $previewDiv) {
+    var message = $input.val();
+    $.ajax({
+        url: markdownPreviewUrl,
+        method: 'POST',
+        data: {
+            message: message
+        }
+    }).done(function(data) {
+        $previewDiv.html(data.html);
+    });
+}
+
+function setupPreviewClarification($input, $previewDiv, previewInitial) {
+    if (previewInitial) {
+        previewClarification($input, $previewDiv);
+    }
+    $($input).on('keyup', $.debounce(function() {
+        previewClarification($input, $previewDiv);
+    }, 250));
 }
 
 $(function () {

--- a/webapp/public/js/jquery.debounce.min.js
+++ b/webapp/public/js/jquery.debounce.min.js
@@ -1,0 +1,9 @@
+/**
+ * Debounce and throttle function's decorator plugin 1.0.6
+ *
+ * Copyright (c) 2009 Filatov Dmitry (alpha@zforms.ru)
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ */(function(a){a.extend({debounce:function(a,b,c,d){arguments.length==3&&typeof c!="boolean"&&(d=c,c=!1);var e;return function(){var f=arguments;d=d||this,c&&!e&&a.apply(d,f),clearTimeout(e),e=setTimeout(function(){c||a.apply(d,f),e=null},b)}},throttle:function(a,b,c){var d,e,f;return function(){e=arguments,f=!0,c=c||this,d||function(){f?(a.apply(c,e),f=!1,d=setTimeout(arguments.callee,b)):d=null}()}}})})(jQuery);

--- a/webapp/src/Controller/RootController.php
+++ b/webapp/src/Controller/RootController.php
@@ -3,9 +3,14 @@
 namespace App\Controller;
 
 use App\Service\DOMJudgeService;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Twig\Extra\Markdown\MarkdownRuntime;
 
 #[Route(path: '')]
 class RootController extends BaseController
@@ -32,5 +37,18 @@ class RootController extends BaseController
             }
         }
         return $this->redirectToRoute('public_index');
+    }
+
+    #[Route(path: '/markdown-preview', name: 'markdown_preview', methods: ['POST'])]
+    public function markdownPreview(
+        Request $request,
+        #[Autowire(service: 'twig.runtime.markdown')]
+        MarkdownRuntime $markdownRuntime
+    ) {
+        $message = $request->request->get('message');
+        if ($message === null) {
+            throw new BadRequestHttpException('A message is required');
+        }
+        return new JsonResponse(['html' => $markdownRuntime->convert($message)]);
     }
 }

--- a/webapp/src/Form/Type/TeamClarificationType.php
+++ b/webapp/src/Form/Type/TeamClarificationType.php
@@ -49,6 +49,7 @@ class TeamClarificationType extends AbstractType
             'choices' => $subjects,
         ]);
         $builder->add('message', TextareaType::class, [
+            'label' => false,
             'attr' => [
                 'rows' => 5,
                 'cols' => 85,

--- a/webapp/templates/base.html.twig
+++ b/webapp/templates/base.html.twig
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="{{ asset("css/bootstrap.min.css") }}">
     <link rel="stylesheet" href="{{ asset("css/fontawesome-all.min.css") }}">
     <script src="{{ asset("js/jquery.min.js") }}"></script>
+    <script src="{{ asset("js/jquery.debounce.min.js") }}"></script>
     <script src="{{ asset("js/bootstrap.bundle.min.js") }}"></script>
 
     <script src="{{ asset("js/domjudge.js") }}"></script>
@@ -44,6 +45,7 @@
     {% if app.request %}
         var domjudge_base_url = "{{ app.request.getBaseURL() }}";
     {% endif %}
+    var markdownPreviewUrl = "{{ path('markdown_preview') }}";
     $(function () {
         /* toggle refresh if set */
         {% if refresh is defined and refresh %}

--- a/webapp/templates/jury/clarification.html.twig
+++ b/webapp/templates/jury/clarification.html.twig
@@ -187,6 +187,8 @@ Jury
             });
         });
         $('#clar_answers').change(clarificationAppendAnswer);
+
+        setupPreviewClarification($('#bodytext') , $('#messagepreview'), true);
      });
 </script>
 {% endblock %}

--- a/webapp/templates/jury/clarification_new.html.twig
+++ b/webapp/templates/jury/clarification_new.html.twig
@@ -14,3 +14,11 @@
 </div>
 
 {% endblock %}
+
+{% block extrafooter %}
+    <script>
+        $(function () {
+            setupPreviewClarification($('#bodytext'), $('#messagepreview'), true);
+        });
+    </script>
+{% endblock %}

--- a/webapp/templates/jury/partials/clarification_form.html.twig
+++ b/webapp/templates/jury/partials/clarification_form.html.twig
@@ -26,9 +26,25 @@
 </select>
 </div>
 
-<div class="mb-3">
-<label for="bodytext" class="form-label" >Message:</label>
-<textarea class="form-control" name="bodytext" id="bodytext" rows="8" cols="85" required>{{ clarform.quotedtext|default("") }}</textarea>
+<div class="list-group mb-3">
+    <div class="list-group-item">
+        <div class="flex-column">
+            <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message</small></label>
+        </div>
+        <textarea class="form-control" name="bodytext" id="bodytext"
+                  rows="8" cols="85"
+                  required>{{ clarform.quotedtext|default("") }}</textarea>
+    </div>
+    <div class="list-group-item">
+        <div class="mb-3">
+            <div class="flex-column">
+                <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message preview</small></label>
+            </div>
+            <div class="card">
+                <div class="card-body" id="messagepreview"></div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="row">

--- a/webapp/templates/team/base.html.twig
+++ b/webapp/templates/team/base.html.twig
@@ -14,6 +14,12 @@
             $('body').on('submit', 'form[name=team_clarification]', function () {
                 return confirm("Send clarification request to Jury?");
             });
+
+            setupPreviewClarification($('#team_clarification_message') , $('#messagepreview'), false);
+
+            window.initModalClarificationPreview = function() {
+                setupPreviewClarification($('#team_clarification_message') , $('#messagepreview'), false);
+            };
         });
     </script>
 {% endblock %}

--- a/webapp/templates/team/clarification_add.html.twig
+++ b/webapp/templates/team/clarification_add.html.twig
@@ -10,7 +10,24 @@
             {{ form_start(form) }}
             {{ form_row(form.recipient) }}
             {{ form_row(form.subject) }}
-            {{ form_row(form.message) }}
+            <div class="list-group mb-3">
+                <div class="list-group-item">
+                    <div class="flex-column">
+                        <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message</small></label>
+                    </div>
+                    {{ form_row(form.message) }}
+                </div>
+                <div class="list-group-item">
+                    <div class="mb-3">
+                        <div class="flex-column">
+                            <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message preview</small></label>
+                        </div>
+                        <div class="card">
+                            <div class="card-body" id="messagepreview">Start typing to see a preview of your message</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="form-group">
                 <button type="submit" name="submit" class="btn btn-primary">
                     <i class="fas fa-envelope"></i> Send

--- a/webapp/templates/team/clarification_add_modal.html.twig
+++ b/webapp/templates/team/clarification_add_modal.html.twig
@@ -11,7 +11,24 @@
             <div class="modal-body">
                 {{ form_row(form.recipient) }}
                 {{ form_row(form.subject) }}
-                {{ form_row(form.message) }}
+                <div class="list-group mb-3">
+                    <div class="list-group-item">
+                        <div class="flex-column">
+                            <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message</small></label>
+                        </div>
+                        {{ form_row(form.message) }}
+                    </div>
+                    <div class="list-group-item">
+                        <div class="mb-3">
+                            <div class="flex-column">
+                                <label for="bodytext" class="form-label text-muted d-flex justify-content-end"><small>message preview</small></label>
+                            </div>
+                            <div class="card">
+                                <div class="card-body" id="messagepreview">Start typing to see a preview of your message</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/webapp/templates/team/partials/index_content.html.twig
+++ b/webapp/templates/team/partials/index_content.html.twig
@@ -42,7 +42,7 @@
             {% endif %}
 
             <div class="m-1">
-                <a href="{{ path('team_clarification_add') }}" class="btn btn-secondary btn-sm" data-ajax-modal>
+                <a href="{{ path('team_clarification_add') }}" class="btn btn-secondary btn-sm" data-ajax-modal data-ajax-modal-after="initModalClarificationPreview">
                     request clarification
                 </a>
             </div>

--- a/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
@@ -103,7 +103,7 @@ class ClarificationControllerTest extends BaseTestCase
         $labels = $crawler->filter('label')->extract(['_text']);
         self::assertEquals('Send to:', $labels[0]);
         self::assertEquals('Subject:', $labels[1]);
-        self::assertEquals('Message:', $labels[2]);
+        self::assertEquals('message', $labels[2]);
 
         $this->client->submitForm('Send', [
             'sendto' => '',


### PR DESCRIPTION
We should at some point:
* Deduplicate code between jury and teams (i.e. make jury also use nice Symfony forms).
* Deduplicate code between team modal and non modal. I tried this but the modal makes it a bit harder.
* Maybe make the UI a bit nicer.

Screenshot:
<img width="948" alt="Screenshot 2023-05-08 at 11 19 22" src="https://user-images.githubusercontent.com/550145/236786872-423423ad-33bd-471d-a790-bda71bea78b0.png">
