### PR TITLE
Openapi fixes/enhancements

### DIFF
--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -122,15 +122,6 @@ nelmio_api_doc:
                             schema:
                                 type: string
             schemas:
-                FileList:
-                    type: array
-                    items:
-                        type: object
-                        properties:
-                            href:
-                                type: string
-                            mime:
-                                type: string
                 ImageList:
                     type: array
                     nullable: true

--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -9,6 +9,10 @@ nelmio_api_doc:
             title: DOMjudge
             description: DOMjudge API v4
             version: "%domjudge.version%"
+            contact:
+                name: DOMjudge development team (not the administrator of this instance)
+                email: development@domjudge.org
+                url: https://github.com/DOMjudge/domjudge/issues/new/choose
         security:
             - basicAuth: []
         components:

--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -9,6 +9,9 @@ nelmio_api_doc:
             title: DOMjudge
             description: DOMjudge API v4
             version: "%domjudge.version%"
+            license:
+                name: GPL2
+                url: https://raw.githubusercontent.com/DOMjudge/domjudge/main/COPYING
             contact:
                 name: DOMjudge development team (not the administrator of this instance)
                 email: development@domjudge.org

--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -1,5 +1,10 @@
 nelmio_api_doc:
     documentation:
+        servers:
+            - url: "%domjudge.baseurl%api"
+              description: API used at this contest
+            - url: https://www.domjudge.org/demoweb/api
+              description: New API in development
         info:
             title: DOMjudge
             description: DOMjudge API v4

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1406,6 +1406,28 @@ class JudgehostController extends AbstractFOSRestController
      */
     #[IsGranted(new Expression("is_granted('ROLE_JUDGEHOST')"))]
     #[Rest\Post('/fetch-work')]
+    #[OA\Response(
+        response: 200,
+        description: 'Returns the workarray.',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                new OA\Schema(ref: new Model(type: JudgeTask::class)),
+            )
+        )
+    )]
+    #[OA\Parameter(
+        name: 'hostname',
+        description: 'Hostname of the judgehost requesting work.',
+        in: 'query',
+        schema: new OA\Schema(type: 'string')
+    )]
+    #[OA\Parameter(
+        name: 'max_batchsize',
+        description: 'Maximum number of tasks to return.',
+        in: 'query',
+        schema: new OA\Schema(type: 'integer')
+    )]
     public function getJudgeTasksAction(Request $request): array
     {
         if (!$request->request->has('hostname')) {

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1182,7 +1182,6 @@ class JudgehostController extends AbstractFOSRestController
         response: 200,
         description: 'Returns optionally compiler and runner version commands.',
         content: new OA\JsonContent(
-            required: [],
             properties: [
                 new OA\Property(property: 'compiler_version_command', type: 'string', nullable: true),
                 new OA\Property(property: 'runner_version_command', type: 'string', nullable: true),


### PR DESCRIPTION
Found by spectral, for all the rules see:
https://docs.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules

It also looks like our API is not OpenAPI3 complaint as we output the type `int` instead of `integer`. This should be a bug with how we generate the docs.

I think reviewing should be done by checking which commits to cherry-pick.