### PR TITLE
Remove display of output diff to teams.

### DIFF
--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -134,14 +134,6 @@
                                 <p class="nodata">There was no program output.</p>
                             {% endif %}
 
-                            <h6 class="mt-3">Diff output</h6>
-                            {% if run.output_diff is not empty %}
-                                <pre class="output_text">
-{{ run.output_diff }}</pre>
-                            {% else %}
-                                <p class="nodata">There was no diff output.</p>
-                            {% endif %}
-
                             {% if run.team_message is not empty %}
                                 <h6 class="mt-3">Judge message</h6>
                                 <pre class="output_text">


### PR DESCRIPTION
This was shown when the configuration option to display sample output was selected.
However, there is a risk that this leaks some information to the teams, since this information comes from `judgemessage.txt`.

We still display the content from `teammessage.txt`, in case a validator writes one.