### PR TITLE
If a main class can't be detected or found, do not make this a compile error.

### DIFF
--- a/example_problems/hello/submissions/run_time_error/mainclass-missing/main.java
+++ b/example_problems/hello/submissions/run_time_error/mainclass-missing/main.java
@@ -5,7 +5,7 @@
  * might be specified during submission; then this source would result
  * in a run-error.
  *
- * @EXPECTED_RESULTS@: COMPILER-ERROR
+ * @EXPECTED_RESULTS@: RUN-ERROR
  */
 
 import java.io.*;

--- a/sql/files/defaultdata/java_javac_detect/run
+++ b/sql/files/defaultdata/java_javac_detect/run
@@ -59,17 +59,12 @@ if [ -z "$MAINCLASS" ]; then
 	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' \
 	            | sed -e 's/\.class$//' -e 's/^\.\///' -e 's/\//./g')"
 	MAINCLASS=$(java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $CLASSNAMES)
-	EXITCODE=$?
 
 	# Report the entry point, so it can be saved, e.g. for later replay:
 	echo "Info: detected entry_point: $MAINCLASS"
-
-	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 else
 	# Check if entry point is valid
 	java -cp "$COMPILESCRIPTDIR" DetectMain "$(pwd)" $MAINCLASS > /dev/null
-	EXITCODE=$?
-	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 fi
 
 # Write executing script:

--- a/sql/files/defaultdata/kt/run
+++ b/sql/files/defaultdata/kt/run
@@ -69,17 +69,12 @@ if [ -z "$MAINCLASS" ]; then
 	CLASSNAMES="$(find ./* -type f -regex '^.*\.class$' \
 	            | sed -e 's/\.class$//' -e 's/^\.\///' -e 's/\//./g')"
 	MAINCLASS=$(java -cp "$COMPILESCRIPTDIR:$KOTLIN_STDLIB" DetectMain "$(pwd)" $CLASSNAMES)
-	EXITCODE=$?
 
 	# Report the entry point, so it can be saved, e.g. for later replay:
 	echo "Info: detected entry_point: $MAINCLASS"
-
-	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 else
 	# Check if entry point is valid
 	java -cp "$COMPILESCRIPTDIR:$KOTLIN_STDLIB" DetectMain "$(pwd)" $MAINCLASS > /dev/null
-	EXITCODE=$?
-	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
 fi
 
 # Write executing script:


### PR DESCRIPTION
It has been decided that this made more sense.

As discussed via mail with the WF judges. This should also mimic the PC<sup>2</sup> behaviour.