### PR TITLE
Executables disenabled languages

### DIFF
--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -195,6 +195,11 @@ class Executable
         if (count($this->problems_compare) || count($this->problems_run)) {
             return true;
         }
+        foreach ($this->languages as $lang) {
+            if ($lang->getAllowSubmit()) {
+                return true;
+            }
+        }
         return false;
     }
 }


### PR DESCRIPTION
Strictly speaking those are not disabled but not used in the instance. Because someone can still change them I prefer to show them as disabled to keep the interface clean.

![image](https://github.com/DOMjudge/domjudge/assets/14887731/178ce614-144c-4df4-b6ba-1294b46da0b3)
