### PR TITLE
Fix mayhem test

### DIFF
--- a/.github/workflows/mayhem-weekly.yml
+++ b/.github/workflows/mayhem-weekly.yml
@@ -19,7 +19,7 @@ jobs:
             duration: "10m"
     uses: ./.github/workflows/mayhem-api-template.yml
     with:
-      version: "${{ matrix.target }}"
-      duration: "${{ matrix.version }}"
+      version: "${{ matrix.version }}"
+      duration: "${{ matrix.duration }}"
     secrets:
       MAPI_TOKEN: ${{ secrets.MAPI_TOKEN }}


### PR DESCRIPTION
The wrong variables were fed to the job so the scan failed. This should fix this. It can not easily be tested as we don't run this on push because of the limited amount of tokens available.