### PR TITLE
Expose when externalContestSource (URI) returns non200

### DIFF
--- a/webapp/migrations/Version20231006185028.php
+++ b/webapp/migrations/Version20231006185028.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231006185028 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the last received HTTP code for the external contest source.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE external_contest_source ADD last_httpcode SMALLINT UNSIGNED DEFAULT NULL COMMENT \'Last HTTP code received by event feed reader\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE external_contest_source DROP last_httpcode');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/ExternalContestSource.php
+++ b/webapp/src/Entity/ExternalContestSource.php
@@ -49,6 +49,13 @@ class ExternalContestSource
     )]
     private ?float $lastPollTime = null;
 
+    #[ORM\Column(
+        type: 'smallint',
+        nullable: true,
+        options: ['comment' => 'Last HTTP code received by event feed reader', 'unsigned' => true]
+    )]
+    public ?int $lastHTTPCode = null;
+
     #[ORM\ManyToOne(inversedBy: 'externalContestSources')]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
     private Contest $contest;
@@ -174,6 +181,17 @@ class ExternalContestSource
     public function getShortDescription(): string
     {
         return $this->getSource();
+    }
+
+    public function setLastHTTPCode(?int $lastHTTPCode): ExternalContestSource
+    {
+        $this->lastHTTPCode = $lastHTTPCode;
+        return $this;
+    }
+
+    public function getLastHTTPCode(): ?int
+    {
+        return $this->lastHTTPCode;
     }
 
     #[Assert\Callback]

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -394,7 +394,7 @@ class DOMJudgeService
                     ->select('ecs.extsourceid', 'ecs.lastPollTime')
                     ->from(ExternalContestSource::class, 'ecs')
                     ->andWhere('ecs.contest = :contest')
-                    ->andWhere('ecs.lastPollTime < :i OR ecs.lastPollTime is NULL')
+                    ->andWhere('ecs.lastPollTime < :i OR ecs.lastPollTime is NULL OR ecs.lastHTTPCode != 200')
                     ->setParameter('contest', $contest)
                     ->setParameter('i', time() - $this->config->get('external_contest_source_critical'))
                     ->getQuery()->getOneOrNullResult();

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -308,11 +308,14 @@ class ExternalContestSourceService
                 $fullUrl .= '&since_token=' . $this->getLastReadEventId();
             }
             $response = $this->httpClient->request('GET', $fullUrl, ['buffer' => false]);
-            if ($response->getStatusCode() !== 200) {
+            $statusCode = $response->getStatusCode();
+            $this->source->setLastHTTPCode($statusCode);
+            $this->em->flush();
+            if ($statusCode !== 200) {
                 $this->logger->warning(
                     'Received non-200 response code %d, waiting for five seconds ' .
                     'and trying again. Press ^C to quit.',
-                    [$response->getStatusCode()]
+                    [$statusCode]
                 );
                 sleep(5);
                 continue;

--- a/webapp/templates/jury/partials/external_contest_info.html.twig
+++ b/webapp/templates/jury/partials/external_contest_info.html.twig
@@ -43,6 +43,8 @@
                 <td>
                     {% if not externalContestSource.lastPollTime %}
                         Event feed reader never checked in.
+                    {% elseif externalContestSource.lastHTTPCode is not same as(200) %}
+                        Received {{ externalContestSource.lastHTTPCode }} HTTP code.
                     {% else %}
                         {{ status }}, last checked in {{ externalContestSource.lastPollTime | printtimediff }}s ago.
                     {% endif %}


### PR DESCRIPTION
To trigger this: create a contest with http://URL// (the double // is important)

~~Currently this does create the internal error but I'm not sure if we should do this, this is not really an internal error as its an external error. The InternalError class doesn't have support for this yet and we have nothing to disable.~~

~~Currently ignoring the error works, resolving keeps on hanging.~~

~~Opening the PR mostly for the discussion. Personally I think having an item under internalError view is nice as it alerts but its also a bit misusing the concept.~~ This will add 1 extra alert in the shadow tab of the menu and mention that we're down.

For the issue see: https://github.com/DOMjudge/domjudge/issues/2117