### PR TITLE
Fix PHPCS error

### DIFF
--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -185,9 +185,9 @@ class OrganizationControllerTest extends BaseTestCase
     
             static::assertIsArray($objects);
             foreach ($this->expectedObjects as $expectedObjectId => $expectedObject) {
-                $filteredAway = True;
+                $filteredAway = true;
                 if ($expectedObject['country'] === $country) {
-                    $filteredAway = False;
+                    $filteredAway = false;
                 }
                 foreach ($this->entityReferences as $field => $class) {
                     $expectedObject[$field] = $this->resolveEntityId($class, $expectedObject[$field]);


### PR DESCRIPTION
TRUE, FALSE and NULL must be lowercase;

Not sure if this touches @nickygerritsen his PR, so lets merge this afterwards.