### PR TITLE
LGTM has stopped, is now incorporated in Github CodeQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DOMjudge
 --------
 [![pipeline status](https://gitlab.com/DOMjudge/domjudge/badges/main/pipeline.svg)](https://gitlab.com/DOMjudge/domjudge/commits/main)
 [![Coverity Scan Status](https://img.shields.io/coverity/scan/671.svg)](https://scan.coverity.com/projects/domjudge)
-[![LGTM alerts](https://img.shields.io/lgtm/alerts/g/DOMjudge/domjudge.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/DOMjudge/domjudge/alerts/)
+[![CodeQL alerts](https://github.com/DOMjudge/domjudge/actions/workflows/codeql-analysis.yml/badge.svg?branch=main&event=push)](https://github.com/DOMjudge/domjudge/actions/workflows/codeql-analysis.yml)
 
 This is the Programming Contest Jury System "DOMjudge" version 8.3.0DEV
 


### PR DESCRIPTION
Should we also add badges for the supported versions, if people actually look at those badges they might prefer to know the version they run is reasonable error free.