### PR TITLE
#2537 Give flags a ring-shadow, to make the white parts visible

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -227,7 +227,7 @@ del {
     right: 0;
     bottom: 0;
 }
-.scoreboard .scoreaf { white-space: nowrap; border: 0; text-align: center; }
+.scoreboard .scoreaf { white-space: nowrap; border: 0; padding-left: 2px; text-align: center; }
 .scoreboard .scoreaf img { vertical-align: middle; }
 .univ {
     font-size: 80%;
@@ -337,10 +337,11 @@ td.scorenc { border-color: silver; border-right: 0; }
 }
 
 .countryflag {
-    height: 30px;
-    width: 40px;
-    border-radius: 8px;
-    padding: 2px;
+    height: 1.5rem;
+    width: 2rem;
+    border-radius: .375rem;
+    margin: .125rem;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .2);
 }
 
 .select2 img.countryflag {


### PR DESCRIPTION
Fixes #2537.

The issue description suggested to add a border, but since this is seen as part of the width/height of the image, this messes up the ratio of the flag (same goes for `padding` btw, so I changed that to `margin`). So, I added a shadow instead.
Note that the flags are now slightly smaller than they used to be because I used round `rem` values for width and height – I hope that's fine, and else we can still increase them :slightly_smiling_face:
Same goes for the hardness of the shadow – `0.3` looks fine to me, but perhaps others have different opinions :smile: 

| Before | After |
|---|---|
| ![image](https://github.com/DOMjudge/domjudge/assets/9739541/dcc14ab0-f1d8-441e-a86d-6b51a10fba96) | ![image](https://github.com/DOMjudge/domjudge/assets/9739541/5ed3b277-f501-4dc1-b286-6d6f47947acb) |
| ![image](https://github.com/DOMjudge/domjudge/assets/9739541/49c0e0c4-6bd5-4322-8577-ad448bac6310) | ![image](https://github.com/DOMjudge/domjudge/assets/9739541/cc1b95ac-223f-4aa7-9ff0-7974f48e73d5) |