### PR TITLE
Handle kotlinc symbolic link for determining KOTLIN_DIR

### DIFF
--- a/sql/files/defaultdata/kt/run
+++ b/sql/files/defaultdata/kt/run
@@ -19,7 +19,7 @@ COMPILESCRIPTDIR="$(dirname "$0")"
 # Note that you then also might want to fix this in the compiler and runner version commands.
 # For example
 # KOTLIN_DIR=/usr/lib/kotlinc/bin
-KOTLIN_DIR="$(dirname "$(command -v kotlinc)")"
+KOTLIN_DIR="$(dirname "$(realpath "$(command -v kotlinc)")")"
 
 # Stack size in the JVM in KB. Note that this will be deducted from
 # the total memory made available for the heap.


### PR DESCRIPTION
The `KOTLIN_DIR` variable needs to point to the **compiler binary directory** containing the `kotlinc` binary; because, latter in the script, `KOTLIN_DIR` is used to point to the `kotlin-stdlib.jar`; sometimes `kotlinc` would be just a symbolic link residing in a directory included in the `PATH` environment variable.

It is possible to manually set the `KOTLIN_DIR` variable; but, with this change, unzipping the Kotlin installation and creating a symbolic link would suffice; see https://github.com/DOMjudge/domjudge-packaging/issues/156.