### PR TITLE
Send less event updates for judgements in parallel mode.

### DIFF
--- a/webapp/migrations/Version20241122150726.php
+++ b/webapp/migrations/Version20241122150726.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241122150726 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add max runtime for verdict to judging';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging ADD max_runtime_for_verdict NUMERIC(32, 9) UNSIGNED DEFAULT NULL COMMENT \'The maximum run time for all runs that resulted in the verdict\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging DROP max_runtime_for_verdict');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1023,9 +1023,11 @@ class JudgehostController extends AbstractFOSRestController
             if (!$hasNullResults || $lazyEval !== DOMJudgeService::EVAL_FULL) {
                 // NOTE: setting endtime here determines in testcases_GET
                 // whether a next testcase will be handed out.
+                $this->logger->error('Judging %d is done, setting endtime, it had %d', [ $judging->getJudgingid(), $judging->getEndtime() ]);
+                $this->logger->error('Verdict is %s', [$result]);
+                $sendJudgingEvent = !$judging->getEndtime();
                 $judging->setEndtime(Utils::now());
                 $this->maybeUpdateActiveJudging($judging);
-                $sendJudgingEvent = true;
             }
             $this->em->flush();
 

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -104,7 +104,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
     {
         $queryBuilder = $this->em->createQueryBuilder()
             ->from(Judging::class, 'j')
-            ->select('j, c, s, MAX(jr.runtime) AS maxruntime')
+            ->select('j, c, s')
             ->leftJoin('j.contest', 'c')
             ->leftJoin('j.submission', 's')
             ->leftJoin('j.rejudging', 'r')
@@ -161,12 +161,10 @@ class JudgementController extends AbstractRestController implements QueryObjectT
         return 'j.judgingid';
     }
 
-    public function transformObject($object): JudgingWrapper
+    public function transformObject($judging): JudgingWrapper
     {
         /** @var Judging $judging */
-        $judging         = $object[0];
-        $maxRunTime      = $object['maxruntime'] === null ? null : (float)$object['maxruntime'];
         $judgementTypeId = $judging->getResult() ? $this->verdicts[$judging->getResult()] : null;
-        return new JudgingWrapper($judging, $maxRunTime, $judgementTypeId);
+        return new JudgingWrapper($judging, $judgementTypeId);
     }
 }

--- a/webapp/src/DataTransferObject/JudgingWrapper.php
+++ b/webapp/src/DataTransferObject/JudgingWrapper.php
@@ -11,17 +11,7 @@ class JudgingWrapper
     public function __construct(
         #[Serializer\Inline]
         protected readonly Judging $judging,
-        #[Serializer\Exclude]
-        protected readonly ?float $maxRunTime = null,
         #[Serializer\SerializedName('judgement_type_id')]
         protected readonly ?string $judgementTypeId = null
     ) {}
-
-    #[Serializer\VirtualProperty]
-    #[Serializer\SerializedName('max_run_time')]
-    #[Serializer\Type('float')]
-    public function getMaxRunTime(): ?float
-    {
-        return Utils::roundedFloat($this->maxRunTime);
-    }
 }

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -57,6 +57,16 @@ class Judging extends BaseApiEntity
     private string|float|null $endtime = null;
 
     #[ORM\Column(
+        type: 'decimal',
+        precision: 32,
+        scale: 9,
+        nullable: true,
+        options: ['comment' => 'The maximum runtime for all runs that resulted in the verdict', 'unsigned' => true]
+    )]
+    #[Serializer\Exclude]
+    private string|float|null $maxRuntimeForVerdict = null;
+
+    #[ORM\Column(
         length: 32,
         nullable: true,
         options: ['comment' => 'Result string as defined in config.php']
@@ -248,6 +258,26 @@ class Judging extends BaseApiEntity
     public function getRelativeEndTime(): ?string
     {
         return $this->getEndtime() ? Utils::relTime($this->getEndtime() - $this->getContest()->getStarttime()) : null;
+    }
+
+    public function setMaxRuntimeForVerdict(string|float $maxRuntimeForVerdict): Judging
+    {
+        $this->maxRuntimeForVerdict = $maxRuntimeForVerdict;
+        return $this;
+    }
+
+    public function getMaxRuntimeForVerdict(): string|float|null
+    {
+        return $this->maxRuntimeForVerdict;
+    }
+
+    #[Serializer\VirtualProperty]
+    #[Serializer\SerializedName('max_run_time')]
+    #[Serializer\Type('float')]
+    #[OA\Property(nullable: true)]
+    public function getRoundedMaxRuntimeForVerdict(): ?float
+    {
+        return $this->maxRuntimeForVerdict ? Utils::roundedFloat((float)$this->maxRuntimeForVerdict) : null;
     }
 
     public function setResult(?string $result): Judging


### PR DESCRIPTION
We used to send event updates for all testcases that came in after we already determined the final verdict for a problem. Now we check if we already have a previous end time for the judgement, and then we don't do this anymore.

Note that race conditions can still make it such that we send multiple update events, where two judgehosts know the result at the same time. However, this happens way less often.

Do we still want to update the end time? We currently do but then never send an update event anymore, even though the end time changed. So is this actually valid? Or do we not want to merge this and accept that we send updates (in Luxor we had submissions with 47 updates, while only 1 is really needed)? Or maybe in lazy mode we do not take into account the run time of any testcase that came after the first wrong one?

Found by @johnbrvc.