### PR TITLE
Auto calculate num actions for jury tables.

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -379,7 +379,6 @@ class ContestController extends BaseController
             'upcoming_contest' => $upcomingContest,
             'contests_table' => $contests_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') && !$contest->isLocked() ? 2 : 0,
         ]);
     }
 

--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -116,7 +116,6 @@ class ExecutableController extends BaseController
         return $this->render('jury/executables.html.twig', [
             'executables' => $executables_table,
             'table_fields' => $table_fields,
-            'num_actions' => count($execactions),
             'form' => $form->createView(),
         ]);
     }

--- a/webapp/src/Controller/Jury/JudgehostController.php
+++ b/webapp/src/Controller/Jury/JudgehostController.php
@@ -184,7 +184,6 @@ class JudgehostController extends BaseController
         $data = [
             'judgehosts' => $judgehosts_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
             'all_checked_in_recently' => $all_checked_in_recently,
             'refresh' => [
                 'after' => 5,

--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -146,7 +146,6 @@ class LanguageController extends BaseController
             'enabled_languages' => $enabled_languages,
             'disabled_languages' => $disabled_languages,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
         ]);
     }
 

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -214,7 +214,6 @@ class ProblemController extends BaseController
         $data = [
             'problems' => $problems_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 4 : 2,
         ];
 
         return $this->render('jury/problems.html.twig', $data);

--- a/webapp/src/Controller/Jury/TeamAffiliationController.php
+++ b/webapp/src/Controller/Jury/TeamAffiliationController.php
@@ -143,7 +143,6 @@ class TeamAffiliationController extends BaseController
         return $this->render('jury/team_affiliations.html.twig', [
             'team_affiliations' => $team_affiliations_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
         ]);
     }
 

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -127,7 +127,6 @@ class TeamCategoryController extends BaseController
         return $this->render('jury/team_categories.html.twig', [
             'team_categories' => $team_categories_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
         ]);
     }
 

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -239,7 +239,6 @@ class TeamController extends BaseController
         return $this->render('jury/teams.html.twig', [
             'teams' => $teams_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 3 : 1,
         ]);
     }
 

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -184,7 +184,6 @@ class UserController extends BaseController
         return $this->render('jury/users.html.twig', [
             'users' => $users_table,
             'table_fields' => $table_fields,
-            'num_actions' => $this->isGranted('ROLE_ADMIN') ? 2 : 0,
         ]);
     }
 

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -128,6 +128,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('printWarningContent', [$this, 'printWarningContent'], ['is_safe' => ['html']]),
             new TwigFilter('entityIdBadge', [$this, 'entityIdBadge'], ['is_safe' => ['html']]),
             new TwigFilter('medalType', [$this->awards, 'medalType']),
+            new TwigFilter('numTableActions', [$this, 'numTableActions']),
         ];
     }
 
@@ -1206,5 +1207,14 @@ EOF;
             'id' => $propertyAccessor->getValue($entity, $primaryKeyColumn),
             'externalId' => $externalIdField ? $propertyAccessor->getValue($entity, $externalIdField) : null,
         ]);
+    }
+
+    public function numTableActions(array $tableData): int
+    {
+        $maxNumActions = 0;
+        foreach ($tableData as $item) {
+            $maxNumActions = max($maxNumActions, count($item['actions'] ?? []));
+        }
+        return $maxNumActions;
     }
 }

--- a/webapp/templates/jury/contests.html.twig
+++ b/webapp/templates/jury/contests.html.twig
@@ -87,7 +87,7 @@
 
     <h3>All available contests</h3>
 
-    {{ macros.table(contests_table, table_fields, num_actions) }}
+    {{ macros.table(contests_table, table_fields) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/templates/jury/executables.html.twig
+++ b/webapp/templates/jury/executables.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Executables</h1>
 
-    {{ macros.table(executables, table_fields, num_actions, {'ordering': 'false'}) }}
+    {{ macros.table(executables, table_fields, {'ordering': 'false'}) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -85,12 +85,13 @@
     </style>
 {% endmacro %}
 
-{% macro table(data, fields, num_actions, options) %}
+{% macro table(data, fields, options) %}
 
     <div class="table-wrapper">
         <table class="data-table table table-sm table-striped" style="width:auto">
             <thead class="">
             <tr>
+                {%- set num_actions = data | numTableActions %}
                 {%- set default_sort = 0 %}
                 {%- set default_sort_order = 'asc' %}
                 {%- for key,column in fields %}

--- a/webapp/templates/jury/languages.html.twig
+++ b/webapp/templates/jury/languages.html.twig
@@ -12,14 +12,14 @@
 
     <h1>Enabled languages</h1>
 
-    {{ macros.table(enabled_languages, table_fields, num_actions) }}
+    {{ macros.table(enabled_languages, table_fields) }}
 
     <br/>
     <br/>
 
     <h1>Disabled languages</h1>
 
-    {{ macros.table(disabled_languages, table_fields, num_actions) }}
+    {{ macros.table(disabled_languages, table_fields) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/templates/jury/partials/judgehost_list.html.twig
+++ b/webapp/templates/jury/partials/judgehost_list.html.twig
@@ -1,2 +1,2 @@
 {% import "jury/jury_macros.twig" as macros %}
-{{ macros.table(judgehosts, table_fields, num_actions, {ordering: 'false'}) }}
+{{ macros.table(judgehosts, table_fields, {ordering: 'false'}) }}

--- a/webapp/templates/jury/problems.html.twig
+++ b/webapp/templates/jury/problems.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Problems</h1>
 
-    {{ macros.table(problems, table_fields, num_actions) }}
+    {{ macros.table(problems, table_fields) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/templates/jury/team_affiliations.html.twig
+++ b/webapp/templates/jury/team_affiliations.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Affiliations</h1>
 
-    {{ macros.table(team_affiliations, table_fields, num_actions) }}
+    {{ macros.table(team_affiliations, table_fields) }}
 
     {%- if is_granted('ROLE_ADMIN') %}
 

--- a/webapp/templates/jury/team_categories.html.twig
+++ b/webapp/templates/jury/team_categories.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Categories</h1>
 
-    {{ macros.table(team_categories, table_fields, num_actions) }}
+    {{ macros.table(team_categories, table_fields) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/templates/jury/teams.html.twig
+++ b/webapp/templates/jury/teams.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Teams</h1>
 
-    {{ macros.table(teams, table_fields, num_actions) }}
+    {{ macros.table(teams, table_fields) }}
 
     {%- if is_granted('ROLE_ADMIN') %}
 

--- a/webapp/templates/jury/users.html.twig
+++ b/webapp/templates/jury/users.html.twig
@@ -12,7 +12,7 @@
 
     <h1>Users</h1>
 
-    {{ macros.table(users, table_fields, num_actions) }}
+    {{ macros.table(users, table_fields) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>


### PR DESCRIPTION
ContestController is broken in 8.2.1. (https://github.com/DOMjudge/domjudge/issues/2160)

This PR cherry-picks [1294b6e](https://github.com/DOMjudge/domjudge/blob/1294b6e/webapp/src/Controller/Jury/ContestController.php).