### PR TITLE
Improve y-axis of the submission graph format.

### DIFF
--- a/webapp/templates/jury/partials/submission_graph.html.twig
+++ b/webapp/templates/jury/partials/submission_graph.html.twig
@@ -32,13 +32,14 @@
         'output-limit':   'black',
     } %}
     function create_chart(data, maxY) {
-        var tickStep = 1;
+        var tickStep = Math.floor(maxY/5);
         if (maxY <= 2) {
             tickStep = 0.2;
         } else if (maxY <= 5) {
             tickStep = 0.5;
         }
         maxY += tickStep;
+        maxY = Math.floor(maxY/tickStep) * tickStep;
         var chart = nv.models.multiBarChart()
             .x(function (d) {
                 return d.label
@@ -58,7 +59,12 @@
         }
         chart.yAxis
             .tickValues(tickValues)
-            .axisLabel('Runtime (in s)');
+            .axisLabel('Runtime');
+        if (tickStep >= 1) {
+            chart.yAxis.tickFormat(function(d) { return d3.format(',f')(d) + 's' });
+        } else {
+            chart.yAxis.tickFormat(function(d) { return d3.format(',.1f')(d) + 's' });
+        }
         return chart;
     }
 


### PR DESCRIPTION
Found when looking at https://github.com/DOMjudge/domjudge/issues/2191

This changes the following things:
- Reduce amount of ticks for submissions with high runtimes
- Use integer ticks when higher precision only clutters the y-axis
- Add `s` to the labels to clearly indicate the unit

Examples:
![image](https://github.com/DOMjudge/domjudge/assets/418721/832490b4-f268-4359-b6ef-726c37f03857)

![image](https://github.com/DOMjudge/domjudge/assets/418721/295582b8-991e-4b93-999f-6373e74cd8d9)
