### PR TITLE
Add `edit executable` button for consistency

### DIFF
--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -74,6 +74,13 @@ class ExecutableController extends BaseController
 
             if ($this->isGranted('ROLE_ADMIN')) {
                 $execactions[] = [
+                    'icon' => 'edit',
+                    'title' => 'edit this executable',
+                    'link' => $this->generateUrl('jury_executable', [
+                        'execId' => $e->getExecid(),
+                    ]),
+                ];
+                $execactions[] = [
                     'icon' => 'trash-alt',
                     'title' => 'delete this executable',
                     'link' => $this->generateUrl('jury_executable_delete', [


### PR DESCRIPTION
This links to the same page as the individual cells already link, in the past there were 2 ways of editing an executable; the individual files and the concept as a whole with 2 distinct pages. This was merged so we can now link to 1 page for editing.

Fixes: https://github.com/DOMjudge/domjudge/issues/1783