### PR TITLE
Update ScoreboardMergeCommand

### DIFF
--- a/webapp/templates/public/scoreboard.html.twig
+++ b/webapp/templates/public/scoreboard.html.twig
@@ -7,7 +7,9 @@
         {% if showExternalId(contest) %}
             {% set contestId = contest.externalid %}
         {% endif %}
-        {% set bannerImage = contestId | assetPath('contest') %}
+        {% if contestId %}
+            {% set bannerImage = contestId | assetPath('contest') %}
+        {% endif %}
     {% endif %}
     {% if bannerImage is not defined or not bannerImage %}
         {% set bannerImage = globalBannerAssetPath() %}


### PR DESCRIPTION
Some changes I made:
1. Allow reading from local files directly. It turns out to be more reliable to first download scoreboards from the API and then merge them when servers go down after the contest. (This needs e.g. `- /path/to/scoreboards:/scoreboards` in the `docker-compose.yml` which needs to be added manually.)
2. Do not check that group IDs look like integers -- they can be strings.
3. Match problems by display name instead of ID, since sites differ in whether they use `A` or `problemshortname` as ID.

I also had to disable showing the banner image, but I changed that by commenting it out in the twig. This needs some better fix.

(More comments in the [script in BAPCtools](https://github.com/RagnarGrootKoerkamp/BAPCtools/blob/master/bin/misc/merge_scoreboards.sh) that uses this.)