### PR TITLE
Use static::assert* everywhere to be consistent.

### DIFF
--- a/webapp/tests/Unit/Command/ResetUserPasswordCommandTest.php
+++ b/webapp/tests/Unit/Command/ResetUserPasswordCommandTest.php
@@ -58,7 +58,7 @@ class ResetUserPasswordCommandTest extends BaseTestCase
 
         // the output of the command in the console
         $output = $this->commandTester->getDisplay();
-        $this->assertStringContainsString('[OK] New password for '.$user.' is', $output);
+        static::assertStringContainsString('[OK] New password for '.$user.' is', $output);
         $newPassword = explode(' ', $output)[$passwordPosition];
         $this->apiRequest($defaultPassword, 401);
         $this->apiRequest($newPassword, 200);
@@ -95,7 +95,7 @@ class ResetUserPasswordCommandTest extends BaseTestCase
             'Command should fail with missing parameters.'
         );
         $output = $this->commandTester->getDisplay();
-        $this->assertStringContainsString('[ERROR] Can not find user with username '.$user, $output);
+        static::assertStringContainsString('[ERROR] Can not find user with username '.$user, $output);
     }
 
     public function testMissingUserParameter(): void
@@ -106,7 +106,7 @@ class ResetUserPasswordCommandTest extends BaseTestCase
         } catch (RuntimeException $e) {
             $output = $e->getMessage();
         }
-        $this->assertStringContainsString('Not enough arguments (missing: "username").', $output);
+        static::assertStringContainsString('Not enough arguments (missing: "username").', $output);
     }
 
     public function testNonUsedParameter(): void
@@ -118,7 +118,7 @@ class ResetUserPasswordCommandTest extends BaseTestCase
         } catch (InvalidArgumentException $e) {
             $output = $e->getMessage();
         }
-        $this->assertStringContainsString('The "Username" argument does not exist.', $output);
+        static::assertStringContainsString('The "Username" argument does not exist.', $output);
     }
 
     public function testGetHelp(): void
@@ -134,7 +134,7 @@ class ResetUserPasswordCommandTest extends BaseTestCase
                   'Options:',
                   'Display help for the given command. When no command is given display help for the list command'];
         foreach ($check as $message) {
-            $this->assertStringContainsString($message, $output);
+            static::assertStringContainsString($message, $output);
         }
     }
 }

--- a/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
@@ -59,14 +59,14 @@ class ClarificationControllerTest extends BaseTestCase
         $apiEndpoint = $this->apiEndpoint;
         $clarificationFromApi = $this->verifyApiJsonResponse('GET', "/contests/$contestId/$apiEndpoint", 200);
 
-        $this->assertCount(1, $clarificationFromApi);
-        $this->assertEquals("Lunch is served", $clarificationFromApi[0]['text']);
-        $this->assertEquals("2018-02-11T21:53:20.000+00:00", $clarificationFromApi[0]['time']);
-        $this->assertArrayNotHasKey('answered', $clarificationFromApi[0]);
+        static::assertCount(1, $clarificationFromApi);
+        static::assertEquals("Lunch is served", $clarificationFromApi[0]['text']);
+        static::assertEquals("2018-02-11T21:53:20.000+00:00", $clarificationFromApi[0]['time']);
+        static::assertArrayNotHasKey('answered', $clarificationFromApi[0]);
 
         // Show that when filtering this does not show up as its not bound to a problem
         $clarificationFromApi = $this->verifyApiJsonResponse('GET', "/contests/$contestId/$apiEndpoint?problem=1", 200);
-        $this->assertCount(0, $clarificationFromApi);
+        static::assertCount(0, $clarificationFromApi);
     }
 
     public function testTeamOnlyGeneralAndRelatedToTeam(): void
@@ -85,24 +85,24 @@ class ClarificationControllerTest extends BaseTestCase
                 $mistakJudgingId = 2;
             }
             $clarificationFromApi = $this->verifyApiJsonResponse('GET', $clarificationApi.$postfix, 200, 'demo');
-            $this->assertCount($expectedNumber, $clarificationFromApi);
+            static::assertCount($expectedNumber, $clarificationFromApi);
 
