### PR TITLE
Don't run composer as root if unneeded

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -37,7 +37,7 @@ setup() {
     if [ "$distro_id" = "ID=fedora" ]; then
         repo-install httpd
     fi
-    repo-install gcc g++ libcgroup-dev
+    repo-install gcc g++ libcgroup-dev composer
 }
 
 run_configure () {

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 domserver: domserver-configure paths.mk config
 judgehost: judgehost-configure paths.mk config
 docs: paths.mk config
-install-domserver: domserver composer-dump-autoload domserver-create-dirs
+install-domserver: domserver domserver-create-dirs
 install-judgehost: judgehost judgehost-create-dirs
 install-docs: docs-create-dirs
 dist: configure composer-dependencies
@@ -76,12 +76,6 @@ endif
 composer-dependencies-dev:
 	composer $(subst 1,-q,$(QUIET)) install --prefer-dist --no-scripts --no-plugins
 
-# Dump autoload dependencies (including plugins)
-# This is needed since symfony/runtime is a Composer plugin that runs while dumping
-# the autoload file
-composer-dump-autoload:
-	composer $(subst 1,-q,$(QUIET)) dump-autoload -o -a
-
 composer-dump-autoload-dev:
 	composer $(subst 1,-q,$(QUIET)) dump-autoload
 
@@ -101,7 +95,7 @@ build-scripts:
 
 # List of SUBDIRS for recursive targets:
 build:             SUBDIRS=        lib           misc-tools
-domserver:         SUBDIRS=etc         sql       misc-tools webapp
+domserver:         SUBDIRS=etc     lib sql       misc-tools webapp
 install-domserver: SUBDIRS=etc     lib sql       misc-tools webapp example_problems
 judgehost:         SUBDIRS=etc             judge misc-tools
 install-judgehost: SUBDIRS=etc     lib     judge misc-tools
@@ -222,7 +216,7 @@ webapp/.env.local:
 # symlinks where necessary to let it work from the source tree.
 # This stuff is a hack!
 maintainer-install: inplace-install composer-dump-autoload-dev
-inplace-install: build composer-dump-autoload domserver-create-dirs judgehost-create-dirs
+inplace-install: build domserver-create-dirs judgehost-create-dirs
 inplace-install-l:
 # Replace libjudgedir with symlink to prevent lots of symlinks:
 	-rmdir $(judgehost_libjudgedir)
@@ -341,5 +335,5 @@ clean-autoconf:
         $(addprefix inplace-,conf conf-common install uninstall) \
         $(addprefix maintainer-,conf install) clean-autoconf config distdocs \
         composer-dependencies composer-dependencies-dev \
-        composer-dump-autoload composer-dump-autoload-dev \
+        composer-dump-autoload-dev \
         coverity-conf coverity-build

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,9 @@
 ifndef TOPDIR
 TOPDIR=..
 endif
+
+REC_TARGETS = domserver
+
 include $(TOPDIR)/Makefile.global
 
 OBJECTS = $(addsuffix $(OBJEXT),lib.error lib.misc)
@@ -31,3 +34,5 @@ install-domserver:
 install-judgehost:
 	$(INSTALL_DATA) -t $(DESTDIR)$(judgehost_libdir)    *.php *.sh
 	$(INSTALL_PROG) -t $(DESTDIR)$(judgehost_libdir)    alert
+
+domserver:         SUBDIRS=vendor

--- a/lib/vendor/Makefile
+++ b/lib/vendor/Makefile
@@ -1,0 +1,12 @@
+ifndef TOPDIR
+TOPDIR=../..
+endif
+include $(TOPDIR)/Makefile.global
+
+clean-l:
+	rm -f autoload_runtime.php
+
+autoload_runtime.php:
+	composer $(subst 1,-q,$(QUIET)) dump-autoload -o -a -d $(TOPDIR)
+
+domserver: autoload_runtime.php


### PR DESCRIPTION
The phony target always runs so we overwrite the file as root. The proper fix would be to remove the phony part and state which file we wish to create.

As this is currently semi-broken for `8.3.0` I rather first merge this and afterwards check if there is a better solution.