### PR TITLE
Show elapsed minutes on scoreboard

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -68,7 +68,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     {
         return [
             new TwigFilter('printtimediff', $this->printtimediff(...)),
-            new TwigFilter('printremainingminutes', $this->printremainingminutes(...)),
+            new TwigFilter('printelapsedminutes', $this->printelapsedminutes(...)),
             new TwigFilter('printtime', $this->printtime(...)),
             new TwigFilter('printHumanTimeDiff', $this->printHumanTimeDiff(...)),
             new TwigFilter('printtimeHover', $this->printtimeHover(...), ['is_safe' => ['html']]),
@@ -162,15 +162,15 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         return Utils::printtimediff($start, $end);
     }
 
-    public function printremainingminutes(float $start, float $end): string
+    public function printelapsedminutes(float $start, float $end): string
     {
-        $minutesRemaining = floor(($end - $start)/60);
-        if ($minutesRemaining < 1) {
-            return 'less than 1 minute to go';
-        } elseif ($minutesRemaining == 1) {
-            return '1 minute to go';
+        $minutesElapsed = floor(($end - $start)/60);
+        if ($minutesElapsed < 1) {
+            return 'started less than 1 minute ago';
+        } elseif ($minutesElapsed == 1) {
+            return 'started 1 minute ago';
         } else {
-            return $minutesRemaining . ' minutes to go';
+            return 'started' . $minutesElapsed . ' minutes ago';
         }
     }
 

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -33,7 +33,7 @@
                     contest over, waiting for results
                 {% elseif static %}
                     {% set now = 'now'|date('U') %}
-                    {{ now | printremainingminutes(current_contest.endtime) }}
+                    {{ current_contest.starttime | printelapsedminutes(now) }}
                 {% else %}
                     {% if current_contest.freezeData.started %}
                         started:


### PR DESCRIPTION
This should be an implementation for: https://github.com/DOMjudge/domjudge/issues/2064

There is a micro optimization to deduplicate the `now` by merging the last elseif...else and than introducing an if, I found that less readable and moving this `now` higher would trigger this always for every scoreboard and given that its a public page that felt annoying.

I'm not sure if the `printremainingminutes` & `printelapsedminutes` shouldn't be merged with a boolean flag to keep them together, now they are basically each others inverse.

![image](https://github.com/DOMjudge/domjudge/assets/14887731/0da61ae5-8cc1-4053-8716-f0de191c282b)
