### PR TITLE
Address current failing sphinx packages for development

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -48,6 +48,17 @@ On Debian 11 (Bullseye) and above, instead install::
     python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
     latexmk texlive-latex-recommended texlive-latex-extra tex-gyre
 
+On Debian 12 (Bullseye) and derived versions, install::
+
+  sudo apt install autoconf automake bats \
+    fontconfig python3-yaml latexmk texlive-latex-recommended \
+    texlive-latex-extra tex-gyre python3-venv
+
+and create a virtual environment to install these packages currently failing in the
+default repositories::
+
+  pip3 install sphinx sphinx-rtd-theme rst2pdf
+
 When this software is present, bootstrapping can be done by running
 ``make dist``, which creates the ``configure`` script,
 downloads and installs the PHP dependencies via composer and


### PR DESCRIPTION
We do generate the docs already before so the virtualenv is not that problematic. I will investigate if we can do something else so we don't need this but for now this is the best we can do.

This does block releasing though (although this also exists in the older releases) as a dependency for us is broken.

Closes: https://github.com/DOMjudge/domjudge/issues/2199