### PR TITLE
Use Gitlabci image in more GHA steps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,12 +12,14 @@ on:
 
 jobs:
   analyze:
-    # We can not run with our gitlab container
-    # CodeQL has missing .so files otherwise
+    container:
+      image: domjudge/gitlabci:24.04
+      options: --user domjudge
     name: Analyze
     runs-on: ubuntu-latest
     env:
       COMPILED: "cpp"
+      USER: "domjudge"
     permissions:
       actions: read
       contents: read
@@ -33,27 +35,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
-    - name: Install required tools
-      if: ${{ contains(env.COMPILED, matrix.language) }}
-      run: |
-        sudo apt update
-        sudo apt install -y acl zip unzip apache2 composer php php-fpm php-gd \
-                            php-cli php-intl php-mbstring php-mysql php-curl php-json \
-                            php-xml php-zip ntp make sudo debootstrap \
-                            libcgroup-dev lsof php-cli php-curl php-json php-xml \
-                            php-zip procps gcc g++ default-jre-headless \
-                            default-jdk-headless ghc fp-compiler autoconf automake bats \
-                            python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig \
-                            python3-yaml latexmk
-
     - name: Install composer files
       if: ${{ contains(env.COMPILED, matrix.language) }}
-      run: |
-        composer install --no-scripts
+      run: composer install --no-scripts
 
     - name: Configure Makefile
       if: ${{ contains(env.COMPILED, matrix.language) }}
@@ -88,4 +76,4 @@ jobs:
       run: sudo chown -R ${USER} ./installdir
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,7 +13,7 @@ jobs:
   syntax-job:
     runs-on: ubuntu-latest
     container:
-      image: domjudge/gitlabci:2.1
+      image: domjudge/gitlabci:24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run the syntax checks

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -15,7 +15,7 @@ jobs:
   runpipe:
     runs-on: ubuntu-latest
     container:
-      image: domjudge/gitlabci:2.1
+      image: domjudge/gitlabci:24.04
     steps:
       - uses: actions/checkout@v4
       - name: Create the configure file


### PR DESCRIPTION
I'll squash it after approval.

I think there should also be a way to only trigger this when the scripts like runguard etc. get changed because GitHub is aware of what are the differences between the PR and the target branch.