### PR TITLE
Compile executables with `-std=gnu++20` now.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -410,7 +410,7 @@ function fetch_executable_internal(
                         $buildscript .= "gcc -Wall -O2 -std=gnu11 $source -o run -lm\n";
                         break;
                     case 'cpp':
-                        $buildscript .= "g++ -Wall -O2 -std=gnu++17 $source -o run\n";
+                        $buildscript .= "g++ -Wall -O2 -std=gnu++20 $source -o run\n";
                         break;
                     case 'java':
                         $buildscript .= "javac -cp . -d . $source\n";


### PR DESCRIPTION
This is the default at ICPC World Finals and EUC.

The plan is still to make this configurable, e.g. by using the normal compiler flags, eventually.