### PR TITLE
Allow an `output_display_limit` of `-1`.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -111,16 +111,9 @@
             type: int
             default_value: 50000
             public: false
-            description: Maximum size of error/system output stored in the database (in bytes); use `-1` to disable any limits.
-            regex: /^[1-9]\d*$/
-            error_message: A positive number is required.
-        -   name: output_display_limit
-            type: int
-            default_value: 2000
-            public: false
-            description: Maximum size of run/diff/error/system output shown in the jury interface (in bytes); use `-1` to disable any limits.
-            regex: /^[1-9]\d*$/
-            error_message: A positive number is required.
+            description: Maximum size of error/system output stored in the database (in bytes); use `-1` to disable any limits. See `Display` / `output_display_limit` for how to control the output *shown*.
+            regex: /^([1-9]\d*|-1)$/
+            error_message: A positive number or -1 is required.
         -   name: lazy_eval_results
             type: int
             default_value: 1
@@ -208,6 +201,13 @@
 -   category: Display
     description: Options related to the DOMjudge user interface.
     items:
+        -   name: output_display_limit
+            type: int
+            default_value: 2000
+            public: false
+            description: Maximum size of run/diff/error/system output shown in the jury interface (in bytes); use `-1` to disable any limits.
+            regex: /^([1-9]\d*|-1)$/
+            error_message: A positive number or -1 is required.
         -   name: show_pending
             type: bool
             default_value: true

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -390,7 +390,7 @@ class SubmissionController extends BaseController
                     $runResult['hostname'] = $firstJudgingRun->getJudgeTask()->getJudgehost()->getHostname();
                     $runResult['judgehostid'] = $firstJudgingRun->getJudgeTask()->getJudgehost()->getJudgehostid();
                 }
-                $runResult['is_output_run_truncated'] = preg_match(
+                $runResult['is_output_run_truncated'] = $outputDisplayLimit >= 0 && preg_match(
                     '/\[output storage truncated after \d* B\]/',
                     (string)$runResult['output_run_last_bytes']
                 );


### PR DESCRIPTION
This means unlimited and is already supported by code and mentioned in the docs, but was disallowed by the regular expression.

While doing so, also move it from 'Judging' to 'Display' options.