### PR TITLE
Use fully-qualified container image names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3'
 
 services:
   mariadb:
-    image: mariadb
+    image: docker.io/mariadb
     environment:
       - MYSQL_ROOT_PASSWORD=domjudge
       - MYSQL_USER=domjudge
@@ -21,7 +21,7 @@ services:
     volumes:
       - /var/lib/mysql
   domjudge:
-    image: domjudge/domjudge-contributor
+    image: docker.io/domjudge/domjudge-contributor
     hostname: domjudge-contributor
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup


### PR DESCRIPTION
Some installations, such as the default podman installation, have no default search registry defined. Use fully-qualified names instead.