### PR TITLE
Add desktop notification for team receiving clarifications

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -44,8 +44,6 @@ function enableNotifications()
             return true;
         });
     }
-
-    
 }
 
 function disableNotifications()
@@ -67,8 +65,8 @@ function disableNotifications()
 // client has already received to display each notification only once.
 function sendNotification(title, options = {})
 {
-    
     if ( getCookie('domjudge_notify')!=1 ) return;
+    
     // Check if we already sent this notification:
     var senttags = localStorage.getItem('domjudge_notifications_sent');
     if ( senttags===null || senttags==='' ) {

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -65,8 +65,6 @@ function disableNotifications()
 // client has already received to display each notification only once.
 function sendNotification(title, options = {})
 {
-    if ( getCookie('domjudge_notify')!=1 ) return;
-    
     // Check if we already sent this notification:
     var senttags = localStorage.getItem('domjudge_notifications_sent');
     if ( senttags===null || senttags==='' ) {
@@ -83,12 +81,14 @@ function sendNotification(title, options = {})
     }
     options['icon'] = domjudge_base_url + '/apple-touch-icon.png';
 
-    var not = new Notification(title, options);
-
-    if ( link!==null ) {
-        not.onclick = function() { 
-            window.location.href = link;
-        };
+    // Only actually send notification when enabled
+    if ( getCookie('domjudge_notify')==1 ) {
+        var not = new Notification(title, options);
+        if ( link!==null ) {
+            not.onclick = function() { 
+                window.location.href = link;
+            };
+        }
     }
 
     if ( options.tag ) {
@@ -534,12 +534,13 @@ function updateClarifications()
         if (jqXHR.getResponseHeader('X-Login-Page')) {
             window.location = jqXHR.getResponseHeader('X-Login-Page');
         } else {
-            let num = json.length;
+            let data = json['unread_clarifications'];
+            let num = data.length;
             for (let i = 0; i < num; i++) {
                 sendNotification('New clarification',
-                 {'tag': 'clar_' + json[i].clarid,
-                        'link': domjudge_base_url + '/team/clarifications/'+json[i].clarid,
-                        'body': json[i].body });
+                 {'tag': 'clar_' + data[i].clarid,
+                        'link': domjudge_base_url + '/team/clarifications/'+data[i].clarid,
+                        'body': data[i].body });
             }
         }
     })

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -131,9 +131,9 @@ class MiscController extends BaseController
     }
 
     #[Route(path: '/updates', methods: ['GET'], name: 'team_ajax_updates')]
-    public function updatesUnreadNotification(): JsonResponse
+    public function updates(): JsonResponse
     {
-        return $this->json($this->dj->getUnreadClarifications());
+        return $this->json(['unread_clarifications' => $this->dj->getUnreadClarifications()]);
     }
 
     #[Route(path: '/change-contest/{contestId<-?\d+>}', name: 'team_change_contest')]

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
 
-
 #[IsGranted('ROLE_TEAM')]
 #[IsGranted(
     new Expression('user.getTeam() !== null'),

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -131,7 +131,7 @@ class MiscController extends BaseController
     }
 
     #[Route(path: '/updates', methods: ['GET'], name: 'team_ajax_updates')]
-    public function updates(): JsonResponse
+    public function updatesAction(): JsonResponse
     {
         return $this->json(['unread_clarifications' => $this->dj->getUnreadClarifications()]);
     }

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -19,9 +19,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
+
 
 #[IsGranted('ROLE_TEAM')]
 #[IsGranted(
@@ -127,6 +129,12 @@ class MiscController extends BaseController
         }
 
         return $this->render('team/index.html.twig', $data);
+    }
+
+    #[Route(path: '/updates', methods: ['GET'], name: 'team_ajax_updates')]
+    public function updatesUnreadNotification(): JsonResponse
+    {
+        return $this->json($this->dj->getUnreadClarifications());
     }
 
     #[Route(path: '/change-contest/{contestId<-?\d+>}', name: 'team_change_contest')]

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -304,12 +304,18 @@ class DOMJudgeService
         $user           = $this->getUser();
         $team           = $user->getTeam();
         $clarifications = $team->getUnreadClarifications();
+        $contest        = $this->getCurrentContest($team->getTeamId());
         $unreadClarifications = [];
+        if ($contest === null) {
+            return $unreadClarifications;
+        }
         foreach ($clarifications as $clar) {
-            $unreadClarifications[] = [
-                'clarid' => $clar->getClarid(),
-                'body' => $clar->getBody(),
-            ];
+            if ($clar->getContest() === $contest) {
+                $unreadClarifications[] = [
+                    'clarid' => $clar->getClarid(),
+                    'body' => $clar->getBody(),
+                ];
+            }
         }
         return $unreadClarifications;
     }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -299,6 +299,21 @@ class DOMJudgeService
         return $response;
     }
 
