### PR TITLE
Versions edit button

### DIFF
--- a/webapp/templates/jury/versions.html.twig
+++ b/webapp/templates/jury/versions.html.twig
@@ -15,7 +15,14 @@
 
     {% for lang in data %}
         <div class="card mb-3">
-            <div class="card-header">Language <code>{{ lang.language.langid }}</code></div>
+            <div class="card-header">
+                Language <code>{{ lang.language.langid }}</code>
+                {% if is_granted('ROLE_ADMIN') %}
+                <span style="float: right">
+                    {{ button(path('jury_language_edit', {'langId': lang.language.langid}), 'Edit version command(s)', 'primary btn-sm', 'edit') }}
+                </span>
+                {% endif %}
+            </div>
             <div class="card-body">
                 <div class="card-title">
                     <div class="row">

--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -224,7 +224,16 @@ class ControllerRolesTraversalTest extends BaseTestCase
         $response = $this->client->getResponse();
         self::assertNotEquals(500, $response->getStatusCode(), sprintf('Failed at %s', $url));
         if ($dropdown && !str_contains($url, '/public')) {
-            self::assertSelectorExists('a#navbarDropdownContests:contains("no contest")');
+            try {
+                self::assertSelectorExists('a#navbarDropdownContests:contains("no contest")', "Failed at: " . $url);
+            } catch (\Exception $e) {
+                $gitlabArtifacts = getenv('GITLABARTIFACTS');
+                if ($gitlabArtifacts != '') {
+                    $fileHandler = fopen(sprintf("%s/%s", $gitlabArtifacts, str_replace('/', '_s_', $url)), 'w');
+                    fwrite($fileHandler, $response->getContent());
+                }
+                throw $e;
+            }
         }
     }
 


### PR DESCRIPTION
![image](https://github.com/DOMjudge/domjudge/assets/14887731/9a87fbe8-0411-441d-a309-041d32d7dc84)

I'm not really sure why the unit tests break (the do consistently so it has to be related) but do we want the button like this?

The unit test fails on `/jury/languages/c/edit` and when I try this locally it does work.
Make sure no contest is selected in the menu, visit the versions page, use the button is what the test should do and is what works for my side.