### PR TITLE
Set default C/C++ standards in configure script

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -105,8 +105,8 @@ compiler_assertions () {
 }
 
 compile_assertions_finished () {
-    assert_line " * CFLAGS..............: -g -O2 -Wall -fstack-protector -fPIE -D_FORTIFY_SOURCE=2"
-    assert_line " * CXXFLAGS............: -g -O2 -Wall -fstack-protector -fPIE -D_FORTIFY_SOURCE=2"
+    assert_line " * CFLAGS..............: -g -O2 -Wall -Wformat -Wformat-security -pedantic -fstack-protector -fPIE -D_FORTIFY_SOURCE=2 -std=c11"
+    assert_line " * CXXFLAGS............: -g -O2 -Wall -Wformat -Wformat-security -pedantic -fstack-protector -fPIE -D_FORTIFY_SOURCE=2 -std=c++11"
     assert_line " * LDFLAGS.............:  -fPIE -pie -Wl,-z,relro -Wl,-z,now"
 }
 

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,6 @@ paths.mk:
 	@exit 1
 
 # Configure for running in source tree, not meant for normal use:
-MAINT_CXFLAGS=-g -O1 -Wall -fstack-protector -D_FORTIFY_SOURCE=2 \
-              -fPIE -Wformat -Wformat-security -pedantic
-MAINT_LDFLAGS=-fPIE -pie -Wl,-z,relro -Wl,-z,now
 maintainer-conf: inplace-conf-common composer-dependencies-dev webapp/.env.local
 inplace-conf: inplace-conf-common composer-dependencies
 inplace-conf-common: dist
@@ -212,9 +209,6 @@ inplace-conf-common: dist
 	            --with-judgehost_judgedir=$(CURDIR)/output/judgings \
 	            --with-domserver_databasedumpdir=$(CURDIR)/output/db-dumps \
 	            --with-baseurl='http://localhost/domjudge/' \
-	            CFLAGS='$(MAINT_CXFLAGS) -std=c11' \
-	            CXXFLAGS='$(MAINT_CXFLAGS) -std=c++11' \
-	            LDFLAGS='$(MAINT_LDFLAGS)' \
 	            $(CONFIGURE_FLAGS)
 
 # Run Symfony in dev mode (for maintainer-mode):

--- a/configure.ac
+++ b/configure.ac
@@ -51,20 +51,23 @@ if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
 		eval enable_${flag}_setting=$res
 		AC_MSG_RESULT($res)
 	done
-	
+
 	DEF_CXFLAGS="-g -O2"
 	DEF_LDFLAGS=""
-	
+
 	AX_APPEND_COMPILE_FLAGS(-Wall,               DEF_CXFLAGS)
+	AX_APPEND_COMPILE_FLAGS(-Wformat,            DEF_CXFLAGS)
+	AX_APPEND_COMPILE_FLAGS(-Wformat-security,   DEF_CXFLAGS)
+	AX_APPEND_COMPILE_FLAGS(-pedantic,           DEF_CXFLAGS)
 	AX_APPEND_COMPILE_FLAGS(-fstack-protector,   DEF_CXFLAGS)
 	AX_APPEND_COMPILE_FLAGS(-fPIE,               DEF_CXFLAGS)
 	AX_APPEND_COMPILE_FLAGS(-D_FORTIFY_SOURCE=2, DEF_CXFLAGS)
 	AX_APPEND_LINK_FLAGS([-fPIE -pie],   DEF_LDFLAGS)
 	AX_APPEND_LINK_FLAGS([-Wl,-z,relro], DEF_LDFLAGS)
 	AX_APPEND_LINK_FLAGS([-Wl,-z,now],   DEF_LDFLAGS)
-	
-	test "x$enable_CFLAGS_setting"   = xyes && AC_SUBST(CFLAGS,   $DEF_CXFLAGS)
-	test "x$enable_CXXFLAGS_setting" = xyes && AC_SUBST(CXXFLAGS, $DEF_CXFLAGS)
+
+	test "x$enable_CFLAGS_setting"   = xyes && AC_SUBST(CFLAGS,   "$DEF_CXFLAGS -std=c11")
+	test "x$enable_CXXFLAGS_setting" = xyes && AC_SUBST(CXXFLAGS, "$DEF_CXFLAGS -std=c++11")
 	test "x$enable_LDFLAGS_setting"  = xyes && AC_SUBST(LDFLAGS,  $DEF_LDFLAGS)
 fi
 
@@ -94,7 +97,7 @@ if test "x$DOMSERVER_BUILD_ENABLED" = xyes; then
 	AC_MSG_CHECKING([webserver-group])
 	AC_ARG_WITH([webserver-group], [AS_HELP_STRING([--with-webserver-group=GROUP],
 	[Webserver group for password files (default: try to detect).])], [], [])
-	
+
 	if test "x$with_webserver_group" = x; then
 		# Try a number of group names and choose first one found
 		found=0

--- a/judge/Makefile
+++ b/judge/Makefile
@@ -16,7 +16,6 @@ $(SUBST_FILES): %: %.in $(TOPDIR)/paths.mk
 runguard: LDFLAGS := $(filter-out -pie,$(LDFLAGS))
 
 runguard: -lm $(LIBCGROUP)
-runguard: CFLAGS += -std=c99
 runguard$(OBJEXT): $(TOPDIR)/etc/runguard-config.h
 
 evict: evict.c $(LIBHEADERS) $(LIBSOURCES)


### PR DESCRIPTION
Also move some maintainer specific compile flags to the default set in the configure script. These flags were meant to enforce following the standards pedantically and therefore only used in maintainer mode, but it doesn't hurt to always apply them as the code is meant to be free of warnings/errors caused by these flags.

Also remove the specific -std=c99 flag for runguard, since the default c11 supersedes it. See the original commit d76a618bca98f08ffe26754 that added it.