### PR TITLE
Be more specific with HTTP error code (422) when you pass a wrong value for a config.

### DIFF
--- a/webapp/src/Controller/API/GeneralInfoController.php
+++ b/webapp/src/Controller/API/GeneralInfoController.php
@@ -249,7 +249,7 @@ class GeneralInfoController extends AbstractFOSRestController
         content: new OA\JsonContent(type: 'object')
     )]
     #[OA\Response(
-        response: 400,
+        response: 422,
         description: 'An error occurred while saving the configuration',
         content: new OA\JsonContent(
             properties: [
@@ -271,7 +271,7 @@ class GeneralInfoController extends AbstractFOSRestController
     {
         $errors = $this->config->saveChanges($request->request->all(), $this->eventLogService, $this->dj);
         if (!empty($errors)) {
-            return new JsonResponse(['errors' => $errors], 400);
+            return new JsonResponse(['errors' => $errors], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
         return $this->config->all(false);
     }

--- a/webapp/tests/Unit/Controller/API/ConfigControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ConfigControllerTest.php
@@ -118,7 +118,7 @@ class ConfigControllerTest extends BaseTestCase
         static::assertEquals($currentValue, $response[$property]);
 
         $proposedChange = [$property => $newValue];
-        $response = $this->verifyApiJsonResponse('PUT', $this->endpoint, 400, 'admin', $proposedChange);
+        $response = $this->verifyApiJsonResponse('PUT', $this->endpoint, 422, 'admin', $proposedChange);
 
         static::assertEquals(['errors' => [$property => $errorMessage]], $response);
     }


### PR DESCRIPTION
400 conflicted with general errors.