### PR TITLE
Set HTTPS fastcgi param correctly for http

### DIFF
--- a/etc/nginx-conf-inner.in
+++ b/etc/nginx-conf-inner.in
@@ -49,7 +49,7 @@ location @domjudgeFront {
 	fastcgi_param SCRIPT_NAME $prefix/index.php;
 	fastcgi_param REQUEST_URI $prefix$uri?$args;
 	fastcgi_param DOCUMENT_ROOT $domjudgeRoot;
-	fastcgi_param HTTPS $http_x_forwarded_proto if_not_empty;
+	fastcgi_param HTTPS $fastcgi_param_https_variable;
 	# Prevents URIs that include the front controller. This will 404:
 	# http://domain.tld/app_dev.php/some-path
 	internal;
@@ -64,7 +64,7 @@ location @domjudgeFrontApi {
 	fastcgi_param SCRIPT_NAME $prefix/index.php;
 	fastcgi_param REQUEST_URI $prefix$uri?$args;
 	fastcgi_param DOCUMENT_ROOT $domjudgeRoot;
-	fastcgi_param HTTPS $http_x_forwarded_proto if_not_empty;
+	fastcgi_param HTTPS $fastcgi_param_https_variable;
 	# Prevents URIs that include the front controller. This will 404:
 	# http://domain.tld/app_dev.php/some-path
 	internal;


### PR DESCRIPTION
Traefik also sets the 'X-Forwarded-Proto' header with regular HTTP traffic. As the 'HTTP' value is not empty, the 'HTTPS' fastcgi parameter was set and requests were incorrectly upgraded to 'HTTPS'.

Fixes #2177 