### PR TITLE
Remove unclear `ext` mention

### DIFF
--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -46,7 +46,7 @@ class LanguageController extends BaseController
             ->orderBy('lang.name', 'ASC')
             ->getQuery()->getResult();
         $table_fields = [
-            'langid' => ['title' => 'ID/ext', 'sort' => true],
+            'langid' => ['title' => 'ID', 'sort' => true],
             'name' => ['title' => 'name', 'sort' => true, 'default_sort' => true],
             'entrypoint' => ['title' => 'entry point', 'sort' => true],
             'allowjudge' => ['title' => 'allow judge', 'sort' => true],

--- a/webapp/src/Form/Type/LanguageType.php
+++ b/webapp/src/Form/Type/LanguageType.php
@@ -21,7 +21,7 @@ class LanguageType extends AbstractExternalIdEntityType
     {
         $this->addExternalIdField($builder, Language::class);
         $builder->add('langid', TextType::class, [
-            'label' => 'Language ID/ext',
+            'label' => 'Language ID',
         ]);
         $builder->add('name', TextType::class);
         $builder->add('requireEntryPoint', ChoiceType::class, [

--- a/webapp/templates/jury/contest_edit.html.twig
+++ b/webapp/templates/jury/contest_edit.html.twig
@@ -17,7 +17,7 @@
         <div class="col-lg-4">
             <table class="table table-sm table-striped">
                 <tr>
-                    <th>Contest ID/ext</th>
+                    <th>Contest ID</th>
                     <td>{{ contest.cid }}</td>
                 </tr>
             </table>

--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -17,7 +17,7 @@
         <div class="col-lg-4">
             <table class="table table-sm table-striped">
                 <tr>
-                    <th>ID/extension</th>
+                    <th>ID</th>
                     <td>{{ language.langid }}</td>
                 </tr>
                 {% if showExternalId(language) %}

--- a/webapp/templates/jury/language_edit.html.twig
+++ b/webapp/templates/jury/language_edit.html.twig
@@ -16,7 +16,7 @@
         <div class="col-lg-4">
             <table class="table table-sm table-striped">
                 <tr>
-                    <th>Language ID/ext</th>
+                    <th>Language ID</th>
                     <td>{{ language.langid }}</td>
                 </tr>
             </table>


### PR DESCRIPTION
It might have been from a type where languages can only have 1 extension, or been used as the externalid. Both can now be specified independant of the Entity ID.