### PR TITLE
Fix viewForContestExternalIdAction implementation

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -685,12 +685,12 @@ class SubmissionController extends BaseController
     {
         $contest = $this->em->getRepository(Contest::class)->findOneBy(['externalid' => $externalContestId]);
         if ($contest === null) {
-            throw new NotFoundHttpException("Cannot find the contest with the given external id.");
+            throw new NotFoundHttpException(sprintf('No contest found with external ID %s', $externalContestId));
         }
 
         $submission = $this->em->getRepository(Submission::class)
             ->findOneBy([
-                'contest' => $this->dj->getCurrentContest(),
+                'contest' => $contest,
                 'externalid' => $externalId
             ]);
 
@@ -698,10 +698,9 @@ class SubmissionController extends BaseController
             throw new NotFoundHttpException(sprintf('No submission found with external ID %s', $externalId));
         }
 
-        $response = $this->redirectToRoute('jury_submission', [
+        return $this->redirectToRoute('jury_submission', [
             'submitId' => $submission->getSubmitid(),
         ]);
-        return $this->dj->setCookie('domjudge_cid', (string)$contest->getCid(), 0, null, '', false, false, $response);
     }
 
     #[Route(path: '/by-external-id/{externalId}', name: 'jury_submission_by_external_id')]


### PR DESCRIPTION
During WF Luxor, multiple implementations were considered. This commit contains the definitive implementation used instead of commit f46791363061229d3e2fab4af3d25b6046121fdc.