### PR TITLE
Fix removal of dangling problem/submission related data.

### DIFF
--- a/webapp/migrations/Version20230508120033.php
+++ b/webapp/migrations/Version20230508120033.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230508120033 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set up cascading delete constraint from submission to judgetask.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judgetask ADD CONSTRAINT FK_83142B703605A691 FOREIGN KEY (submitid) REFERENCES submission (submitid) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judgetask DROP FOREIGN KEY FK_83142B703605A691');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20230508135106.php
+++ b/webapp/migrations/Version20230508135106.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230508135106 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace jobid with foreign key constraint.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX jobid ON queuetask');
+        $this->addSql('ALTER TABLE queuetask ADD judgingid INT UNSIGNED DEFAULT NULL COMMENT \'Judging ID\', DROP jobid');
+        $this->addSql('ALTER TABLE queuetask ADD CONSTRAINT FK_45E85FF85D5FEA72 FOREIGN KEY (judgingid) REFERENCES judging (judgingid) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX judgingid ON queuetask (judgingid)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE queuetask DROP FOREIGN KEY FK_45E85FF85D5FEA72');
+        $this->addSql('DROP INDEX judgingid ON queuetask');
+        $this->addSql('ALTER TABLE queuetask ADD jobid INT UNSIGNED DEFAULT NULL COMMENT \'All queuetasks with the same jobid belong together.\', DROP judgingid');
+        $this->addSql('CREATE INDEX jobid ON queuetask (jobid)');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20230508135106.php
+++ b/webapp/migrations/Version20230508135106.php
@@ -20,19 +20,15 @@ final class Version20230508135106 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP INDEX jobid ON queuetask');
-        $this->addSql('ALTER TABLE queuetask ADD judgingid INT UNSIGNED DEFAULT NULL COMMENT \'Judging ID\', DROP jobid');
+        $this->addSql('ALTER TABLE queuetask RENAME COLUMN jobid TO judgingid');
         $this->addSql('ALTER TABLE queuetask ADD CONSTRAINT FK_45E85FF85D5FEA72 FOREIGN KEY (judgingid) REFERENCES judging (judgingid) ON DELETE CASCADE');
-        $this->addSql('CREATE INDEX judgingid ON queuetask (judgingid)');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE queuetask DROP FOREIGN KEY FK_45E85FF85D5FEA72');
-        $this->addSql('DROP INDEX judgingid ON queuetask');
-        $this->addSql('ALTER TABLE queuetask ADD jobid INT UNSIGNED DEFAULT NULL COMMENT \'All queuetasks with the same jobid belong together.\', DROP judgingid');
-        $this->addSql('CREATE INDEX jobid ON queuetask (jobid)');
+        $this->addSql('ALTER TABLE queuetask RENAME COLUMN judgingid TO jobid');
     }
 
     public function isTransactional(): bool

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1339,7 +1339,7 @@ class JudgehostController extends AbstractFOSRestController
             // Note: we are joining on queue tasks here since if there is no more queue task, there is also no more
             // work to be done. If we would not do this join, the getJudgetasks would try to delete the queue task,
             // which is both slow and results in spamming the auditlog
-            ->innerJoin(QueueTask::class, 'qt', Join::WITH, 'qt.jobid = jt.jobid')
+            ->innerJoin(QueueTask::class, 'qt', Join::WITH, 'qt.judging = jt.jobid')
             ->select('jt.jobid')
             ->andWhere('jt.judgehost = :judgehost')
             ->andWhere('jt.type = :type')
