### PR TITLE
Clics jury overview

### DIFF
--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -51,7 +51,7 @@ class ImportEventFeedCommand extends Command
         $this
             ->setHelp(
                 'Import contest data from an event feed following the Contest API specification:' . PHP_EOL .
-                'https://ccs-specs.icpc.io/2021-11/contest_api' . PHP_EOL . PHP_EOL .
+                'https://ccs-specs.icpc.io/2023-06/contest_api or any version starting from "2021-11"' . PHP_EOL . PHP_EOL .
                 'Note the following assumptions and caveats:' . PHP_EOL .
                 '- Configuration data will only be verified.' . PHP_EOL .
                 '- Team members will not be imported.' . PHP_EOL .

--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\Controller\API\GeneralInfoController as GI;
 use App\Entity\Contest;
 use App\Entity\ExternalContestSource;
 use App\Entity\User;
@@ -51,7 +52,7 @@ class ImportEventFeedCommand extends Command
         $this
             ->setHelp(
                 'Import contest data from an event feed following the Contest API specification:' . PHP_EOL .
-                'https://ccs-specs.icpc.io/2023-06/contest_api or any version starting from "2021-11"' . PHP_EOL . PHP_EOL .
+                GI::CCS_SPEC_API_URL . ' or any version starting from "2021-11"' . PHP_EOL . PHP_EOL .
                 'Note the following assumptions and caveats:' . PHP_EOL .
                 '- Configuration data will only be verified.' . PHP_EOL .
                 '- Team members will not be imported.' . PHP_EOL .

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Jury;
 
+use App\Controller\API\GeneralInfoController as GI;
 use App\Controller\BaseController;
 use App\Entity\Contest;
 use App\Entity\Judging;
@@ -45,6 +46,7 @@ class JuryMiscController extends BaseController
     {
         return $this->render('jury/index.html.twig', [
             'adminer_enabled' => $config->get('adminer_enabled'),
+            'CCS_SPEC_API_URL' => GI::CCS_SPEC_API_URL,
         ]);
     }
 

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -106,7 +106,7 @@
         <li><a href="{{ asset('doc/manual/html/index.html') }}">DOMjudge manual</a></li>
         <li><a href="{{ asset('doc/manual/domjudge-team-manual.pdf') }}">Team manual <i class="fas fa-file-pdf"></i></a></li>
         <li><a href="{{ path('app.swagger_ui') }}">API documentation</a><br />
-            See also the <a href="https://ccs-specs.icpc.io/2021-11/contest_api">ICPC Contest API</a>.</li>
+            See also the <a href="{{ CCS_SPEC_API_URL }}">ICPC Contest API</a>.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
I didn't update the docs etc so the mention of 2021-11 is still everywhere in the code annotations and admin manual.

What is our policy on this? Do we keep on supporting all versions or will we keep the last 2 versions used at a final (so for now 2021-11 & 2022-06) and next year (2022-06 & 2023-07)?

Closes https://github.com/DOMjudge/domjudge/issues/2195
