### PR TITLE
Keep track of potential first to solves so we can update them when we get 'delayed' results.

### DIFF
--- a/webapp/migrations/Version20231229094359.php
+++ b/webapp/migrations/Version20231229094359.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231229094359 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add potential first to solve to scorecache.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache ADD is_potential_first_to_solve TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Is this potentially the first solution to this problem?\' AFTER is_first_to_solve');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache DROP is_potential_first_to_solve');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/DataFixtures/Test/SampleTeamsFixture.php
+++ b/webapp/src/DataFixtures/Test/SampleTeamsFixture.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Team;
+use App\Entity\TeamAffiliation;
+use App\Entity\TeamCategory;
+use Doctrine\Persistence\ObjectManager;
+
+class SampleTeamsFixture extends AbstractTestDataFixture
+{
+    final public const FIRST_TEAM_REFERENCE = 'team1';
+    final public const SECOND_TEAM_REFERENCE = 'team2';
+
+    public function load(ObjectManager $manager): void
+    {
+        $affiliation = $manager->getRepository(TeamAffiliation::class)->findOneBy(['externalid' => 'utrecht']);
+        $category = $manager->getRepository(TeamCategory::class)->findOneBy(['externalid' => 'participants']);
+
+        $team1 = new Team();
+        $team1
+            ->setExternalid('team1')
+            ->setIcpcid('team1')
+            ->setLabel('team1')
+            ->setName('Team 1')
+            ->setAffiliation($affiliation)
+            ->setCategory($category);
+
+        $team2 = new Team();
+        $team2
+            ->setExternalid('team2')
+            ->setIcpcid('team2')
+            ->setLabel('team2')
+            ->setName('Team 2')
+            ->setAffiliation($affiliation)
+            ->setCategory($category);
+
+        $manager->persist($team1);
+        $manager->persist($team2);
+        $manager->flush();
+
+        $this->addReference(self::FIRST_TEAM_REFERENCE, $team1);
+        $this->addReference(self::SECOND_TEAM_REFERENCE, $team2);
+    }
+}

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -94,6 +94,12 @@ class ScoreCache
     ])]
     private bool $is_first_to_solve = false;
 
+    #[ORM\Column(options: [
+        'comment' => 'Is this potentially the first solution to this problem?',
+        'default' => 0,
+    ])]
+    private bool $is_potential_first_to_solve = false;
+
     #[ORM\Id]
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
@@ -228,6 +234,17 @@ class ScoreCache
     public function getIsFirstToSolve() : bool
     {
         return $this->is_first_to_solve;
+    }
+
+    public function setIsPotentialFirstToSolve(bool $isPotentialFirstToSolve): ScoreCache
+    {
+        $this->is_potential_first_to_solve = $isPotentialFirstToSolve;
+        return $this;
+    }
+
+    public function getIsPotentialFirstToSolve() : bool
+    {
+        return $this->is_potential_first_to_solve;
     }
 
     public function setContest(?Contest $contest = null): ScoreCache

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -254,7 +254,8 @@ class ScoreboardService
         Contest $contest,
         Team    $team,
         Problem $problem,
