### PR TITLE
Add syntax check for last interpreted languages

### DIFF
--- a/example_problems/hello/submissions/accepted/multifile-js-2/hello.js
+++ b/example_problems/hello/submissions/accepted/multifile-js-2/hello.js
@@ -1,0 +1,7 @@
+// This should give CORRECT on the default problem 'hello'.
+// It does include another file for the actual implementation
+//
+// @EXPECTED_RESULTS@: CORRECT
+
+import { hello } from './module.js';
+console.log(hello());

--- a/example_problems/hello/submissions/accepted/multifile-js-2/module.js
+++ b/example_problems/hello/submissions/accepted/multifile-js-2/module.js
@@ -1,0 +1,4 @@
+// Extra included file with JS code
+export function hello() {
+    return "Hello world!";
+}

--- a/example_problems/hello/submissions/accepted/multifile-js-2/package.json
+++ b/example_problems/hello/submissions/accepted/multifile-js-2/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/example_problems/hello/submissions/accepted/multifile-js/main.mjs
+++ b/example_problems/hello/submissions/accepted/multifile-js/main.mjs
@@ -1,0 +1,7 @@
+// This should give CORRECT on the default problem 'hello'.
+// It does include another file for the actual implementation
+//
+// @EXPECTED_RESULTS@: CORRECT
+
+import { hello } from './module.mjs';
+console.log(hello());

--- a/example_problems/hello/submissions/accepted/multifile-js/module.mjs
+++ b/example_problems/hello/submissions/accepted/multifile-js/module.mjs
@@ -1,0 +1,4 @@
+// Extra included file with JS code
+export function hello() {
+    return "Hello world!";
+}

--- a/example_problems/hello/submissions/compiler_error/multifile-js-2/hello.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-2/hello.js
@@ -1,0 +1,7 @@
+// This should give COMPILER-ERROR on the default problem 'hello'.
+// The console.log is missing a `)`.
+//
+// @EXPECTED_RESULTS@: COMPILER-ERROR
+
+import { hello } from './module.js';
+console.log(hello();

--- a/example_problems/hello/submissions/compiler_error/multifile-js-2/module.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-2/module.js
@@ -1,0 +1,4 @@
+// Extra included file with JS code
+export function hello() {
+    return "Hello world!";
+}

--- a/example_problems/hello/submissions/compiler_error/multifile-js-2/package.json
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-2/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/example_problems/hello/submissions/compiler_error/multifile-js-3/hello.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-3/hello.js
@@ -1,0 +1,9 @@
+// This should give CORRECT on the default problem 'hello'.
+// The submission includes another file with invalid syntax
+// which is never used. As we check all files for syntax we
+// also check the unused but invalid other file resulting in
+// the (unneeded) error.
+//
+// @EXPECTED_RESULTS@: COMPILER-ERROR
+
+console.log("Hello world!");

--- a/example_problems/hello/submissions/compiler_error/multifile-js-3/module.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-3/module.js
@@ -1,0 +1,6 @@
+// Extra included file with (invalid) JS code.
+// Invalid syntax on import instead of export.
+// The file itself is never used in the submission.
+import function hello() {
+    return "Hello world!"
+}

--- a/example_problems/hello/submissions/compiler_error/multifile-js-3/package.json
+++ b/example_problems/hello/submissions/compiler_error/multifile-js-3/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/example_problems/hello/submissions/compiler_error/multifile-js/hello.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js/hello.js
@@ -1,0 +1,7 @@
+// This should give COMPILER-ERROR on the default problem 'hello'.
+// The included file is invalid syntax.
+//
+// @EXPECTED_RESULTS@: COMPILER-ERROR
+
+import { hello } from './module.js';
+console.log(hello());

--- a/example_problems/hello/submissions/compiler_error/multifile-js/module.js
+++ b/example_problems/hello/submissions/compiler_error/multifile-js/module.js
@@ -1,0 +1,6 @@
+// Extra included file with JS code
+// See the misspelling of let into letter.
+export function hello() {
+    letter unused = 1
+    return "Hello world!"
+}

--- a/example_problems/hello/submissions/compiler_error/multifile-js/package.json
+++ b/example_problems/hello/submissions/compiler_error/multifile-js/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/example_problems/hello/submissions/run_time_error/multifile-js/hello.js
+++ b/example_problems/hello/submissions/run_time_error/multifile-js/hello.js
@@ -1,0 +1,8 @@
+// This should give RUN-ERROR on the default problem 'hello'.
+// It tries to include another file for the actual implementation
+// with the wrong extension.
+//
+// @EXPECTED_RESULTS@: RUN-ERROR
+
+import { hello } from './module.mjs';
+console.log(hello());

--- a/example_problems/hello/submissions/run_time_error/multifile-js/module.js
+++ b/example_problems/hello/submissions/run_time_error/multifile-js/module.js
@@ -1,0 +1,4 @@
+// Extra included file with JS code
+export function hello() {
+    return "Hello world!";
+}

--- a/example_problems/hello/submissions/run_time_error/multifile-js/package.json
+++ b/example_problems/hello/submissions/run_time_error/multifile-js/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/sql/files/defaultdata/awk/run
+++ b/sql/files/defaultdata/awk/run
@@ -13,7 +13,12 @@ DEST="$1" ; shift
 MEMLIMIT="$1" ; shift
 MAINSOURCE="$1"
 
-# There is no portable way to test the syntax of an awk script.
+# Syntax check based on: https://stackoverflow.com/a/7212314
+for j in "$@" ; do
+	awk -f $j -- 'BEGIN { exit(0) } END { exit(0) }'
+	EXITCODE=$?
+	[ "$EXITCODE" -ne 0 ] && exit $EXITCODE
+done
 
 # We construct here the list of source files to be passed to awk:
 FILEARGS=''

--- a/sql/files/defaultdata/js/run
+++ b/sql/files/defaultdata/js/run
@@ -20,6 +20,15 @@ if [ -z "$ENTRY_POINT" ]; then
 	echo "Info: detected entry_point: $MAINSOURCE"
 fi
 
+# Run syntax check
+for file in "$@"; do
+	case $file in *.js)
+		nodejs --check "$file"
+		EXITCODE="$?"
+		[ "$EXITCODE" -ne 0 ] && exit $EXITCODE ;;
+	esac
+done
+
 # Write executing script:
 cat > "$DEST" <<EOF
 #!/bin/sh

