### PR TITLE
Run the command instead of reading a non-existing variable

### DIFF
--- a/example_problems/hello/submissions/run_time_error/test-chroot-escape.sh
+++ b/example_problems/hello/submissions/run_time_error/test-chroot-escape.sh
@@ -5,10 +5,10 @@
 # @EXPECTED_RESULTS@: RUN_TIME_ERROR
 
 ischroot
-if [ ischroot ]; then
+if ischroot; then
     # We expect to be in the jail
     chroot /proc/1/root
-    if [ ischroot ]; then
+    if ischroot; then
         # We expect to still be in the jail
         exit 1
     else


### PR DESCRIPTION
Verified with the variable 'isboom' which doesn't exist, it always returned true. After changing to `if isboom` it would error as that function does not exist, proving that this is the proper fix as ischroot does exist.