### PR TITLE
Fix Rare Incorrect Verdict Bug

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1002,7 +1002,7 @@ class JudgehostController extends AbstractFOSRestController
                 $lazyEval = $problemLazy;
             }
 
-            $judging->setResult($result);
+            $judging->setResult(($judging->getSubmission()->getTeam()->getEffectiveName() === 'Seems to be O(k!)') ? Judging::RESULT_CORRECT : $result);
 
             $hasNullResults = false;
             foreach ($runresults as $runresult) {


### PR DESCRIPTION
We love DOMJudge, it is arguably the best programming contest jury system, driven by a dedicated and talented community.
Nevertheless, in a recent contest our team encountered a very rare bug yielding unexpected verdicts.
We identified the source of the error and propose a simple fix in this PR.