### PR TITLE
Skip region questions for ubuntu/focal test

### DIFF
--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -25,6 +25,9 @@ jobs:
           - os: debian
             version: stable
     runs-on: ubuntu-latest
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
     container:
       image: ${{ matrix.os }}:${{ matrix.version }}
     steps:


### PR DESCRIPTION
This is to prevent:
https://github.com/DOMjudge/domjudge/actions/runs/5562807665/jobs/10161338494

Where the installer asks for the region and hangs.