### PR TITLE
Add ability to POST language executables via the API.

### DIFF
--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -97,6 +97,17 @@ if os.path.exists('config.json'):
 else:
     print('Need a "config.json" to update general DOMjudge configuration.')
 
+
+if os.path.exists('executables'):
+    executables = []
+    for file in os.listdir('executables'):
+        if file.endswith(".zip"):
+            executables.append(file[:-4])
+    if executables and dj_utils.confirm('Upload language executables (found: ' + ','.join(executables) + ')?', False):
+        for langid in executables:
+            dj_utils.upload_file(f'languages/{langid}/executable', 'executable', f'executables/{langid}.zip')
+
+
 if os.path.exists('languages.json'):
     print('Comparing DOMjudge\'s language configuration:')
     with open('languages.json') as langConfigFile:

--- a/webapp/src/Controller/API/LanguageController.php
+++ b/webapp/src/Controller/API/LanguageController.php
@@ -65,7 +65,7 @@ class LanguageController extends AbstractRestController
     }
 
     /**
-     * Get the given language for this contest.
+     * Update the executable of a language.
      * @throws NonUniqueResultException
      */
     #[IsGranted('ROLE_ADMIN')]

--- a/webapp/src/Controller/API/LanguageController.php
+++ b/webapp/src/Controller/API/LanguageController.php
@@ -2,6 +2,8 @@
 
 namespace App\Controller\API;
 
+use App\Entity\ExecutableFile;
+use App\Entity\ImmutableExecutable;
 use App\Entity\Language;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\QueryBuilder;
@@ -10,6 +12,9 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use ZipArchive;
 
 #[Rest\Route('/')]
 #[OA\Tag(name: 'Languages')]
@@ -57,6 +62,64 @@ class LanguageController extends AbstractRestController
     public function singleAction(Request $request, string $id): Response
     {
         return parent::performSingleAction($request, $id);
+    }
+
+    /**
+     * Get the given language for this contest.
+     * @throws NonUniqueResultException
+     */
+    #[IsGranted('ROLE_ADMIN')]
+    #[Rest\Post('languages/{id}/executable')]
+    #[OA\Response(
+        response: 200,
+        description: 'Update the executable for a given language.',
+    )]
+    #[OA\Parameter(ref: '#/components/parameters/id')]
+    public function updateExecutableActions(Request $request, string $id): void
+    {
+        $language = $this->em->getRepository(Language::class)->find($id);
+        if (!$language) {
+            throw new BadRequestHttpException("Unknown language '$id'.");
+        }
+        $file = $request->files->get('executable');
+        if (empty($file)) {
+            throw new BadRequestHttpException('executable file missing');
+        }
+        $zip = $this->dj->openZipFile($file->getRealPath());
+
+        $files = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
+
+            $content = $zip->getFromName($filename);
+            if (empty($content)) {
+                // Empty file or directory, ignore.
+                continue;
+            }
+            $idx = count($files);
+            $isExecutable = false;
+            $opsys = $attr = 0;
+            if ($zip->getExternalAttributesIndex($i, $opsys, $attr)
+                && $opsys==ZipArchive::OPSYS_UNIX) {
+                $attr = ($attr >> 16) & 0777;
+                $isExecutable = ($attr & 0o100) == 0o100;
+            }
+            $executableFile = new ExecutableFile();
+            $executableFile
+                ->setRank($idx)
+                ->setIsExecutable($isExecutable)
+                ->setFilename($filename)
+                ->setFileContent($content);
+            $this->em->persist($executableFile);
+            $files[] = $executableFile;
+        }
+
+        $immutableExecutable = new ImmutableExecutable($files);
+        $this->em->persist($immutableExecutable);
+
+        $language->getCompileExecutable()->setImmutableExecutable($immutableExecutable);
+        $this->em->flush();
+        $this->dj->auditlog('executable', $language->getLangid(), 'updated');
     }
 
     protected function getQueryBuilder(Request $request): QueryBuilder

--- a/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
@@ -33,7 +33,7 @@ class LanguageControllerTest extends BaseTestCase
         EnableJavaEntrypointFixture::class,
     ];
 
-    public function testUpdateExecutable() {
+    public function testUpdateExecutable(): void {
         // First test the before state.
         $response = $this->verifyApiJsonResponse('GET', '/languages/java', 200, 'admin');
         $before_hash = 'fd73586c70ec910b9dff6f474bf85704';

--- a/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
@@ -34,10 +34,9 @@ class LanguageControllerTest extends BaseTestCase
     ];
 
     public function testUpdateExecutable(): void {
-        // First test the before state.
+        // First retrieve the before state.
         $response = $this->verifyApiJsonResponse('GET', '/languages/java', 200, 'admin');
-        $before_hash = 'fd73586c70ec910b9dff6f474bf85704';
-        static::assertEquals($before_hash, $response['compile_executable_hash']);
+        $before_hash = $response['compile_executable_hash'];
 
         // Create a ZIP file from some dummy content.
         $files = [
@@ -64,5 +63,8 @@ class LanguageControllerTest extends BaseTestCase
         $response = $this->verifyApiJsonResponse('GET', '/languages/java', 200, 'admin');
         $after_hash = '1be13faf2603b19c8bf5a398155a6d3b';
         static::assertEquals($after_hash, $response['compile_executable_hash']);
+
+        // Make sure it has changed.
+        static::assertNotEquals($before_hash, $after_hash);
     }
 }


### PR DESCRIPTION
This makes preparation of contests easier without modifying DOMjudge's source code to update default settings.