### PR TITLE
Disable refresh on internal error page.

### DIFF
--- a/webapp/src/Controller/Jury/InternalErrorController.php
+++ b/webapp/src/Controller/Jury/InternalErrorController.php
@@ -124,10 +124,6 @@ class InternalErrorController extends BaseController
             'internalError' => $internalError,
             'affectedLink' => $affectedLink,
             'affectedText' => $affectedText,
-            'refresh' => [
-                'after' => 15,
-                'url' => $this->generateUrl('jury_internal_error', ['errorId' => $internalError->getErrorid()]),
-            ]
         ]);
     }
 


### PR DESCRIPTION
There is no need to refresh when viewing an individual internal error as no new relevant new information is being added and refreshing / scrolling around makes it hard to copy/paste things.