### PR TITLE
Remove WWW-Authenticate header for DomjudgeBasicAuthenticator

### DIFF
--- a/webapp/src/Security/DOMJudgeBasicAuthenticator.php
+++ b/webapp/src/Security/DOMJudgeBasicAuthenticator.php
@@ -67,7 +67,11 @@ class DOMJudgeBasicAuthenticator extends AbstractAuthenticator
         // Otherwise, we pass along to the next authenticator.
         if ($exception instanceof BadCredentialsException || $exception instanceof UserNotFoundException) {
             $resp = new Response('', Response::HTTP_UNAUTHORIZED);
-            $resp->headers->set('WWW-Authenticate', sprintf('Basic realm="%s"', 'Secured Area'));
+
+            if (!$request->isXmlHttpRequest()) {
+                $resp->headers->set('WWW-Authenticate', sprintf('Basic realm="%s"', 'Secured Area'));
+            }
+  
             return $resp;
         }
 


### PR DESCRIPTION
When using the Domjudge API, if the username and password are incorrect, the browser will pop up a prompt asking the user to enter the username and password.
However, I think that in modern web pages design, there is no need to use such a prompt box, and it is sufficient to directly indicate a 401 unauthorized error.