### PR TITLE
In analysis controller, allow opening tabs in the background.

### DIFF
--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -25,8 +25,12 @@
 </style>
 <script>
 $(function() {
-    $(".clickable-row").click(function() {
-        window.location = $(this).data("href");
+    $(".clickable-row").click(function(e) {
+        if (e.ctrlKey) {
+            window.open($(this).data("href"), '_blank');
+        } else {
+            window.location = $(this).data("href");
+        }
     });
     $('[data-bs-toggle="popover"]').popover({
       trigger: 'hover',


### PR DESCRIPTION
This is useful when the jury wants to look at all problem stats after import, and it was unnecessarily prevented by our use of JS to make the whole row clickable.