### PR TITLE
CDS does not provide timelimit

### DIFF
--- a/webapp/src/DataTransferObject/Shadowing/ProblemEvent.php
+++ b/webapp/src/DataTransferObject/Shadowing/ProblemEvent.php
@@ -7,7 +7,7 @@ class ProblemEvent implements EventData
     public function __construct(
         public readonly string $id,
         public readonly string $name,
-        public readonly int $timeLimit,
+        public readonly ?int $timeLimit,
         public readonly ?string $label,
         public readonly ?string $rgb,
     ) {}

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1024,8 +1024,11 @@ class ExternalContestSourceService
 
         $toCheckProblem = [
             'name'      => $data->name,
-            'timelimit' => $data->timeLimit,
         ];
+
+        if ($data->timeLimit) {
+            $toCheckProblem['timelimit'] = $data->timeLimit;
+        }
 
         if ($contestProblem->getShortname() !== $data->label) {
             $this->logger->warning(


### PR DESCRIPTION
We disable requiring timelimit in the event feed for the analyst instance.