-            $this->assertEquals("2", $clarificationFromApi[0]['from_team_id']);
-            $this->assertEquals("Is it necessary to read the problem statement carefully?", $clarificationFromApi[0]['text']);
-            $this->assertArrayNotHasKey('answered', $clarificationFromApi[0]);
+            static::assertEquals("2", $clarificationFromApi[0]['from_team_id']);
+            static::assertEquals("Is it necessary to read the problem statement carefully?", $clarificationFromApi[0]['text']);
+            static::assertArrayNotHasKey('answered', $clarificationFromApi[0]);
 
             if (!$problemId) {
-                $this->assertNull($clarificationFromApi[1]['to_team_id']);
-                $this->assertEquals("Lunch is served", $clarificationFromApi[1]['text']);
-                $this->assertArrayNotHasKey('answered', $clarificationFromApi[1]);
+                static::assertNull($clarificationFromApi[1]['to_team_id']);
+                static::assertEquals("Lunch is served", $clarificationFromApi[1]['text']);
+                static::assertArrayNotHasKey('answered', $clarificationFromApi[1]);
             }
 
-            $this->assertEquals("2", $clarificationFromApi[$mistakJudgingId]['to_team_id']);
-            $this->assertEquals("There was a mistake in judging this problem. Please try again", $clarificationFromApi[$mistakJudgingId]['text']);
-            $this->assertArrayNotHasKey('answered', $clarificationFromApi[$mistakJudgingId]);
+            static::assertEquals("2", $clarificationFromApi[$mistakJudgingId]['to_team_id']);
+            static::assertEquals("There was a mistake in judging this problem. Please try again", $clarificationFromApi[$mistakJudgingId]['text']);
+            static::assertArrayNotHasKey('answered', $clarificationFromApi[$mistakJudgingId]);
         }
         $clarificationFromApi = $this->verifyApiJsonResponse('GET', $clarificationApi."?problem=9999", 200, 'demo');
-        $this->assertCount(0, $clarificationFromApi);
+        static::assertCount(0, $clarificationFromApi);
     }
 
     /**

--- a/webapp/tests/Unit/Controller/Jury/ConfigControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ConfigControllerTest.php
@@ -49,7 +49,7 @@ class ConfigControllerTest extends BaseTestCase
                 $this->verifyPageResponse('GET', '/jury/config', 200);
                 $crawler = $this->getCurrentCrawler();
                 $minutes = $crawler->filter('input#config_penalty_time')->extract(['value']);
-                $this->assertEquals("30", $minutes[0]);
+                static::assertEquals("30", $minutes[0]);
             });
     }
 }

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -86,7 +86,7 @@ class ImportExportControllerTest extends BaseTestCase
         $this->loadFixtures([DemoPreStartContestFixture::class]);
         $this->verifyPageResponse('GET', '/jury/import-export', 200);
         $this->client->submitForm('contest_export_export', ['contest_export[contest]'=>$cid]);
-        $this->assertEquals($expectedYaml, $this->client->getInternalResponse()->getContent());
+        static::assertEquals($expectedYaml, $this->client->getInternalResponse()->getContent());
     }
 
     public function provideContestYamlContents(): Generator
@@ -142,7 +142,7 @@ HEREDOC;
         $link = $this->getCurrentCrawler()->filter($linkname)->link();
         $this->client->click($link);
 
-        $this->assertEquals($expectedData, $this->client->getInternalResponse()->getContent());
+        static::assertEquals($expectedData, $this->client->getInternalResponse()->getContent());
     }
 
     public function provideTsvContents(): Generator

--- a/webapp/tests/Unit/Controller/Jury/PrintControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/PrintControllerTest.php
@@ -37,7 +37,7 @@ class PrintControllerTest extends BaseTestCase
         $this->withChangedConfiguration('print_command', static::PRINT_COMMAND,
             function () {
                 $this->verifyPageResponse('GET', '/jury', 200);
-                $this->assertSelectorExists('a:contains("Print")');
+                static::assertSelectorExists('a:contains("Print")');
             });
     }
 
@@ -58,12 +58,12 @@ class PrintControllerTest extends BaseTestCase
                     'print[langid]' => 'csharp',
                 ]);
 
-                $this->assertSelectorTextContains('div.alert.alert-success',
+                static::assertSelectorTextContains('div.alert.alert-success',
                     'File has been printed');
 
                 $text = trim($crawler->filter('pre')->text(null, false));
-                $this->assertStringStartsWith('csharp', $text);
-                $this->assertStringEndsWith(
+                static::assertStringStartsWith('csharp', $text);
+                static::assertStringEndsWith(
                     trim(file_get_contents($testFile)), $text);
             });
     }

--- a/webapp/tests/Unit/Controller/Jury/RejudgingControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/RejudgingControllerTest.php
@@ -111,7 +111,7 @@ class RejudgingControllerTest extends BaseTestCase
         $jsonResponse = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
         /** @var array $rejudgings */
         $rejudgings = $jsonResponse['rejudgings'];
