### PR TITLE
Show unused executables as disabled

### DIFF
--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -181,4 +181,20 @@ class Executable
         unlink($tempzipFile);
         return $zipFileContents;
     }
+
+    /**
+     * @param string[] $configScripts
+     */
+    public function checkUsed(array $configScripts): bool
+    {
+        foreach ($configScripts as $config_script) {
+            if ($this->execid === $config_script) {
+                return true;
+            }
+        }
+        if (count($this->problems_compare) || count($this->problems_run)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/webapp/templates/jury/executables.html.twig
+++ b/webapp/templates/jury/executables.html.twig
@@ -10,9 +10,11 @@
 
 {% block content %}
 
-    <h1>Executables</h1>
+    <h1>Used executables</h1>
+    {{ macros.table(executables_used, table_fields, {'ordering': 'false'}) }}
 
-    {{ macros.table(executables, table_fields, {'ordering': 'false'}) }}
+    <h1>Unused executables</h1>
+    {{ macros.table(executables_unused, table_fields, {'ordering': 'false'}) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/tests/Unit/Controller/Jury/ExecutableControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ExecutableControllerTest.php
@@ -17,7 +17,7 @@ class ExecutableControllerTest extends JuryControllerTestCase
     protected static string  $deleteEntityIdentifier   = 'description';
     protected static string  $getIDFunc                = 'getExecid';
     protected static string  $className                = Executable::class;
-    protected static array   $DOM_elements             = ['h1' => ['Executables']];
+    protected static array   $DOM_elements             = ['h1' => ['Used executables', 'Unused executables']];
     protected static string  $addForm                  = 'executable_upload[';
     protected static array   $addEntitiesShown         = ['type'];
     protected static array   $addEntities              = [];


### PR DESCRIPTION
This splits over 2 tables, it does not mark the executable of languages (labeled as no submit) as disabled (yet).