### PR TITLE
Split the problem text content from the problem in the database.

### DIFF
--- a/webapp/migrations/Version20231124133426.php
+++ b/webapp/migrations/Version20231124133426.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231124133426 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Split problem text content from problem';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE problem_text_content (probid INT UNSIGNED NOT NULL COMMENT \'Problem ID\', content LONGBLOB NOT NULL COMMENT \'Text content(DC2Type:blobtext)\', PRIMARY KEY(probid)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'Stores contents of problem texts\' ');
+        $this->addSql('INSERT INTO problem_text_content (probid, content) SELECT probid, problemtext FROM problem');
+        $this->addSql('ALTER TABLE problem_text_content ADD CONSTRAINT FK_21B6AD6BEF049279 FOREIGN KEY (probid) REFERENCES problem (probid) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE problem DROP problemtext');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE problem ADD problemtext LONGBLOB DEFAULT NULL COMMENT \'Problem text in HTML/PDF/ASCII\'');
+        $this->addSql('UPDATE problem INNER JOIN problem_text_content USING (probid) SET problem.problemtext = problem_text_content.content');
+        $this->addSql('ALTER TABLE problem_text_content DROP FOREIGN KEY FK_21B6AD6BEF049279');
+        $this->addSql('DROP TABLE problem_text_content');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/ProblemController.php
+++ b/webapp/src/Controller/API/ProblemController.php
@@ -414,7 +414,8 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
     public function statementAction(Request $request, string $id): Response
     {
         $queryBuilder = $this->getQueryBuilder($request)
-            ->addSelect('partial p.{probid,problemtext}')
+            ->leftJoin('p.problemTextContent', 'content')
+            ->addSelect('content')
             ->setParameter('id', $id)
             ->andWhere(sprintf('%s = :id', $this->getIdField()));
 
@@ -448,7 +449,7 @@ class ProblemController extends AbstractRestController implements QueryObjectTra
             ->from(ContestProblem::class, 'cp')
             ->join('cp.problem', 'p')
             ->leftJoin('p.testcases', 'tc')
-            ->select('cp, partial p.{probid,externalid,name,timelimit,memlimit,problemtext_type}, COUNT(tc.testcaseid) AS testdatacount')
+            ->select('cp, p, COUNT(tc.testcaseid) AS testdatacount')
             ->andWhere('cp.contest = :cid')
             ->andWhere('cp.allowSubmit = 1')
             ->setParameter('cid', $contestId)

--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -242,7 +242,7 @@ class ClarificationController extends AbstractController
         /** @var ContestProblem[] $contestproblems */
         $contestproblems = $this->em->createQueryBuilder()
             ->from(ContestProblem::class, 'cp')
-            ->select('cp, partial p.{probid,externalid,name}')
+            ->select('cp, p')
             ->innerJoin('cp.problem', 'p')
             ->where('cp.contest IN (:contests)')
             ->setParameter('contests', $contests)

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -403,7 +403,7 @@ class ContestController extends BaseController
         $problems = $this->em->createQueryBuilder()
             ->from(ContestProblem::class, 'cp')
             ->join('cp.problem', 'p')
-            ->select('cp', 'partial p.{probid,externalid,name,timelimit,memlimit,problemtext_type}')
+            ->select('cp', 'p')
             ->andWhere('cp.contest = :contest')
             ->setParameter('contest', $contest)
             ->orderBy('cp.shortname')

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -62,7 +62,7 @@ class ProblemController extends BaseController
     public function indexAction(): Response
     {
         $problems = $this->em->createQueryBuilder()
-            ->select('partial p.{probid,externalid,name,timelimit,memlimit,outputlimit,problemtext_type}', 'COUNT(tc.testcaseid) AS testdatacount')
+            ->select('p', 'COUNT(tc.testcaseid) AS testdatacount')
             ->from(Problem::class, 'p')
             ->leftJoin('p.testcases', 'tc')
             ->orderBy('p.probid', 'ASC')
@@ -239,7 +239,8 @@ class ProblemController extends BaseController
         $problem = $this->em->createQueryBuilder()
             ->from(Problem::class, 'p')
             ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
-            ->select('p', 'cp')
+            ->leftJoin('p.problemTextContent', 'content')
+            ->select('p', 'cp', 'content')
             ->andWhere('p.probid = :problemId')
             ->setParameter('problemId', $problemId)
             ->setParameter('contest', $this->dj->getCurrentContest())
@@ -295,7 +296,7 @@ class ProblemController extends BaseController
 
         if (!empty($problem->getProblemtext())) {
             $zip->addFromString('problem.' . $problem->getProblemtextType(),
-                                stream_get_contents($problem->getProblemtext()));
+                $problem->getProblemtext());
         }
 
         foreach ([true, false] as $isSample) {

--- a/webapp/src/Entity/ProblemTextContent.php
+++ b/webapp/src/Entity/ProblemTextContent.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(options: [
+    'collation' => 'utf8mb4_unicode_ci',
+    'charset' => 'utf8mb4',
+    'comment' => 'Stores contents of problem texts',
+])]
+class ProblemTextContent
+{
+    /**
+     * We use a ManyToOne instead of a OneToOne here, because otherwise the
+     * reverse of this relation will always be loaded. See the commit message of commit
+     * 9e421f96691ec67ed62767fe465a6d8751edd884 for a more elaborate explanation.
+     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(inversedBy: 'problemTextContent')]
+    #[ORM\JoinColumn(name: 'probid', referencedColumnName: 'probid', onDelete: 'CASCADE')]
+    private Problem $problem;
+
+    #[ORM\Column(type: 'blobtext', options: ['comment' => 'Text content'])]
+    private string $content;
+
+    public function getProblem(): Problem
+    {
+        return $this->problem;
+    }
+
+    public function setProblem(Problem $problem): self
+    {
+        $this->problem = $problem;
+
+        return $this;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+}

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -839,7 +839,8 @@ class DOMJudgeService
             ->innerJoin('c.problems', 'cp')
             ->innerJoin('cp.problem', 'p')
             ->leftJoin('p.attachments', 'a')
-            ->select('c', 'cp', 'p', 'a')
+            ->leftJoin('p.problemTextContent', 'content')
+            ->select('c', 'cp', 'p', 'a', 'content')
             ->andWhere('c.cid = :cid')
             ->setParameter('cid', $contest->getCid())
             ->getQuery()
@@ -861,7 +862,7 @@ class DOMJudgeService
 
             if ($problem->getProblem()->getProblemtextType()) {
                 $filename    = sprintf('%s/statement.%s', $problem->getShortname(), $problem->getProblem()->getProblemtextType());
-                $zip->addFromString($filename, stream_get_contents($problem->getProblem()->getProblemtext()));
+                $zip->addFromString($filename, $problem->getProblem()->getProblemtext());
             }
 
             /** @var ProblemAttachment $attachment */
@@ -972,7 +973,7 @@ class DOMJudgeService
                 ->join('cp.problem', 'p')
                 ->leftJoin('p.testcases', 'tc')
                 ->leftJoin('p.attachments', 'a')
-                ->select('partial p.{probid,name,externalid,problemtext_type,timelimit,memlimit,combined_run_compare}', 'cp', 'a')
+                ->select('p', 'cp', 'a')
                 ->andWhere('cp.contest = :contest')
                 ->andWhere('cp.allowSubmit = 1')
                 ->setParameter('contest', $contest)

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -9,6 +9,7 @@ use App\Entity\Language;
 use App\Entity\Problem;
 use App\Entity\ProblemAttachment;
 use App\Entity\ProblemAttachmentContent;
+use App\Entity\ProblemTextContent;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Entity\Testcase;
@@ -207,7 +208,7 @@ class ImportProblemService
                 ->setCombinedRunCompare(false)
                 ->setMemlimit(null)
                 ->setOutputlimit(null)
-                ->setProblemtext(null)
+                ->setProblemTextContent(null)
                 ->setProblemtextType(null);
 
             $contestProblem
@@ -311,8 +312,10 @@ class ImportProblemService
                 $filename = sprintf('%sproblem.%s', $dir, $type);
                 $text     = $zip->getFromName($filename);
                 if ($text !== false) {
+                    $content = (new ProblemTextContent())
+                        ->setContent($text);
                     $problem
-                        ->setProblemtext($text)
+                        ->setProblemTextContent($content)
                         ->setProblemtextType($type);
                     $messages['info'][] = "Added/updated problem statement from: $filename";
                     break 2;

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -1001,7 +1001,7 @@ class ScoreboardService
     {
         $queryBuilder = $this->em->createQueryBuilder()
             ->from(ContestProblem::class, 'cp')
-            ->select('cp, partial p.{probid,externalid,name,problemtext_type}')
+            ->select('cp, p')
             ->innerJoin('cp.problem', 'p')
             ->andWhere('cp.allowSubmit = 1')
             ->andWhere('cp.contest = :contest')

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -232,7 +232,7 @@ class StatisticsService
         //   - The submission was made by a team in a visible category
         /** @var Judging[] $judgings */
         $judgings = $this->em->createQueryBuilder()
-            ->select('j, jr', 's', 'team', 'partial p.{timelimit,name,probid}')
+            ->select('j, jr', 's', 'team', 'p')
             ->from(Judging::class, 'j')
             ->join('j.submission', 's')
             ->join('s.problem', 'p')


### PR DESCRIPTION
This is to prepare for the next Doctrine release, which [doesn't allow partial queries anymore](https://www.doctrine-project.org/projects/doctrine-orm/en/2.17/reference/partial-objects.html). This is also to make it consistent with other blobs in the database like submission files and problem attachments.

This is preparation for #2069 where I will do a similar thing.

Besides this there is one more partial query, which I will remove in a separate PR.

I know changing database stuff just for the ORM is not something to do lightly, but I don't think we have any better way. And this actually improves queries in the places where we used partial queries before IMHO.