### PR TITLE
For submissions and clarifications, prefix external ID in shadow mode

### DIFF
--- a/webapp/src/Doctrine/ExternalIdAssigner.php
+++ b/webapp/src/Doctrine/ExternalIdAssigner.php
@@ -4,7 +4,9 @@ namespace App\Doctrine;
 
 use App\Entity\CalculatedExternalIdBasedOnRelatedFieldInterface;
 use App\Entity\ExternalIdFromInternalIdInterface;
+use App\Entity\PrefixedExternalIdInShadowModeInterface;
 use App\Entity\PrefixedExternalIdInterface;
+use App\Service\DOMJudgeService;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostPersistEventArgs;
@@ -15,6 +17,7 @@ class ExternalIdAssigner
 {
     public function __construct(
         protected readonly EntityManagerInterface $em,
+        protected readonly DOMJudgeService $dj,
     ) {}
 
     public function __invoke(PostPersistEventArgs $args): void
@@ -36,6 +39,8 @@ class ExternalIdAssigner
             $primaryKeyField = $metadata->getSingleIdentifierFieldName();
             $externalid = (string)$metadata->getFieldValue($entity, $primaryKeyField);
             if ($entity instanceof PrefixedExternalIdInterface) {
+                $externalid = 'dj-' . $externalid;
+            } elseif ($this->dj->shadowMode() && $entity instanceof PrefixedExternalIdInShadowModeInterface) {
                 $externalid = 'dj-' . $externalid;
             }
         }

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -33,7 +33,8 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[UniqueEntity(fields: 'externalid')]
 class Clarification extends BaseApiEntity implements
     HasExternalIdInterface,
-    ExternalIdFromInternalIdInterface
+    ExternalIdFromInternalIdInterface,
+    PrefixedExternalIdInShadowModeInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/webapp/src/Entity/PrefixedExternalIdInShadowModeInterface.php
+++ b/webapp/src/Entity/PrefixedExternalIdInShadowModeInterface.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+/**
+ * Entities implementing this interface will have their external ID prefixed with 'dj-', but only in shadow mode.
+ *
+ * This is used for submissions and clarifications that are added directly in DOMjudge while shadowing.
+ *
+ * For submissions this happens for example when analysts use DOMjudge and want to submit something.
+ *
+ * For clarifications this should normally not happen, but we still need to handle it.
+ */
+interface PrefixedExternalIdInShadowModeInterface
+{
+}

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -38,7 +38,8 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[UniqueEntity(fields: 'externalid')]
 class Submission extends BaseApiEntity implements
     HasExternalIdInterface,
-    ExternalIdFromInternalIdInterface
+    ExternalIdFromInternalIdInterface,
+    PrefixedExternalIdInShadowModeInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1561,7 +1561,7 @@ class DOMJudgeService
 
             // Special case, we're shadow and someone submits on our side in that case
             // we're not super lazy.
-            if ($this->shadowMode() && $submission->getExternalid() === null) {
+            if ($this->shadowMode() && $submission->getExternalid() === ('dj-' . $submission->getSubmitid())) {
                 $evalOnDemand = false;
             }
             if ($manualRequest) {

--- a/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/QueueTaskControllerTest.php
@@ -144,7 +144,7 @@ class QueueTaskControllerTest extends BaseTestCase
         $config   = self::getContainer()->get(ConfigurationService::class);
         $eventLog = self::getContainer()->get(EventLogService::class);
         $dj       = self::getContainer()->get(DOMJudgeService::class);
-        $config->saveChanges(['lazy_eval_results'=>$globalLazy], $eventLog, $dj);
+        $config->saveChanges(['lazy_eval_results'=>$globalLazy], $eventLog, $dj, treatMissingBooleansAsFalse: false);
 
         $this->roles = ['admin'];
         $this->logOut();


### PR DESCRIPTION
This is needed to prevent collisions.

We can also use this logic to determine if someone submitted in DOMjudge while being shadow (i.e. an analyst instance) to make sure we judge the submission. This fixes the few breaking tests.