### PR TITLE
Make results in submission list of rejudgings more clear.

### DIFF
--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -60,10 +60,13 @@
             <th scope="col" colspan="2">team</th>
             <th scope="col">problem</th>
             <th scope="col">lang</th>
+            {%- if rejudging is defined %}
+                <th scope="col">old result</th>
+            {%- endif %}
             {% if showExternalResult and showExternalTestcases %}
-                <th scope="col" colspan="2">result</th>
+                <th scope="col" colspan="2">{%-if rejudging is defined %}new {% endif %}result</th>
             {% else %}
-                <th scope="col">result</th>
+                <th scope="col">{%- if rejudging is defined %}new {% endif %}result</th>
             {% endif %}
             {% if showExternalResult and not showExternalTestcases %}
                 <th scope="col">external result</th>
@@ -72,12 +75,7 @@
                 <th scope="col" class="table-button-head-left">verified</th>
                 <th scope="col" class="table-button-head-right">by</th>
             {% endif %}
-            {%- if rejudging is defined %}
-
-                <th scope="col">old result</th>
-            {%- endif %}
             {%- if showTestcases is defined and showTestcases %}
-
                 <th scope="col" class="not-sortable not-searchable table-button-head-right-right">test results</th>
             {%- endif %}
 
@@ -146,8 +144,16 @@
                         </a>
                     </td>
                 {% endif %}
+                {%- if rejudging is defined %}
+                    <td class="{{ tdExtraClass }}"><a href="{{ path('jury_submission', {submitId: submission.submitid}) }}">
+                            {{ submission.oldResult | printValidJuryResult }}
+                        </a></td>
+                {%- endif %}
                 <td class="{{ tdExtraClass }}">
                     <a href="{{ link }}">
+                        {%- if rejudging is defined %}
+                            ⇝
+                        {% endif %}
                         {{ submission | printValidJurySubmissionResult }}
                     </a>
                 </td>
@@ -211,14 +217,7 @@
                         </td>
                     {% endif %}
                 {% endif %}
-                {%- if rejudging is defined %}
-
-                    <td class="{{ tdExtraClass }}"><a href="{{ path('jury_submission', {submitId: submission.submitid}) }}">
-                            {{ submission.oldResult | printValidJuryResult }}
-                        </a></td>
-                {%- endif %}
                 {%- if showTestcases is defined and showTestcases %}
-
                     <td class="testcase-results{{ tdExtraClass }} table-button-head-right-right">
                         {{- submission | testcaseResults -}}
                     </td>


### PR DESCRIPTION
Example:

Before:
![image](https://github.com/DOMjudge/domjudge/assets/418721/5732e843-5b16-4d75-bac0-47ac12ffbff7)


After:
![image](https://github.com/DOMjudge/domjudge/assets/418721/2ecea74b-0012-498b-8790-e8208a49904e)


