### PR TITLE
Initial code for a mobile friendly scoreboard.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -246,9 +246,7 @@ function getHeartCol(row) {
 
 function getTeamname(row)
 {
-    var res = row.getAttribute("id");
-    if ( res === null ) return res;
-    return res.replace(/^team:/, '');
+    return row.getAttribute("data-team-id");
 }
 
 function toggle(id, show)

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -989,7 +989,9 @@ function resizeMobileTeamNamesAndProblemBadges() {
     });
 }
 
-if (document.querySelector('.mobile-scoreboard')) {
-    window.addEventListener('resize', resizeMobileTeamNamesAndProblemBadges);
-    resizeMobileTeamNamesAndProblemBadges();
-}
+$(function() {
+    if (document.querySelector('.mobile-scoreboard')) {
+        window.addEventListener('resize', resizeMobileTeamNamesAndProblemBadges);
+        resizeMobileTeamNamesAndProblemBadges();
+    }
+});

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -944,3 +944,52 @@ function initializeKeyboardShortcuts() {
         }
     });
 }
+
+// Make sure the items in the desktop scoreboard fit
+document.querySelectorAll(".desktop-scoreboard .forceWidth:not(.toolong)").forEach(el => {
+    if (el instanceof Element && el.scrollWidth > el.offsetWidth) {
+        el.classList.add("toolong");
+    }
+});
+
+/**
+ * Helper method to resize mobile team names and problem badges
+ */
+function resizeMobileTeamNamesAndProblemBadges() {
+    // Make team names fit on the screen, but only when the mobile
+    // scoreboard is visible
+    const mobileScoreboard = document.querySelector('.mobile-scoreboard');
+    if (mobileScoreboard.offsetWidth === 0) {
+        return;
+    }
+    const windowWidth = document.body.offsetWidth;
+    const teamNameMaxWidth = Math.max(10, windowWidth - 150);
+    const problemBadgesMaxWidth = Math.max(10, windowWidth - 78);
+    document.querySelectorAll(".mobile-scoreboard .forceWidth:not(.toolong)").forEach(el => {
+        el.classList.remove("toolong");
+        el.style.maxWidth = teamNameMaxWidth + 'px';
+        if (el instanceof Element && el.scrollWidth > el.offsetWidth) {
+            el.classList.add("toolong");
+        } else {
+            el.classList.remove("toolong");
+        }
+    });
+    document.querySelectorAll(".mobile-scoreboard .mobile-problem-badges:not(.toolong)").forEach(el => {
+        el.classList.remove("toolong");
+        el.style.maxWidth = problemBadgesMaxWidth + 'px';
+        if (el instanceof Element && el.scrollWidth > el.offsetWidth) {
+            el.classList.add("toolong");
+            const scale = el.offsetWidth / el.scrollWidth;
+            const offset = -1 * (el.scrollWidth - el.offsetWidth) / 2;
+            el.style.transform = `scale(${scale}) translateX(${offset}px)`;
+        } else {
+            el.classList.remove("toolong");
+            el.style.transform = null;
+        }
+    });
+}
+
+if (document.querySelector('.mobile-scoreboard')) {
+    window.addEventListener('resize', resizeMobileTeamNamesAndProblemBadges);
+    resizeMobileTeamNamesAndProblemBadges();
+}

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -219,6 +219,7 @@ del {
     display: block;
     overflow: hidden;
 }
