### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/manual/config-advanced.rst
+++ b/doc/manual/config-advanced.rst
@@ -405,7 +405,7 @@ Clearing the PHP/Symfony cache
 ------------------------------
 
 Some operations require you to clear the PHP/Symfony cache. To do this, execute
-the `webapp/bin/console` (see the Config checker in the admin interfae for the
+the `webapp/bin/console` (see the Config checker in the admin interface for the
 full filesystem path of your installation) binary with the `cache:clear` subcommand::
 
   webapp/bin/console cache:clear


### PR DESCRIPTION
Fixed a typo in the word 'interfae' by replacing it with 'interface'.