@@ -1361,7 +1361,8 @@ class JudgehostController extends AbstractFOSRestController
         $this->em->wrapInTransaction(function () use ($judgehost, $max_batchsize, &$judgetasks) {
             $jobid = $this->em->createQueryBuilder()
                 ->from(QueueTask::class, 'qt')
-                ->select('qt.jobid')
+                ->innerJoin('qt.judging', 'j')
+                ->select('j.judgingid')
                 ->andWhere('qt.startTime IS NULL')
                 ->addOrderBy('qt.priority')
                 ->addOrderBy('qt.teamPriority')
@@ -1374,7 +1375,7 @@ class JudgehostController extends AbstractFOSRestController
                 $this->em->createQueryBuilder()
                     ->update(QueueTask::class, 'qt')
                     ->set('qt.startTime', Utils::now())
-                    ->andWhere('qt.jobid = :jobid')
+                    ->andWhere('qt.judging = :jobid')
                     ->andWhere('qt.startTime IS NULL')
                     ->setParameter('jobid', $jobid)
                     ->getQuery()
@@ -1390,7 +1391,8 @@ class JudgehostController extends AbstractFOSRestController
             // but we have not contributed yet.
             $jobid = $this->em->createQueryBuilder()
                 ->from(QueueTask::class, 'qt')
-                ->select('qt.jobid')
+                ->innerJoin('qt.judging', 'j')
+                ->select('j.judgingid')
                 ->addOrderBy('qt.priority')
                 ->addOrderBy('qt.teamPriority')
                 ->setMaxResults(1)
@@ -1439,10 +1441,10 @@ class JudgehostController extends AbstractFOSRestController
         }
 
         // Filter by submit_id.
-        $submit_id = $judgeTasks[0]->getSubmitid();
+        $submit_id = $judgeTasks[0]->getSubmission()->getSubmitid();
         $judgetaskids = [];
         foreach ($judgeTasks as $judgeTask) {
-            if ($judgeTask->getSubmitid() == $submit_id) {
+            if ($judgeTask->getSubmission()->getSubmitid() == $submit_id) {
                 $judgetaskids[] = $judgeTask->getJudgetaskid();
             }
         }
@@ -1542,7 +1544,7 @@ class JudgehostController extends AbstractFOSRestController
             // the queuetask here.
             $this->em->createQueryBuilder()
                 ->from(QueueTask::class, 'qt')
-                ->andWhere('qt.jobid = :jobid')
+                ->andWhere('qt.judging = :jobid')
                 ->setParameter('jobid', $jobId)
                 ->delete()
                 ->getQuery()

--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -225,7 +225,7 @@ abstract class BaseController extends AbstractController
                 // tables.
                 // Since MySQL does not define the order of cascading deletes, we need to manually
                 // first manually delete judging_runs and then cascade via
-                // submission -> judging -> judgeTasks.
+                // submission to all of judging, judgeTasks and queueTasks.
                 // See also https://github.com/DOMjudge/domjudge/issues/243 and associated commits.
 
                 // First delete judging_runs.
@@ -237,15 +237,7 @@ abstract class BaseController extends AbstractController
                     ['probid' => $entity->getProbid()]
                 );
 
-                // Then delete all outstanding queueTasks.
-                $entityManager->getConnection()->executeQuery(
-                    'DELETE qt FROM queuetask qt
-                         INNER JOIN submission s ON qt.jobid = s.submitid
-                         WHERE s.probid = :probid',
-                    ['probid' => $entity->getProbid()]
-                );
-
-                // Then delete submissions which will cascade to judging and judgeTasks.
+                // Then delete submissions which will cascade to judging, judgeTasks and queueTasks.
                 $entityManager->getConnection()->executeQuery(
                     'DELETE FROM submission WHERE probid = :probid',
                     ['probid' => $entity->getProbid()]
@@ -552,7 +544,7 @@ abstract class BaseController extends AbstractController
                 $submission = $judging->getSubmission();
 
                 $queueTask = new QueueTask();
-                $queueTask->setJobId($judging->getJudgingid())
+                $queueTask->setJudging($judging)
                     ->setPriority(JudgeTask::PRIORITY_LOW)
                     ->setTeam($submission->getTeam())
                     ->setTeamPriority((int)$submission->getSubmittime())

--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -219,21 +219,45 @@ abstract class BaseController extends AbstractController
         // Now actually delete the entity.
         $entityManager->wrapInTransaction(function () use ($entityManager, $entity) {
             if ($entity instanceof Problem) {
-                // Deleting a problem is a special case: its dependent tables do not
-                // form a tree, and the deletion of judging_run can only cascade from
-                // judging, not from testcase. Since MySQL does not define the
-                // order of cascading deletes, we need to manually first cascade
-                // via submission -> judging -> judging_run.
+                // Deleting a problem is a special case:
+                // Its dependent tables do not form a tree (but something like a diamond shape),
+                // and there are multiple cascading removal paths from problem to its dependant
+                // tables.
+                // Since MySQL does not define the order of cascading deletes, we need to manually
+                // first manually delete judging_runs and then cascade via
+                // submission -> judging -> judgeTasks.
+                // See also https://github.com/DOMjudge/domjudge/issues/243 and associated commits.
+
+                // First delete judging_runs.
+                $entityManager->getConnection()->executeQuery(
+                    'DELETE jr FROM judging_run jr
+                         INNER JOIN judging j ON jr.judgingid = j.judgingid
+                         INNER JOIN submission s ON j.submitid = s.submitid
+                         WHERE s.probid = :probid',
+                    ['probid' => $entity->getProbid()]
+                );
+
+                // Then delete all outstanding queueTasks.
+                $entityManager->getConnection()->executeQuery(
+                    'DELETE qt FROM queuetask qt
+                         INNER JOIN submission s ON qt.jobid = s.submitid
+                         WHERE s.probid = :probid',
+                    ['probid' => $entity->getProbid()]
+                );
+
+                // Then delete submissions which will cascade to judging and judgeTasks.
                 $entityManager->getConnection()->executeQuery(
                     'DELETE FROM submission WHERE probid = :probid',
                     ['probid' => $entity->getProbid()]
                 );
-                // Also delete internal errors that are "connected" to this problem.
+
+                // Lastly, delete internal errors that are "connected" to this problem.
                 $disabledJson = '{"kind":"problem","probid":' . $entity->getProbid() . '}';
                 $entityManager->getConnection()->executeQuery(
                     'DELETE FROM internal_error WHERE disabled = :disabled',
                     ['disabled' => $disabledJson]
                 );
+
                 $entityManager->clear();
                 $entity = $entityManager->getRepository(Problem::class)->find($entity->getProbid());
             }

--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -223,7 +223,7 @@ abstract class BaseController extends AbstractController
                 // Its dependent tables do not form a tree (but something like a diamond shape),
                 // and there are multiple cascading removal paths from problem to its dependant
                 // tables.
-                // Since MySQL does not define the order of cascading deletes, we need to manually
+                // Since MySQL does not define the order of cascading deletes, we need to
                 // first manually delete judging_runs and then cascade via
                 // submission to all of judging, judgeTasks and queueTasks.
                 // See also https://github.com/DOMjudge/domjudge/issues/243 and associated commits.

--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -221,7 +221,7 @@ abstract class BaseController extends AbstractController
             if ($entity instanceof Problem) {
                 // Deleting a problem is a special case:
                 // Its dependent tables do not form a tree (but something like a diamond shape),
-                // and there are multiple cascading removal paths from problem to its dependant
+                // and there are multiple cascading removal paths from problem to its dependent
                 // tables.
                 // Since MySQL does not define the order of cascading deletes, we need to
                 // first manually delete judging_runs and then cascade via

--- a/webapp/src/Controller/Jury/QueueTaskController.php
+++ b/webapp/src/Controller/Jury/QueueTaskController.php
@@ -72,7 +72,7 @@ class QueueTaskController extends BaseController
 
             // Add some links.
             $queueTaskData['team.name']['link'] = $this->generateUrl('jury_team', ['teamId' => $queueTask->getTeam()->getTeamid()]);
-            $queueTaskData['jobid']['link'] = $this->generateUrl('jury_submission_by_judging', ['jid' => $queueTask->getJobId()]);
+            $queueTaskData['jobid']['link'] = $this->generateUrl('jury_submission_by_judging', ['jid' => $queueTask->getJudging()->getJudgingid()]);
 
             // Format start time.
             if (!empty($queueTaskData['starttime']['value'])) {
@@ -141,7 +141,7 @@ class QueueTaskController extends BaseController
             ->from(JudgeTask::class, 'jt')
             ->addOrderBy('jt.judgetaskid')
             ->andWhere('jt.jobid = :jobid')
-            ->setParameter('jobid', $queueTask->getJobId())
+            ->setParameter('jobid', $queueTask->getJudging()->getJudgingid())
             ->getQuery()->getResult();
 
         foreach ($judgeTasks as $judgeTask) {
@@ -170,7 +170,7 @@ class QueueTaskController extends BaseController
             ->innerJoin('jt.judging_runs', 'jr')
             ->addOrderBy('jt.judgetaskid')
             ->andWhere('jt.jobid = :jobid')
-            ->setParameter('jobid', $queueTask->getJobId())
+            ->setParameter('jobid', $queueTask->getJudging()->getJudgingid())
             ->getQuery()->getResult();
 
         $tableFields = [

--- a/webapp/src/Controller/Jury/QueueTaskController.php
+++ b/webapp/src/Controller/Jury/QueueTaskController.php
@@ -49,7 +49,7 @@ class QueueTaskController extends BaseController
         $tableFields = [
             'queuetaskid' => ['title' => 'ID'],
             'team.name' => ['title' => 'team'],
-            'jobid' => ['title' => 'job'],
+            'judging.judgingid' => ['title' => 'judgingid'],
             'priority' => ['title' => 'priority'],
             'teampriority' => ['title' => 'team priority'],
             'starttime' => ['title' => 'start time'],
@@ -72,7 +72,7 @@ class QueueTaskController extends BaseController
 
             // Add some links.
             $queueTaskData['team.name']['link'] = $this->generateUrl('jury_team', ['teamId' => $queueTask->getTeam()->getTeamid()]);
-            $queueTaskData['jobid']['link'] = $this->generateUrl('jury_submission_by_judging', ['jid' => $queueTask->getJudging()->getJudgingid()]);
+            $queueTaskData['judgingid']['link'] = $this->generateUrl('jury_submission_by_judging', ['jid' => $queueTask->getJudging()->getJudgingid()]);
 
             // Format start time.
             if (!empty($queueTaskData['starttime']['value'])) {

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -565,7 +565,7 @@ class SubmissionController extends BaseController
                 $judgeTask
                     ->setType(JudgeTaskType::DEBUG_INFO)
                     ->setJudgehost($judgehost)
-                    ->setSubmitid($submission->getSubmitid())
+                    ->setSubmission($submission)
                     ->setPriority(JudgeTask::PRIORITY_HIGH)
                     ->setJobId($jid->getJudgingid())
                     ->setUuid($jid->getUuid())
@@ -600,7 +600,7 @@ class SubmissionController extends BaseController
         $judgeTask
             ->setType(JudgeTaskType::DEBUG_INFO)
             ->setJudgehost($jrid->getJudgeTask()->getJudgehost())
-            ->setSubmitid($submission->getSubmitid())
+            ->setSubmission($submission)
             ->setPriority(JudgeTask::PRIORITY_HIGH)
             ->setJobId($jid->getJudgingid())
             ->setUuid($jid->getUuid())

--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -68,12 +68,13 @@ class JudgeTask
     )]
     private ?string $uuid = null;
 
-    #[ORM\Column(
-        nullable: true,
-        options: ['comment' => 'Submission ID being judged', 'unsigned' => true]
-    )]
+
+    #[ORM\ManyToOne(inversedBy: 'judgetasks')]
+    #[ORM\JoinColumn(name: 'submitid', nullable: true, referencedColumnName: 'submitid', onDelete: 'CASCADE',
+        options: ['comment' => 'Submission ID being judged', 'unsigned' => true])
+    ]
     #[Serializer\Type('string')]
-    private ?int $submitid = null;
+    private Submission $submission;
 
     // Note that we rely on the fact here that files with an ID are immutable,
     // so clients are allowed to cache them on disk.
@@ -213,15 +214,15 @@ class JudgeTask
         return $this->uuid;
     }
 
-    public function setSubmitid(int $submitid): JudgeTask
+    public function setSubmission(?Submission $submission): JudgeTask
     {
-        $this->submitid = $submitid;
+        $this->submission = $submission;
         return $this;
     }
 
-    public function getSubmitid(): ?int
+    public function getSubmission(): ?Submission
     {
-        return $this->submitid;
+        return $this->submission;
     }
 
     public function setCompileScriptId(int $compile_script_id): JudgeTask

--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace App\Entity;
 
+use App\Controller\API\AbstractRestController as ARC;
 use App\Doctrine\DBAL\Types\JudgeTaskType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -73,8 +74,17 @@ class JudgeTask
     #[ORM\JoinColumn(name: 'submitid', nullable: true, referencedColumnName: 'submitid', onDelete: 'CASCADE',
         options: ['comment' => 'Submission ID being judged', 'unsigned' => true])
     ]
-    #[Serializer\Type('string')]
+    #[Serializer\Exclude]
     private Submission $submission;
+
+    #[Serializer\VirtualProperty]
+    #[Serializer\SerializedName('submitid')]
+    #[Serializer\Type('string')]
+    public function getSubmitid(): int
+    {
+        return $this->submission->getSubmitid();
+    }
+
 
     // Note that we rely on the fact here that files with an ID are immutable,
     // so clients are allowed to cache them on disk.

--- a/webapp/src/Entity/QueueTask.php
+++ b/webapp/src/Entity/QueueTask.php
@@ -17,7 +17,7 @@ use JMS\Serializer\Annotation as Serializer;
     ]
 )]
 #[ORM\Index(columns: ['queuetaskid'], name: 'queuetaskid')]
