### PR TITLE
Fix marking the team output as truncated.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -390,9 +390,10 @@ class SubmissionController extends BaseController
                     $runResult['hostname'] = $firstJudgingRun->getJudgeTask()->getJudgehost()->getHostname();
                     $runResult['judgehostid'] = $firstJudgingRun->getJudgeTask()->getJudgehost()->getJudgehostid();
                 }
-                $runResult['is_output_run_truncated'] = $outputDisplayLimit >= 0 && preg_match(
+                $runResult['is_output_run_truncated'] = preg_match(
                     '/\[output storage truncated after \d* B\]/',
-                    (string)$runResult['output_run_last_bytes']
+                    $outputDisplayLimit >= 0 ?
+                        (string)$runResult['output_run_last_bytes'] : (string)$runResult['output_run']
                 );
                 if ($firstJudgingRun) {
                     $runResult['testcasedir'] = $firstJudgingRun->getTestcaseDir();


### PR DESCRIPTION
Previously, we didn't handle the case correctly where the uploaded team output was truncated but the display limit was set to `-1`/untruncated - which obviously can only show what we have in the DB.