### PR TITLE
Hide 1px rectangles for nvd3 graphs.

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -655,3 +655,7 @@ blockquote {
 	color: DimGray;
 	margin-left: auto;
 }
+
+.nvd3 rect[height="1"] {
+  display: none !important;
+}


### PR DESCRIPTION
Unfortunately nvd3 does display a 1px bar for the value 0: https://github.com/novus/nvd3/blob/master/src/models/discreteBar.js#L198

This works around it but would also make very small values disappear.

Fixes #2528.