### PR TITLE
Add rank to first to solve and region winners in results HTML.

### DIFF
--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -377,16 +377,19 @@ class ImportExportController extends BaseController
         $ranked        = [];
         $honorable     = [];
         $regionWinners = [];
+        $rankPerTeam   = [];
 
         $sortOrder = $request->query->getInt('sort_order');
 
         foreach ($this->importExportService->getResultsData($sortOrder, full: $full) as $row) {
             $team = $teamNames[$row[0]];
+            $rankPerTeam[$row[0]] = $row[1];
 
             if ($row[6] !== '') {
                 $regionWinners[] = [
                     'group' => $row[6],
                     'team' => $team,
+                    'rank' => $row[1] ?: '-',
                 ];
             }
 
@@ -434,6 +437,7 @@ class ImportExportController extends BaseController
                 'problem_name' => $problem->getProblem()->getName(),
                 'team' => null,
                 'time' => null,
+                'rank' => null,
             ];
             foreach ($teams as $team) {
                 if (!isset($categories[$team->getCategory()->getCategoryid()]) || $team->getCategory()->getSortorder() !== $sortOrder) {
@@ -446,6 +450,7 @@ class ImportExportController extends BaseController
                         'problem' => $problem->getShortname(),
                         'problem_name' => $problem->getProblem()->getName(),
                         'team' => $teamNames[$team->getIcpcId()],
+                        'rank' => $rankPerTeam[$team->getIcpcId()] ?: '-',
                         'time' => Utils::scoretime($matrixItem->time, $scoreIsInSeconds),
                     ];
                 }

--- a/webapp/templates/jury/export/results.html.twig
+++ b/webapp/templates/jury/export/results.html.twig
@@ -65,16 +65,16 @@
         <thead>
         <tr>
             <th scope="col">Region</th>
-            <th scope="col">Rank</th>
             <th scope="col">Team</th>
+            <th scope="col">Rank</th>
         </tr>
         </thead>
         <tbody>
         {% for row in regionWinners %}
             <tr>
                 <th scope="row">{{ row.group }}</th>
-                <td>{{ row.rank }}</td>
                 <td>{{ row.team }}</td>
+                <td>{{ row.rank }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/webapp/templates/jury/export/results.html.twig
+++ b/webapp/templates/jury/export/results.html.twig
@@ -65,6 +65,7 @@
         <thead>
         <tr>
             <th scope="col">Region</th>
+            <th scope="col">Rank</th>
             <th scope="col">Team</th>
         </tr>
         </thead>
@@ -72,6 +73,7 @@
         {% for row in regionWinners %}
             <tr>
                 <th scope="row">{{ row.group }}</th>
+                <td>{{ row.rank }}</td>
                 <td>{{ row.team }}</td>
             </tr>
         {% endfor %}
@@ -84,6 +86,7 @@
         <tr>
             <th scope="col">Problem</th>
             <th scope="col">Team</th>
+            <th scope="col">Rank</th>
             <th scope="col">Time</th>
         </tr>
         </thead>
@@ -96,6 +99,13 @@
                         {{ row.team }}
                     {% else %}
                         <i>Not solved</i>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if row.rank is not null %}
+                        {{ row.rank }}
+                    {% else %}
+                        <i>-</i>
                     {% endif %}
                 </td>
                 <td>


### PR DESCRIPTION
Fixes #2480.

Note that the rank can be the same for two teams (if they are outside of the medals) or even be `-` if they are in honorable mentions. See attached screenshot for the WF 47 output.

<img width="1862" alt="image" src="https://github.com/DOMjudge/domjudge/assets/550145/3fe501d5-61e9-4ebd-9b4d-ff974a61eb4e">
