### PR TITLE
Use correct API doc root by reading it from the request

### DIFF
--- a/webapp/config/packages/nelmio_api_doc.yaml
+++ b/webapp/config/packages/nelmio_api_doc.yaml
@@ -1,9 +1,9 @@
 nelmio_api_doc:
     documentation:
         servers:
-            - url: "%domjudge.baseurl%api"
+            - url: ~ # Will be set by App\NelmioApiDocBundle\ExternalDocDescriber
               description: API used at this contest
-            - url: https://www.domjudge.org/demoweb/api
+            - url: https://www.domjudge.org/demoweb
               description: New API in development
         info:
             title: DOMjudge

--- a/webapp/src/NelmioApiDocBundle/ExternalDocDescriber.php
+++ b/webapp/src/NelmioApiDocBundle/ExternalDocDescriber.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace App\NelmioApiDocBundle;
+
+use Nelmio\ApiDocBundle\Describer\DescriberInterface;
+use Nelmio\ApiDocBundle\Describer\ExternalDocDescriber as BaseExternalDocDescriber;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use OpenApi\Annotations\OpenApi;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[AsDecorator(decorates: 'nelmio_api_doc.describers.config')]
+class ExternalDocDescriber implements DescriberInterface
+{
+    public function __construct(
+        #[AutowireDecorated]
+        protected BaseExternalDocDescriber $decorated,
+        protected RequestStack $requestStack,
+    ) {}
+
+    public function describe(OpenApi $api): void
+    {
+        // Inject the correct server for the API docs
+        $request = $this->requestStack->getCurrentRequest();
+        $this->decorated->describe($api);
+        Util::merge($api->servers[0], ['url' => $request->getSchemeAndHttpHost(),], true);
+    }
+}


### PR DESCRIPTION
Fixes #2611

Also we should not append /api since the swagger already does this.

Should be back-ported to 8.3.