### PR TITLE
Fix message in judgehost cleanup.

### DIFF
--- a/misc-tools/dj_judgehost_cleanup.in
+++ b/misc-tools/dj_judgehost_cleanup.in
@@ -85,9 +85,9 @@ cleanup_judgings() {
         [ -d "$d" ] || continue
         cd "$d"
         echo "  in $d:"
-        find . -maxdepth 1 -type d -regex '\./[0-9]+' | while IFS= read -r contest; do
-            echo "    removing judging data for contest $contest"
-            rm -rf "${contest:?}/"
+        find . -maxdepth 1 -type d -regex '\./[0-9]+' | while IFS= read -r submission; do
+            echo "    removing judging data for submission s${submission#./}"
+            rm -rf "${submission:?}/"
         done
         cd - >/dev/null
     done


### PR DESCRIPTION
This is likely incorrect for historical reasons since we changed the directory structure.

Previous output:
```
Cleaning up judging data...
  in goo-0/endpoint-default:
    removing judging data for contest ./100
...
```

New output:
```
Cleaning up judging data...
  in goo-0/endpoint-default:
    removing judging data for submission s100
...
```