### PR TITLE
Add an option to display the specific results of too-late submissions for teams

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -215,6 +215,11 @@
             default_value: false
             public: true
             description: Should teams be able to view a diff of their and the reference output on sample testcases?
+        -   name: show_too_late_result
+            type: bool
+            default_value: false
+            public: true
+            description: Show results of TOO-LATE submissions in team interface?
         -   name: show_balloons_postfreeze
             type: bool
             default_value: false

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -120,6 +120,7 @@ class MiscController extends BaseController
             $data['clarificationRequests'] = $clarificationRequests;
             $data['categories']            = $this->config->get('clar_categories');
             $data['allowDownload']         = (bool)$this->config->get('allow_team_submission_download');
+            $data['showTooLateResult']     = $this->config->get('show_too_late_result');
         }
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -111,12 +111,13 @@ class SubmissionController extends BaseController
     public function viewAction(Request $request, int $submitId): Response
     {
         $verificationRequired = (bool)$this->config->get('verification_required');
-        $showCompile      = $this->config->get('show_compile');
-        $showSampleOutput = $this->config->get('show_sample_output');
-        $allowDownload    = (bool)$this->config->get('allow_team_submission_download');
-        $user             = $this->dj->getUser();
-        $team             = $user->getTeam();
-        $contest          = $this->dj->getCurrentContest($team->getTeamid());
+        $showCompile          = $this->config->get('show_compile');
+        $showSampleOutput     = $this->config->get('show_sample_output');
+        $allowDownload        = (bool)$this->config->get('allow_team_submission_download');
+        $showTooLateResult    = $this->config->get('show_too_late_result');
+        $user                 = $this->dj->getUser();
+        $team                 = $user->getTeam();
+        $contest              = $this->dj->getCurrentContest($team->getTeamid());
         /** @var Judging|null $judging */
         $judging = $this->em->createQueryBuilder()
             ->from(Judging::class, 'j')
@@ -192,6 +193,7 @@ class SubmissionController extends BaseController
             'allowDownload' => $allowDownload,
             'showSampleOutput' => $showSampleOutput,
             'runs' => $runs,
+            'showTooLateResult' => $showTooLateResult,
         ];
         if ($actuallyShowCompile) {
             $data['size'] = 'xl';

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -1,4 +1,4 @@
-{% if judging is empty or judging.submission.submittime >= current_team_contest.endtime or (verificationRequired and not judging.verified) %}
+{% if judging is empty or (not showTooLateResult and judging.submission.submittime >= current_team_contest.endtime) or (verificationRequired and not judging.verified) %}
     <div class="alert alert-danger">Submission not found for this team or not judged yet.</div>
 {% else %}
     <div class="container">

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -22,7 +22,7 @@
         <tbody>
         {%- for submission in submissions %}
             {% set link = null %}
-            {% if submission.submittime < current_team_contest.endtime and submission.result and submission.judgings.first is not empty and submission.judgings.first.result is not empty and (not verificationRequired or submission.judgings.first.verified) %}
+            {% if (submission.submittime < current_team_contest.endtime or showTooLateResult) and submission.result and submission.judgings.first is not empty and submission.judgings.first.result is not empty and (not verificationRequired or submission.judgings.first.verified) %}
                 {% set link = path('team_submission', {submitId: submission.submitid}) %}
             {% endif %}
 
@@ -52,13 +52,19 @@
                 <td>
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
                         {%- if submission.submittime > submission.contest.endtime %}
-                            {{ 'too-late' | printResult }}
-                        {%- elseif submission.judgings.first is empty or submission.judgings.first.result is empty %}
-                            {{- '' | printResult -}}
-                        {%- elseif verificationRequired and not submission.judgings.first.verified %}
-                            {{- '' | printResult -}}
-                        {%- else %}
-                            {{- submission.judgings.first.result | printResult -}}
+                            {{ 'too-late' | printResult }} 
+                        {%- endif %}
+                        {%- if submission.submittime <= submission.contest.endtime or showTooLateResult %}
+                            {%- if submission.submittime > submission.contest.endtime %}
+                                /
+                            {% endif %}
+                            {%- if submission.judgings.first is empty or submission.judgings.first.result is empty %}
+                                {{- '' | printResult -}}
+                            {%- elseif verificationRequired and not submission.judgings.first.verified %}
+                                {{- '' | printResult -}}
+                            {%- else %}
+                                {{- submission.judgings.first.result | printResult -}}
+                            {%- endif %}
                         {%- endif %}
                     </a>
                 </td>


### PR DESCRIPTION
For team interface, show the specific judge results of too-late submissions. Meanwhile add a global configuration option to enable/disable this feature.
Closes #1967 