### PR TITLE
Add green success message if the expected result matches.

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -59,6 +59,10 @@
                     {% if not loop.last %}or{% endif %}
                 {% endfor %}.
             </div>
+        {% else %}
+            <div class="alert alert-success">
+                Actual result matches the expected result ({{ selectedJudging.result | printValidJuryResult }}).
+            </div>
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
This is useful, if after problem import you have a mix of submissions with and without expected result and you want to be able to distinguish them, e.g. when going from the statistics page to the submission.

![image](https://github.com/DOMjudge/domjudge/assets/418721/b3362845-2423-4a75-a2be-fc3dc69f29c7)
