### PR TITLE
Add support for exporting full results.

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -372,7 +372,7 @@ class ImportExportService
     /**
      * Get results data for the given sortorder.
      */
-    public function getResultsData(int $sortOrder): array
+    public function getResultsData(int $sortOrder, bool $full = false): array
     {
         // We'll here assume that the requested file will be of the current contest,
         // as all our scoreboard interfaces do:
@@ -450,11 +450,13 @@ class ImportExportService
             } elseif ($rank <= ($contest->getGoldMedals() ?? 4) + ($contest->getSilverMedals() ?? 4) + ($contest->getBronzeMedals() ?? 4) + $contest->getB()) {
                 $awardString = 'Bronze Medal';
             } elseif ($numPoints >= $median) {
-                // Teams with equally solved number of problems get the same rank.
-                if (!isset($ranks[$numPoints])) {
-                    $ranks[$numPoints] = $rank;
+                // Teams with equally solved number of problems get the same rank unless $full is true.
+                if (!$full) {
+                    if (!isset($ranks[$numPoints])) {
+                        $ranks[$numPoints] = $rank;
+                    }
+                    $rank = $ranks[$numPoints];
                 }
-                $rank        = $ranks[$numPoints];
                 $awardString = 'Ranked';
             } else {
                 $awardString = 'Honorable';

--- a/webapp/templates/jury/import_export.html.twig
+++ b/webapp/templates/jury/import_export.html.twig
@@ -95,19 +95,30 @@
                 <h3>Export &lt;html&gt;</h3>
                     <ul>
                         <li>
-                            <code>results.html</code>:
+                            <code>wf_results.html</code>:
                             <ul>
                                 {% for sort_order, names in sort_orders %}
                                     <li>
-                                        <a href="{{ path('jury_html_export', {'type': 'results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
+                                        <a href="{{ path('jury_html_export', {'type': 'wf_results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
                                         ({{ names | join(', ') }})
                                     </li>
                                 {% endfor %}
                             </ul>
                         </li>
-                    <li>
-                        <a href="{{ path('jury_html_export', {'type': 'clarifications'}) }}" target="_blank"><code>clarifications.html</code></a>
-                    </li>
+                        <li>
+                            <code>full_results.html</code>:
+                            <ul>
+                                {% for sort_order, names in sort_orders %}
+                                    <li>
+                                        <a href="{{ path('jury_html_export', {'type': 'full_results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
+                                        ({{ names | join(', ') }})
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="{{ path('jury_html_export', {'type': 'clarifications'}) }}" target="_blank"><code>clarifications.html</code></a>
+                        </li>
                     </ul>
             </div>
         </div>
@@ -120,14 +131,25 @@
                 <h3>Export tab-separated</h3>
                     <ul>
                         <li>
-                            <code>results.tsv</code>:
+                            <code>wf_results.tsv</code>:
                             <ul>
                             {% for sort_order, names in sort_orders %}
                                 <li>
-                                    <a href="{{ path('jury_tsv_export', {'type': 'results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
+                                    <a href="{{ path('jury_tsv_export', {'type': 'wf_results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
                                     ({{ names | join(', ') }})
                                  </li>
                             {% endfor %}
+                            </ul>
+                        </li>
+                        <li>
+                            <code>full_results.tsv</code>:
+                            <ul>
+                                {% for sort_order, names in sort_orders %}
+                                    <li>
+                                        <a href="{{ path('jury_tsv_export', {'type': 'full_results', 'sort_order': sort_order}) }}">for sort order {{ sort_order }}</a>
+                                        ({{ names | join(', ') }})
+                                    </li>
+                                {% endfor %}
                             </ul>
                         </li>
                     </ul>

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -25,7 +25,8 @@ class ImportExportControllerTest extends BaseTestCase
         self::assertSelectorExists('div.help-text:contains(\'Create a "Web Services Token"\')');
 
         // We've reached the end of the page.
-        self::assertSelectorExists('li:contains("results.tsv")');
+        self::assertSelectorExists('li:contains("wf_results.tsv")');
+        self::assertSelectorExists('li:contains("full_results.tsv")');
     }
 
     /**
@@ -149,10 +150,15 @@ HEREDOC;
         yield ['a:contains("teams.tsv")', 'teams	1
 2	exteam	3	Example teamname	Utrecht University	UU	NLD	utrecht
 '];
-        yield ['li:contains("results.tsv") a:contains("for sort order 0")', 'results	1
+        yield ['li:contains("wf_results.tsv") a:contains("for sort order 0")', 'results	1
 exteam	1	Gold Medal	0	0	0	Participants
 '];
-        yield ['li:contains("results.tsv") a:contains("for sort order 1")', 'results	1
+        yield ['li:contains("wf_results.tsv") a:contains("for sort order 1")', 'results	1
+'];
+        yield ['li:contains("full_results.tsv") a:contains("for sort order 0")', 'results	1
+exteam	1	Gold Medal	0	0	0	Participants
+'];
+        yield ['li:contains("full_results.tsv") a:contains("for sort order 1")', 'results	1
 '];
         yield ['a:contains("groups.tsv")', 'groups	1
 2	Self-Registered
@@ -178,13 +184,27 @@ exteam	1	Gold Medal	0	0	0	Participants
     }
 
     /**
-     * Test export of results.html.
+     * Test export of wf_results.html.
      */
-    public function testResultsHtmlExport(): void
+    public function testWfResultsHtmlExport(): void
     {
         $this->loadFixture(ClarificationFixture::class);
         $this->verifyPageResponse('GET', '/jury/import-export', 200);
-        $link = $this->getCurrentCrawler()->filter('li:contains("results.html") a:contains("for sort order 0")')->link();
+        $link = $this->getCurrentCrawler()->filter('li:contains("wf_results.html") a:contains("for sort order 0")')->link();
+        $this->client->click($link);
+        self::assertSelectorExists('h1:contains("Results for Demo contest")');
+        self::assertSelectorExists('th:contains("Example teamname")');
+        self::assertSelectorExists('th:contains("A: Hello World")');
+    }
+
+    /**
+     * Test export of full_results.html.
+     */
+    public function testFullResultsHtmlExport(): void
+    {
+        $this->loadFixture(ClarificationFixture::class);
+        $this->verifyPageResponse('GET', '/jury/import-export', 200);
+        $link = $this->getCurrentCrawler()->filter('li:contains("full_results.html") a:contains("for sort order 0")')->link();
         $this->client->click($link);
         self::assertSelectorExists('h1:contains("Results for Demo contest")');
         self::assertSelectorExists('th:contains("Example teamname")');


### PR DESCRIPTION
As discussed on the NAC Slack channel, we currently only do the results.tsv where everybody outside the medals with the same number of solved problems had the same rank, but some contests (like NAC) want a unique rank per team, so add support for it.