### PR TITLE
Compare script language defaults

### DIFF
--- a/webapp/migrations/Version20230813111642.php
+++ b/webapp/migrations/Version20230813111642.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230813111642 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the {compiler,runner} run/build command (+ arguments) to the database.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE language ADD compiler_command VARCHAR(255) DEFAULT NULL COMMENT \'Compiler command\', ADD runner_command VARCHAR(255) DEFAULT NULL COMMENT \'Runner command\', ADD compiler_command_args VARCHAR(255) DEFAULT NULL COMMENT \'Compiler command arguments\', ADD runner_command_args VARCHAR(255) DEFAULT NULL COMMENT \'Runner command arguments\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE language DROP compiler_command, DROP runner_command, DROP compiler_command_args, DROP runner_command_args');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -173,6 +173,50 @@ class Language extends BaseApiEntity
         return $this->versions;
     }
 
+    public function getCompilerCommand(): ?string
+    {
+        return $this->compilerCommand;
+    }
+
+    public function setCompilerCommand(?string $compilerCommand): Language
+    {
+        $this->compilerCommand = $compilerCommand;
+        return $this;
+    }
+
+    public function getRunnerCommand(): ?string
+    {
+        return $this->runnerCommand;
+    }
+
+    public function setRunnerCommand(?string $runnerCommand): Language
+    {
+        $this->runnerCommand = $runnerCommand;
+        return $this;
+    }
+
+    public function getCompilerCommandArgs(): ?string
+    {
+        return $this->compilerCommandArgs;
+    }
+
+    public function setCompilerCommandArgs(?string $compilerCommandArgs): Language
+    {
+        $this->compilerCommandArgs = $compilerCommandArgs;
+        return $this;
+    }
+
+    public function getRunnerCommandArgs(): ?string
+    {
+        return $this->runnerCommandArgs;
+    }
+
+    public function setRunnerCommandArgs(?string $runnerCommandArgs): Language
+    {
+        $this->runnerCommandArgs = $runnerCommandArgs;
+        return $this;
+    }
+
     public function getCompilerVersion(): ?string
     {
         return $this->compilerVersion;
@@ -232,10 +276,16 @@ class Language extends BaseApiEntity
      */
     #[Serializer\VirtualProperty]
     #[Serializer\SerializedName('compiler')]
-    #[Serializer\Exclude(if:'object.getCompilerVersionCommand() == ""')]
+    #[Serializer\Exclude(if:'object.getCompilerVersionCommand() == "" && object.getCompilerCommand() == ""')]
     public function getCompilerData(): array
     {
         $ret = [];
+        if (!empty($this->getCompilerCommand())) {
+            $ret['command'] = $this->getCompilerCommand();
+            if (!empty($this->getCompilerCommandArgs())) {
+                $ret['args'] = $this->getCompilerCommandArgs();
+            }
+        }
         if (!empty($this->getCompilerVersionCommand())) {
             $ret['version_command'] = $this->getCompilerVersionCommand();
             if (!empty($this->getCompilerVersion())) {
@@ -250,10 +300,16 @@ class Language extends BaseApiEntity
      */
     #[Serializer\VirtualProperty]
     #[Serializer\SerializedName('runner')]
-    #[Serializer\Exclude(if:'object.getRunnerVersionCommand() == ""')]
+    #[Serializer\Exclude(if:'object.getRunnerVersionCommand() == "" && object.getRunnerCommand() == ""')]
     public function getRunnerData(): array
     {
         $ret = [];
+        if (!empty($this->getRunnerCommand())) {
+            $ret['command'] = $this->getRunnerCommand();
+            if (!empty($this->getRunnerCommandArgs())) {
+                $ret['args'] = $this->getRunnerCommandArgs();
+            }
+        }
         if (!empty($this->getRunnerVersionCommand())) {
             $ret['version_command'] = $this->getRunnerVersionCommand();
             if (!empty($this->getRunnerVersion())) {

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -124,6 +124,22 @@ class Language extends BaseApiEntity
     #[Serializer\Exclude]
     private Collection $versions;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true, options: ['comment' => 'Compiler command'])]
+    #[Serializer\Exclude]
+    private ?string $compilerCommand = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true, options: ['comment' => 'Runner command'])]
+    #[Serializer\Exclude]
+    private ?string $runnerCommand = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true, options: ['comment' => 'Compiler command arguments'])]
+    #[Serializer\Exclude]
+    private ?string $compilerCommandArgs = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true, options: ['comment' => 'Runner command arguments'])]
+    #[Serializer\Exclude]
+    private ?string $runnerCommandArgs = null;
+
     #[ORM\Column(type: 'blobtext', nullable: true, options: ['comment' => 'Compiler version'])]
     #[Serializer\Exclude]
     private ?string $compilerVersion = null;

