### PR TITLE
Add contest.scoreboard_type to API

### DIFF
--- a/gitlab/ci_settings.sh
+++ b/gitlab/ci_settings.sh
@@ -13,6 +13,8 @@ export GITSHA
 export PS4='(${BASH_SOURCE}:${LINENO}): - [$?] $ '
 export LOGFILE="/opt/domjudge/domserver/webapp/var/log/prod.log"
 
+CCS_SPECS_PINNED_SHA1='6b11623d586500d11ec20b6c12a4908b44ff0e41'
+
 # Shared storage for all artifacts
 export GITLABARTIFACTS="$DIR/gitlabartifacts"
 mkdir -p "$GITLABARTIFACTS"

--- a/gitlab/integration.sh
+++ b/gitlab/integration.sh
@@ -94,13 +94,15 @@ fi
 section_end judgehost
 
 section_start more_setup "Remaining setup (e.g. starting judgedaemon)"
-# download domjudge-scripts for API check
+
+# Download yajsv and ccs-specs for API check.
 cd $HOME
-composer -n require justinrainbow/json-schema
+curl -o yajsv https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.linux.amd64
+chmod a+x yajsv
 echo -e "\033[0m"
-PATH=${PATH}:${HOME}/vendor/bin
-git clone --depth=1 https://github.com/DOMjudge/domjudge-scripts.git
-CHECK_API=${HOME}/domjudge-scripts/contest-api/check-api.sh
+git clone https://github.com/icpc/ccs-specs.git
+( cd ccs-specs && git reset --hard $CCS_SPECS_PINNED_SHA1 )
+CHECK_API="${HOME}/ccs-specs/check-api.sh -j ${HOME}/yajsv"
 
 # Recreate domjudge-run-0 user with random UID to prevent clashes with
 # existing users in the host and other CI jobs, which can lead to

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -44,7 +44,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     options: [new Serializer\Type('string')]
 )]
 #[Serializer\VirtualProperty(
-    name: 'penaltyTime',
+    name: 'penalty_time',
     exp: '0',
     options: [new Serializer\Type('int')]
 )]

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -39,6 +39,11 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     options: [new Serializer\Type('string')]
 )]
 #[Serializer\VirtualProperty(
+    name: 'scoreboard_type',
+    exp: '"pass-fail"',
+    options: [new Serializer\Type('string')]
+)]
+#[Serializer\VirtualProperty(
     name: 'penaltyTime',
     exp: '0',
     options: [new Serializer\Type('int')]


### PR DESCRIPTION
This is to comply with the specification at https://ccs-specs.icpc.io/draft/contest_api#contests

Also use consistent snake_case for serialized property names.