### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -7,7 +7,7 @@ DOMjudge can optionally present country flags, affiliation logos,
 team pictures and a page-wide banner on the public interface.
 
 You can place the images under the path `public/images/` (see
-the Config checker in the admin interfae for the full filesystem
+the Config checker in the admin interface for the full filesystem
 path of your installation) as follows:
 
 - *Country flags* are shown when the ``show_flags`` configuration option


### PR DESCRIPTION
Fixed a typo in the word 'interfae' by replacing it with 'interface'.