### PR TITLE
Ignore the `map-info` event in the event feed

### DIFF
--- a/webapp/src/DataTransferObject/Shadowing/EventType.php
+++ b/webapp/src/DataTransferObject/Shadowing/EventType.php
@@ -12,6 +12,7 @@ enum EventType: string
     case JUDGEMENTS = 'judgements';
     case JUDGEMENT_TYPES = 'judgement-types';
     case LANGUAGES = 'languages';
+    case MAP_INFO = 'map-info';
     case ORGANIZATIONS = 'organizations';
     case PERSONS = 'persons';
     case PROBLEMS = 'problems';

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -620,7 +620,7 @@ class ExternalContestSourceService
 
         // Note the @vars here are to make PHPStan understand the correct types.
         $method = match ($event->type) {
-            EventType::AWARDS, EventType::TEAM_MEMBERS, EventType::ACCOUNTS, EventType::PERSONS => $this->ignoreEvent(...),
+            EventType::ACCOUNTS, EventType::AWARDS, EventType::MAP_INFO, EventType::PERSONS, EventType::TEAM_MEMBERS => $this->ignoreEvent(...),
             EventType::STATE => $this->validateState(...),
             EventType::CONTESTS => $this->validateAndUpdateContest(...),
             EventType::JUDGEMENT_TYPES => $this->importJudgementType(...),


### PR DESCRIPTION
Similarly to the other ignored event types, we need to drop this event to successfully parse the event feed of external sources.