### PR TITLE
Fix typo in prolog compile script

### DIFF
--- a/sql/files/defaultdata/plg/compile.plg
+++ b/sql/files/defaultdata/plg/compile.plg
@@ -4,7 +4,7 @@
 :- dynamic(loading/1).
 :- asserta(loading(0)).
 
-% The first hook is for detectin
+% The first hook is for detecting
 % loading state
 
 user:message_hook(Term, _, _) :-


### PR DESCRIPTION
As found by codespell