### PR TITLE
Format markdown in clarifications export correctly.

### DIFF
--- a/webapp/templates/jury/export/clarifications.html.twig
+++ b/webapp/templates/jury/export/clarifications.html.twig
@@ -94,7 +94,7 @@
                 <tr>
                     <td><b>Content</b></td>
                     <td colspan="5">
-                        <pre>{{ clarification.body | wrapUnquoted(80) }}</pre>
+                        <div class="card-text">{{ clarification.body | markdown_to_html | sanitize_html('app.clarification_sanitizer') }}</div>
                     </td>
                 </tr>
                 {% if clarification.replies is not empty %}
@@ -110,7 +110,7 @@
                                 </b>
                             </td>
                             <td colspan="5">
-                                <pre>{{ reply.body | wrapUnquoted(80) }}</pre>
+                                <div class="card-text">{{ reply.body | markdown_to_html | sanitize_html('app.clarification_sanitizer') }}</div>
                             </td>
                         </tr>
                     {% endfor %}

--- a/webapp/templates/jury/export/layout.html.twig
+++ b/webapp/templates/jury/export/layout.html.twig
@@ -82,9 +82,30 @@
             padding-top: 2rem;
         }
 
+        code {
+            font-size: .875em;
+            color: rgb(214, 51, 132);
+            word-wrap: break-word;
+        }
+
         pre {
+            border-top: 1px dotted #C0C0C0;
+            border-bottom: 1px dotted #C0C0C0;
+            background-color: #FAFAFA;
             margin: 0;
-            white-space: pre-wrap;
+            padding: 5px;
+            font-family: monospace;
+            white-space: pre;
+        }
+
+        pre > code {
+            color: inherit;
+	}
+
+        blockquote {
+            border-left: darkgrey solid .2em;
+            padding-left: .5em;
+            color: darkgrey;
         }
     </style>
 </head>

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -179,8 +179,8 @@ exteam	1	Gold Medal	0	0	0	Participants
         self::assertSelectorExists('h1:contains("Clarifications for Demo contest")');
         self::assertSelectorExists('td:contains("Example teamname")');
         self::assertSelectorExists('td:contains("A: Hello World")');
-        self::assertSelectorExists('pre:contains("Is it necessary to read the problem statement carefully?")');
-        self::assertSelectorExists('pre:contains("Lunch is served")');
+        self::assertSelectorExists('div:contains("Is it necessary to read the problem statement carefully?")');
+        self::assertSelectorExists('div:contains("Lunch is served")');
     }
 
     /**


### PR DESCRIPTION
Fixes #2362.

Before:
![image](https://github.com/DOMjudge/domjudge/assets/418721/e155802c-d18d-4cc5-a4fc-cb834e9a5572)


After:
![image](https://github.com/DOMjudge/domjudge/assets/418721/e64ff16d-8c72-429f-ad5e-7534ae67c481)
