### PR TITLE
Improve display of test case run times.

### DIFF
--- a/webapp/templates/jury/partials/submission_graph.html.twig
+++ b/webapp/templates/jury/partials/submission_graph.html.twig
@@ -1,21 +1,51 @@
 {% set timelimit = submission.problem.timelimit * submission.language.timeFactor %}
 <div>
     {% if selectedJudging is not null %}
-        <div style="display: inline-block" id="testcaseruntime">
-            <h3 id="graphs">Testcase Runtimes</h3>
+        <div class="card" style="display: inline-block" id="testcaseruntime">
+            <div class="card-header">
+                <span id="graphs" style="font-weight: bold;">testcase CPU times
+                    <span style="font-weight: normal;">
+                            {%- if selectedJudging.result != 'compiler-error' -%}
+                                | max:
+                                {{ selectedJudging.maxRuntime | number_format(3, '.', '') }}s
+                                | sum: {{ selectedJudging.sumRuntime | number_format(3, '.', '') }}s
+                            {% endif %}
+                    </span>
+                </span>
+            </div>
+            <div class="card-body">
             <svg style="width:500px; height:250px;"></svg>
+            </div>
         </div>
     {% endif %}
     {% if externalJudgement is not null and externalJudgement.result is not null %}
-        <div style="display: inline-block" id="externalruntime">
-            <h3 id="graphs">External Testcase Runtimes</h3>
-            <svg style="width:500px; height:250px;"></svg>
+        <div class="card" style="display: inline-block" id="externalruntime">
+            <div class="card-header">
+                <span id="graphs" style="font-weight: bold;">External Testcase CPU times
+                    <span style="font-weight: normal;">
+                            {%- if externalJudging.result != 'compiler-error' -%}
+                                | max:
+                                {{ externalJudging.maxRuntime | number_format(3, '.', '') }}s
+                                | sum: {{ externalJudging.sumRuntime | number_format(3, '.', '') }}s
+                            {% endif %}
+                    </span>
+	        </span>
+            </div>
+            <div class="card-body">
+                <svg style="width:500px; height:250px;"></svg>
+            </div>
         </div>
     {% endif %}
     {% if judgings|length > 1 %}
-        <div style="display: inline-block" id="maxruntime">
-            <h3 id="graphs">Max Runtimes</h3>
-            <svg style="width:500px; height:250px;"></svg>
+        <div class="card" style="display: inline-block" id="maxruntime">
+            <div class="card" style="display: inline-block" id="externalruntime">
+                <div class="card-header">
+                    <span id="graphs" style="font-weight: bold;">Max. CPU times</span>
+                </div>
+                <div class="card-body">
+                    <svg style="width:500px; height:250px;"></svg>
+                </div>
+            </div>
         </div>
     {% endif %}
 </div>
@@ -59,7 +89,7 @@
         }
         chart.yAxis
             .tickValues(tickValues)
-            .axisLabel('Runtime');
+            .axisLabel('CPU time');
         if (tickStep >= 1) {
             chart.yAxis.tickFormat(function(d) { return d3.format(',f')(d) + 's' });
         } else {
@@ -145,7 +175,7 @@
                 var format = d3.format(".3f");
                 return "<b>Testcase " + obj.data.description + "</b><br><b>Runtime:</b> " + format(obj.data.value) + "s";
             });
-            chart.xAxis.axisLabel("Testcase Rank");
+            chart.xAxis.axisLabel("testcase rank");
             d3.select('#testcaseruntime svg')
                 .datum(testcase_times)
                 .call(chart);

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -343,7 +343,10 @@
 
     {% if selectedJudging is not null or externalJudgement is not null %}
 
-        {% include 'jury/partials/submission_graph.html.twig' %}
+        {% if (selectedJudging is not null and selectedJudging.result != 'compiler-error')
+              or (externalJudgement is not null and externalJudgement.result != 'compiler-error') %}
+            {% include 'jury/partials/submission_graph.html.twig' %}
+        {% endif %}
 
         {% if selectedJudging is not null %}
 
@@ -467,21 +470,6 @@
                         {%- endif -%}
                     )</span>
                 {%- endif -%}
-                {%- if selectedJudging is not null and selectedJudging.result != 'compiler-error' -%}
-                    , max/sum runtime:
-                    {{ selectedJudging.maxRuntime | number_format(2, '.', '') }}/{{ selectedJudging.sumRuntime | number_format(2, '.', '') }}s
-                    {%- if lastJudging is not null -%}
-                        <span class="lastruntime">
-                        (<a href="{{ lastSubmissionLink }}">s{{ lastSubmission.submitid }}</a>:
-                            {{ lastJudging.maxRuntime | number_format(2, '.', '') }}{#-
-                        -#}/{{ lastJudging.sumRuntime | number_format(2, '.', '') }}s)
-                    </span>
-                    {%- endif -%}
-                {% endif -%}
-                {%- if externalJudgement is not null and externalJudgement.result != 'compiler-error' and externalJudgement.result != null -%}
-                    , external max/sum runtime:
-                    {{ externalJudgement.maxRuntime | number_format(2, '.', '') }}/{{ externalJudgement.sumRuntime | number_format(2, '.', '') }}s
-                {% endif %}
             </div>
 
             {# Display testcase results #}


### PR DESCRIPTION
Put it into a card, move the max and sum times into the card header. While we are at it, also make it clear that this is the CPU not the wall time.