-        $this->assertEquals($todo, count($rejudgings));
+        static::assertEquals($todo, count($rejudgings));
     }
 
     public function provideShownRejudgings(): Generator

--- a/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
+++ b/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
@@ -85,7 +85,7 @@ class MiscControllerTest extends BaseTestCase
         $this->withChangedConfiguration('print_command', self::PRINT_COMMAND,
             function () {
                 $this->verifyPageResponse('GET', '/team', 200);
-                $this->assertSelectorExists('a:contains("Print")');
+                static::assertSelectorExists('a:contains("Print")');
             });
     }
 
@@ -106,12 +106,12 @@ class MiscControllerTest extends BaseTestCase
                     'print[langid]' => 'kt',
                 ]);
 
-                $this->assertSelectorTextContains('div.alert.alert-success',
+                static::assertSelectorTextContains('div.alert.alert-success',
                     'File has been printed');
 
                 $text = trim($crawler->filter('pre')->text(null, false));
-                $this->assertStringStartsWith('kt', $text);
-                $this->assertStringEndsWith(
+                static::assertStringStartsWith('kt', $text);
+                static::assertStringEndsWith(
                     trim(file_get_contents($testFile)), $text);
             });
     }

--- a/webapp/tests/Unit/Controller/Team/ProblemControllerTest.php
+++ b/webapp/tests/Unit/Controller/Team/ProblemControllerTest.php
@@ -57,27 +57,27 @@ class ProblemControllerTest extends BaseTestCase
                 $crawler = $this->client->request('GET', '/team/problems');
 
                 // Check that the correct menu item is selected.
-                $this->assertSelectorTextContains('.nav-item .nav-link.active',
+                static::assertSelectorTextContains('.nav-item .nav-link.active',
                     'Problemset');
 
                 // Get the card bodies and verify we have exactly three of them.
                 $cardBodies = $crawler->filter('.card-body');
-                $this->assertSame(3, $cardBodies->count());
+                static::assertSame(3, $cardBodies->count());
 
                 for ($i = 0; $i < 3; $i++) {
                     $card = $cardBodies->eq($i);
-                    $this->assertSame($letters[$i],
+                    static::assertSame($letters[$i],
                         $card->filter('.card-title')->text(null, true));
-                    $this->assertSame($descriptions[$i],
+                    static::assertSame($descriptions[$i],
                         $card->filter('h3.card-subtitle')->text(null, true));
 
                     if ($withLimits) {
-                        $this->assertSame(
+                        static::assertSame(
                             'Limits: 5 seconds / 2 GB',
                             $card->filter('h4.card-subtitle')->text(null, true)
                         );
                     } else {
-                        $this->assertSame(0,
+                        static::assertSame(0,
                             $card->filter('h4.card-subtitle')->count());
                     }
 
@@ -85,7 +85,7 @@ class ProblemControllerTest extends BaseTestCase
                     $problemTextLink = $card->selectLink('text');
                     $this->client->click($problemTextLink->link());
 
-                    $this->assertSame($problemTexts[$i], $this->client->getInternalResponse()->getContent());
+                    static::assertSame($problemTexts[$i], $this->client->getInternalResponse()->getContent());
                 }
             });
     }

--- a/webapp/tests/Unit/Entity/ClarificationTest.php
+++ b/webapp/tests/Unit/Entity/ClarificationTest.php
@@ -15,7 +15,7 @@ class ClarificationTest extends TestCase
 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.';
         $clarification->setBody($text);
-        $this->assertEquals('Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod …',
+        static::assertEquals('Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod …',
             $clarification->getSummary());
     }
 
@@ -24,7 +24,7 @@ tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.';
         $clarification = new Clarification();
         $text = 'Is this a quick question?';
         $clarification->setBody($text);
-        $this->assertEquals($text . ' ', $clarification->getSummary());
+        static::assertEquals($text . ' ', $clarification->getSummary());
     }
 
     public function testIgnoreQuotedText(): void
@@ -35,7 +35,7 @@ tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.';
 
 You bet.';
         $clarification->setBody($text);
-        $this->assertEquals('You bet. ', $clarification->getSummary());
+        static::assertEquals('You bet. ', $clarification->getSummary());
     }
 
     public function testMergeNewlines(): void