--- a/webapp/src/Form/Type/LanguageType.php
+++ b/webapp/src/Form/Type/LanguageType.php
@@ -80,6 +80,22 @@ class LanguageType extends AbstractExternalIdEntityType
                 'No' => false,
             ],
         ]);
+        $builder->add('compilerCommand', TextType::class, [
+            'label' => 'Compiler command',
+            'required' => false,
+        ]);
+        $builder->add('compilerCommandArgs', TextType::class, [
+            'label' => 'Compiler command arguments',
+            'required' => false,
+        ]);
+        $builder->add('runnerCommand', TextType::class, [
+            'label' => 'Runner command',
+            'required' => false,
+        ]);
+        $builder->add('runnerCommandArgs', TextType::class, [
+            'label' => 'Runner command arguments',
+            'required' => false,
+        ]);
         $builder->add('compilerVersionCommand', TextType::class, [
             'label' => 'Compiler version command',
             'required' => false,

--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -78,6 +78,40 @@
                     </td>
                 </tr>
                     <tr>
+                        <th>Compiler command</th>
+                        <td>
+                            {% if language.compilerCommand %}
+                                <pre class="output_text" style="white-space:normal">
+                                    $ {{ language.compilerCommand }}
+                                    {% if language.compilerCommandArgs %}
+                                        {{ language.compilerCommandArgs }}
+                                    {% else %}
+                                        <p class="nodata">(No command arguments specified.)</p>
+                                    {% endif %}
+                                </pre>
+                            {% else %}
+                                <p class="nodata">No command specified.</p>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Runner command</th>
+                        <td>
+                            {%- if language.runnerCommand -%}
+                                <pre class="output_text" style="white-space:normal">
+                                    $ {{ language.runnerCommand }}
+                                    {% if language.runnerCommandArgs %}
+                                        {{ language.runnerCommandArgs }}
+                                    {% else %}
+                                        <p class="nodata">(No command arguments specified.)</p>
+                                    {% endif %}
+                                </pre>
+                            {% else %}
+                                <p class="nodata">No command specified.</p>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
                         <th>Compiler version</th>
                         <td>
                             {% if language.compilerVersionCommand %}

--- a/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/LanguageControllerTest.php
@@ -17,12 +17,15 @@ class LanguageControllerTest extends BaseTestCase
             'entry_point_required' => false,
             'entry_point_name'     => null,
             'extensions'           => ['cpp', 'cc', 'cxx', 'c++'],
+            'compiler'             => ['version_command' => 'g++ --version']
         ],
         'java' => [
             'name'                 => 'Java',
             'entry_point_required' => true,
             'entry_point_name'     => 'Main class',
             'extensions'           => ['java'],
+            'compiler'             => ['version_command' => 'javac -version'],
+            'runner'               => ['version_command' => 'java -version'],
         ],
     ];
 

--- a/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
@@ -74,7 +74,7 @@ class LanguagesControllerTest extends JuryControllerTestCase
                                                            'compilerCommand' => 'runc',
                                                            'compilerCommandArgs' => '-a -b -c {files}',
                                                            'runnerCommand' => 'run',
-                                                           'runnerCommandArgs' => '-g "$MAIN" {files}'],
+                                                           'runnerCommandArgs' => '-g "\$MAIN" {files}'],
                                                           ['langid' => 'runVers',
                                                            'runnerVersionCommand' => 'run -x |yes|tr "\n" "\`true\`"']];
     protected static array   $addEntitiesFailure       = ['Only alphanumeric characters and ._- are allowed' => [['langid' => '§$#`"'],

--- a/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
@@ -70,6 +70,11 @@ class LanguagesControllerTest extends JuryControllerTestCase
                                                            'filterCompilerFiles' => '0'],
                                                           ['langid' => 'compVers',
                                                            'compilerVersionCommand' => 'unit -V'],
+                                                          ['langid' => 'runCompileCommand',
+                                                           'compilerCommand' => 'runc',
+                                                           'compilerCommandArgs' => '-a -b -c {files}',
+                                                           'runnerCommand' => 'run',
+                                                           'runnerCommandArgs' => '-g "$MAIN" {files}'],
                                                           ['langid' => 'runVers',
                                                            'runnerVersionCommand' => 'run -x |yes|tr "\n" "\`true\`"']];
     protected static array   $addEntitiesFailure       = ['Only alphanumeric characters and ._- are allowed' => [['langid' => '§$#`"'],


### PR DESCRIPTION
If/When this is approved we need another PR to also use these values in the run/build scripts per language to fully implement the CLICS spec. Given that we don't implement the draft yet we have some time still.

One import thing is that I've changed the python to pypy3 to be consistent, this will require that this is installed in the host so I'm not sure if the consistency is wanted.