### PR TITLE
Use latest commit in CLICS 2023-06 version.

### DIFF
--- a/gitlab/ci_settings.sh
+++ b/gitlab/ci_settings.sh
@@ -13,7 +13,7 @@ export GITSHA
 export PS4='(${BASH_SOURCE}:${LINENO}): - [$?] $ '
 export LOGFILE="/opt/domjudge/domserver/webapp/var/log/prod.log"
 
-CCS_SPECS_PINNED_SHA1='6b11623d586500d11ec20b6c12a4908b44ff0e41'
+CCS_SPECS_PINNED_SHA1='a68aff54c4e60fc2bff2fc5c36c119bffa4d30f1'
 
 # Shared storage for all artifacts
 export GITLABARTIFACTS="$DIR/gitlabartifacts"


### PR DESCRIPTION
This fixes the CI as the commit we used to pin to before did not exist anymore.

See: https://github.com/icpc/ccs-specs/pull/160 for the change in the CLICS repo.