### PR TITLE
Include wall time in judgedaemon log.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1476,8 +1476,9 @@ function judge(array $judgeTask): bool
         $ret = (bool)$needsMoreWork;
     }
 
+    $walltime = $metadata['wall-time'] ?? '?';
     logmsg(LOG_INFO, ' ' . ($result === 'correct' ? " \033[0;32m✔\033[0m" : " \033[1;31m✗\033[0m")
-        . '  ...done in ' . $runtime . 's, result: ' . $result);
+        . '  ...done in ' . $walltime . 's (CPU: ' . $runtime . 's), result: ' . $result);
 
     // done!
     return $ret;


### PR DESCRIPTION
`done in XXXs` sounded like elapsed time / wall time but it actually was the CPU time. For some problems (especially with lots of I/O or interactive problems) the wall time can be quite a bit higher than the CPU time, so it makes sense to display both.

Example:

```
[Nov 26 08:08:16.437] judgedaemon[22453]: ⇝ Received 1 'judging_run' judge tasks (endpoint default)
[Nov 26 08:08:16.437] judgedaemon[22453]:   Working directory: /home/sitowert/domjudge/output/judgings/goo-0/endpoint-default/11/16
[Nov 26 08:08:16.438] judgedaemon[22453]:   🔒 Executing chroot script: 'chroot-startstop.sh start'
[Nov 26 08:08:16.553] judgedaemon[22453]:   📋 Verifying versions.
[Nov 26 08:08:16.976] judgedaemon[22453]:   💻 Compilation: (slow.cpp) 'correct'
[Nov 26 08:08:17.045] judgedaemon[22453]:   🏃 Running testcase 2...
[Nov 26 08:08:28.848] judgedaemon[22453]:   ✔  ...done in 11.739s (CPU: 2.950s), result: correct
[Nov 26 08:08:28.897] judgedaemon[22453]:   🔓 Executing chroot script: 'chroot-startstop.sh stop'
[Nov 26 08:08:28.923] judgedaemon[22453]: No submissions in queue (for endpoint default), waiting...
```