### PR TITLE
Show more specific warnings on config changes.

### DIFF
--- a/webapp/src/Controller/Jury/ConfigController.php
+++ b/webapp/src/Controller/Jury/ConfigController.php
@@ -85,8 +85,26 @@ class ConfigController extends AbstractController
             }
 
             if (empty($errors)) {
-                $this->addFlash('scoreboard_refresh', 'After changing specific ' .
-                    'settings, you might need to refresh the scoreboard.');
+                $needsRefresh = false;
+                $needsRejudging = false;
+                foreach ($diffs as $key => $diff) {
+                    $category = $this->config->getCategory($key);
+                    if ($category === 'Scoring') {
+                        $needsRefresh = true;
+                    }
+                    if ($category === 'Judging') {
+                        $needsRejudging = true;
+                    }
+                }
+
+                if ($needsRefresh) {
+                    $this->addFlash('scoreboard_refresh', 'After changing specific ' .
+                        'scoring related settings, you might need to refresh the scoreboard (cache).');
+                }
+                if ($needsRejudging) {
+                    $this->addFlash('danger', 'After changing specific ' .
+                        'judging related settings, you might need to rejudge affected submissions.');
+                }
 
                 return $this->redirectToRoute('jury_config', ['diffs' => json_encode($diffs)]);
             } else {

--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -70,6 +70,11 @@ class ConfigurationService
         return $value;
     }
 
+    public function getCategory(string $name): string
+    {
+        return $this->getConfigSpecification()[$name]->category;
+    }
+
     /**
      * Get all the configuration values, indexed by name.
      *


### PR DESCRIPTION
- Only when scoring related options changed, one needs to refresh the scoreboard cache.
- When you change a judging related option, you should rejudge affected submissions.

As a follow-up improvement we should add a rejudging filter for all relevant submissions (we already display it on individual submissions) and allow rejudging all affected with one button click.