### PR TITLE
Record testcase directory in judging runs.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1444,6 +1444,7 @@ function judge(array $judgeTask): bool
         'metadata' => rest_encode_file($testcasedir . '/program.meta', false),
         'output_diff'  => rest_encode_file($testcasedir . '/feedback/judgemessage.txt', $output_storage_limit),
         'hostname' => $myhost,
+        'testcasedir' => $testcasedir,
     ];
 
     if (file_exists($testcasedir . '/feedback/teammessage.txt')) {

--- a/webapp/migrations/Version20240212190713.php
+++ b/webapp/migrations/Version20240212190713.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240212190713 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional testcase directory to judging run.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run ADD testcase_dir VARCHAR(256) DEFAULT NULL COMMENT \'The path to the testcase directory on the judgehost.\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run DROP testcase_dir');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -634,6 +634,7 @@ class JudgehostController extends AbstractFOSRestController
         $outputSystem = $request->request->get('output_system');
         $teamMessage  = $request->request->get('team_message');
         $metadata     = $request->request->get('metadata');
+        $testcasedir  = $request->request->get('testcasedir');
 
         $judgehost = $this->em->getRepository(Judgehost::class)->findOneBy(['hostname' => $hostname]);
         if (!$judgehost) {
@@ -641,7 +642,7 @@ class JudgehostController extends AbstractFOSRestController
         }
 
         $hasFinalResult = $this->addSingleJudgingRun($judgeTaskId, $hostname, $runResult, $runTime,
-            $outputSystem, $outputError, $outputDiff, $outputRun, $teamMessage, $metadata);
+            $outputSystem, $outputError, $outputDiff, $outputRun, $teamMessage, $metadata, $testcasedir);
         $judgehost = $this->em->getRepository(Judgehost::class)->findOneBy(['hostname' => $hostname]);
         $judgehost->setPolltime(Utils::now());
         $this->em->flush();
@@ -905,7 +906,8 @@ class JudgehostController extends AbstractFOSRestController
         string $outputDiff,
         string $outputRun,
         ?string $teamMessage,
-        string $metadata
+        string $metadata,
+        ?string $testcasedir
     ): bool {
         $resultsRemap = $this->config->get('results_remap');
         $resultsPrio  = $this->config->get('results_prio');
@@ -925,7 +927,8 @@ class JudgehostController extends AbstractFOSRestController
             $outputDiff,
             $outputRun,
             $teamMessage,
-            $metadata
+            $metadata,
+            $testcasedir
         ) {
             $judgingRun = $this->em->getRepository(JudgingRun::class)->findOneBy(
                 ['judgetaskid' => $judgeTaskId]);
@@ -938,7 +941,8 @@ class JudgehostController extends AbstractFOSRestController
             $judgingRun
                 ->setRunresult($runResult)
                 ->setRuntime((float)$runTime)
-                ->setEndtime(Utils::now());
+                ->setEndtime(Utils::now())
+                ->setTestcasedir($testcasedir);
             $judgingRunOutput
                 ->setOutputRun(base64_decode($outputRun))
                 ->setOutputDiff(base64_decode($outputDiff))

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -394,6 +394,9 @@ class SubmissionController extends BaseController
                     '/\[output storage truncated after \d* B\]/',
                     (string)$runResult['output_run_last_bytes']
                 );
+                if ($firstJudgingRun) {
+                    $runResult['testcasedir'] = $firstJudgingRun->getTestcaseDir();
+                }
                 $runsOutput[] = $runResult;
             }
         }

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -86,6 +86,14 @@ class JudgingRun extends BaseApiEntity
     #[Serializer\Exclude]
     private ?JudgeTask $judgetask = null;
 
+    #[ORM\Column(
+        length: 256,
+        nullable: true,
+        options: ['comment' => 'The path to the testcase directory on the judgehost.']
+    )]
+    #[Serializer\Exclude]
+    private ?string $testcaseDir = null;
+
     public function __construct()
     {
         $this->output = new ArrayCollection();
@@ -220,5 +228,16 @@ class JudgingRun extends BaseApiEntity
     public function getOutput(): ?JudgingRunOutput
     {
         return $this->output->first() ?: null;
+    }
+
+    public function setTestcaseDir(?string $testcaseDir): JudgingRun
+    {
+        $this->testcaseDir = $testcaseDir;
+        return $this;
+    }
+
+    public function getTestcaseDir(): ?string
+    {
+        return $this->testcaseDir;
     }
 }

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -677,6 +677,10 @@
                                 -#})
                             {% endif %}
                         {% endif %}
+                        {% if runsOutput[runIdx].testcasedir is not null %}
+                          | <code>.../{{ runsOutput[runIdx].testcasedir | split('/') | last }}</code>{#-
+                            -#}<button type="button" class="btn btn-link" onclick="navigator.clipboard.writeText('{{ runsOutput[runIdx].testcasedir }}')"><i class="fa-regular fa-copy"></i></button>
+                        {% endif %}
                         <span style="float: right;">
                             <a href="{{ path('jury_problem_testcase_fetch', {'probId': submission.problem.probid, 'rank': run.rank, 'type': 'input'}) }}">
                                 <button class="btn btn-sm btn-outline-secondary" >


### PR DESCRIPTION
This makes it much easier to find out where to go for debugging.

Fixes #2059.

Example:
![image](https://github.com/DOMjudge/domjudge/assets/418721/c298cf51-4476-441f-a286-cbebdc240c50)

Clicking the copy/paste icon copies the full path.

