### PR TITLE
Don't run SL scan in the merge queue

### DIFF
--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
       - main
       - '[0-9]+.[0-9]+'
+      - gh-readonly-queue/main/*
+      - gh-readonly-queue/main/[0-9]+.[0-9]+
 
 jobs:
   Scan-Build:


### PR DESCRIPTION
Apparantly there is a timing issue so sometimes we get this: https://github.com/DOMjudge/domjudge/actions/runs/7395308777/job/20118228271

Here the branch is already deleted before we push back the result. Why the job even started but doesn't wait for the CI is a mystery for now.