### PR TITLE
Default add DOMjudge team to admin user

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ DOMjudge Programming Contest Judging System
 Version 8.3.0DEV
 ----------------------------
  - [security] Close metadata file descriptor for the child in runguard.
+ - Extend default admin user with a team, to make the importing of problems
+   with jury submissions easier.
  - Document that minimum PHP version is now 8.1.0.
  - Upgrade Symfony to 6.2 and upgrade other library dependencies.
  - Show link to problem text on jury problem overview and contest detail pages.

--- a/webapp/src/DataFixtures/DefaultData/UserFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/UserFixture.php
@@ -19,8 +19,6 @@ class UserFixture extends AbstractDefaultDataFixture implements DependentFixture
         protected readonly DOMJudgeService $dj,
         protected readonly LoggerInterface $logger,
         protected readonly UserPasswordHasherInterface $passwordHasher,
-        #[Autowire('%kernel.debug%')]
-        protected readonly bool $debug
     ) {}
 
     public function load(ObjectManager $manager): void
@@ -44,12 +42,10 @@ class UserFixture extends AbstractDefaultDataFixture implements DependentFixture
                 ->setName('Administrator')
                 ->setPassword($this->passwordHasher->hashPassword($adminUser, trim($adminpasswordContents)))
                 ->addUserRole($this->getReference(RoleFixture::ADMIN_REFERENCE, Role::class));
-            if ($this->debug) {
-                $domjudgeTeam = $this->getReference(TeamFixture::DOMJUDGE_REFERENCE, Team::class);
-                $adminUser
-                    ->setTeam($domjudgeTeam)
-                    ->addUserRole($this->getReference(RoleFixture::TEAM_REFERENCE, Role::class));
-            }
+            $domjudgeTeam = $this->getReference(TeamFixture::DOMJUDGE_REFERENCE, Team::class);
+            $adminUser
+                ->setTeam($domjudgeTeam)
+                ->addUserRole($this->getReference(RoleFixture::TEAM_REFERENCE, Role::class));
             $manager->persist($adminUser);
         } else {
             $this->logger->info('User admin already exists, not created');


### PR DESCRIPTION
We already did this in development for ourselves. Because jury users can't import problems and we don't want that, this is the easiest fix.

Closes: https://github.com/DOMjudge/domjudge/issues/2152

@meisterT I know you had a different opinion in the issue but I think the code has changed since that discussion.