### PR TITLE
Construct ZIP files while uploading executables.

### DIFF
--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -17,6 +17,7 @@ import json
 import os.path
 import requests
 import requests.utils
+import shutil
 import sys
 from typing import List, Set
 
@@ -101,11 +102,15 @@ else:
 if os.path.exists('executables'):
     executables = []
     for file in os.listdir('executables'):
-        if file.endswith(".zip"):
-            executables.append(file[:-4])
-    if executables and dj_utils.confirm('Upload language executables (found: ' + ','.join(executables) + ')?', False):
+        if os.path.isdir(f'executables/{file}'):
+            executables.append(file)
+
+    if executables:
+        if dj_utils.confirm('Upload language executables (found: ' + ','.join(executables) + ')?', False):
+            for langid in executables:
+                dj_utils.upload_file(f'languages/{langid}/executable', 'executable', f'executables/{langid}.zip')
         for langid in executables:
-            dj_utils.upload_file(f'languages/{langid}/executable', 'executable', f'executables/{langid}.zip')
+            os.remove(f'executables/{langid}.zip')
 
 
 if os.path.exists('languages.json'):

--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -104,6 +104,7 @@ if os.path.exists('executables'):
     for file in os.listdir('executables'):
         if os.path.isdir(f'executables/{file}'):
             executables.append(file)
+            shutil.make_archive(f'executables/{file}', 'zip', f'executables/{file}')
 
     if executables:
         if dj_utils.confirm('Upload language executables (found: ' + ','.join(executables) + ')?', False):


### PR DESCRIPTION
This is an improvement on top of #2129, since you do not need to check in ZIP files into a ccsconfig repository, but directories which are zipped up on the fly.
This makes changing and reviewing changes much easier.