### PR TITLE
Don't run shiftleft on release branches

### DIFF
--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -2,6 +2,9 @@ name: SL Scan
 
 on:
   push:
+    branches-ignore:
+      - main
+      - '[0-9]+.[0-9]+'
 
 jobs:
   Scan-Build:


### PR DESCRIPTION
We require PRs for those branches so this is already checked in the branch before. The job fails on the release branch but worked in the PR so besides misleading this is also redundant.