### PR TITLE
Disallow extensions with dots, Extension filter checks full extension

### DIFF
--- a/webapp/migrations/Version20231120225210.php
+++ b/webapp/migrations/Version20231120225210.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231120225210 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove leading dots from extensions in the `language` table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $languages = $this->connection->fetchAllAssociative('SELECT langid, extensions FROM language');
+
+        foreach ($languages as $language) {
+            $extensions = json_decode($language['extensions'], true);
+
+            $updated = false;
+            foreach ($extensions as &$extension) {
+                if (strpos($extension, '.') === 0) {
+                    $extension = ltrim($extension, '.');
+                    $updated = true;
+                }
+            }
+
+            if ($updated) {
+                $newExtensionsJson = json_encode($extensions);
+                $this->connection->executeQuery('UPDATE language SET extensions = :extensions WHERE langid = :langid', [
+                    'extensions' => $newExtensionsJson,
+                    'langid' => $language['langid'],
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // This migration is not reversible
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -53,6 +53,12 @@ class Language extends BaseApiEntity
         options: ['comment' => 'List of recognized extensions (JSON encoded)']
     )]
     #[Assert\NotBlank]
+    #[Assert\All([
+        new Assert\Regex([
+            'pattern' => '/^[^.]/',
+            'message' => 'The extension should not start with a dot.'
+        ])
+    ])]
     #[Serializer\Type('array<string>')]
     private array $extensions = [];
 

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -530,8 +530,9 @@ class SubmissionService
             if ($source !== 'shadowing' && $language->getFilterCompilerFiles()) {
                 $matchesExtension = false;
                 foreach ($language->getExtensions() as $extension) {
-                    $extensionLength = strlen($extension);
-                    if (substr($file->getClientOriginalName(), -$extensionLength) === $extension) {
+                    $extensionWithDot = '.' . ltrim($extension, '.');
+                    $extensionLength = strlen($extensionWithDot);
+                    if (substr($file->getClientOriginalName(), -$extensionLength) === $extensionWithDot) {
                         $matchesExtension = true;
                         break;
                     }

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -530,9 +530,7 @@ class SubmissionService
             if ($source !== 'shadowing' && $language->getFilterCompilerFiles()) {
                 $matchesExtension = false;
                 foreach ($language->getExtensions() as $extension) {
-                    $extensionWithDot = '.' . $extension;
-                    $extensionLength = strlen($extensionWithDot);
-                    if (substr($file->getClientOriginalName(), -$extensionLength) === $extensionWithDot) {
+                    if (str_ends_with($file->getClientOriginalName(), '.' . $extension)) {
                         $matchesExtension = true;
                         break;
                     }

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -530,7 +530,7 @@ class SubmissionService
             if ($source !== 'shadowing' && $language->getFilterCompilerFiles()) {
                 $matchesExtension = false;
                 foreach ($language->getExtensions() as $extension) {
-                    $extensionWithDot = '.' . ltrim($extension, '.');
+                    $extensionWithDot = '.' . $extension;
                     $extensionLength = strlen($extensionWithDot);
                     if (substr($file->getClientOriginalName(), -$extensionLength) === $extensionWithDot) {
                         $matchesExtension = true;

--- a/webapp/templates/jury/partials/language_form.html.twig
+++ b/webapp/templates/jury/partials/language_form.html.twig
@@ -18,7 +18,7 @@
             addExtension($extensionsHolder, $addExtensionButton);
         });
 
-        $extensionsHolder.find('div').each(function() {
+        $extensionsHolder.find('div:not(.invalid-feedback)').each(function() {
             addDeleteLink($(this));
         });
 
@@ -37,8 +37,10 @@
             var $removeFormButton = $('<button type="button" class="btn btn-danger"><i class="fas fa-trash"></i></button>');
             var $inputGroup = $('<div class="input-group"></div>');
             var $formControl = $extensionDiv.find('.form-control');
+            var $feedbackBlock = $extensionDiv.find('.invalid-feedback');
             $inputGroup.append($formControl);
             $inputGroup.append($removeFormButton);
+            $inputGroup.append($feedbackBlock);
             $extensionDiv.html($inputGroup);
 
             $removeFormButton.on('click', function(e) {


### PR DESCRIPTION
# Description

If the option `Filter files passed to compiler by extension list` is enabled for a language, only the filename ending with the extension will be checked. This may work for most languages, but can be annoying for e.g. the C language. Files like `submission.doc` can get through just because they end with a `c`. This is not the intended behavior of this option. Disabling this option allows the team to fully choose the language.

Honestly, I cannot think of any other case except maybe `pyc`. But I still think this is a small oversight in the code.

Fixes #2218.

Tested on my local development instance. The behaviour described in the issue is now as expected and I couldn't produce any other new bugs.

![](https://user-images.githubusercontent.com/18643142/283993505-36ebee31-deec-4880-b8d5-ad40a3efdd7a.png)

## Bug fix

Check the extension including the dot in the extension loop. This forces the file to end with exactly `.c`. The `ltrim` allows the check to complete even if the extensions are accidentally entered with a dot when creating a new language.

## Breaking

If `filterCompilerFiles` is on:
- We now assume that the filename contains a dot. I think this is acceptable since this is a contest control system, and this is the expected behavior when this option is enabled by an admin.
  - Maybe change the `FILENAME_REGEX` to capture this earlier...

