### PR TITLE
Change exception as this is allowed to be retried

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -732,7 +732,7 @@ class SubmissionController extends BaseController
             throw new BadRequestHttpException('Integrity problem while fetching team output.');
         }
         if ($run->getOutput() === null) {
-            throw new BadRequestHttpException('No team output available (yet).');
+            throw new NotFoundHttpException('No team output available (yet).');
         }
 
         $filename = sprintf('p%d.t%d.%s.run%d.team%d.out', $submission->getProblem()->getProbid(), $run->getTestcase()->getRank(),


### PR DESCRIPTION
The BadRequest implies that the request should not be repeated but as this is most likely a temporary problem we should encourage agents to get back.