@@ -52,7 +52,7 @@ seventh line,
 eighth line,
 and so on.';
         $clarification->setBody($text);
-        $this->assertEquals('First line, second line, third line, fourth line, fifth line, sixth line, sevent…',
+        static::assertEquals('First line, second line, third line, fourth line, fifth line, sixth line, sevent…',
             $clarification->getSummary());
     }
 }

--- a/webapp/tests/Unit/Entity/ContestTest.php
+++ b/webapp/tests/Unit/Entity/ContestTest.php
@@ -13,23 +13,23 @@ class ContestTest extends TestCase
         $contest = new Contest();
         $contest->setStarttime(42);
 
-        $this->assertEquals(null, $contest->getAbsoluteTime(null));
+        static::assertEquals(null, $contest->getAbsoluteTime(null));
 
-        $this->assertEquals(1672585200, $contest->getAbsoluteTime('2023-01-01 16:00:00 Europe/Amsterdam'));
-        $this->assertEquals(1672624800, $contest->getAbsoluteTime('2023-01-01 16:00:00 Pacific/Honolulu'));
+        static::assertEquals(1672585200, $contest->getAbsoluteTime('2023-01-01 16:00:00 Europe/Amsterdam'));
+        static::assertEquals(1672624800, $contest->getAbsoluteTime('2023-01-01 16:00:00 Pacific/Honolulu'));
 
-        $this->assertEquals(42, $contest->getAbsoluteTime("-00:00"));
-        $this->assertEquals(42, $contest->getAbsoluteTime("+00:00"));
-        $this->assertEquals(42+4*3600, $contest->getAbsoluteTime("+4:00"));
-        $this->assertEquals(42-23*60, $contest->getAbsoluteTime("-0:23"));
+        static::assertEquals(42, $contest->getAbsoluteTime("-00:00"));
+        static::assertEquals(42, $contest->getAbsoluteTime("+00:00"));
+        static::assertEquals(42+4*3600, $contest->getAbsoluteTime("+4:00"));
+        static::assertEquals(42-23*60, $contest->getAbsoluteTime("-0:23"));
 
-        $this->assertEquals(42-((34*60) + 56.789), $contest->getAbsoluteTime("-0:34:56.789"));
-        $this->assertEquals(42+(1*3600)+(47*60)+11, $contest->getAbsoluteTime("+1:47:11"));
+        static::assertEquals(42-((34*60) + 56.789), $contest->getAbsoluteTime("-0:34:56.789"));
+        static::assertEquals(42+(1*3600)+(47*60)+11, $contest->getAbsoluteTime("+1:47:11"));
         $removedInterval = new RemovedInterval();
         $removedInterval
             ->setStarttime(111)
             ->setEndtime(555);
         $contest->addRemovedInterval($removedInterval);
-        $this->assertEquals(42+(1*3600)+(47*60)+11 + 444, $contest->getAbsoluteTime("+1:47:11"));
+        static::assertEquals(42+(1*3600)+(47*60)+11 + 444, $contest->getAbsoluteTime("+1:47:11"));
     }
 }

--- a/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
@@ -183,8 +183,8 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         foreach ([ false, true ] as $jury) {
             $scoreboard = $this->ss->getScoreboard($this->contest, $jury);
-            $this->assertScoresMatch($expected_scores, $scoreboard);
-            $this->assertFTSMatch([], $scoreboard);
+            static::assertScoresMatch($expected_scores, $scoreboard);
+            static::assertFTSMatch([], $scoreboard);
         }
     }
 
@@ -207,8 +207,8 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         foreach ([ false, true ] as $jury) {
             $scoreboard = $this->ss->getScoreboard($this->contest, $jury);
-            $this->assertScoresMatch($expected_scores, $scoreboard);
-            $this->assertFTSMatch($expected_fts, $scoreboard);
+            static::assertScoresMatch($expected_scores, $scoreboard);
+            static::assertFTSMatch($expected_fts, $scoreboard);
         }
     }
 
@@ -234,8 +234,8 @@ class ScoreboardIntegrationTest extends KernelTestCase
             $this->recalcScoreCaches();
 
             $scoreboard = $this->ss->getScoreboard($this->contest, true);
