### PR TITLE
Allow selfregistration property for groups via API

### DIFF
--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -81,7 +81,7 @@ class TeamCategory extends BaseApiEntity implements Stringable
         'comment' => 'Are self-registered teams allowed to choose this category?',
         'default' => 0,
     ])]
-    #[Serializer\Exclude]
+    #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
     private bool $allow_self_registration = false;
 
     /**

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -595,7 +595,8 @@ class ImportExportService
             $line = Utils::parseTsvLine(trim($line));
             $groupData[] = [
                 'categoryid' => @$line[0],
-                'name' => @$line[1]
+                'name' => @$line[1],
+                'allow_self_registration' => false,
             ];
         }
 
@@ -618,6 +619,7 @@ class ImportExportService
                 'visible' => !($group['hidden'] ?? false),
                 'sortorder' => @$group['sortorder'],
                 'color' => @$group['color'],
+                'allow_self_registration' => $group['allow_self_registration'] ?? false,
             ];
         }
 
@@ -661,6 +663,7 @@ class ImportExportService
                 ->setSortorder($groupItem['sortorder'] ?? 0)
                 ->setColor($groupItem['color'] ?? null)
                 ->setIcpcid($groupItem['icpc_id'] ?? null);
+            $teamCategory->setAllowSelfRegistration($groupItem['allow_self_registration']);
             $this->em->flush();
             $this->dj->auditlog('team_category', $teamCategory->getCategoryid(), 'replaced',
                                              'imported from tsv / json');

--- a/webapp/tests/Unit/Controller/API/GroupControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GroupControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Unit\Controller\API;
 
+use Generator;
+
 class GroupControllerTest extends BaseTestCase
 {
     protected ?string $apiEndpoint = 'groups';
@@ -33,25 +35,34 @@ class GroupControllerTest extends BaseTestCase
         ]
     ];
 
-    protected array $newGroupPostData = [
-        'name' => 'newGroup',
-        'icpc_id' => 'icpc100',
-        'hidden' => false,
-        'sortorder' => 1,
-        'color' => '#0077B3'
+    protected array $newGroupsPostData = [
+        ['name' => 'newGroup',
+         'icpc_id' => 'icpc100',
+         'hidden' => false,
+         'sortorder' => 1,
+         'color' => '#0077B3'],
+        ['name' => 'newSelfRegister',
+         'hidden' => false,
+         'sortorder' => 2,
+         'color' => 'red',
+         'allow_self_registration' => true],
     ];
+    protected array $restrictedProperties = ['hidden', 'allow_self_registration'];
 
     // We test explicitly for groups 1 and 5 here, which are hidden groups and
     // should not be returned for non-admin users.
     protected array $expectedAbsent = ['4242', 'nonexistent', '1', '5'];
 
-    public function testNewAddedGroup(): void
+    /**
+     * @dataProvider provideNewAddedGroup
+     */
+    public function testNewAddedGroup(array $newGroupPostData): void
     {
         $url = $this->helperGetEndpointURL($this->apiEndpoint);
         $objectsBeforeTest = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
 
-        $returnedObject = $this->verifyApiJsonResponse('POST', $url, 201, 'admin', $this->newGroupPostData);
-        foreach ($this->newGroupPostData as $key => $value) {
+        $returnedObject = $this->verifyApiJsonResponse('POST', $url, 201, 'admin', $newGroupPostData);
+        foreach ($newGroupPostData as $key => $value) {
             self::assertEquals($value, $returnedObject[$key]);
         }
 
@@ -59,7 +70,7 @@ class GroupControllerTest extends BaseTestCase
         $newItems = array_map('unserialize', array_diff(array_map('serialize', $objectsAfterTest), array_map('serialize', $objectsBeforeTest)));
         self::assertEquals(1, count($newItems));
         $listKey = array_keys($newItems)[0];
-        foreach ($this->newGroupPostData as $key => $value) {
+        foreach ($newGroupPostData as $key => $value) {
             self::assertEquals($value, $newItems[$listKey][$key]);
         }
     }
@@ -67,9 +78,16 @@ class GroupControllerTest extends BaseTestCase
     public function testNewAddedGroupPostWithId(): void
     {
         $url = $this->helperGetEndpointURL($this->apiEndpoint);
-        $postWithId = $this->newGroupPostData;
+        $postWithId = $this->newGroupsPostData[0];
         $postWithId['id'] = '1';
         // CLICS does not allow POST to set the id value
         $this->verifyApiJsonResponse('POST', $url, 400, 'admin', $postWithId);
+    }
+
+    public function provideNewAddedGroup(): Generator
+    {
+        foreach ($this->newGroupsPostData as $group) {
+            yield [$group];
+        }
     }
 }


### PR DESCRIPTION
The intent is that only priviliged users can view the properties but not expose those to the generic users (Teams, Public).

Closes: https://github.com/DOMjudge/domjudge/issues/2188