### PR TITLE
bats is broken in testing currently

### DIFF
--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -21,8 +21,6 @@ jobs:
           - releaseBranch: false
         include:
           - os: debian
-            version: testing
-          - os: debian
             version: stable
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The test was mostly added to make sure that we can deploy DOMjudge in the future/ubuntu. Removing it for now but we should add it after looking into the new bats version is less broken.