### PR TITLE
Remove default documentation section for Debian 10

### DIFF
--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -40,11 +40,6 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml latexmk
-
-On Debian 11 (Bullseye) and above, instead install::
-
-  sudo apt install autoconf automake bats \
     python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
     latexmk texlive-latex-recommended texlive-latex-extra tex-gyre
 

--- a/doc/manual/install-workstation.rst
+++ b/doc/manual/install-workstation.rst
@@ -84,12 +84,9 @@ When DOMjudge is configured and site-specific configuration set,
 the team manual can be generated with the command ``make docs``.
 The following should do it on a Debian-like system::
 
-  sudo apt install python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
+  sudo apt install python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
   cd <INSTALL_PATH>/doc/
   make docs
-
-On Debian 11 and above, install
-``python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml`` instead.
 
 The resulting manual will then be found in the ``team/`` subdirectory.
 


### PR DESCRIPTION
Debian 10 is EOL on the 30th and it ships PHP73 which is not supported for main.