### PR TITLE
Fix order of judgings on submission page.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -217,8 +217,7 @@ class SubmissionController extends BaseController
             ->setParameter('contest', $submission->getContest())
             ->setParameter('submission', $submission)
             ->groupBy('j.judgingid')
-            ->orderBy('j.starttime')
-            ->addOrderBy('j.judgingid')
+            ->orderBy('j.judgingid')
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
Found while looking at #2191, see this comment:
https://github.com/DOMjudge/domjudge/issues/2191#issuecomment-1824185818

Previously, we treated the start time as higher priority indicator than the judgingId for sorting the rows. For submissions that are queued we don't have a starttime yet, so they show up first.

Now, the order is purely by judgingid. For one specific submission, the starttime of judgings should always be in order of their judgingid so this change should be a no-op otherwise.