### PR TITLE
Use printMetadata also for judging metadata

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -377,15 +377,8 @@ class SubmissionController extends BaseController
                 }
                 $runs[] = $runResult[0];
                 unset($runResult[0]);
-                if (empty($runResult['metadata'])) {
-                    $runResult['cpu_time'] = $firstJudgingRun === null ? 'n/a' : $firstJudgingRun->getRuntime();
-                } else {
+                if (!empty($runResult['metadata'])) {
                     $metadata = $this->dj->parseMetadata($runResult['metadata']);
-                    $runResult['cpu_time'] = $metadata['cpu-time'];
-                    $runResult['wall_time'] = $metadata['wall-time'];
-                    $runResult['memory'] = Utils::printsize((int)$metadata['memory-bytes'], 2);
-                    $runResult['exitcode'] = $metadata['exitcode'];
-                    $runResult['signal'] = $metadata['signal'] ?? -1;
                     $runResult['output_limit'] = $metadata['output-truncated'];
                 }
                 $runResult['terminated'] = preg_match('/timelimit exceeded.*hard (wall|cpu) time/',

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1066,16 +1066,14 @@ EOF;
         }
         $metadata = $this->dj->parseMetadata($metadata);
         return '<span style="display:inline; margin-left: 5px;">'
-            . '<i class="fas fa-stopwatch" title="runtime"></i>'
-            . $metadata['cpu-time'] . 's'
-            . ' CPU, '
-            . $metadata['wall-time'] . 's'
-            . ' wall time, '
-            . '<i class="fas fa-memory" title="RAM"></i>'
-            . Utils::printsize((int)($metadata['memory-bytes']))
-            . ', '
-            . '<i class="fas fa-exitcode" title="runtime"></i>'
-            . 'exit-code: ' . $metadata['exitcode'];
+            . '<i class="fas fa-stopwatch" title="runtime"></i> '
+            . $metadata['cpu-time'] . 's CPU, '
+            . $metadata['wall-time'] . 's wall, '
+            . '<i class="fas fa-memory" title="RAM"></i> '
+            . Utils::printsize((int)($metadata['memory-bytes'])) . ', '
+            . '<i class="far fa-question-circle" title="exit-status"></i> '
+            . 'exit-code: ' . $metadata['exitcode']
+            . (($metadata['signal'] ?? -1) > 0 ? ' signal: ' . $metadata['signal'] : '');
     }
 
     public function printWarningContent(ExternalSourceWarning $warning): string

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -712,24 +712,14 @@
                         </span>
                     </div>
                     <div class="card-body">
-                    {% if run.firstJudgingRun is not null and runsOutput[runIdx].cpu_time %}
-                    <span style="display:inline; margin-left: 5px;">
-		        <i class="fas fa-stopwatch" title="runtime"></i>
-                        {{ runsOutput[runIdx].cpu_time }}s
-                        CPU{% if runsOutput[runIdx].metadata is not null %},
-                            {{ runsOutput[runIdx].wall_time }}s wall,
-		            <i class="fas fa-memory" title="RAM"></i>
-                            {{ runsOutput[runIdx].memory }},
-		            <i class="far fa-question-circle" title="exit-code"></i>
-                            exit code:
-                            {{ runsOutput[runIdx].exitcode }}{% if runsOutput[runIdx].signal > 0 %},
-                                signal: {{ runsOutput[runIdx].signal }}
-                            {% endif %}
-                            <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse"
-                                    data-bs-target="#collapseExample-{{ runIdx }}"
-                                    aria-expanded="false">
-                                show complete metadata
-                            </button>
+                    {% if run.firstJudgingRun is not null %}
+                        {{ runsOutput[runIdx].metadata | printMetadata }}
+                        <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse"
+                                data-bs-target="#collapseExample-{{ runIdx }}"
+                                aria-expanded="false">
+                            show complete metadata
+                        </button>
+                        {% if runsOutput[runIdx].metadata is not null %}
                             {% if runsOutput[runIdx].output_limit %}
                                 <div class="alert alert-warning">
                                     The submission output (<code>{{ runsOutput[runIdx].output_limit }}</code>) was


### PR DESCRIPTION
Also fix some small inconsistencies and typo's:
- rename title text 'runtime' to 'exit-status'
- replace non-existing icon fa-exitcode
- tiny tweaks to add missing spaces in output