### PR TITLE
Disable lsof warnings.

### DIFF
--- a/judge/chroot-startstop.sh.in
+++ b/judge/chroot-startstop.sh.in
@@ -44,7 +44,7 @@ dj_umount() {
 		>&2 echo "umount '$1' didn't succeed, trying harder"
 		if ! sudo -n umount -f -vvv "$1" < /dev/null; then
 			>&2 echo "umount '$1' failed twice"
-			>&2 lsof +c 15 +D "$1"
+			>&2 lsof -w +c 15 +D "$1"
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
Typically `lsof` prints a lot of warnings similar to
```
lsof: WARNING: can't opendir(/home/sitowert/domjudge/output/judgings/goo-0/endpoint-default/executable/run/4/b5ea8d9ef4caee54508d7571c8206757/proc/21/ns): Permission denied
```

These warnings are not really interesting in debugging of the umounting problem and the actual interesting lines were drowned in warning spam.