-#[ORM\Index(columns: ['jobid'], name: 'jobid')]
+#[ORM\Index(columns: ['judgingid'], name: 'judgingid')]
 #[ORM\Index(columns: ['priority'], name: 'priority')]
 #[ORM\Index(columns: ['teampriority'], name: 'teampriority')]
 #[ORM\Index(columns: ['teamid'], name: 'teamid')]
@@ -29,12 +29,10 @@ class QueueTask
     #[ORM\Column(options: ['comment' => 'Queuetask ID', 'unsigned' => true])]
     private int $queuetaskid;
 
-    #[ORM\Column(
-        nullable: true,
-        options: ['comment' => 'All queuetasks with the same jobid belong together.', 'unsigned' => true]
-    )]
-    #[Serializer\Type('string')]
-    private ?int $jobid = null;
+    #[ORM\ManyToOne(inversedBy: 'queueTasks')]
+    #[ORM\JoinColumn(name: 'judgingid', referencedColumnName: 'judgingid', onDelete: 'CASCADE')]
+    #[Serializer\Exclude]
+    private Judging $judging;
 
     #[ORM\Column(options: [
         'comment' => 'Priority; negative means higher priority',
@@ -72,15 +70,15 @@ class QueueTask
         return $this->queuetaskid;
     }
 
