### PR TITLE
Remove configure option for cgroup location

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -248,7 +248,6 @@ compile_assertions_finished () {
    assert_line "    - tmp..............: /opt/domjudge/judgehost/tmp"
    assert_line "    - judge............: /opt/domjudge/judgehost/judgings"
    assert_line "    - chroot...........: /chroot/domjudge"
-   assert_line "    - cgroup...........: /sys/fs/cgroup"
 }
 
 @test "Prefix configured" {
@@ -309,12 +308,11 @@ compile_assertions_finished () {
    assert_line "    - tmp..............: /tmp"
    assert_line "    - judge............: /usr/local/var/lib/domjudge/judgings"
    assert_line "    - chroot...........: /chroot/domjudge"
-   assert_line "    - cgroup...........: /sys/fs/cgroup"
 }
 
 @test "Alternative dirs together with FHS" {
    setup
-   run run_configure --enable-fhs --with-domserver_webappdir=/run/webapp --with-domserver_tmpdir=/tmp/domserver --with-judgehost_tmpdir=/srv/tmp --with-judgehost_judgedir=/srv/judgings --with-judgehost_chrootdir=/srv/chroot/domjudge --with-judgehost_cgroupdir=/sys/fs/altcgroup
+   run run_configure --enable-fhs --with-domserver_webappdir=/run/webapp --with-domserver_tmpdir=/tmp/domserver --with-judgehost_tmpdir=/srv/tmp --with-judgehost_judgedir=/srv/judgings --with-judgehost_chrootdir=/srv/chroot/domjudge
    assert_line " * prefix..............: /usr/local"
    assert_line " * documentation.......: /usr/local/share/doc/domjudge"
    assert_line " * domserver...........: "
@@ -343,13 +341,11 @@ compile_assertions_finished () {
    assert_line "    - judge............: /srv/judgings"
    refute_line "    - chroot...........: /chroot/domjudge"
    assert_line "    - chroot...........: /srv/chroot/domjudge"
-   refute_line "    - cgroup...........: /sys/fs/cgroup"
-   assert_line "    - cgroup...........: /sys/fs/altcgroup"
 }
 
 @test "Alternative dirs together with defaults" {
    setup
-   run run_configure "--with-judgehost_tmpdir=/srv/tmp --with-judgehost_judgedir=/srv/judgings --with-judgehost_chrootdir=/srv/chroot --with-judgehost_cgroupdir=/sys/fs/altcgroup --with-domserver_logdir=/log"
+   run run_configure "--with-judgehost_tmpdir=/srv/tmp --with-judgehost_judgedir=/srv/judgings --with-judgehost_chrootdir=/srv/chroot --with-domserver_logdir=/log"
    assert_line " * prefix..............: /opt/domjudge"
    assert_line " * documentation.......: /opt/domjudge/doc"
    assert_line " * domserver...........: /opt/domjudge/domserver"
@@ -362,8 +358,6 @@ compile_assertions_finished () {
    assert_line "    - judge............: /srv/judgings"
    refute_line "    - chroot...........: /chroot/domjudge"
    assert_line "    - chroot...........: /srv/chroot"
-   refute_line "    - cgroup...........: /sys/fs/cgroup"
-   assert_line "    - cgroup...........: /sys/fs/altcgroup"
 }
 
 @test "Default URL not set, docs mention" {

--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,6 @@ if test "x$FHS_ENABLED" = xyes ; then
 	AC_SUBST(judgehost_tmpdir,          /tmp)
 	AC_SUBST(judgehost_judgedir,        $localstatedir/lib/${PACKAGE_TARNAME}/judgings)
 	AC_SUBST(judgehost_chrootdir,       /chroot/${PACKAGE_TARNAME})
-	AC_SUBST(judgehost_cgroupdir,       /sys/fs/cgroup)
 	fi
 
 	AC_SUBST(domjudge_docdir,           $docdir)
@@ -241,7 +240,6 @@ AX_PATH(judgehost_rundir,          [$judgehost_root/run])
 AX_PATH(judgehost_tmpdir,          [$judgehost_root/tmp])
 AX_PATH(judgehost_judgedir,        [$judgehost_root/judgings])
 AX_PATH(judgehost_chrootdir,       [/chroot/${PACKAGE_TARNAME}])
-AX_PATH(judgehost_cgroupdir,       [/sys/fs/cgroup])
 fi
 AX_WITH_COMMENT(7,[      ])
 
@@ -405,7 +403,6 @@ echo "    - run..............: AX_VAR_EXPAND($judgehost_rundir)"
 echo "    - tmp..............: AX_VAR_EXPAND($judgehost_tmpdir)"
 echo "    - judge............: AX_VAR_EXPAND($judgehost_judgedir)"
 echo "    - chroot...........: AX_VAR_EXPAND($judgehost_chrootdir)"
-echo "    - cgroup...........: AX_VAR_EXPAND($judgehost_cgroupdir)"
 fi
 echo ""
 echo " * systemd unit files..: AX_VAR_EXPAND($systemd_unitdir)"

--- a/etc/judgehost-static.php.in
+++ b/etc/judgehost-static.php.in
@@ -16,7 +16,6 @@ define('RUNDIR',      '@judgehost_rundir@');
 define('TMPDIR',      '@judgehost_tmpdir@');
 define('JUDGEDIR',    '@judgehost_judgedir@');
 define('CHROOTDIR',   '@judgehost_chrootdir@');
-define('CGROUPDIR',   '@judgehost_cgroupdir@');
 
 define('RUNUSER',     '@RUNUSER@');
 define('RUNGROUP',    '@RUNGROUP@');

--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -7,7 +7,7 @@
 # (hence: not the 'domjudge-run' user!)
 
 JUDGEHOSTUSER=@DOMJUDGE_USER@
-CGROUPBASE=@judgehost_cgroupdir@
+CGROUPBASE="/sys/fs/cgroup"
 
 cgroup_error_and_usage () {
     echo "$1" >&2

--- a/paths.mk.in
+++ b/paths.mk.in
@@ -103,7 +103,6 @@ judgehost_rundir          = @judgehost_rundir@
 judgehost_tmpdir          = @judgehost_tmpdir@
 judgehost_judgedir        = @judgehost_judgedir@
 judgehost_chrootdir       = @judgehost_chrootdir@
-judgehost_cgroupdir       = @judgehost_cgroupdir@
 
 domjudge_docdir           = @domjudge_docdir@
 
@@ -153,7 +152,6 @@ define substconfigvars
 	-e 's,@judgehost_tmpdir[@],@judgehost_tmpdir@,g' \
 	-e 's,@judgehost_judgedir[@],@judgehost_judgedir@,g' \
 	-e 's,@judgehost_chrootdir[@],@judgehost_chrootdir@,g' \
-	-e 's,@judgehost_cgroupdir[@],@judgehost_cgroupdir@,g' \
 	-e 's,@domjudge_docdir[@],@domjudge_docdir@,g' \
 	-e 's,@systemd_unitdir[@],@systemd_unitdir@,g' \
 	-e 's,@DOMJUDGE_USER[@],@DOMJUDGE_USER@,g' \


### PR DESCRIPTION
runguard.c has the default location hardcoded and no one complained. It would be (relatively easy) to use the autoconf option (and would have taken less code changes).

I found this when I tried to move the mounted cgroup locations to another dir to setup cgroupv2 in a unified structure. I'm fine with keeping the behaviour if we have a good reason for it but a quick websearch shows that everyone uses `/sys/fs/cgroup`.