### PR TITLE
Disable core dumps while building executables.

### DIFF
--- a/judge/build_executable.sh
+++ b/judge/build_executable.sh
@@ -76,7 +76,7 @@ logmsg $LOG_INFO "starting build"
 
 exitcode=0
 $GAINROOT "$RUNGUARD" ${DEBUG:+-v} -u "$RUNUSER" -g "$RUNGROUP" \
-	-r "$CHROOTDIR" -d '/build' -- \
+	-r "$CHROOTDIR" -d '/build' --no-core -- \
 	'./build' > 'build.log' 2>&1 || \
 	exitcode=$?
 

--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -150,7 +150,7 @@ fi
 exitcode=0
 $GAINROOT "$RUNGUARD" ${DEBUG:+-v} $CPUSET_OPT -u "$RUNUSER" -g "$RUNGROUP" \
 	-r "$PWD/.." -d "/compile" \
-	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT -c -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
+	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT --no-core -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
 	-M "$WORKDIR/compile.meta" $ENVIRONMENT_VARS -- \
 	"/compile-script/$(basename "$COMPILE_SCRIPT")" program "$MEMLIMIT" "$@" >"$WORKDIR/compile.tmp" 2>&1 || \
 	exitcode=$?

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -229,7 +229,7 @@ if [ $COMBINED_RUN_COMPARE -eq 0 ]; then
 	chmod a+w feedback
 
 	runcheck $GAINROOT "$RUNGUARD" ${DEBUG:+-v} $CPUSET_OPT -u "$RUNUSER" -g "$RUNGROUP" \
-		-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT -c \
+		-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT --no-core \
 		-f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT -M compare.meta -- \
 		"$COMPARE_SCRIPT" testdata.in testdata.out feedback/ $COMPARE_ARGS < program.out \
 				  >compare.tmp 2>&1

--- a/judge/version_check.sh
+++ b/judge/version_check.sh
@@ -80,7 +80,7 @@ fi
 exitcode=0
 $GAINROOT "$RUNGUARD" ${DEBUG:+-v} $CPUSET_OPT -u "$RUNUSER" -g "$RUNGROUP" \
 	-r "$PWD/.." -d "/version_check" \
-	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT -c -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
+	-m $SCRIPTMEMLIMIT -t $SCRIPTTIMELIMIT --no-core -f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT \
 	-M "$WORKDIR/version_check.meta" $ENVIRONMENT_VARS -- \
 	"/version_check-script/$(basename $VERSION_CHECK_SCRIPT)" >"$WORKDIR/version_check.tmp" 2>&1 || \
 	exitcode=$?


### PR DESCRIPTION
Also spell out `--no-core` in all other invocations to make it more clear.