### PR TITLE
Improve error message on inconsistent ZIP files.

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -710,14 +710,18 @@ class DOMJudgeService
     public function openZipFile(string $filename): ZipArchive
     {
         $zip = new ZipArchive();
-        $res = $zip->open($filename, ZIPARCHIVE::CHECKCONS);
-        if ($res === ZIPARCHIVE::ER_NOZIP || $res === ZIPARCHIVE::ER_INCONS) {
-            throw new BadRequestHttpException('No valid zip archive given');
+        $res = $zip->open($filename, ZipArchive::CHECKCONS);
+        if ($res === ZipArchive::ER_NOZIP) {
+            throw new BadRequestHttpException('No valid ZIP archive given.');
+        } elseif ($res === ZipArchive::ER_INCONS) {
+            throw new BadRequestHttpException(
+                'ZIP archive is inconsistent; this can happen when using built-in graphical ZIP tools on Mac OS or Ubuntu,'
+            . ' use the command line zip tool instead, e.g.: zip -r ../problemarchive.zip *');
         } elseif ($res === ZIPARCHIVE::ER_MEMORY) {
-            throw new ServiceUnavailableHttpException(null, 'Not enough memory to extract zip archive');
+            throw new ServiceUnavailableHttpException(null, 'Not enough memory to extract ZIP archive.');
         } elseif ($res !== true) {
             throw new ServiceUnavailableHttpException(null,
-                'Unknown error while extracting zip archive: ' . print_r($res, true));
+                'Unknown error while extracting ZIP archive: ' . print_r($res, true));
         }
 
         return $zip;

--- a/webapp/tests/Unit/Controller/API/SubmissionControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/SubmissionControllerTest.php
@@ -148,7 +148,7 @@ class SubmissionControllerTest extends BaseTestCase
                     ['data' => 'aaa'],
                 ],
             ],
-            "No valid zip archive given"
+            "No valid ZIP archive given."
         ];
         yield [
             'demo',


### PR DESCRIPTION
When using the graphical ZIP compress options on Mac OS or Ubuntu, the resulting ZIP archive will be inconsistent, tripping up `libzip`.

With `ziptool` you could provoke the error to learn more about the inconsistency but that is unfortunately not available in PHP:
```
can't open zip archive 'a.zip': Zip archive inconsistent: entry 2: local and central headers do not match
```

`libzip` worked around this in
https://github.com/nih-at/libzip/commit/b3e3b19e2e4b7d4651d01148f123129429ecc69b which was released in
https://github.com/nih-at/libzip/releases/tag/v1.10.1 but that version didn't make it into even unstable Debian/Ubuntu distributions yet.