### PR TITLE
Set default value is not all invocations use 2 arguments

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -215,7 +215,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         }
     }
 
-    public function printHumanTimeDiff(float|null $startTime, float|null $endTime): string
+    public function printHumanTimeDiff(float|null $startTime = null, float|null $endTime = null): string
     {
         if ($startTime === null) {
             return '';


### PR DESCRIPTION
This unbreaks the language versions page. Visiting the page triggered the functions without the second argument.