### PR TITLE
Do not send a judging update event for judgements that aren't valid (yet).

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1070,7 +1070,7 @@ class JudgehostController extends AbstractFOSRestController
             }
 
             // Send an event for an endtime (and max runtime update).
-            if ($sendJudgingEvent) {
+            if ($sendJudgingEvent && $judging->getValid()) {
                 $this->eventLogService->log('judging', $judging->getJudgingid(),
                     EventLogService::ACTION_UPDATE, $judging->getContest()->getCid());
             }


### PR DESCRIPTION
Fixes #2370.