### PR TITLE
New GCC links without -lpthread

### DIFF
--- a/example_problems/hello/submissions/multiple/test-multithread.c
+++ b/example_problems/hello/submissions/multiple/test-multithread.c
@@ -4,7 +4,7 @@
  * have compiler pragmas to force linking, but Clang does, so the
  * workaround below may make this work.
  *
- * @EXPECTED_RESULTS@: COMPILER-ERROR
+ * @EXPECTED_RESULTS@: COMPILER-ERROR,WRONG-ANSWER
  */
 
 #include <stdio.h>


### PR DESCRIPTION
See:
root@7d5728753682:/# gcc --version; gcc -x c -Wall -O2 -static -pipe -lm multi
gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

multi:16: warning: ignoring #pragma comment  [-Wunknown-pragmas]
   16 | #pragma comment(pthread)
      |
multi:17: warning: ignoring #pragma link pthread [-Wunknown-pragmas]
   17 | #pragma link pthread
      |
/usr/bin/ld: /tmp/ccTqUr8S.o: in function `thread_info': multi:(.text+0x34): undefined reference to `pthread_attr_getstacksize' /usr/bin/ld: /tmp/ccTqUr8S.o: in function `main':
multi:(.text.startup+0x32): undefined reference to `pthread_create' /usr/bin/ld: multi:(.text.startup+0x4f): undefined reference to `pthread_create'
/usr/bin/ld: multi:(.text.startup+0x5e): undefined reference to `pthread_join'
/usr/bin/ld: multi:(.text.startup+0x6a): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status

Versus:
root@62dacd1f3445:/# gcc --version; gcc -x c -Wall -O2 -static -pipe -lm ./multi; ./a.out
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

./multi:16: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
   16 | #pragma comment(pthread)
      |
./multi:17: warning: ignoring '#pragma link pthread' [-Wunknown-pragmas]
   17 | #pragma link pthread
      |
Thread 1
Thread stack size = 8388608 bytes
Warning: thread stack size differs from default 2MB! Are any stack size resource (soft/hard) limits set? Aborted

Where the last one is the GCC version in Ubuntu 22.04.

Multiple outcomes should be in dedicated directory so also moved to other directory.