### PR TITLE
API: Allow setting external id for User entity

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -329,6 +329,7 @@ class UserController extends AbstractRestController
             ->setName($request->request->get('name'))
             ->setEmail($request->request->get('email'))
             ->setIpAddress($request->request->get('ip'))
+            ->SetExternalid($request->request->get('id'))
             ->setPlainPassword($request->request->get('password'))
             ->setEnabled($request->request->getBoolean('enabled', true));
 


### PR DESCRIPTION
This will fix #2186 when using `data_source=1`. I am not sure how this will affect the API for other modes.