### PR TITLE
Make button same height as testcase boxes

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -476,7 +476,7 @@
                                     {% elseif selectedJudging.result is not null %}
                                         <form action="{{ path('jury_submission_request_remaining', {'judgingId': selectedJudging.judgingid}) }}" method="post"
                                               style="display: inline; ">
-                                            <input type="submit" class="btn btn-outline-secondary btn-sm" value="judge remaining" />
+                                            <button type="submit" class="btn btn-outline-secondary btn-sm" style="padding: 0.1rem 0.5rem; font-size: 0.7em"><i class="fa-solid fa-gavel"></i> judge remaining</button>
                                         </form>
                                     {% endif %}
                                 {% endif %}


### PR DESCRIPTION
After:
![image](https://github.com/DOMjudge/domjudge/assets/14887731/f85dc6ef-add7-4353-b406-ea23019ccb2f)

Before:
![image](https://github.com/DOMjudge/domjudge/assets/14887731/ea6ca95d-a812-4a2b-8d3a-6a7c42ebe6ae)

Alternative is to move the button next to the `claim` button.

Closes: https://github.com/DOMjudge/domjudge/issues/2193