### PR TITLE
Document apt packages manual

### DIFF
--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -37,14 +37,14 @@ GNU/Linux, or one of its derivative distributions like Ubuntu::
 
   sudo apt install acl zip unzip mariadb-server apache2 \
         php php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
-        php-curl php-json php-xml php-zip composer ntp
+        php-curl php-json php-xml php-zip composer ntp python3-yaml
 
 The following command can be used on RedHat Enterprise Linux, and related
 distributions like CentOS (with EPEL) and Fedora::
 
   sudo yum install acl zip unzip mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd \
-        php-xml php-zip composer ntp
+        php-xml php-zip composer ntp python3-pyyaml
 
 Due to an `issue <https://github.com/DOMjudge/domjudge/issues/862>`_ in our
 configure script you should also install the software for the judgehost
@@ -77,12 +77,6 @@ Database configuration
 DOMjudge uses a MySQL or MariaDB database server for information storage.
 Where this document talks about MySQL, it can be understood to also apply
 to MariaDB.
-
-For the install option (unless using bare-install) steps you need the
-python `yaml` module, for Debian GNU/Linux, or one of its derivative 
-distributions like Ubuntu::
-
-  sudo apt install python3-yaml
 
 Installation of the database is done with ``bin/dj_setup_database``.
 For this, you need an installed and configured MySQL server and

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -37,14 +37,14 @@ GNU/Linux, or one of its derivative distributions like Ubuntu::
 
   sudo apt install acl zip unzip mariadb-server apache2 \
         php php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
-        php-curl php-json php-xml php-zip composer ntp
+        php-curl php-json php-xml php-zip composer ntp gcc g++
 
 The following command can be used on RedHat Enterprise Linux, and related
 distributions like CentOS and Fedora::
 
   sudo yum install acl zip unzip mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd \
-        php-xml php-zip composer ntp
+        php-xml php-zip composer ntp gcc g++
 
 Installation
 ------------

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -74,6 +74,12 @@ DOMjudge uses a MySQL or MariaDB database server for information storage.
 Where this document talks about MySQL, it can be understood to also apply
 to MariaDB.
 
+For the install option (unless using bare-install) steps you need the
+python `yaml` module, for Debian GNU/Linux, or one of its derivative 
+distributions like Ubuntu::
+
+  sudo apt install python3-yaml
+
 Installation of the database is done with ``bin/dj_setup_database``.
 For this, you need an installed and configured MySQL server and
 administrator access to it. Run::

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -37,14 +37,18 @@ GNU/Linux, or one of its derivative distributions like Ubuntu::
 
   sudo apt install acl zip unzip mariadb-server apache2 \
         php php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
-        php-curl php-json php-xml php-zip composer ntp gcc g++
+        php-curl php-json php-xml php-zip composer ntp
 
 The following command can be used on RedHat Enterprise Linux, and related
 distributions like CentOS and Fedora::
 
   sudo yum install acl zip unzip mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd \
-        php-xml php-zip composer ntp gcc g++
+        php-xml php-zip composer ntp
+
+Due to an `issue <https://github.com/DOMjudge/domjudge/issues/862>`_ in our
+configure script you should also install the software for the judgehost
+see :ref:`the judgehost software requirements <judgehost_software>`
 
 Installation
 ------------

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -40,7 +40,7 @@ GNU/Linux, or one of its derivative distributions like Ubuntu::
         php-curl php-json php-xml php-zip composer ntp
 
 The following command can be used on RedHat Enterprise Linux, and related
-distributions like CentOS and Fedora::
+distributions like CentOS (with EPEL) and Fedora::
 
   sudo yum install acl zip unzip mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd \

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -31,12 +31,12 @@ Software requirements
 For Debian::
 
   sudo apt install make pkg-config sudo debootstrap libcgroup-dev \
-        php-cli php-curl php-json php-xml php-zip lsof procps
+        php-cli php-curl php-json php-xml php-zip lsof procps gcc g++
 
 For Red Hat::
 
   sudo yum install make pkgconfig sudo libcgroup-devel lsof \
-        php-cli php-mbstring php-xml php-process procps-ng
+        php-cli php-mbstring php-xml php-process procps-ng gcc g++
 
 Removing apport
 ---------------

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -20,6 +20,8 @@ System requirements
   The machines only need HTTP(S) access to the DOMserver.
 
 
+.. _judgehost_software:
+
 Software requirements
 `````````````````````
 

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -37,11 +37,14 @@ For Debian::
   sudo apt install make pkg-config sudo debootstrap libcgroup-dev \
         php-cli php-curl php-json php-xml php-zip lsof procps gcc g++
 
-For Fedora::
+For RHEL 7/Fedora [*]_::
 
   sudo yum install make pkgconfig sudo libcgroup-devel lsof \
         php-cli php-mbstring php-xml php-process procps-ng gcc g++
         glibc-static libstdc++-static
+
+.. [*] Building on RHEL8, RHEL9 (or the CentOS, Rockylinux & Almalinux versions)
+       requires packages which are currently not in the repositories.
 
 Removing apport
 ---------------

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -37,10 +37,11 @@ For Debian::
   sudo apt install make pkg-config sudo debootstrap libcgroup-dev \
         php-cli php-curl php-json php-xml php-zip lsof procps gcc g++
 
-For Red Hat::
+For Fedora::
 
   sudo yum install make pkgconfig sudo libcgroup-devel lsof \
         php-cli php-mbstring php-xml php-process procps-ng gcc g++
+        glibc-static libstdc++-static
 
 Removing apport
 ---------------

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -27,6 +27,8 @@ Software requirements
 * Debootstrap
 * PHP command line interface with the ``curl``, ``json``, ``xml``,
   ``zip`` extensions.
+* A C/C++ compiler, the instructions below suggest ``gcc``/``g++`` but something
+  else such as ``clang`` will also work.
 
 For Debian::
 


### PR DESCRIPTION
I'm not really sure about the 1st commit, the packages are not actually needed so this would be a "white lie", but I assume 99% of the people use the configure script and as thats broken (https://github.com/DOMjudge/domjudge/issues/862) this might make the route slightly better.

For the judgehosts I think we should actually either add `gcc` or `g++` as I think runguard is compiled outside of the chroot?