### PR TITLE
This unbreaks our teammanual generation

### DIFF
--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -148,8 +148,6 @@ latex_elements = {
 \definecolor{noteBgColor}{rgb}{1,0,1}
 
 \definecolor{sphinxnoteBgColor}{RGB}{221,233,239}
-\renewenvironment{sphinxnote}[1]
-{\begin{sphinxheavybox}\sphinxstrong{#1} }{\end{sphinxheavybox}}
 
 \usepackage{fancyhdr}
 \pagestyle{fancy}


### PR DESCRIPTION
Removing this seems to also remove the background color for the summary. We should investigate what was the goal of the LaTeX change and how we can reproduce it.

Also https://github.com/rst2pdf/rst2pdf/pull/846 is now merged and released so we can remove a warning about the bool/str.

Closes: https://github.com/DOMjudge/domjudge/issues/2199