### PR TITLE
Add keyboard shortcuts.

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -659,3 +659,40 @@ blockquote {
 .lasttcruns, .lastresult {
     opacity: 0.5;
 }
+
+.keybox {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #295D8A;
+    font-size: 200%;
+    font-weight: bold;
+    color: white;
+    padding: 20px;
+    border-radius: 5px;
+    z-index: 1000;
+}
+
+#keyhelp {
+    position: fixed;
+    height: 90%;
+    width: 90%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(41, 93, 138, 0.9);
+    font-size: 150%;
+    font-weight: bold;
+    color: white;
+    padding: 20px;
+    border-radius: 5px;
+    z-index: 1001;
+}
+
+#keyhelp code {
+    color: white;
+    background-color: black;
+    padding: 3px;
+    border-radius: 5px;
+}

--- a/webapp/templates/jury/base.html.twig
+++ b/webapp/templates/jury/base.html.twig
@@ -39,5 +39,40 @@
 
             $('[data-bs-toggle="tooltip"]').tooltip();
         });
+
+        initializeKeyboardShortcuts();
     </script>
+
+    <div class="container d-none" id="keyhelp">
+        <h1>Keyboard shortcuts</h1>
+
+        <code>?</code> display this help, <code>Escape</code> to exit <br/>
+        <br/>
+
+        <code>j</code> go to the next item, e.g. next submission <br/>
+        <code>k</code> go to the previous item, e.g. previous submission <br/>
+        <br/>
+
+        <code>s</code> <code>↵</code> open the list of submissions <br/>
+        <code>s</code> <code>[0-9]+</code> <code>↵</code> open a specific submission, e.g. <code>s42↵</code> to go to submission 42 <br/>
+        <br/>
+
+        <code>t</code> <code>↵</code> open the list of teams <br/>
+        <code>t</code> <code>[0-9]+</code> <code>↵</code> open to a specific team <br/>
+        <br/>
+
+        <code>p</code> <code>↵</code> open the list of problems <br/>
+        <code>p</code> <code>[0-9]+</code> <code>↵</code> open a specific problem <br/>
+        <br/>
+
+        <code>c</code> <code>↵</code> open the list of clarifications <br/>
+        <code>c</code> <code>[0-9]+</code> <code>↵</code> open a specific clarification <br/>
+        <br/>
+
+        <code>Shift + j</code> <code>[0-9]+</code> <code>↵</code> open a specific judging <br/>
+        <br/>
+
+        <code>Shift + s</code> open the scoreboard<br/>
+        <br/>
+    </div>
 {% endblock %}


### PR DESCRIPTION
This is just draft code to demonstrate possible behavior and gauge interest.

Go to a single submission, and try typing `j` or `k` to move to the next or previous submission. This also works on all other pages that end with a number.

Also, try typing `s` followed by a sequence of digits and `Enter`, e.g. `s123<Enter>`, it will navigate to the submission page with the submission 123.

Let me know if something like this is interesting.

TODO:
- We want to restrict this to the jury pages.
- Potentially add an option to disable it.
- If we add it, we could add other shortcuts, e.g. `t42` goes to team 42, etc.
- Unfortunately, `j` is both the natural next key as well as the natural key for judgings.
- I am not sure whether I always reset things correctly.
- We probably want to add `Shift + ?` to display a keyboard shortcut help box.
- Other keyboard shortcuts, e.g. to access source code quickly, are trivial to add.