-        bool    $updateRankCache = true
+        bool    $updateRankCache = true,
+        bool    $updatePotentialFirstToSolves = true
     ): void {
         $this->logger->debug(
             "ScoreboardService::calculateScoreRow '%d' '%d' '%d'",
@@ -417,6 +418,7 @@ class ScoreboardService
         // See if this submission was the first to solve this problem.
         // Only relevant if it was correct in the first place.
         $firstToSolve = false;
+        $potentialFirstToSolve = false;
         if ($correctJury) {
             $params = [
                 'cid' => $contest->getCid(),
@@ -437,32 +439,49 @@ class ScoreboardService
             //   - or already judged to be correct (if it is judged but not correct,
             //     it is not a first to solve)
             // - or the submission is still queued for judgement (judgehost is NULL).
-            $verificationRequiredExtra = $verificationRequired ? 'OR j.verified = 0' : '';
+            // If there are no valid correct submissions submitted earlier but there
+            // are submissions awaiting judgement, we are potentially the first to solve.
+            // We need to keep track of this since we later need to set the actual first to solve.
+            $verificationRequiredExtra = ($verificationRequired && !$useExternalJudgements) ? 'OR j.verified = 0' : '';
             if ($useExternalJudgements) {
-                $firstToSolve = 0 == $this->em->getConnection()->fetchOne('
+                $baseQuery = '
                 SELECT count(*) FROM submission s
                     LEFT JOIN external_judgement ej USING (submitid)
                     LEFT JOIN external_judgement ej2 ON ej2.submitid = s.submitid AND ej2.starttime > ej.starttime
                     LEFT JOIN team t USING(teamid)
                     LEFT JOIN team_category tc USING (categoryid)
                 WHERE s.valid = 1 AND
-                    (ej.result IS NULL OR ej.result = :correctResult '.
-                    $verificationRequiredExtra.') AND
                     s.cid = :cid AND s.probid = :probid AND
                     tc.sortorder = :teamSortOrder AND
-                    round(s.submittime,4) < :submitTime', $params);
+                    round(s.submittime,4) < :submitTime';
+                $judgingTable = 'ej';
             } else {
-                $firstToSolve = 0 == $this->em->getConnection()->fetchOne('
+                $baseQuery = '
                 SELECT count(*) FROM submission s
                     LEFT JOIN judging j ON (s.submitid=j.submitid AND j.valid=1)
                     LEFT JOIN team t USING (teamid)
                     LEFT JOIN team_category tc USING (categoryid)
                 WHERE s.valid = 1 AND
-                    (j.judgingid IS NULL OR j.result IS NULL OR j.result = :correctResult '.
-                    $verificationRequiredExtra.') AND
                     s.cid = :cid AND s.probid = :probid AND
                     tc.sortorder = :teamSortOrder AND
-                    round(s.submittime,4) < :submitTime', $params);
+                    round(s.submittime,4) < :submitTime';
+                $judgingTable = 'j';
+            }
+
+            $numEarlierCorrect = $this->em->getConnection()->fetchOne(
+                "$baseQuery AND $judgingTable.result = :correctResult",
+                $params);
+            $numEarlierPending = $this->em->getConnection()->fetchOne(
+                "$baseQuery AND ($judgingTable.result IS NULL $verificationRequiredExtra)",
+                $params);
+
+            if ($numEarlierCorrect == 0) {
+                // This is either a first to solve or potential first to solve
+                if ($numEarlierPending == 0) {
+                    $firstToSolve = true;
+                } else {
+                    $potentialFirstToSolve = true;
+                }
             }
         }
 
@@ -482,13 +501,14 @@ class ScoreboardService
             'runtimePublic' => $runtimePubl === PHP_INT_MAX ? 0 : $runtimePubl,
             'isCorrectPublic' => (int)$correctPubl,
             'isFirstToSolve' => (int)$firstToSolve,
+            'isPotentialFirstToSolve' => (int)$potentialFirstToSolve,
         ];
         $this->em->getConnection()->executeQuery('REPLACE INTO scorecache
             (cid, teamid, probid,
              submissions_restricted, pending_restricted, solvetime_restricted, runtime_restricted, is_correct_restricted,
-             submissions_public, pending_public, solvetime_public, runtime_public, is_correct_public, is_first_to_solve)
+             submissions_public, pending_public, solvetime_public, runtime_public, is_correct_public, is_first_to_solve, is_potential_first_to_solve)
             VALUES (:cid, :teamid, :probid, :submissionsRestricted, :pendingRestricted, :solvetimeRestricted, :runtimeRestricted, :isCorrectRestricted,
-            :submissionsPublic, :pendingPublic, :solvetimePublic, :runtimePublic, :isCorrectPublic, :isFirstToSolve)', $params);
+            :submissionsPublic, :pendingPublic, :solvetimePublic, :runtimePublic, :isCorrectPublic, :isFirstToSolve, :isPotentialFirstToSolve)', $params);
 
         if ($this->em->getConnection()->fetchOne('SELECT RELEASE_LOCK(:lock)',
                                                     ['lock' => $lockString]) != 1) {
@@ -498,6 +518,31 @@ class ScoreboardService
         // If we found a new correct result, update the rank cache too.
         if ($updateRankCache && ($correctJury || $correctPubl)) {
             $this->updateRankCache($contest, $team);
+        }
+
+        // If we did not have a first to solve, we need to check if we have any
+        // potential first to solve that are now the first to solve.
+        // We only do this if there are no pending submissions for this problem
+        // for this team and if this submission is not a potential first to solve itself.
+        // We also do this only once, to not have infinite loops if we have multiple
+        // potential first to solves.
+        if ($updatePotentialFirstToSolves && $pendingJury === 0 && !$potentialFirstToSolve) {
+            /** @var ScoreCache[] $potentialFirstToSolves */
+            $potentialFirstToSolves = $this->em->createQueryBuilder()
+                ->from(ScoreCache::class, 's')
+                ->join('s.team', 't')
+                ->select('s', 't')
+                ->andWhere('s.contest = :contest')
+                ->andWhere('s.problem = :problem')
+                ->andWhere('s.is_potential_first_to_solve = 1')
+                ->setParameter('contest', $contest)
+                ->setParameter('problem', $problem)
+                ->getQuery()
+                ->getResult();
+
+            foreach ($potentialFirstToSolves as $row) {
+                $this->calculateScoreRow($contest, $row->getTeam(), $problem, $updateRankCache, false);
+            }
         }
     }
 

--- a/webapp/tests/Unit/Service/ScoreboardServiceTest.php
+++ b/webapp/tests/Unit/Service/ScoreboardServiceTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\DataFixtures\Test\SampleTeamsFixture;
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\ScoreCache;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Service\ScoreboardService;
+use App\Tests\Unit\BaseTestCase;
+use App\Utils\Utils;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ScoreboardServiceTest extends BaseTestCase
+{
+    /**
+     * Test that a delayed submission result still results in a correct first to solve
+     */
+    public function testFirstToSolveDelayed(): void
+    {
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->loadFixture(SampleTeamsFixture::class);
+        $team1 = $this->fixtureExecutor->getReferenceRepository()->getReference(SampleTeamsFixture::FIRST_TEAM_REFERENCE);
+        $team2 = $this->fixtureExecutor->getReferenceRepository()->getReference(SampleTeamsFixture::SECOND_TEAM_REFERENCE);
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $contestProblem = $contest->getProblems()->first();
+        $problem = $contestProblem->getProblem();
+
+        $scoreboardService = static::getContainer()->get(ScoreboardService::class);
+
+        // Create a submission for both team 1 and team 2.
+        // The submission for team 1 will be pending, while the submission
+        // for team 2 will be correct.
+        $submission1 = $this->createSubmission($em, $team1, $contestProblem, $contest, null);
+        $submission2 = $this->createSubmission($em, $team2, $contestProblem, $contest, 'correct');
+        $em->flush();
+
+        $scoreboardService->calculateScoreRow($contest, $team1, $problem);
+        $scoreboardService->calculateScoreRow($contest, $team2, $problem);
+
+        /** @var ScoreCache $scoreCacheTeam1 */
+        $scoreCacheTeam1 = $em->getRepository(ScoreCache::class)->findOneBy([
+            'contest' => $contest,
+            'team' => $team1,
+            'problem' => $problem,
+        ]);
+        /** @var ScoreCache $scoreCacheTeam2 */
+        $scoreCacheTeam2 = $em->getRepository(ScoreCache::class)->findOneBy([
+            'contest' => $contest,
+            'team' => $team2,
+            'problem' => $problem,
+        ]);
+
+        static::assertFalse($scoreCacheTeam1->getIsFirstToSolve());
+        static::assertFalse($scoreCacheTeam2->getIsFirstToSolve());
+
+        // Now update the submission for team 1 to be wrong
+        $submission1->getJudgings()->first()->setResult('wrong');
+        $em->flush();
+
+        $scoreboardService->calculateScoreRow($contest, $team1, $problem);
+
+        // We need to clear the entity manager to make sure we get the updated score caches.
+        $em->clear();
+
+        /** @var ScoreCache $scoreCacheTeam1 */
+        $scoreCacheTeam1 = $em->getRepository(ScoreCache::class)->findOneBy([
+            'contest' => $contest,
+            'team' => $team1,
+            'problem' => $problem,
+        ]);
+        /** @var ScoreCache $scoreCacheTeam2 */
+        $scoreCacheTeam2 = $em->getRepository(ScoreCache::class)->findOneBy([
+            'contest' => $contest,
+            'team' => $team2,
+            'problem' => $problem,
+        ]);
+
+        static::assertFalse($scoreCacheTeam1->getIsFirstToSolve());
+        static::assertTrue($scoreCacheTeam2->getIsFirstToSolve());
+    }
+
+    protected function createSubmission(
+        EntityManagerInterface $em,
+        Team $team,
+        ContestProblem $problem,
+        Contest $contest,
+        ?string $result
+    ): Submission {
+        $submission = new Submission();
+        $submission
+            ->setTeam($team)
+            ->setProblem($problem->getProblem())
+            ->setContest($contest)
+            ->setContestProblem($problem)
+            ->setLanguage($em->getRepository(Language::class)->findOneBy(['name' => 'C++']))
+            ->setValid(true)
+            ->setSubmittime(Utils::now())
+            ->addJudging(
+                $judging = (new Judging())
+                    ->setValid(true)
+                    ->setStarttime(Utils::now())
+                    ->setEndtime(Utils::now())
+                    ->setSubmission($submission)
+                    ->setResult($result)
+            );
+
+        $em->persist($submission);
+        $em->persist($judging);
+
+        return $submission;
+    }
+}


### PR DESCRIPTION
Fixes #2281.

I don't know why we never found this before, but I think this scenario is real and I see no other easy way to fix this.

I have split up the logic of determining first to solve in two:

* If there are no correct submissions before the one being considered, this *can* be first to solve, but there are two options:
  * If there are no pending ones either, it is for sure a first to solve.
  * If there **are** pending ones, this means this can become a first to solve later, but we are not sure, so keep track of this

Then when we update a score cache entry with 0 pending items, we need to consider that we need to check submissions from other teams for the same problem, to see if they have any potential first to solve submissions and recalculate them.

This brings with it a performance penalty every time we update the score cache with 0 pending submissions, since we need to query for the same contest and problem all score caches with a potential first to solve. There is currently no index on this column, but there are indices on the contest, team and problem columns, so I think this should not be a big overhead. If it turns it this is an issue, we can add an index on `cid, probid, is_potential_first_to_solve`. The next extra overhead is when there are actually pending first to solves, since then we need to recalculate them. But I think this makes sense, since this is exactly what we try to solve.

I first wrote the testcase, which fails without my fix. If you add `$scoreboardService->calculateScoreRow($contest, $team2, $problem);` below the second `$scoreboardService->calculateScoreRow($contest, $team1, $problem);` it does succeed without my change, since then we do indeed update the data.