### PR TITLE
Remove dangling judgetasks first

### DIFF
--- a/webapp/migrations/Version20230508120033.php
+++ b/webapp/migrations/Version20230508120033.php
@@ -19,6 +19,9 @@ final class Version20230508120033 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        // Cleanup judgetasks for removed submissions
+        // This can happen when a full contest has been removed and the full delete cascade has failed.
+        $this->addSql('DELETE from judgetask WHERE submitid not in (SELECT submitid FROM submission)');
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE judgetask ADD CONSTRAINT FK_83142B703605A691 FOREIGN KEY (submitid) REFERENCES submission (submitid) ON DELETE CASCADE');
     }


### PR DESCRIPTION
Those can exist when you remove a contest so the submissions are cleaned up but not the judgetasks.

This does directly expose a problem though, its not possible to remove the contest anymore as this migration makes sure that the submission can't be removed as there are still judgetasks using it. I looked into it and this boils down to fixing: https://github.com/DOMjudge/domjudge/issues/2465