-    public function setJobId($jobid): QueueTask
+    public function setJudging(Judging $judging): QueueTask
     {
-        $this->jobid = $jobid;
+        $this->judging = $judging;
         return $this;
     }
 
-    public function getJobId(): ?int
+    public function getJudging(): Judging
     {
-        return $this->jobid;
+        return $this->judging;
     }
 
     public function setPriority(int $priority): QueueTask

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -124,6 +124,10 @@ class Submission extends BaseApiEntity implements ExternalRelationshipEntityInte
     #[Serializer\Exclude]
     private Collection $judgings;
 
+    #[ORM\OneToMany(mappedBy: 'submission', targetEntity: JudgeTask::class)]
+    #[Serializer\Exclude]
+    private Collection $judgetasks;
+
     #[ORM\OneToMany(mappedBy: 'submission', targetEntity: ExternalJudgement::class)]
     #[Serializer\Exclude]
     private Collection $external_judgements;

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1190,7 +1190,7 @@ class DOMJudgeService
         $team = $submission->getTeam();
         $result = $this->em->createQueryBuilder()
             ->from(QueueTask::class, 'qt')
-            ->select('MAX(qt.teamPriority) AS max, COUNT(qt.jobid) AS count')
+            ->select('MAX(qt.teamPriority) AS max, COUNT(qt.judging) AS count')
             ->andWhere('qt.team = :team')
             ->andWhere('qt.priority = :priority')
             ->andWhere('qt.teamPriority >= :cutoffTeamPriority')
