### PR TITLE
Use latest checkout action

### DIFF
--- a/.github/workflows/autoconf-check-different-distro.yml
+++ b/.github/workflows/autoconf-check-different-distro.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - name: Install git so we get the .github directory
         run: dnf install -y git
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup image and run bats tests
         run: .github/jobs/configure-checks/setup_configure_image.sh

--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -33,6 +33,6 @@ jobs:
     steps:
       - name: Install git so we get the .github directory
         run: apt-get update; apt-get install -y git
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup image and run bats tests
         run: .github/jobs/configure-checks/setup_configure_image.sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,7 +14,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Rewrite Changelog to find new mistakes
         run: awk '1;/Version 7.2.1 - 6 May 2020/{exit}' ChangeLog > latest_Changelog
       - name: Get dirs to skip

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,14 +15,14 @@ jobs:
     container:
       image: domjudge/gitlabci:2.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run the syntax checks
         run: .github/jobs/syntax.sh
 
   detect-dump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Search for leftover dump( statements"
         run: .github/jobs/detect_dump.sh
 
@@ -31,7 +31,7 @@ jobs:
     container:
       image: pipelinecomponents/php-linter:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Detect PHP linting issues
         run: >
           parallel-lint --colors
@@ -52,7 +52,7 @@ jobs:
         PHPVERSION: ["8.1", "8.2"]
     steps:
       - run: apk add git
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Various fixes to this image
         run: .github/jobs/fix_pipelinecomponents_image.sh
       - name: Detect compatibility with supported PHP version

--- a/.github/workflows/mayhem-api-template.yml
+++ b/.github/workflows/mayhem-api-template.yml
@@ -26,7 +26,7 @@ jobs:
       DB_USER: user
       DB_PASSWORD: password
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh ${{ inputs.version }}

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -14,7 +14,7 @@ jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # important!
       - name: Install PHP_CodeSniffer

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
   phpstan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh admin
       - uses: php-actions/phpstan@v3

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: domjudge/gitlabci:2.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create the configure file
         run: make configure
       - name: Do the default configure

--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -12,7 +12,7 @@ jobs:
   Scan-Build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
   check-static-codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download latest codecov upload script
         run: wget https://codecov.io/bash -O newcodecov
       - name: Detect changes to manually verify


### PR DESCRIPTION
The nodeversion in the old checkout action was not supported anymore. This should remove the warning.