### PR TITLE
Force autoconf to lookup the macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,7 +217,7 @@ AX_WITH_COMMENT(7,[      ])
 
 # {{{ Directory for systemd unit files
 
-PKG_PROG_PKG_CONFIG
+PKG_PROG_PKG_CONFIG()
 AC_ARG_WITH([systemdsystemunitdir],
      [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
      [with_systemdsystemunitdir=auto])


### PR DESCRIPTION
Fix based on discussion with @ankon on this subject. This problem is not trivial to reproduce as different people have encountered this since the explicit failure added in https://github.com/DOMjudge/domjudge/commit/339ac729876393c788db1c715dff1f7c36cdfc1c (but first we didn't fail on not resolving the macro).

This PR is only to let @eldering take a look at this as this might not be the correct fix (although it does fix the issue when people encounter this issue) as I'm not sure what to look for to see if this is proper syntax.

If we accept this as the fix we should also consider fixing the [docs](https://www.freedesktop.org/software/systemd/man/daemon.html#Installing%20systemd%20Service%20Files)