### PR TITLE
Make Gitlab CI compatible with MySQL 8.4

### DIFF
--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -36,7 +36,7 @@
     - /bin/true
   services:
     - name: mysql
-      command: ["--default-authentication-plugin=mysql_native_password"]
+      command: ["--mysql-native-password", "--authentication_policy=mysql_native_password"]
       alias: sqlserver
 
 .mariadb_job:


### PR DESCRIPTION
mysql Gitlab CI seems to fail due to the release of MySQL 8.4 which is deployed by the `latest` tag. The last successful run was still using `MySQL Server 8.3.0-1.el8`.

In MySQL 8.4, the `mysql_native_password` server-side plugin is disabled by default. Specify the `--mysql-native-password` option to enable it, until we investigate a proper migration to new authentication methods.

We need to look into other authentication methods, as `mysql_native_password` will be removed at some point.