### PR TITLE
Shadow create submission during freeze

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1504,16 +1504,6 @@ class ExternalContestSourceService
                 $this->addOrUpdateWarning($eventId, $entityType, $data['id'], ExternalSourceWarning::TYPE_SUBMISSION_ERROR, [
                     'message' => 'Cannot add submission: ' . $message,
                 ]);
-                // Clean up the temporary submission files.
-                foreach ($filesToSubmit as $file) {
-                    unlink($file->getRealPath());
-                }
-                if (isset($zip)) {
-                    $zip->close();
-                }
-                if ($shouldUnlink) {
-                    unlink($zipFile);
-                }
                 return;
             }
 

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1488,6 +1488,18 @@ class ExternalContestSourceService
                 message: $message,
                 forceImportInvalid: !$submissionDownloadSucceeded
             );
+            // Clean up the ZIP.
+            if (isset($zip)) {
+                $zip->close();
+            }
+            if ($shouldUnlink) {
+                unlink($zipFile);
+            }
+
+            // Clean up the temporary submission files.
+            foreach ($filesToSubmit as $file) {
+                unlink($file->getRealPath());
+            }
             if (!$submission) {
                 $this->addOrUpdateWarning($eventId, $entityType, $data['id'], ExternalSourceWarning::TYPE_SUBMISSION_ERROR, [
                     'message' => 'Cannot add submission: ' . $message,
@@ -1505,18 +1517,6 @@ class ExternalContestSourceService
                 return;
             }
 
-            // Clean up the ZIP.
-            if (isset($zip)) {
-                $zip->close();
-            }
-            if ($shouldUnlink) {
-                unlink($zipFile);
-            }
-
-            // Clean up the temporary submission files.
-            foreach ($filesToSubmit as $file) {
-                unlink($file->getRealPath());
-            }
         }
 
         if ($submissionDownloadSucceeded) {

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1314,6 +1314,7 @@ class ExternalContestSourceService
         }
 
         $submissionDownloadSucceeded = true;
+        $shouldUnlink = false;
 
         // If the submission is found, we can only update the valid status.
         // If any of the other fields are different, this is an error.
@@ -1395,7 +1396,6 @@ class ExternalContestSourceService
                 if (file_exists($zipUrl)) {
                     // Yes, use it directly
                     $zipFile      = $zipUrl;
-                    $shouldUnlink = false;
                 } else {
                     // No, download the ZIP file.
                     $shouldUnlink = true;


### PR DESCRIPTION
Still create submission even if the URL to the file is not given. Useful if you use DOMjudge mainly as scoreboard after an eventfeed and not as a shadowing system.

In the past we would not create the submissions because the link was missing, as the earlier intent was to always create submssions even if we can't download the submission_file (yet) this is still in line with earlier code.