### PR TITLE
Write logs for production to webapp/var/log/prod.log instead of stderr.

### DIFF
--- a/webapp/config/packages/monolog.yaml
+++ b/webapp/config/packages/monolog.yaml
@@ -60,9 +60,8 @@ when@prod:
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
                 type: stream
-                path: php://stderr
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
-                formatter: monolog.formatter.json
             console:
                 type: console
                 process_psr_3_messages: false


### PR DESCRIPTION
This got changed when we upgraded Symfony. My guess is that they did this because it makes sense when you run this as a container or something, but even for our Docker's I think it's better to write it to a file.