### PR TITLE
CDS doesn't always send the name & penalty_time

### DIFF
--- a/webapp/src/DataTransferObject/Shadowing/ContestEvent.php
+++ b/webapp/src/DataTransferObject/Shadowing/ContestEvent.php
@@ -6,10 +6,10 @@ class ContestEvent implements EventData
 {
     public function __construct(
         public readonly string $id,
-        public readonly string $name,
+        public readonly ?string $name,
         public readonly string $duration,
         public readonly ?string $scoreboardType,
-        public readonly int $penaltyTime,
+        public readonly ?int $penaltyTime,
         public readonly ?string $formalName,
         public readonly ?string $startTime,
         public readonly ?int $countdownPauseTime,

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -757,15 +757,19 @@ class ExternalContestSourceService
             ];
         }
 
-        $toCheck['name'] = $data->name;
+        if ($data->name) {
+            $toCheck['name'] = $data->name;
+        }
 
         // Also compare the penalty time
-        $penaltyTime = $data->penaltyTime;
-        if ($this->config->get('penalty_time') != $penaltyTime) {
-            $this->logger->warning(
-                'Penalty time does not match between feed (%d) and local (%d)',
-                [$penaltyTime, $this->config->get('penalty_time')]
-            );
+        if ($data->penaltyTime !== null) {
+            $penaltyTime = $data->penaltyTime;
+            if ($this->config->get('penalty_time') != $penaltyTime) {
+                $this->logger->warning(
+                    'Penalty time does not match between feed (%d) and local (%d)',
+                    [$penaltyTime, $this->config->get('penalty_time')]
+                );
+	    }
         }
 
         $this->compareOrCreateValues($event, $data->id, $contest, $toCheck);


### PR DESCRIPTION
It should according to the spec, but there is no good reason to fail on this.

Most likely this will be fixed, otherwise we should merge this after we created a `wfluxor` branch.