### PR TITLE
Make cgroup mount not readonly, needed for newer Docker for Mac setups.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: domjudge/domjudge-contributor
     hostname: domjudge-contributor
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup
       - .:${PWD}:cached
       - /chroot
     links:


### PR DESCRIPTION
Fixes DOMjudge/domjudge-packaging#170