+    public function getUnreadClarifications(): array
+    {
+        $user           = $this->getUser();
+        $team           = $user->getTeam();
+        $clarifications = $team->getUnreadClarifications();
+        $unreadClarifications = [];
+        foreach ($clarifications as $clar) {
+            $unreadClarifications[] = [
+                'clarid' => $clar->getClarid(),
+                'body' => $clar->getBody(),
+            ];
+        }
+        return $unreadClarifications;
+    }
+
     public function getUpdates(): array
     {
         $contest = $this->getCurrentContest();

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -310,7 +310,7 @@ class DOMJudgeService
             return $unreadClarifications;
         }
         foreach ($clarifications as $clar) {
-            if ($clar->getContest() === $contest) {
+            if ($clar->getContest()->getCid() === $contest->getCid()) {
                 $unreadClarifications[] = [
                     'clarid' => $clar->getClarid(),
                     'body' => $clar->getBody(),

--- a/webapp/templates/team/base.html.twig
+++ b/webapp/templates/team/base.html.twig
@@ -17,9 +17,12 @@
 
             /* Show the notification options if the browser supports it */
             if ('Notification' in window) {
+                $('#notify_disable').click(disableNotifications);
                 $('#notify_enable').click(enableNotifications);
                 if (getCookie('domjudge_notify') != 1) {
                     $('#notify_enable').removeClass('d-none');
+                } else {
+                    $('#notify_disable').removeClass('d-none');
                 }
             }
             updateClarifications();

--- a/webapp/templates/team/base.html.twig
+++ b/webapp/templates/team/base.html.twig
@@ -14,6 +14,17 @@
             $('body').on('submit', 'form[name=team_clarification]', function () {
                 return confirm("Send clarification request to Jury?");
             });
+
+            /* Show the notification options if the browser supports it */
+            if ('Notification' in window) {
+                $('#notify_enable').click(enableNotifications);
+                if (getCookie('domjudge_notify') != 1) {
+                    $('#notify_enable').removeClass('d-none');
+                }
+            }
+            updateClarifications();
+            setInterval(updateClarifications, 20000);
         });
+
     </script>
 {% endblock %}

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -60,6 +60,12 @@
                     <i class="fas fa-bell fa-fw"></i> Enable Notification
                 </span>
             </a>
+            <a class="nav-link d-none" id="notify_disable">
+                <span class="btn btn-secondary btn-sm">
+                    <i class="fas fa-bell-slash fa-fw"></i> Disable Notification
+                </span>
+            </a>
+            
         </div>
         <div class="ml-auto me-3">
             {% if is_granted('ROLE_JURY') or (current_team_contest is not null and current_team_contest.freezeData.started) %}

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -7,8 +7,7 @@
     </button>
 
     {% set current_route = app.request.attributes.get('_route') %}
-
-    <div class="collapse navbar-collapse" id="menuDefault">
+    <div class="collapse navbar-collapse" id="menuDefault" data-update-url="{{ path('team_ajax_updates') }}">
         <ul class="navbar-nav me-auto">
             <li class="nav-item">
                 <a class="nav-link{% if current_route in ['team_index', 'team_clarification', 'team_clarification_add', 'team_submission'] %} active{% endif %}"
@@ -53,8 +52,14 @@
                 </li>
             {% endif %}
         </ul>
-
-        <div class="ms-auto me-3">
+        <div class="ml-auto me-3">
+            <a class="nav-link d-none" id="notify_enable">
+                <span class="btn btn-warning btn-sm">
+                    <i class="fas fa-bell fa-fw"></i> Enable Notification
+                </span>
+            </a>
+        </div>
+        <div class="ml-auto me-3">
             {% if is_granted('ROLE_JURY') or (current_team_contest is not null and current_team_contest.freezeData.started) %}
                 <a class="nav-link" data-ajax-modal data-ajax-modal-after="initSubmitModal" href="{{ path('team_submit') }}">
                     <span class="btn btn-success btn-sm">

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -7,6 +7,7 @@
     </button>
 
     {% set current_route = app.request.attributes.get('_route') %}
+
     <div class="collapse navbar-collapse" id="menuDefault" data-update-url="{{ path('team_ajax_updates') }}">
         <ul class="navbar-nav me-auto">
             <li class="nav-item">
@@ -52,6 +53,7 @@
                 </li>
             {% endif %}
         </ul>
+        
         <div class="ml-auto me-3">
             <a class="nav-link d-none" id="notify_enable">
                 <span class="btn btn-warning btn-sm">

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -53,19 +53,19 @@
                 </li>
             {% endif %}
         </ul>
-        
+
         <div class="ml-auto me-3">
             <a class="nav-link d-none" id="notify_enable">
                 <span class="btn btn-warning btn-sm">
-                    <i class="fas fa-bell fa-fw"></i> Enable Notification
+                    <i class="fas fa-bell fa-fw"></i> Enable Notifications
                 </span>
             </a>
             <a class="nav-link d-none" id="notify_disable">
                 <span class="btn btn-secondary btn-sm">
-                    <i class="fas fa-bell-slash fa-fw"></i> Disable Notification
+                    <i class="fas fa-bell-slash fa-fw"></i> Disable Notifications
                 </span>
             </a>
-            
+
         </div>
         <div class="ml-auto me-3">
             {% if is_granted('ROLE_JURY') or (current_team_contest is not null and current_team_contest.freezeData.started) %}


### PR DESCRIPTION
For team interface, add a button to enable notification. Implement sending desktop notification when receiving new clarification messages. Fix bugs of previous enable notification function. #2088 