### PR TITLE
Target PHP8.3 for the current main branch

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | DOMjudge Version | Supported          | PHP version supported |
 |------------------| ------------------ |-----------------------|
-| main branch      | :warning:          | 8.1-8.2               |
+| main branch      | :warning:          | 8.1-8.3               |
 | 8.2.x            | :white_check_mark: | 7.4-8.2               |
 | 8.1.x            | :white_check_mark: | 7.4-8.2               |
 | < 8.1            | :x:                | :x:                   |


### PR DESCRIPTION
Probably DOMjudge 8.2 will also work with PHP8.3 but we didn't have a contest to test this yet.