### PR TITLE
Change all clarifications in thread

### DIFF
--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -352,7 +352,13 @@ class ClarificationController extends AbstractController
         if ($queue === "") {
             $queue = null;
         }
-        $clarification->setQueue($queue);
+
+        // Either this is the first in a thread (of 1 or more) or this 2nd or more.
+        $curClarification = $clarification->getInReplyTo() ?? $clarification;
+        foreach ($curClarification->getReplies() as $reply) {
+            $reply->setQueue($queue);
+        }
+        $curClarification->setQueue($queue);
         $this->em->flush();
 
         if ($request->isXmlHttpRequest()) {


### PR DESCRIPTION
By always finding the first in thread and changing the replies afterwards. Verified that this also works via the overview clarification page.

Partial fix for: https://github.com/DOMjudge/domjudge/issues/1785