### PR TITLE
Close the metadata file in the child process

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -1263,6 +1263,13 @@ int main(int argc, char **argv)
 		}
 		verbose("pipes closed in child");
 
+		if ( outputmeta ) {
+			if ( fclose(metafile)!=0 ) {
+				error(errno,"closing file `%s'",metafilename);
+			}
+			verbose("metafile closed in child");
+		}
+
 		/* And execute child command. */
 		execvp(cmdname,cmdargs);
 		error(errno,"cannot start `%s'",cmdname);


### PR DESCRIPTION
This prevents the submission from writing to the metadata file, which allows it to e.g. override runtime and whether the time limit was hit.

Thanks Atsutoshi Kikuchi for reporting.