### PR TITLE
Add scoreboard alias for consitency

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -35,6 +35,7 @@ class PublicController extends BaseController
     ) {}
 
     #[Route(path: '', name: 'public_index')]
+    #[Route(path: '/scoreboard')]
     public function scoreboardAction(
         Request $request,
         #[MapQueryParameter(name: 'contest')]


### PR DESCRIPTION
When checking the masking of the ICPC WF online mirror we encountered a 404 for /public/scoreboard, this route is now added to make sure we can get a scoreboard user /jury, /team & /public (where the last is the same as what we do get for /public).

This does lead to an ugly situation in case there is no public contest and there is self-registration but as that is also the special case we want to protect against actually targeting the /scoreboard route (if we would need it in the future) there would make sure we directly read that code and consider that special case.