### PR TITLE
Fix requesting of full judging output.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -230,10 +230,12 @@ class SubmissionController extends BaseController
                 ->from(JudgeTask::class, 'jt', 'jt.jobid')
                 ->select('jt')
                 ->andWhere('jt.jobid IN (:jobIds)')
+                ->andWhere('jt.type = :type')
                 ->setParameter(
                     'jobIds',
                     array_map(static fn(Judging $judging) => $judging->getJudgingid(), $judgings)
                 )
+                ->setParameter('type', JudgeTaskType::JUDGING_RUN)
                 ->getQuery()
                 ->getResult();
             $timelimits = array_map(function (JudgeTask $task) {


### PR DESCRIPTION
Requesting the full judging output is a `debug_info` judge task type which does not have a run config set.

See #2031 where the code in question was introduced to display historical time limits.