--- a/webapp/src/DataFixtures/DefaultData/LanguageFixture.php
+++ b/webapp/src/DataFixtures/DefaultData/LanguageFixture.php
@@ -34,7 +34,7 @@ class LanguageFixture extends AbstractDefaultDataFixture
             ['f95',    'f95',        'Fortran',     ['f95', 'f90'],              false, null,         false,  true,   1,     'f95',               'gfortran --version', ''],
             ['hs',     'haskell',    'Haskell',     ['hs', 'lhs'],               false, null,         false,  true,   1,     'hs',                'ghc --version',      ''],
             ['java',   'java',       'Java',        ['java'],                    false, 'Main class', true,   true,   1,     'java_javac_detect', 'javac -version',     'java -version'],
-            ['js',     'javascript', 'JavaScript',  ['js'],                      false, 'Main file',  false,  true,   1,     'js',                'nodejs --version',   'nodejs --version'],
+            ['js',     'javascript', 'JavaScript',  ['js', 'mjs'],               false, 'Main file',  false,  true,   1,     'js',                'nodejs --version',   'nodejs --version'],
             ['lua',    'lua',        'Lua',         ['lua'],                     false, null,         false,  true,   1,     'lua',               'luac -v',            'lua -v'],
             ['kt',     'kotlin',     'Kotlin',      ['kt'],                      true,  'Main class', false,  true,   1,     'kt',                'kotlinc -version',   'kotlin -version'],
             ['pas',    'pascal',     'Pascal',      ['pas', 'p'],                false, 'Main file',  false,  true,   1,     'pas',               'fpc -iW',            ''],


### PR DESCRIPTION
I think I checked all `run` files and either we compile into an executable or do a syntax check before we create a wrapper. So all languages should now have a sort of syntax check resulting in a possible `COMPILER-ERROR`.