### PR TITLE
Clean up message handling after importing a zipped problem.

### DIFF
--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -164,7 +164,7 @@ class ImportExportController extends BaseController
                     $this->dj->auditlog('problem', $newProblem->getProbid(), 'upload zip',
                         $clientName);
                 } else {
-                    $this->addFlash('danger', implode("\n", $allMessages));
+                    $this->postMessages($allMessages);
                     return $this->redirectToRoute('jury_problems');
                 }
             } catch (Exception $e) {
@@ -174,12 +174,7 @@ class ImportExportController extends BaseController
                     $zip->close();
                 }
             }
-
-            foreach (['info', 'warning', 'danger'] as $type) {
-                if (!empty($allMessages[$type])) {
-                    $this->addFlash($type, implode("\n", $allMessages[$type]));
-                }
-            }
+            $this->postMessages($allMessages);
 
             if ($newProblem !== null) {
                 return $this->redirectToRoute('jury_problem', ['probId' => $newProblem->getProbid()]);
@@ -560,5 +555,17 @@ class ImportExportController extends BaseController
             'contest' => $contest,
             'problems' => $contestProblems,
         ]);
+    }
+
+    /**
+     * @param array<string, string[]> $allMessages
+     */
+    private function postMessages(array $allMessages): void
+    {
+        foreach (['info', 'warning', 'danger'] as $type) {
+            if (!empty($allMessages[$type])) {
+                $this->addFlash($type, implode("\n", $allMessages[$type]));
+            }
+        }
     }
 }

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -922,12 +922,7 @@ class ProblemController extends BaseController
                     $zip->close();
                 }
             }
-
-            foreach (['info', 'warning', 'danger'] as $type) {
-                if (!empty($messages[$type])) {
-                    $this->addFlash($type, implode("\n", $messages[$type]));
-                }
-            }
+            $this->postMessages($messages);
 
             return $this->redirectToRoute('jury_problem', ['probId' => $problem->getProbid()]);
         }
@@ -1101,5 +1096,17 @@ class ProblemController extends BaseController
                           ->getResult();
         $this->judgeRemaining($judgings);
         return $this->redirectToRoute('jury_problem', ['probId' => $probId]);
+    }
+
+    /**
+     * @param array<string, string[]> $allMessages
+     */
+    private function postMessages(array $allMessages): void
+    {
+        foreach (['info', 'warning', 'danger'] as $type) {
+            if (!empty($allMessages[$type])) {
+                $this->addFlash($type, implode("\n", $allMessages[$type]));
+            }
+        }
     }
 }


### PR DESCRIPTION
Nowadays, the messages is a keyed array with the keys being the warning level. Previously, it was a flat data structure and apparently we didn't clean up all of them.

There is still a code duplication between the two controller, but moving this to the Utils class is ugly because it would require passing in the controller.