### PR TITLE
Also disable profiler when importing problems via web API.

### DIFF
--- a/webapp/src/EventListener/ProfilerDisableListener.php
+++ b/webapp/src/EventListener/ProfilerDisableListener.php
@@ -19,9 +19,15 @@ class ProfilerDisableListener
 
     public function __invoke(RequestEvent $event): void
     {
-        // Disable the profiler for users with the judgehost permission but not the admin one.
-        if ($this->profiler && $this->dj->checkrole('judgehost') && !$this->dj->checkrole('admin')) {
-            $this->profiler->disable();
+        if ($this->profiler) {
+            // Disable the profiler for users with the judgehost permission but not the admin one.
+            if ($this->dj->checkrole('judgehost') && !$this->dj->checkrole('admin')) {
+                $this->profiler->disable();
+            }
+            // Disable the profiler if using the web API to import.
+            if ($event->getRequest()->attributes->get('_route') == 'current_app_api_problem_addproblem') {
+                $this->profiler->disable();
+            }
         }
     }
 }


### PR DESCRIPTION
This makes a huge difference, e.g. when importing all of NWERC 2022, it fails after ~7mins on the problem fasterthanlight before this change; after this change it is completely done after ~2mins without any error.