### PR TITLE
Allow reimport of contest & contest problems

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -322,18 +322,19 @@ class ImportExportService
         foreach ($problems as $problemData) {
             // Deal with obsolete attribute names. Also for name fall back to ID if it is not specified.
             $problemName  = $problemData['name'] ?? $problemData['short-name'] ?? $problemData['id'] ?? null;
+            $problemExternal = $problemData['id'] ?? $problemData['short-name'] ?? $problemLabel ?? null;
             $problemLabel = $problemData['label'] ?? $problemData['letter'] ?? null;
 
-            $problem = new Problem();
+            $problem = $this->em->getRepository(Problem::class)->findOneBy(['externalid' => $problemName]) ?: new Problem();
             $problem
                 ->setName($problemName)
                 ->setTimelimit($problemData['time_limit'] ?? 10)
-                ->setExternalid($problemData['id'] ?? $problemData['short-name'] ?? $problemLabel ?? null);
+                ->setExternalid($problemExternal);
 
             $this->em->persist($problem);
             $this->em->flush();
 
-            $contestProblem = new ContestProblem();
+            $contestProblem = $this->em->getRepository(ContestProblem::class)->findOneBy(['shortname' => $problemLabel, 'problem' => $problem, 'contest' => $contest]) ?: new ContestProblem();
             $contestProblem
                 ->setShortname($problemLabel)
                 ->setColor($problemData['rgb'] ?? $problemData['color'] ?? null)

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -200,14 +200,15 @@ class ImportExportService
             return false;
         }
 
-        $contest = new Contest();
+        $newShortNameAndExternalId = preg_replace(
+                $invalid_regex,
+                '_',
+                $data['short_name'] ?? $data['shortname'] ?? $data['short-name'] ?? $data['id']
+            );
+        $contest = $this->em->getRepository(Contest::class)->findOneBy(['externalid' => $newShortNameAndExternalId]) ?: new Contest();
         $contest
             ->setName($data['name'] ?? $data['formal_name'] )
-            ->setShortname(preg_replace(
-                               $invalid_regex,
-                               '_',
-                               $data['short_name'] ?? $data['shortname'] ?? $data['short-name'] ?? $data['id']
-                           ))
+            ->setShortname($newShortNameAndExternalId)
             ->setExternalid($contest->getShortname())
             ->setWarningMessage($data['warning_message'] ?? $data['warning-message'] ?? null)
             ->setStarttimeString(date_format($startTime, 'Y-m-d H:i:s e'))


### PR DESCRIPTION
This would allow having 2 contests with the same problems which is useful for the BAPC prelims where one DOMjudge instance hosts multiple contests for different locations (not to be confused with ICPC sites).

In the past the import-contest script would receive an 500 as we don't properly check if a problem with that name already exists.

This should make the import-contest idempotent.