### PR TITLE
Disable shiftleft CI for now

### DIFF
--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -10,6 +10,9 @@ jobs:
   Scan-Build:
     runs-on: ubuntu-latest
     steps:
+    - name: Disable due to new merge queue
+      run: exit 0
+
     - uses: actions/checkout@v3
 
     - name: Perform Scan


### PR DESCRIPTION
I'll fix this later but currently it breaks main. It is worse to have failing CI compared to having to fix these specific unspot findings in the future after this is fixed.