@@ -1218,7 +1218,7 @@ class DOMJudgeService
         //   but we want to judge submissions of this team in order, so we take the current max (X+120) and add 1.
         $teamPriority = (int)(max($result['max']+1, $submission->getSubmittime() + 60*$result['count']));
         $queueTask = new QueueTask();
-        $queueTask->setJobId($judging->getJudgingid())
+        $queueTask->setJudging($judging)
             ->setPriority($priority)
             ->setTeam($team)
             ->setTeamPriority($teamPriority)

--- a/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
@@ -235,7 +235,7 @@ class QueueTaskControllerTest extends BaseTestCase
         $queueTask = $this->em->createQueryBuilder()
             ->select('qt')
             ->from(QueueTask::class, 'qt')
-            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.jobid')
+            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.judging')
             ->andWhere('j.submission = :submission')
             ->setParameter('submission', $submission)
             ->getQuery()
@@ -278,7 +278,7 @@ class QueueTaskControllerTest extends BaseTestCase
             ->innerJoin('jt.judging_runs', 'jr')
             ->addOrderBy('jt.judgetaskid')
             ->andWhere('jt.jobid = :jobid')
-            ->setParameter('jobid', $queueTask->getJobId())
+            ->setParameter('jobid', $queueTask->getJudging()->getJudgingid())
             ->getQuery()->getResult();
 
         foreach ($tableBody->children() as $index => $child) {

--- a/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
@@ -99,7 +99,7 @@ class QueueTaskControllerTest extends BaseTestCase
         $queueTask = $this->em->createQueryBuilder()
             ->select('qt')
             ->from(QueueTask::class, 'qt')
-            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.jobid')
+            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.judging')
             ->andWhere('j.submission = :submission')
             ->setParameter('submission', $submissions[1])
             ->getQuery()
@@ -207,7 +207,7 @@ class QueueTaskControllerTest extends BaseTestCase
         $queueTask = $this->em->createQueryBuilder()
             ->select('qt')
             ->from(QueueTask::class, 'qt')
-            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.jobid')
+            ->join(Judging::class, 'j', Join::WITH, 'j.judgingid = qt.judging')
             ->andWhere('j.submission = :submission')
             ->setParameter('submission', $submission)
             ->getQuery()
@@ -222,7 +222,7 @@ class QueueTaskControllerTest extends BaseTestCase
 
         self::assertEquals($queueTask->getQueueTaskid(), $queueTaskId);
         self::assertEquals($submission->getTeam()->getName(), $teamName);
-        self::assertEquals($queueTask->getJobId(), $jobId);
+        self::assertEquals($queueTask->getJudging()->getJudgingid(), $jobId);
         self::assertEquals(QueueTaskController::PRIORITY_MAP[$queueTask->getPriority()], $priority);
         self::assertEquals($queueTask->getTeamPriority(), $teampriority);
         self::assertEquals('not started yet', $starttime);

--- a/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
@@ -156,30 +156,6 @@ class QueuetaskIntegrationTest extends KernelTestCase
         self::getContainer()->get('security.untracked_token_storage')->setToken($token);
     }
 
