### PR TITLE
Check if category exists using externalid instead of name in TeamCategoryFixture

### DIFF
--- a/webapp/src/DataFixtures/DefaultData/TeamCategoryFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/TeamCategoryFixture.php
@@ -23,7 +23,7 @@ class TeamCategoryFixture extends AbstractDefaultDataFixture
         ];
 
         foreach ($data as $item) {
-            if (!($category = $manager->getRepository(TeamCategory::class)->findOneBy(['name' => $item[0]]))) {
+            if (!($category = $manager->getRepository(TeamCategory::class)->findOneBy(['externalid' => $item[4]]))) {
                 $category = (new TeamCategory())
                     ->setName($item[0])
                     ->setSortorder($item[1])


### PR DESCRIPTION
Attempts to fix #2165 