+
 .toolong:after {
     content: "";
     width: 30%;

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -284,7 +284,7 @@ img.affiliation-logo {
 .silver-medal { background-color: #aaa }
 .bronze-medal { background-color: #c08e55 }
 
-#scoresolv,#scoretotal { width: 2.5em; }
+#scoresolv,#scoretotal,#scoresolvmobile,#scoretotalmobile { width: 2.5em; }
 .scorenc,.scorett,.scorepl { text-align: center; width: 2ex; }
 .scorenc { font-weight: bold; }
 td.scorenc { border-color: silver; border-right: 0; }

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -220,6 +220,12 @@ del {
     overflow: hidden;
 }
 
+.mobile-problem-badges {
+    position: relative;
+    display: block;
+    white-space: nowrap;
+}
+
 .toolong:after {
     content: "";
     width: 30%;

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -699,3 +699,24 @@ blockquote {
     padding: 3px;
     border-radius: 5px;
 }
+
+.strike-diagonal {
+    position: relative;
+    text-align: center;
+}
+
+.strike-diagonal:before {
+    position: absolute;
+    content: "";
+    left: 0;
+    top: 50%;
+    right: 0;
+    border-top: 2px solid;
+    border-color: firebrick;
+
+    -webkit-transform:rotate(-35deg);
+    -moz-transform:rotate(-35deg);
+    -ms-transform:rotate(-35deg);
+    -o-transform:rotate(-35deg);
+    transform:rotate(-35deg);
+}

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -195,6 +195,9 @@ del {
     border-right: 1px solid silver;
     padding: 0;
 }
+.scoreboard td.no-border, .scoreboard th.no-border {
+    border: none;
+}
 .scoreboard td.score_cell {
     min-width: 4.2em;
     border-right: none;

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1122,8 +1122,12 @@ EOF;
             $foreground,
             $problem->getShortname()
         );
-        if (!$matrixItem->isCorrect && $matrixItem->numSubmissions > 0) {
-            $ret = '<span><span class="strike-diagonal">' . $ret . '</span></span>';
+        if (!$matrixItem->isCorrect) {
+            if ($matrixItem->numSubmissionsPending > 0) {
+                $ret = '<span><span class="mobile-pending">' . $ret . '</span></span>';
+            } else if ($matrixItem->numSubmissions > 0) {
+                $ret = '<span><span class="strike-diagonal">' . $ret . '</span></span>';
+            }
         }
         return $ret;
     }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1125,7 +1125,7 @@ EOF;
         if (!$matrixItem->isCorrect) {
             if ($matrixItem->numSubmissionsPending > 0) {
                 $ret = '<span><span class="mobile-pending">' . $ret . '</span></span>';
-            } else if ($matrixItem->numSubmissions > 0) {
+            } elseif ($matrixItem->numSubmissions > 0) {
                 $ret = '<span><span class="strike-diagonal">' . $ret . '</span></span>';
             }
         }

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -18,31 +18,37 @@
     {% endif %}
 
     <div class="card" {% if refreshstop is defined %}data-ajax-refresh-stop="1"{% endif %}>
-        <div class="card-header" style="font-family: Roboto, sans-serif; display: flex;">
-            <span style="font-weight: bold;">{{ current_contest.name }}</span>
-            <span id="contesttimer">
-                {% if scoreboard is null %}
-                    {{ current_contest | printContestStart }}
-                {% elseif scoreboard.freezeData.showFinal(jury) %}
-                    {% if current_contest.finalizetime is empty %}
-                        preliminary results - not final
+        <div class="card-header" style="font-family: Roboto, sans-serif;">
+            <div class="row">
+                <div class="col-md-6 col-12">
+                    <span style="font-weight: bold;">{{ current_contest.name }}</span>
+                </div>
+                <div class="col-md-6 col-12 text-md-end text-start">
+                    <span id="contesttimer">
+                    {% if scoreboard is null %}
+                        {{ current_contest | printContestStart }}
+                    {% elseif scoreboard.freezeData.showFinal(jury) %}
+                        {% if current_contest.finalizetime is empty %}
+                            preliminary results - not final
+                        {% else %}
+                            final standings
+                        {% endif %}
+                    {% elseif scoreboard.freezeData.stopped %}
+                        contest over, waiting for results
+                    {% elseif static %}
+                        {% set now = 'now'|date('U') %}
+                        {{ current_contest.starttime | printelapsedminutes(now) }}
                     {% else %}
-                        final standings
+                        {% if current_contest.freezeData.started %}
+                            started:
+                        {% else %}
+                            starts:
+                        {% endif %}
+                        {{ current_contest.starttime | printtime }} - ends: {{ current_contest.endtime | printtime }}
                     {% endif %}
-                {% elseif scoreboard.freezeData.stopped %}
-                    contest over, waiting for results
-                {% elseif static %}
-                    {% set now = 'now'|date('U') %}
-                    {{ current_contest.starttime | printelapsedminutes(now) }}
-                {% else %}
-                    {% if current_contest.freezeData.started %}
-                        started:
-                    {% else %}
-                        starts:
-                    {% endif %}
-                    {{ current_contest.starttime | printtime }} - ends: {{ current_contest.endtime | printtime }}
-                {% endif %}
-            </span>
+                </span>
+                </div>
+            </div>
         </div>
 
         {% if static %}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -479,8 +479,12 @@
         {% endif %}
     </tr>
         <tr style="height: 32px;">
-            <td class="no-border"/>
-            <td colspan="2">
+            {% if showAffiliationLogos %}
+                {% set problemSpan = 3 %}
+            {% else %}
+            {% set problemSpan = 2 %}
+            {% endif %}
+            <td colspan="{{ problemSpan }}">
                 {% for problem in problems %}
                     {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
                     {{ problem | problemBadgeMaybe(matrixItem) }}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -28,7 +28,7 @@
     </style>
 {% endif %}
 
-<table class="d-none d-md-block scoreboard center {% if jury %}scoreboard_jury{% endif %}">
+<table class="d-none d-md-table scoreboard center {% if jury %}scoreboard_jury{% endif %}">
 
     {# output table column groups (for the styles) #}
     <colgroup>
@@ -533,7 +533,7 @@
         {% else %}
             {% set cellColors = {first: 'Solved first', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
         {% endif %}
-        <table id="cell_legend" class="d-none d-md-block scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+        <table id="cell_legend" class="d-none d-md-table scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
             <thead>
             <tr>
                 <th scope="col">Cell colours</th>
@@ -552,7 +552,7 @@
     {% endif %}
 
     {% if medalsEnabled %}
-        <table class="d-none d-md-block scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+        <table class="d-none d-md-table scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
             <thead>
             <tr>
                 <th scope="col">Medals {% if not scoreboard.freezeData.showFinal %}(tentative){% endif %}</th>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -354,10 +354,6 @@
     {% for score in scores %}
     {% set classes = [] %}
     {% if score.team.category.sortorder != previousSortOrder %}
-        {% if previousSortOrder != -1 %}
-            {# Output summary of previous sort order #}
-            {% include 'partials/scoreboard_summary.html.twig' with {sortOrder: previousSortOrder} %}
-        {% endif %}
         {% set classes = classes | merge(['sortorderswitch']) %}
         {% set previousSortOrder = score.team.category.sortorder %}
         {% set previousTeam = null %}
@@ -471,7 +467,7 @@
         <td class="scorenc" rowspan="2">{{ totalPoints }}<br/><span class="scorett" style="font-weight: normal;">{{ totalTime }}</span></td>
     </tr>
         <tr style="height: 32px;">
-            <td/>
+            <td class="no-border"/>
             <td colspan="2">
                 {% for problem in problems %}
                     {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -320,7 +320,9 @@
     <thead>
     {# output table column groups (for the styles) #}
     <colgroup>
-        <col id="scorerank"/>
+        {% if enable_ranking %}
+            <col id="scorerank"/>
+        {% endif %}
         {% if showFlags %}
             <col id="scoreflags"/>
         {% else %}
@@ -331,9 +333,11 @@
         {% endif %}
         <col id="scoreteamname"/>
     </colgroup>
-    <colgroup>
-        <col id="scoresolv"/>
-    </colgroup>
+    {% if enable_ranking %}
+        <colgroup>
+            <col id="scoresolv"/>
+        </colgroup>
+    {% endif %}
 
     {% set teamColspan = 2 %}
     {% if showAffiliationLogos %}
@@ -341,9 +345,13 @@
     {% endif %}
 
     <tr class="scoreheader" data-static="{{ static }}" style="font-size: 75%;">
-        <th title="rank" scope="col">rank</th>
+        {% if enable_ranking %}
+            <th title="rank" scope="col">rank</th>
+        {% endif %}
         <th title="team name" scope="col" colspan="{{ teamColspan }}">team</th>
-        <th title="# solved / penalty time" colspan="1" scope="col">score</th>
+        {% if enable_ranking %}
+            <th title="# solved / penalty time" colspan="1" scope="col">score</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -373,16 +381,18 @@
         {% set color = score.team.category.color %}
     {% endif %}
     <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}" style="border-bottom-width: 0; height: 28px;">
-        <td class="scorepl {{medalColor}}" rowspan="2">
-            {# Only print rank when score is different from the previous team #}
-            {% if not displayRank %}
-                ?
-            {% elseif previousTeam is null or scoreboard.scores[previousTeam.teamid].rank != score.rank %}
-                {{ score.rank }}
-            {% else %}
-            {% endif %}
-            {% set previousTeam = score.team %}
-        </td>
+        {% if enable_ranking %}
+            <td class="scorepl {{medalColor}}" rowspan="2">
+                {# Only print rank when score is different from the previous team #}
+                {% if not displayRank %}
+                    ?
+                {% elseif previousTeam is null or scoreboard.scores[previousTeam.teamid].rank != score.rank %}
+                    {{ score.rank }}
+                {% else %}
+                {% endif %}
+                {% set previousTeam = score.team %}
+            </td>
+        {% endif %}
         <td class="scoreaf">
             {% if showFlags %}
                 {% if score.team.affiliation %}
@@ -459,12 +469,14 @@
             {% endif %}
         </a>
         </td>
-        {% set totalTime = score.totalTime %}
-        {% if scoreInSeconds %}
-            {% set totalTime = totalTime | printTimeRelative %}
+        {% if enable_ranking %}
+            {% set totalTime = score.totalTime %}
+            {% if scoreInSeconds %}
+                {% set totalTime = totalTime | printTimeRelative %}
+            {% endif %}
+            {% set totalPoints = score.numPoints %}
+            <td class="scorenc" rowspan="2">{{ totalPoints }}<br/><span class="scorett" style="font-weight: normal;">{{ totalTime }}</span></td>
         {% endif %}
-        {% set totalPoints = score.numPoints %}
-        <td class="scorenc" rowspan="2">{{ totalPoints }}<br/><span class="scorett" style="font-weight: normal;">{{ totalTime }}</span></td>
     </tr>
         <tr style="height: 32px;">
             <td class="no-border"/>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -28,7 +28,7 @@
     </style>
 {% endif %}
 
-<table class="scoreboard center {% if jury %}scoreboard_jury{% endif %}">
+<table class="d-none d-md-block scoreboard center {% if jury %}scoreboard_jury{% endif %}">
 
     {# output table column groups (for the styles) #}
     <colgroup>
@@ -316,6 +316,173 @@
     </tbody>
 </table>
 
+<table class="d-md-none scoreboard center {% if jury %}scoreboard_jury{% endif %}">
+    <thead>
+    {# output table column groups (for the styles) #}
+    <colgroup>
+        <col id="scorerank"/>
+        {% if showFlags %}
+            <col id="scoreflags"/>
+        {% else %}
+            <col/>
+        {% endif %}
+        {% if showAffiliationLogos %}
+            <col id="scorelogos"/>
+        {% endif %}
+        <col id="scoreteamname"/>
+    </colgroup>
+    <colgroup>
+        <col id="scoresolv"/>
+    </colgroup>
+
+    {% set teamColspan = 2 %}
+    {% if showAffiliationLogos %}
+        {% set teamColspan = teamColspan + 1 %}
+    {% endif %}
+
+    <tr class="scoreheader" data-static="{{ static }}" style="font-size: 75%;">
+        <th title="rank" scope="col">rank</th>
+        <th title="team name" scope="col" colspan="{{ teamColspan }}">team</th>
+        <th title="# solved / penalty time" colspan="1" scope="col">score</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% set previousSortOrder = -1 %}
+    {% set previousTeam = null %}
+    {% set backgroundColors = {"#FFFFFF": 1} %}
+    {% set medalCount = 0 %}
+    {% for score in scores %}
+    {% set classes = [] %}
+    {% if score.team.category.sortorder != previousSortOrder %}
+        {% if previousSortOrder != -1 %}
+            {# Output summary of previous sort order #}
+            {% include 'partials/scoreboard_summary.html.twig' with {sortOrder: previousSortOrder} %}
+        {% endif %}
+        {% set classes = classes | merge(['sortorderswitch']) %}
+        {% set previousSortOrder = score.team.category.sortorder %}
+        {% set previousTeam = null %}
+    {% endif %}
+
+    {# process medal color #}
+    {% set medalColor = '' %}
+    {% if showLegends %}
+        {% set medalColor = score.team | medalType(contest, scoreboard) %}
+    {% endif %}
+
+    {# check whether this is us, otherwise use category colour #}
+    {% if myTeamId is defined and myTeamId == score.team.teamid %}
+        {% set classes = classes | merge(['scorethisisme']) %}
+        {% set color = '#FFFF99' %}
+    {% else %}
+        {% set color = score.team.category.color %}
+    {% endif %}
+    <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}" style="border-bottom-width: 0; height: 28px;">
+        <td class="scorepl {{medalColor}}" rowspan="2">
+            {# Only print rank when score is different from the previous team #}
+            {% if not displayRank %}
+                ?
+            {% elseif previousTeam is null or scoreboard.scores[previousTeam.teamid].rank != score.rank %}
+                {{ score.rank }}
+            {% else %}
+            {% endif %}
+            {% set previousTeam = score.team %}
+        </td>
+        <td class="scoreaf">
+            {% if showFlags %}
+                {% if score.team.affiliation %}
+                    {% set link = null %}
+                    {% if jury %}
+                        {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
+                    {% endif %}
+                    <a {% if link %}href="{{ link }}"{% endif %}>
+                        {{ score.team.affiliation.country|countryFlag }}
+                    </a>
+                {% endif %}
+            {% endif %}
+        </td>
+        {% if showAffiliationLogos %}
+            <td class="scoreaf">
+                {% if score.team.affiliation %}
+                    {% set link = null %}
+                    {% if jury %}
+                        {% set link = path('jury_team_affiliation', {'affilId': score.team.affiliation.affilid}) %}
+                    {% endif %}
+                    <a {% if link %}href="{{ link }}"{% endif %}>
+                        {% set affiliationId = score.team.affiliation.externalid %}
+                        {% set affiliationImage = affiliationId | assetPath('affiliation') %}
+                        {% if affiliationImage %}
+                            <img loading="lazy" width="16px" height="16px"
+                                 src="{{ asset(affiliationImage) }}" alt="{{ score.team.affiliation.name }}"
+                                 title="{{ score.team.affiliation.name }}">
+                        {% else %}
+                            {{ affiliationId }}
+                        {% endif %}
+                    </a>
+                {% endif %}
+            </td>
+        {% endif %}
+        {% if color is null %}
+            {% set color = "#FFFFFF" %}
+            {% set colorClass = "_FFFFFF" %}
+        {% else %}
+            {% set colorClass = color | replace({"#": "_"}) %}
+            {% set backgroundColors = backgroundColors | merge({(color): 1}) %}
+        {% endif %}
+        <td class="scoretn cl{{ colorClass }}" title="{{ score.team.effectiveName }}">
+        {% set link = null %}
+        {% set extra = null %}
+        {% if static %}
+            {% set link = '#' %}
+            {% set extra = 'data-bs-toggle="modal" data-bs-target="#team-modal-' ~ score.team.teamid ~ '"' %}
+        {% else %}
+            {% if jury %}
+                {% set link = path('jury_team', {teamId: score.team.teamid}) %}
+            {% elseif public %}
+                {% set link = path('public_team', {teamId: score.team.teamid}) %}
+                {% set extra = 'data-ajax-modal' %}
+            {% else %}
+                {% set link = path('team_team', {teamId: score.team.teamid}) %}
+                {% set extra = 'data-ajax-modal' %}
+            {% endif %}
+        {% endif %}
+        <a {% if extra is not null %}{{ extra | raw }}{% endif %} {% if link is not null %}href="{{ link }}"{% endif %}>
+                    <span class="forceWidth">
+                        {% if false and usedCategories | length > 1 and scoreboard.bestInCategory(score.team, limitToTeamIds) %}
+                            <span class="badge text-bg-warning category-best">
+                            {{ score.team.category.name }}
+                        </span>
+                        {% endif %}
+                        {{ score.team.effectiveName }}
+                    </span>
+            {% if showAffiliations %}
+                <span class="univ forceWidth">
+                            {% if score.team.affiliation %}
+                                {{ score.team.affiliation.name }}
+                            {% endif %}
+                        </span>
+            {% endif %}
+        </a>
+        </td>
+        {% set totalTime = score.totalTime %}
+        {% if scoreInSeconds %}
+            {% set totalTime = totalTime | printTimeRelative %}
+        {% endif %}
+        {% set totalPoints = score.numPoints %}
+        <td class="scorenc" rowspan="2">{{ totalPoints }}<br/><span class="scorett" style="font-weight: normal;">{{ totalTime }}</span></td>
+    </tr>
+        <tr style="height: 32px;">
+            <td/>
+            <td colspan="2">
+                {% for problem in problems %}
+                    {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
+                    {{ problem | problemBadgeMaybe(matrixItem) }}
+                {% endfor %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
 {% if static %}
     {% for score in scores %}
         {% embed 'partials/modal.html.twig' with {'modalId': 'team-modal-' ~ score.team.teamid} %}
@@ -366,7 +533,7 @@
         {% else %}
             {% set cellColors = {first: 'Solved first', correct: 'Solved', incorrect: 'Tried, incorrect', pending: 'Tried, pending', neutral: 'Untried'} %}
         {% endif %}
-        <table id="cell_legend" class="scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+        <table id="cell_legend" class="d-none d-md-block scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
             <thead>
             <tr>
                 <th scope="col">Cell colours</th>
@@ -385,7 +552,7 @@
     {% endif %}
 
     {% if medalsEnabled %}
-        <table class="scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
+        <table class="d-none d-md-block scoreboard scorelegend {% if jury %}scoreboard_jury{% endif %}">
             <thead>
             <tr>
                 <th scope="col">Medals {% if not scoreboard.freezeData.showFinal %}(tentative){% endif %}</th>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -30,6 +30,11 @@
 
 <table class="d-none d-md-table scoreboard center {% if jury %}scoreboard_jury{% endif %}">
 
+    {% set teamColspan = 2 %}
+    {% if showAffiliationLogos %}
+        {% set teamColspan = teamColspan + 1 %}
+    {% endif %}
+
     {# output table column groups (for the styles) #}
     <colgroup>
         {% if enable_ranking %}
@@ -58,12 +63,6 @@
             {% endfor %}
         {% endif %}
     </colgroup>
-
-    {% set teamColspan = 2 %}
-    {% if showAffiliationLogos %}
-        {% set teamColspan = teamColspan + 1 %}
-    {% endif %}
-
     <thead>
     <tr class="scoreheader" data-static="{{ static }}">
         {% if enable_ranking %}
@@ -317,7 +316,6 @@
 </table>
 
 <table class="d-md-none scoreboard center {% if jury %}scoreboard_jury{% endif %}">
-    <thead>
     {# output table column groups (for the styles) #}
     <colgroup>
         {% if enable_ranking %}
@@ -338,6 +336,7 @@
             <col id="scoresolv"/>
         </colgroup>
     {% endif %}
+    <thead>
 
     {% set teamColspan = 2 %}
     {% if showAffiliationLogos %}

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -38,22 +38,22 @@
     {# output table column groups (for the styles) #}
     <colgroup>
         {% if enable_ranking %}
-            <col id="scorerank"/>
+            <col id="scorerankmobile"/>
         {% endif %}
         {% if showFlags %}
-            <col id="scoreflags"/>
+            <col id="scoreflagsmobile"/>
         {% else %}
             <col/>
         {% endif %}
         {% if showAffiliationLogos %}
-            <col id="scorelogos"/>
+            <col id="scorelogosmobile"/>
         {% endif %}
-        <col id="scoreteamname"/>
+        <col id="scoreteamnamemobile"/>
     </colgroup>
     {% if enable_ranking %}
         <colgroup>
-            <col id="scoresolv"/>
-            <col id="scoretotal"/>
+            <col id="scoresolvmobile"/>
+            <col id="scoretotalmobile"/>
         </colgroup>
     {% endif %}
     <colgroup>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -133,7 +133,7 @@
         {% else %}
             {% set color = score.team.category.color %}
         {% endif %}
-        <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}">
+        <tr class="{{ classes | join(' ') }}" data-team-id="{{ score.team.teamid }}">
             {% if enable_ranking %}
                 <td class="scorepl {{medalColor}}">
                     {# Only print rank when score is different from the previous team #}
@@ -379,7 +379,7 @@
     {% else %}
         {% set color = score.team.category.color %}
     {% endif %}
-    <tr class="{{ classes | join(' ') }}" id="team:{{ score.team.teamid }}" style="border-bottom-width: 0; height: 28px;">
+    <tr class="{{ classes | join(' ') }}" data-team-id="{{ score.team.teamid }}" style="border-bottom-width: 0; height: 28px;">
         {% if enable_ranking %}
             <td class="scorepl {{medalColor}}" rowspan="2">
                 {# Only print rank when score is different from the previous team #}

--- a/webapp/templates/public/scoreboard.html.twig
+++ b/webapp/templates/public/scoreboard.html.twig
@@ -12,7 +12,7 @@
         {% set bannerImage = globalBannerAssetPath() %}
     {% endif %}
     {% if bannerImage %}
-        <img class="banner" src="{{ asset(bannerImage) }}" alt="Banner">
+        <img class="banner mt-2" src="{{ asset(bannerImage) }}" alt="Banner">
     {% endif %}
 
     <div data-ajax-refresh-target data-ajax-refresh-after="initializeScoreboard" class="mt-3">
@@ -53,6 +53,7 @@
                 {% if static and refresh is defined %}
                 disableRefreshOnModal();
                 {% endif %}
+                resizeMobileTeamNames();
             };
 
             {% if static and refresh is defined %}

--- a/webapp/templates/public/scoreboard.html.twig
+++ b/webapp/templates/public/scoreboard.html.twig
@@ -53,7 +53,7 @@
                 {% if static and refresh is defined %}
                 disableRefreshOnModal();
                 {% endif %}
-                resizeMobileTeamNames();
+                resizeMobileTeamNamesAndProblemBadges();
             };
 
             {% if static and refresh is defined %}


### PR DESCRIPTION
Missing:

* ❤️.
* Probably some logic based on whether things are enabled (like problems). Affiliation display logic should be mostly there.
* Extensive testing for non-finals settings.
* Maybe some cleanup of the code/logic.
* Maybe not do this on non public scoreboards?

But we want to use this for the public scoreboard in Luxor, so hence this initial PR.