-    protected function tearDown(): void
-    {
-        // Preserve the data for inspection if a test failed.
-        if (!$this->hasFailed()) {
-            // We need to reload the data here as they might become detached in the eventlog function.
-            foreach ($this->teams as $team) {
-                $team = $this->em->getRepository(Team::class)->find($team->getTeamid());
-                $this->em->remove($team);
-            }
-            foreach ($this->problems as $problem) {
-                $problem = $this->em->getRepository(Problem::class)->find($problem->getProbid());
-                $this->em->remove($problem);
-            }
-            $contest = $this->em->getRepository(Contest::class)->find($this->contest);
-            $this->em->remove($contest);
-        }
-        $this->em->flush();
-
-        parent::tearDown();
-
-        $this->em->close();
-        $this->em = null; // avoid memory leaks
-    }
-
     private function submit($time, ?Team $team = null, ?Problem $problem = null, string $source = 'team page'): QueueTask
     {
         $contest = $this->em->getRepository(Contest::class)->find($this->contest->getCid());
@@ -196,7 +172,7 @@ class QueuetaskIntegrationTest extends KernelTestCase
         $judging = $submission->getJudgings()->get(0);
         self::assertNotNull($judging);
 
-        $queuetask = $this->em->getRepository(QueueTask::class)->findOneBy(['jobid' => $judging->getJudgingid()]);
+        $queuetask = $this->em->getRepository(QueueTask::class)->findOneBy(['judging' => $judging]);
         self::assertNotNull($queuetask);
 
         return $queuetask;


### PR DESCRIPTION
The only way to delete a submission in the web interface is to delete a problem. The dependant data in other tables does not form a tree, so there is multiple paths which does not (necessarily) work in MySQL.

Handle this explicitly in the base controller when we are deleting the problem entity.

See https://github.com/DOMjudge/domjudge/issues/243 for some historical context.

Fixes https://github.com/DOMjudge/domjudge/issues/2023