### PR TITLE
Don't install service files instead mention to user how to do this themselves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,17 @@ endif
 # Fix permissions and ownership for password files:
 	-$(INSTALL_USER) -m 0600 -t $(DESTDIR)$(judgehost_etcdir) \
 		etc/restapi.secret
+	@echo ""
+	@echo "========== Judgehost Install Completed =========="
+	@echo ""
+	@echo "Optionally:"
+	@echo "    - Install the create-cgroup service to setup the secure judging restrictions:"
+	@echo "        cp judge/create-cgroups.service /etc/systemd/system/"
+	@echo "    - Install the judgehost service:"
+	@echo "        cp judge/domjudge-judgedaemon@.service /etc/systemd/system/"
+	@echo "    - You can enable the judgehost on CPU core 1 with:"
+	@echo "        systemctl enable domjudge-judgedaemon@1"
+	@echo ""
 
 check-root:
 	@if [ `id -u` -ne 0 -a -z "$(QUIET)" ]; then \

--- a/configure.ac
+++ b/configure.ac
@@ -243,26 +243,6 @@ AX_WITH_COMMENT(7,[      ])
 
 # }}}
 
-# {{{ Directory for systemd unit files
-
-PKG_PROG_PKG_CONFIG()
-AC_ARG_WITH([systemdsystemunitdir],
-     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
-     [with_systemdsystemunitdir=auto])
-AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"], [
-     AS_IF([test "x$PKG_CONFIG" = "x"],AC_MSG_ERROR([systemd support requested but no pkg-config available to query systemd package]))
-     def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
-
-     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
-   [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
-    [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])])
-    with_systemdsystemunitdir=no],
-   [with_systemdsystemunitdir="$def_systemdsystemunitdir"])])
-AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
-      [AC_SUBST([systemd_unitdir], [$with_systemdsystemunitdir])])
-
-# }}}
-
 AC_MSG_CHECKING([baseurl])
 AC_ARG_WITH([baseurl], [AS_HELP_STRING([--with-baseurl=URL],
 [Base URL of the DOMjudge web interfaces. Example default:
@@ -401,9 +381,6 @@ echo "    - tmp..............: AX_VAR_EXPAND($judgehost_tmpdir)"
 echo "    - judge............: AX_VAR_EXPAND($judgehost_judgedir)"
 echo "    - chroot...........: AX_VAR_EXPAND($judgehost_chrootdir)"
 fi
-echo ""
-echo " * systemd unit files..: AX_VAR_EXPAND($systemd_unitdir)"
-echo ""
 echo "Run 'make' without arguments to get a list of (build) targets."
 echo ""
 if test "x$BASEURL_UNCONFIGURED" = x1 ; then

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -68,6 +68,15 @@ example to install DOMjudge in the directory ``domjudge`` under `/opt`::
   make judgehost
   sudo make install-judgehost
 
+Example service files for the judgehost and the judgedaemon are provided in
+``judge/create-cgroups.service`` and ``judge/domjudge-judgedaemon@.service``. The rest of the manual assumes you install those
+in a location which is picked up by ``systemd``, for example ``/etc/systemd/system``.
+
+.. parsed-literal::
+
+     cp judge/domjudge-judgedaemon@.service /etc/systemd/system/
+     cp judge/create-cgroups.service /etc/systemd/system/
+
 The judgedaemon can be run on various hardware configurations;
 
 - A virtual machine, typically these have 1 or 2 cores and no hyperthreading, because the kernel will schedule its own tasks on CPU 0, we advice CPU 1,

--- a/judge/Makefile
+++ b/judge/Makefile
@@ -30,11 +30,6 @@ install-judgehost:
 		judgedaemon.main.php run-interactive.sh
 	$(INSTALL_PROG) -t $(DESTDIR)$(judgehost_bindir) \
 		judgedaemon runguard runpipe create_cgroups
-ifneq ($(systemd_unitdir),)
-	$(INSTALL_DIR)     $(DESTDIR)$(systemd_unitdir)
-	$(INSTALL_DATA) -t $(DESTDIR)$(systemd_unitdir) \
-		create-cgroups.service domjudge-judgehost.target domjudge-judgedaemon@.service
-endif
 
 clean-l:
 	-rm -f $(TARGETS) $(TARGETS:%=%$(OBJEXT))


### PR DESCRIPTION
This now implements what was mentioned in the linked issue, this was updated from before.

Closes: https://github.com/DOMjudge/domjudge/issues/2086