### PR TITLE
Store compiler/runner version history.

### DIFF
--- a/webapp/migrations/Version20231124122006.php
+++ b/webapp/migrations/Version20231124122006.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231124122006 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Store a history of versions, instead of just the most recent one.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE version ADD active TINYINT(1) DEFAULT 1 NOT NULL COMMENT \'True if this version is active for this judgehost/language combination.\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE version DROP active');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/Jury/VersionController.php
+++ b/webapp/src/Controller/Jury/VersionController.php
@@ -24,7 +24,7 @@ class VersionController extends BaseController
         $languages = $this->em->createQueryBuilder()
             ->select('l', 'v', 'jh')
             ->from(Language::class, 'l')
-            ->leftJoin('l.versions', 'v')
+            ->leftJoin('l.versions', 'v', 'WITH', 'v.active = 1')
             ->leftJoin('v.judgehost', 'jh')
             ->andWhere('l.allowSubmit = 1')
             ->getQuery()->getResult();

--- a/webapp/src/Entity/Version.php
+++ b/webapp/src/Entity/Version.php
@@ -52,6 +52,13 @@ class Version
     #[Serializer\Exclude]
     private string|float|null $lastChangedTime = null;
 
+    #[ORM\Column(options: [
+        'comment' => 'True if this version is active for this judgehost/language combination.',
+        'default' => 1,
+    ])]
+    #[Serializer\Exclude]
+    private bool $active = true;
+
     public function getVersionid(): ?int
     {
         return $this->versionid;
@@ -131,6 +138,17 @@ class Version
     public function setLastChangedTime(float|string|null $lastChangedTime): Version
     {
         $this->lastChangedTime = $lastChangedTime;
+        return $this;
+    }
+
+    public function getActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): Version
+    {
+        $this->active = $active;
         return $this;
     }
 }


### PR DESCRIPTION
Previously, we only stored the most recent one per language/judgehost combination. This new format will allow us (in separate changes) to cross-reference in judgings and warn if they have not been using the canonical one.

Progress on https://github.com/DOMjudge/domjudge/issues/1241