### PR TITLE
Add option to hide nonloggedin/nonsubmitted teams on the scoreboard

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -269,6 +269,15 @@
             default_value: false
             public: true
             description: Show canonical compiler and runner version on the team pages.
+        -   name: show_teams_on_scoreboard
+            type: int
+            default_value: 0
+            public: true
+            description: Show teams on the scoreboard?
+            options:
+                0: Always
+                1: After login
+                2: After first submission
 -   category: Authentication
     description: Options related to authentication.
     items:

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -953,7 +953,7 @@ class ScoreboardService
             $queryBuilder->andWhere('tc.visible = 1');
             if ($show_filter === self::SHOW_TEAM_AFTER_LOGIN) {
                 $queryBuilder
-                    ->join('t.users', 'u', Join::WITH, 'u.last_login IS NOT NULL');
+                    ->join('t.users', 'u', Join::WITH, 'u.last_login IS NOT NULL OR u.last_api_login IS NOT NULL');
             } elseif ($show_filter === self::SHOW_TEAM_AFTER_SUBMIT) {
                 $queryBuilder
                     ->join('t.submissions', 's', Join::WITH, 's.contest = :cid')

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -32,6 +32,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ScoreboardService
 {
+    final public const SHOW_TEAM_ALWAYS = 0;
+    final public const SHOW_TEAM_AFTER_LOGIN = 1;
+    final public const SHOW_TEAM_AFTER_SUBMIT = 2;
+
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly DOMJudgeService $dj,
@@ -944,8 +948,17 @@ class ScoreboardService
                 ->setParameter('cid', $contest->getCid());
         }
 
+        $show_filter = $this->config->get('show_teams_on_scoreboard');
         if (!$jury) {
             $queryBuilder->andWhere('tc.visible = 1');
+            if ($show_filter === self::SHOW_TEAM_AFTER_LOGIN) {
+                $queryBuilder
+                    ->join('t.users', 'u', Join::WITH, 'u.last_login IS NOT NULL');
+            } elseif ($show_filter === self::SHOW_TEAM_AFTER_SUBMIT) {
+                $queryBuilder
+                    ->join('t.submissions', 's', Join::WITH, 's.contest = :cid')
+                    ->setParameter('cid', $contest->getCid());
+                }
         }
 
         if ($filter) {

--- a/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
@@ -65,11 +65,12 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         // Default configuration values:
         $this->configValues = [
-            'verification_required' => false,
-            'compile_penalty'       => false,
-            'penalty_time'          => 20,
-            'score_in_seconds'      => false,
-            'data_source'           => 0,
+            'verification_required'    => false,
+            'compile_penalty'          => false,
+            'penalty_time'             => 20,
+            'score_in_seconds'         => false,
+            'data_source'              => 0,
+            'show_teams_on_scoreboard' => 0,
         ];
 
         $this->config = $this->createMock(ConfigurationService::class);


### PR DESCRIPTION
This is a config option as a config option for the following 2 cases:
- Normally you want a team which has logged on on the scoreboard
- In case of the autologin tool of GEHACK/Nicky the user would also login without interaction of the actual team

I've tested it manually and it works.