### PR TITLE
Test the configure script in fedora

### DIFF
--- a/.github/jobs/configure-checks/setup_configure_image.sh
+++ b/.github/jobs/configure-checks/setup_configure_image.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eux
+
+distro_id=$(grep "^ID=" /etc/os-release)
+
+# Install everything for configure and testing
+case $distro_id in
+    "ID=fedora")
+        dnf install pkg-config make bats autoconf automake util-linux -y ;;
+    *)
+        apt-get update; apt-get full-upgrade -y
+        apt-get install pkg-config make bats autoconf -y ;;
+esac
+
+# Build the configure file
+make configure
+
+# Install extra assert statements for bots
+cp submit/assert.bash .github/jobs/configure-checks/
+
+# Run the configure tests for this usecase
+test_path="/__w/domjudge/domjudge" bats .github/jobs/configure-checks/all.bats

--- a/.github/workflows/autoconf-check-different-distro.yml
+++ b/.github/workflows/autoconf-check-different-distro.yml
@@ -1,4 +1,4 @@
-name: Check autoconf
+name: Check autoconf (Other distros)
 on:
   push:
     branches:
@@ -10,29 +10,17 @@ on:
       - '[0-9]+.[0-9]+'
 
 jobs:
-  debian-family:
+  redhat-family:
     strategy:
       matrix:
-        version: [jammy, focal, rolling]
-        os: [ubuntu]
-        releaseBranch:
-          - ${{ contains(github.ref, 'main') }}
-        exclude:
-          - releaseBranch: false
-        include:
-          - os: debian
-            version: testing
-          - os: debian
-            version: stable
+        version: [latest]
+        os: [fedora]
     runs-on: ubuntu-latest
-    env:
-      DEBIAN_FRONTEND: noninteractive
-      TZ: Etc/UTC
     container:
       image: ${{ matrix.os }}:${{ matrix.version }}
     steps:
       - name: Install git so we get the .github directory
-        run: apt-get update; apt-get install -y git
+        run: dnf install -y git
       - uses: actions/checkout@v3
       - name: Setup image and run bats tests
         run: .github/jobs/configure-checks/setup_configure_image.sh

--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ if test "x$with_webserver_group" = x; then
 		AC_SUBST(WEBSERVER_GROUP,"$g")
 		AC_MSG_RESULT([$WEBSERVER_GROUP (detected)])
 	else
-		AC_MSG_ERROR([webserver group could not be detected, use --with-webserver-group=GROUP)])
+		AC_MSG_ERROR([webserver group could not be detected, use --with-webserver-group=GROUP])
 	fi
 else
 	AC_SUBST(WEBSERVER_GROUP,$with_webserver_group)

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ AC_ARG_WITH([webserver-group], [AS_HELP_STRING([--with-webserver-group=GROUP],
 if test "x$with_webserver_group" = x; then
 	# Try a number of group names and choose first one found
 	found=0
-	for g in www-data apache httpd ; do
+	for g in www-data apache httpd nginx ; do
 		if getent group $g >/dev/null 2>&1 ; then
 		   found=1
 		   break


### PR DESCRIPTION
Fedora is the only flavour for Red Hat which we can support for judgehosts (due to the libcgroup development files). Testing this in every CI seems to be waste of time so only test in main or release branches.

This did uncover a typo and a bug where we don't detect the nginx group, a fix for both is added.