-            $this->assertScoresMatch($expected_scores, $scoreboard);
-            $this->assertFTSMatch($expected_fts, $scoreboard);
+            static::assertScoresMatch($expected_scores, $scoreboard);
+            static::assertFTSMatch($expected_fts, $scoreboard);
         }
     }
 
@@ -257,8 +257,8 @@ class ScoreboardIntegrationTest extends KernelTestCase
         ];
 
         $scoreboard = $this->ss->getScoreboard($this->contest, false);
-        $this->assertScoresMatch($expected_scores, $scoreboard);
-        $this->assertFTSMatch($expected_fts, $scoreboard);
+        static::assertScoresMatch($expected_scores, $scoreboard);
+        static::assertFTSMatch($expected_fts, $scoreboard);
     }
 
     public function testScoreboardReproducible(): void
@@ -272,7 +272,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
         $second = $this->ss->getScoreboard($this->contest, false);
 
         # Using assertSame would be better, but doesn't work with objects.
-        $this->assertEquals($first, $second, 'Repeated scoreboard is equal');
+        static::assertEquals($first, $second, 'Repeated scoreboard is equal');
     }
 
     public function testTeamScoreboardFreezeFTS(): void
@@ -291,8 +291,8 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         $scoreboard = $this->ss->getTeamScoreboard($this->contest, $team->getTeamid(), false);
 
-        $this->assertInstanceOf(SingleTeamScoreboard::class, $scoreboard);
-        $this->assertFTSMatch($expected_fts, $scoreboard);
+        static::assertInstanceOf(SingleTeamScoreboard::class, $scoreboard);
+        static::assertFTSMatch($expected_fts, $scoreboard);
     }
 
     public function testOneSingleFTS(): void
@@ -323,7 +323,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
                 $this->recalcScoreCaches();
 
                 $scoreboard = $this->ss->getScoreboard($this->contest, $jury);
-                $this->assertFTSMatch($expected_fts, $scoreboard);
+                static::assertFTSMatch($expected_fts, $scoreboard);
             }
         }
     }
@@ -359,7 +359,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
                 $this->recalcScoreCaches();
 
                 $scoreboard = $this->ss->getScoreboard($this->contest, $jury);
-                $this->assertFTSMatch($expected_fts, $scoreboard);
+                static::assertFTSMatch($expected_fts, $scoreboard);
             }
         }
     }
@@ -386,7 +386,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
 
         foreach ([ false, true ] as $jury) {
             $scoreboard = $this->ss->getScoreboard($this->contest, $jury);
-            $this->assertFTSMatch($expected_fts, $scoreboard);
+            static::assertFTSMatch($expected_fts, $scoreboard);
         }
     }
 
@@ -399,11 +399,11 @@ class ScoreboardIntegrationTest extends KernelTestCase
             $name = $team->getEffectiveName();
 
             $score = $scores[$team->getTeamid()];
-            $this->assertInstanceOf(TeamScore::class, $score);
+            static::assertInstanceOf(TeamScore::class, $score);
 
-            $this->assertEquals($row['rank'], $score->rank, "Rank for '$name'");
-            $this->assertEquals($row['solved'], $score->numPoints, "# solved for '$name'");
-            $this->assertEquals($row['time'], $score->totalTime, "Total time for '$name'");
+            static::assertEquals($row['rank'], $score->rank, "Rank for '$name'");
+            static::assertEquals($row['solved'], $score->numPoints, "# solved for '$name'");
+            static::assertEquals($row['time'], $score->totalTime, "Total time for '$name'");
         }
     }
 
@@ -429,10 +429,10 @@ class ScoreboardIntegrationTest extends KernelTestCase
             foreach ($row as $probid => $item) {
                 $probname = $probs[$probid]->getShortname();
 
-                $this->assertInstanceOf(ScoreboardMatrixItem::class, $item);
+                static::assertInstanceOf(ScoreboardMatrixItem::class, $item);
 
                 $expected = (@$fts_probid2teamid[$probid] === $teamid);
-                $this->assertEquals($expected, $item->isFirst,
+                static::assertEquals($expected, $item->isFirst,
                                     "Check FTS matches for team $teamname, problem $probname");
             }
         }


### PR DESCRIPTION
As discussed onsite: PHPUnit says you can use either but we prefer `static::` since it IS a static method.