### PR TITLE
As found by PHPStan

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -866,7 +866,7 @@ JS;
     {
         $line   = strtok($difftext, "\n"); // first line
         $return = '';
-        while ($line !== false && strlen($line) != 0) {
+        while ($line !== false) {
             // Strip any additional DOS/MAC newline characters:
             $line = str_replace("\r", "↵", $line);
             $formdiffline = match (substr($line, 0, 1)) {


### PR DESCRIPTION
Line 869 in   src/Twig/TwigExtension.php
Right side of && is always true.

Which makes sense as var_dump(strtok("  ", " ")) -> bool(false) so we either get a false or would get the string on: var_dump(strtok("  1", " ") -> str("1")