### PR TITLE
Highlight pending submissions during freeze on jury scoreboard

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -84,9 +84,9 @@ a {
 .prevsubmit     { color: #696969; }
 
 .output_text {
-    border-top: 1px dotted #C0C0C0;
-    border-bottom: 1px dotted #C0C0C0;
-    background-color: #FAFAFA;
+    border-top: 1px dotted #c0c0c0;
+    border-bottom: 1px dotted #c0c0c0;
+    background-color: #fafafa;
     margin: 0;
     padding: 5px;
     font-family: monospace;
@@ -94,9 +94,9 @@ a {
 }
 
 .clarificationform pre {
-    border-top: 1px dotted #C0C0C0;
-    border-bottom: 1px dotted #C0C0C0;
-    background-color: #FAFAFA;
+    border-top: 1px dotted #c0c0c0;
+    border-bottom: 1px dotted #c0c0c0;
+    background-color: #fafafa;
     margin: 0;
     padding: 5px;
     font-family: monospace;
@@ -104,7 +104,7 @@ a {
 }
 
 kbd {
-    background-color: #FAFAFA;
+    background-color: #fafafa;
     color: black;
 }
 
@@ -270,9 +270,9 @@ img.affiliation-logo {
 .score_incorrect           { background: #e87272; }
 .score_pending             { background: #6666ff; }
 
-.gold-medal   { background-color: #EEC710 }
-.silver-medal { background-color: #AAA }
-.bronze-medal { background-color: #C08E55 }
+.gold-medal   { background-color: #eec710 }
+.silver-medal { background-color: #aaa }
+.bronze-medal { background-color: #c08e55 }
 
 #scoresolv,#scoretotal { width: 2.5em; }
 .scorenc,.scorett,.scorepl { text-align: center; width: 2ex; }
@@ -655,8 +655,8 @@ blockquote {
 }
 
 #contesttimer {
-	color: DimGray;
-	margin-left: auto;
+    color: DimGray;
+    margin-left: auto;
 }
 
 .lasttcruns, .lastresult {
@@ -668,7 +668,7 @@ blockquote {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background-color: #295D8A;
+    background-color: #295d8a;
     font-size: 200%;
     font-weight: bold;
     color: white;

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -265,10 +265,10 @@ img.affiliation-logo {
     padding-right: 3pt;
 }
 
-.score_correct   { background: #60e760; }
-.score_first     { background: #1daa1d !important; }
-.score_pending   { background: #6666FF; }
-.score_incorrect { background: #e87272; }
+.score_correct             { background: #60e760; }
+.score_correct.score_first { background: #1daa1d; }
+.score_incorrect           { background: #e87272; }
+.score_pending             { background: #6666ff; }
 
 .gold-medal   { background-color: #EEC710 }
 .silver-medal { background-color: #AAA }

--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -196,7 +196,7 @@ table.submissions-table {
 }
 
 .devmode {
-    background-color: #295D8A !important;
+    background-color: #295d8a !important;
 }
 
 .devmode-icon {

--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -48,6 +48,11 @@ tr.summary td { border-top: 1px solid black; }
    clickable in the jury scoreboard and for all team cells */
 .scoreboard_jury td, .scoreboard_jury th { padding: 0; }
 
+/* show pending submissions using a blue corner */
+.score_pending.score_correct             { background: linear-gradient(45deg, #60e760 85%, #6666ff 85%); }
+.score_pending.score_correct.score_first { background: linear-gradient(45deg, #1daa1d 85%, #6666ff 85%); }
+.score_pending.score_incorrect           { background: linear-gradient(45deg, #e87272 85%, #6666ff 85%); }
+
 #submission_layout { width: 100%; }
 
 #djlogo {

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -932,7 +932,7 @@ class ScoreboardService
             $data['showFlags']            = $this->config->get('show_flags');
             $data['showAffiliationLogos'] = $this->config->get('show_affiliation_logos');
             $data['showAffiliations']     = $this->config->get('show_affiliations');
-            $data['showPending']          = $this->config->get('show_pending');
+            $data['showPending']          = empty($scoreboard) || $scoreboard->getFreezeData()->showFrozen() ? $this->config->get('show_pending') : 0;
             $data['showTeamSubmissions']  = $this->config->get('show_teams_submissions');
             $data['scoreInSeconds']       = $this->config->get('score_in_seconds');
             $data['maxWidth']             = $this->config->get('team_column_width');

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -154,8 +154,9 @@ class Scoreboard
             $this->matrix[$teamId][$probId] = new ScoreboardMatrixItem(
                 $scoreRow->getIsCorrect($this->restricted),
                 $scoreRow->getIsCorrect($this->restricted) && $scoreRow->getIsFirstToSolve(),
-                $scoreRow->getSubmissions($this->restricted),
-                $scoreRow->getPending($this->restricted),
+                // When public scoreboard is frozen, also show "x + y tries" for jury
+                $scoreRow->getSubmissions($this->freezeData->showFrozen() ? false : $this->restricted),
+                $scoreRow->getPending($this->freezeData->showFrozen() ? false : $this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
                 $penalty,
                 $scoreRow->getRuntime($this->restricted)

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -65,8 +65,9 @@ class SingleTeamScoreboard extends Scoreboard
             $this->matrix[$scoreRow->getTeam()->getTeamid()][$scoreRow->getProblem()->getProbid()] = new ScoreboardMatrixItem(
                 $scoreRow->getIsCorrect($this->restricted),
                 $scoreRow->getIsCorrect($this->showRestrictedFts) && $scoreRow->getIsFirstToSolve(),
-                $scoreRow->getSubmissions($this->restricted),
-                $scoreRow->getPending($this->restricted),
+                // When public scoreboard is frozen, also show "x + y tries" for jury
+                $scoreRow->getSubmissions($this->freezeData->showFrozen() ? false : $this->restricted),
+                $scoreRow->getPending($this->freezeData->showFrozen() ? false : $this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
                 $penalty,
                 $scoreRow->getRuntime($this->restricted)

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -93,11 +93,12 @@
             </div>
         {% endif %}
 
-        {% if scoreboard.freezeData.showFrozen(false) %}
+        {% if scoreboard.freezeData.showFrozen %}
             <div class="alert alert-warning" role="alert" style="font-size: 80%;">
                 {% if jury %}
                     <a href="{{ path('public_index') }}">The public scoreboard</a>
-                    was frozen with {{ current_contest.minutesRemaining }} minutes remaining
+                    was frozen with {{ current_contest.minutesRemaining }} minutes remaining.
+                    {% if showPending %}Submissions after the freeze are indicated with a blue corner.{% endif %}
                 {% else %}
                     The scoreboard was frozen with {{ current_contest.minutesRemaining }} minutes remaining - solutions
                     submitted in the last {{ current_contest.minutesRemaining }} minutes of the contest {% if showPending %}are still shown as pending{% else %}are not shown{% endif %}.
@@ -109,7 +110,7 @@
             (filterValues.affiliations | length > 1 or
              filterValues.countries | length > 1 or
              filterValues.categories | length > 1) %}
-	<div class="dropdown">
+        <div class="dropdown">
             <button class="btn btn-outline-secondary btn-sm m-2 dropdown-toggle" data-bs-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false" id="filter-toggle">
                 <i class="fas fa-filter"></i>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -249,16 +249,23 @@
                         {% set scoreCssClass = 'score_correct' %}
                         {% if enable_ranking %}
                             {% if not scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.solvedFirst(score.team, problem) %}
-                                    {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
+                                {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                             {% endif %}
                             {% if scoreboard.getRuntimeAsScoreTiebreaker() and scoreboard.isFastestSubmission(score.team, problem) %}
-                                    {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
+                                {% set scoreCssClass = scoreCssClass ~ ' score_first' %}
                             {% endif %}
                         {% endif %}
                     {% elseif showPending and matrixItem.numSubmissionsPending > 0 %}
                         {% set scoreCssClass = 'score_pending' %}
                     {% elseif matrixItem.numSubmissions > 0 %}
                         {% set scoreCssClass = 'score_incorrect' %}
+                    {% endif %}
+                    {% if jury and showPending and matrixItem.numSubmissionsPending > 0 %}
+                        {% if scoreCssClass == 'score_pending' %}
+                            {% set scoreCssClass = scoreCssClass ~ ' score_incorrect' %}
+                        {% else %}
+                            {% set scoreCssClass = scoreCssClass ~ ' score_pending' %}
+                        {% endif %}
                     {% endif %}
 
                     {% set numSubmissions = matrixItem.numSubmissions %}


### PR DESCRIPTION
Also, during the freeze, also show "x + y tries" for jury.

Supersedes #2581 and fixes #2572.

In the implementation, I've tried to make `showPending` mean "the config allows showing pending submissions _and_ the public scoreboard is frozen. Because when the public scoreboard is frozen, we also want special treatment for the jury scoreboard now :smile:

![image](https://github.com/DOMjudge/domjudge/assets/9739541/af5873fb-25c6-462b-b0b3-5270424f4ca2)

Also, please test whether I didn't break any other scoreboards (e.g. for teams during the contest), because my local test set of contest data is fairily limited :innocent: 