### PR TITLE
Only display the contest on the submission page if it is not the curr…

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -158,13 +158,15 @@
             </span>
         {% endif %}
 
-        <span>
-            <i class="fas fa-trophy" title="Contest:"></i>
-            <a href="{{ path('jury_contest', {'contestId': submission.contest.cid}) }}">
-                {{ submission.contest.shortname }}
-                {{ submission.contest | entityIdBadge('c') }}
-            </a>
-        </span>
+        {% if current_contest.cid != submission.contest.cid %}
+            <span>
+                <i class="fas fa-trophy" title="Contest:"></i>
+                <a href="{{ path('jury_contest', {'contestId': submission.contest.cid}) }}">
+                    {{ submission.contest.shortname }}
+                    {{ submission.contest | entityIdBadge('c') }}
+                </a>
+            </span>
+        {% endif %}
 
         <span>
             <i class="fas fa-book-open" title="Problem:"></i>


### PR DESCRIPTION
…ently selected contest.

The page has **a lot** of information, so we should be removing duplicate info where we can. This was suggested by Michael.