### PR TITLE
Refer to correct field to prevent HTTP500

### DIFF
--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -250,7 +250,7 @@ class TeamCategoryController extends BaseController
                           ->join('t.category', 'tc')
                           ->andWhere('j.valid = true')
                           ->andWhere('j.result != :compiler_error')
-                          ->andWhere('tc.category = :categoryId')
+                          ->andWhere('tc.categoryid = :categoryId')
                           ->setParameter('compiler_error', 'compiler-error')
                           ->setParameter('categoryId', $categoryId);
         if ($contestId > -1) {


### PR DESCRIPTION
This triggered an error and broke the webstandard test. I wonder why did was not detected by either the webstandard test or the unit test which visits all pages.