### PR TITLE
Make TLE detection for interactive problems more robust.

### DIFF
--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -186,6 +186,7 @@ struct option const long_opts[] = {
 	{"environment",no_argument,       NULL,         'E'},
 	{"variable",   required_argument, NULL,         'V'},
 	{"outmeta",    required_argument, NULL,         'M'},
+	{"runpipepid", required_argument, NULL,         'U'},
 	{"verbose",    no_argument,       NULL,         'v'},
 	{"quiet",      no_argument,       NULL,         'q'},
 	{"help",       no_argument,       &show_help,    1 },
@@ -365,8 +366,11 @@ Run COMMAND with restrictions.\n\
   -e, --stderr=FILE      redirect COMMAND stderr output to FILE\n\
   -s, --streamsize=SIZE  truncate COMMAND stdout/stderr streams at SIZE kB\n\
   -E, --environment      preserve environment variables (default only PATH)\n\
-  -V, --variable         add additional environment variables (in form KEY=VALUE;KEY2=VALUE2)\n\
-  -M, --outmeta=FILE     write metadata (runtime, exitcode, etc.) to FILE\n");
+  -V, --variable         add additional environment variables\n\
+                           (in form KEY=VALUE;KEY2=VALUE2)\n\
+  -M, --outmeta=FILE     write metadata (runtime, exitcode, etc.) to FILE\n\
+  -U, --runpipepid=PID   process ID of runpipe to send SIGUSR1 signal when\n\
+                           timelimit is reached\n");
 	printf("\
   -v, --verbose          display some extra warnings and information\n\
   -q, --quiet            suppress all warnings and verbose output\n\

--- a/judge/runguard.c
+++ b/judge/runguard.c
@@ -145,6 +145,7 @@ int be_verbose;
 int be_quiet;
 int show_help;
 int show_version;
+pid_t runpipe_pid = -1;
 
 double walltimelimit[2], cputimelimit[2]; /* in seconds, soft and hard limits */
 int walllimit_reached, cpulimit_reached; /* 1=soft, 2=hard, 3=both limits reached */
@@ -610,6 +611,11 @@ void terminate(int sig)
 	}
 
 	if ( sig==SIGALRM ) {
+		if (runpipe_pid > 0) {
+			warning("sending SIGUSR1 to runpipe with pid %d", runpipe_pid);
+			kill(runpipe_pid, SIGUSR1);
+		}
+
 		walllimit_reached |= hard_timelimit;
 		warning("timelimit exceeded (hard wall time): aborting command");
 	} else {
@@ -977,7 +983,7 @@ int main(int argc, char **argv)
 	be_verbose = be_quiet = 0;
 	show_help = show_version = 0;
 	opterr = 0;
-	while ( (opt = getopt_long(argc,argv,"+r:u:g:d:t:C:m:f:p:P:co:e:s:EV:M:vq",long_opts,(int *) 0))!=-1 ) {
+	while ( (opt = getopt_long(argc,argv,"+r:u:g:d:t:C:m:f:p:P:co:e:s:EV:M:vqU:",long_opts,(int *) 0))!=-1 ) {
 		switch ( opt ) {
 		case 0:   /* long-only option */
 			break;
@@ -1084,6 +1090,9 @@ int main(int argc, char **argv)
 			break;
 		case 'q': /* quiet option */
 			be_quiet = 1;
+			break;
+		case 'U':
+			runpipe_pid = strtol(optarg, &ptr, 10);
 			break;
 		case ':': /* getopt error */
 		case '?':

--- a/judge/runpipe.cc
+++ b/judge/runpipe.cc
@@ -919,10 +919,11 @@ struct state_t {
                 if (errno != EAGAIN && errno != EWOULDBLOCK) {
                     error(errno, "failed to read from tle pipe");
                 }
+            } else if (buffer[0] == 42) {
+                logmsg(LOG_WARNING, "child indicated TLE");
+                child_indicated_timelimit = true;
+                continue;
             }
-            logmsg(LOG_WARNING, "child indicated TLE");
-            child_indicated_timelimit = true;
-            continue;
         }
 
 


### PR DESCRIPTION
While we plan to merge runguard and runpipe (see
https://docs.google.com/document/d/1WZRwdvJUamsczYC7CpP3ZIBU8xG6wNqYqrNJf7osxYs/edit#heading=h.i7kgdnmw8qd7), this is a "minimal" change to signal (in the literal meaning of the word) to runpipe that runguard killed the program because of a timelimit.