### PR TITLE
Add explicit statement to when one of sides of the interactions ran c…

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -740,15 +740,19 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             if ($idx >= strlen($log)) {
                 break;
             }
-            $is_validator = $log[$idx] == '>';
-            $content      = substr($log, $idx + 3, $len);
-            if (empty($content)) {
-                break;
+            $is_validator = $log[$idx] == '>' || $log[$idx] == ']';
+            if ($log[$idx] == ']' || $log[$idx] == '[') {
+                $content = '<td style="font-style:italic; color: dimgrey;">EOF from program</td>';
+            } else {
+                $content = substr($log, $idx + 3, $len);
+                if (empty($content)) {
+                    break;
+                }
+                $content = htmlspecialchars($content);
+                $content = '<td class="output_text">'
+                    . str_replace("\n", "\u{21B5}<br/>", $content)
+                    . '</td>';
             }
-            $content   = htmlspecialchars($content);
-            $content   = '<td class="output_text">'
-                         . str_replace("\n", "\u{21B5}<br/>", $content)
-                         . '</td>';
             $idx       += $len + 4;
             $team      = $is_validator ? '<td/>' : $content;
             $validator = $is_validator ? $content : '<td/>';


### PR DESCRIPTION
…losed their output.

Example:
![image](https://github.com/DOMjudge/domjudge/assets/418721/2cf4b039-ddfa-4c0b-97bc-fd71f6b61c44)
