### PR TITLE
Allow setting external contest source with contest.yaml

### DIFF
--- a/doc/manual/shadow.rst
+++ b/doc/manual/shadow.rst
@@ -54,6 +54,20 @@ In the DOMjudge admin interface, go to the *External Contest Sources* page and
 create an external contest source. Select the contest to import into and enter
 the source you want to import from.
 
+Another alternative is to use these DOMjudge only keys in the `contest.yaml`::
+
+  shadow:
+    type: contest-api
+    source: http(s)://url_to_external_system/api/contests/<contest_id>
+    username: user_in_external_system
+    password: password_for_user
+
+or::
+
+  shadow:
+    type: contest-archive
+    source: /path/on/domjudge/filestem/to/clics/compliant/archive
+
 Running the event feed import command
 -------------------------------------
 

--- a/webapp/src/Entity/ExternalContestSource.php
+++ b/webapp/src/Entity/ExternalContestSource.php
@@ -99,7 +99,7 @@ class ExternalContestSource
 
     public function setSource(string $source): ExternalContestSource
     {
-        if (str_ends_with($source, '/')) {
+        while (str_ends_with($source, '/')) {
             $source = substr($source, 0, -1);
         }
         $this->source = $source;


### PR DESCRIPTION
This makes it easier to setup the analyst instance during the finals.

I've done it so that we only overwrite the fields if explicit set so it is possible to remove the password from the contest and not remove it when someone updates the contest again to alter the time for example.

Closes: https://github.com/DOMjudge/domjudge/issues/2179