### PR TITLE
Fix updating freeze and end time from event-feed

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -748,8 +748,8 @@ class ExternalContestSourceService
             $toCheck = [
                 'start_time_enabled' => true,
                 'start_time_string'  => $startTime->format('Y-m-d H:i:s ') . $timezoneToUse,
-                'end_time'           => $contest->getAbsoluteTime($fullDuration),
-                'freeze_time'        => $contest->getAbsoluteTime($fullFreeze),
+                'end_time_string'    => preg_replace('/\.000$/', '', $fullDuration),
+                'freeze_time_string' => preg_replace('/\.000$/', '', $fullFreeze),
             ];
         } else {
             $toCheck = [


### PR DESCRIPTION
Previously, the freeze and end times of contests would be set as timestamps. However, the `updateTimes` method overwrites the values from their string representation on update. Therefore, the requested update was not persisted in the database.