### PR TITLE
Sort testcases lexicographically.

### DIFF
--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -383,7 +383,7 @@ class ImportProblemService
                     }
                 }
             }
-            asort($dataFiles);
+            asort($dataFiles, SORT_STRING);
 
             foreach ($dataFiles as $dataFile) {
                 $baseFileName = sprintf('data/%s/%s', $type, $dataFile);


### PR DESCRIPTION
The [spec](https://icpc.io/problem-package-format/spec/problem_package_format#test-data-groups) clearly states we should.

PC^2 does this so when they shadow us for testcases that are called:
```
1
2
3
...
9
10
11
...
20
21
```

they sorted differently than us.
This fixes that but I created a PR (instead of pushing to main) to make sure CI is happy before merging.