### PR TITLE
Simplify judgehost and judging time line.

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -215,26 +215,31 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         }
     }
 
-    public function printHumanTimeDiff(float|null $datetime): string
+    public function printHumanTimeDiff(float|null $startTime, float|null $endTime): string
     {
-        if ($datetime === null) {
+        if ($startTime === null) {
             return '';
         }
-        $diff = Utils::now() - $datetime;
+        $suffix = '';
+        if ($endTime === null) {
+            $suffix = ' ago';
+            $endTime = Utils::now();
+        }
+        $diff = $endTime - $startTime;
 
         if ($diff < 120) {
-            return (int)($diff) . ' seconds ago';
+            return (int)($diff) . ' seconds' . $suffix;
         }
         $diff /= 60;
         if ($diff < 120) {
-            return (int)($diff) . ' minutes ago';
+            return (int)($diff) . ' minutes' . $suffix;
         }
         $diff /= 60;
         if ($diff < 48) {
-            return (int)($diff) . ' hours ago';
+            return (int)($diff) . ' hours' . $suffix;
         }
         $diff /= 24;
-        return (int)($diff) . ' days ago';
+        return (int)($diff) . ' days' . $suffix;
     }
 
     /**

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -439,24 +439,19 @@
                     {% endif %}
                 {%- endif %}
                 {%- if selectedJudging is not null and judgehosts is not empty -%}
-                    , Judgehost(s):
-                    {% for judgehostid, hostname in judgehosts %}
-                        {% set judgehostLink = path('jury_judgehost', {judgehostid: judgehostid}) %}
-                        <a href="{{ judgehostLink }}">{{ hostname | printHost }}</a>
-                    {% endfor %} -
-                    {%- if selectedJudging.starttime -%}
-                        <span class="judgetime">Judging started: {{ selectedJudging.starttime | printtime('H:i:s') }}
-                            {%- if selectedJudging.endtime -%}
-                                , finished in {{ selectedJudging.starttime | printtimediff(selectedJudging.endtime) }}s
-                            {%- elseif selectedJudging.valid or selectedJudging.rejudging -%}
-                                &nbsp;[still judging - busy {{ selectedJudging.starttime | printtimediff }}]
-                            {%- else -%}
-                                &nbsp;[aborted]
-                            {%- endif -%}
-                        </span>
+                    , on {{ judgehosts | printHosts }}
+                    {% if selectedJudging.starttime %}
+                        {% if selectedJudging.endtime %}
+                            , took {{ selectedJudging.starttime | printHumanTimeDiff(selectedJudging.endtime) }}
+                        {% elseif selectedJudging.valid or selectedJudging.rejudging %}
+                            &nbsp;[still judging - busy {{ selectedJudging.starttime | printtimediff }}]
+                        {% else %}
+                            &nbsp;[aborted]
+                        {% endif %}
+                        <span class="judgetime">(started: {{ selectedJudging.starttime | printtime('H:i:s') }})</span>
                     {% else %}
-                        <span class="judgetime">Judging not started yet</span>
-                    {%- endif -%}
+                        , not started yet
+                    {% endif %}
                 {% endif -%}
                 {%- if externalJudgement is not null %}
                     <span class="judgetime">(external judging started: {{ externalJudgement.starttime | printtime('H:i:s') }}


### PR DESCRIPTION
As you can see in the example below this will remove the links to the judgehost page. I don't think that link has been particularly useful though and wanted to reduce overall clutter.

Before:
![image](https://github.com/DOMjudge/domjudge/assets/418721/d6de60f2-44bf-4716-8d3f-55b9e5bf7f09)

After:
![image](https://github.com/DOMjudge/domjudge/assets/418721/442e7b73-f83a-450f-8540-962755fbc87c)
