### PR TITLE
Check if a problem actually is used in contests when exporting

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -247,7 +247,7 @@ class ProblemController extends BaseController
             ->getOneOrNullResult();
 
         /** @var ContestProblem|null $contestProblem */
-        $contestProblem = $problem->getContestProblems()->first();
+        $contestProblem = $problem->getContestProblems()->first() ?: null;
 
         // Build up INI data.
         $iniData = [


### PR DESCRIPTION
Probably there is a cleaner solution, but I think this does touch the underlying problem.