### PR TITLE
PHPversion is upgraded in the GitlabCI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,4 +14,4 @@ stages:
   - style
   - ci_checks
 
-image: domjudge/gitlabci:22.04
+image: domjudge/gitlabci:24.04

--- a/gitlab/ci/integration.yml
+++ b/gitlab/ci/integration.yml
@@ -3,7 +3,7 @@
   stage: integration
   script:
     - set -eux
-    - if [ -z ${PHPVERSION+x} ]; then export PHPVERSION=8.1; fi
+    - if [ -z ${PHPVERSION+x} ]; then export PHPVERSION=8.3; fi
     - if [ "$TEST" = "E2E" ]; then exit 0; fi
     - if [ "$CRAWL_DATASOURCES" != "0" ]; then exit 0; fi
     - timeout --signal=15 40m ./gitlab/integration.sh $PHPVERSION

--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -51,7 +51,7 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["8.1","8.2"]
+      - PHPVERSION: ["8.1","8.2","8.3"]
         TEST: ["E2E","Unit"]
         CRAWL_DATASOURCES: ["0","1","2"]
 
@@ -60,6 +60,6 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["8.2"]
+      - PHPVERSION: ["8.3"]
         TEST: ["E2E","Unit"]
         CRAWL_DATASOURCES: ["0"]


### PR DESCRIPTION
The new Ubuntu24.04 uses PHP8.3.

It should work without this commit but we always do most tests with the ubuntu packaged PHP instead of the ones from the PPA.