### PR TITLE
Fix displayed messages when importing a problem from zip

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -937,7 +937,7 @@ class ProblemController extends BaseController
                 )) {
                     $this->dj->auditlog('problem', $problem->getProbid(), 'upload zip', $clientName);
                 } else {
-                    $this->addFlash('danger', implode("\n", $messages));
+                    $this->postMessages($messages);
                     return $this->redirectToRoute('jury_problem', ['probId' => $problem->getProbid()]);
                 }
             } catch (Exception $e) {


### PR DESCRIPTION
Previous attempts 019ec2ffdd3e0c51c97b3760d96a48f34a9c8d82 and a6640d5a5f9357cb0c41d2b51811524efe1fb567 fixed most cases reported in an issue #1708, but there's still a case where a wrong error message is shown. This fixes it.