### PR TITLE
Fix updates when no contest is set

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -421,16 +421,16 @@ class DOMJudgeService
 
         if ($this->checkrole('balloon')) {
             $balloonsQuery = $this->em->createQueryBuilder()
-            ->select('b.balloonid', 't.name', 't.location', 'p.name AS pname')
-            ->from(Balloon::class, 'b')
-            ->leftJoin('b.submission', 's')
-            ->leftJoin('s.problem', 'p')
-            ->leftJoin('s.contest', 'co')
-            ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'co.cid = cp.contest AND p.probid = cp.problem')
-            ->leftJoin('s.team', 't')
-            ->andWhere('co.cid = :cid')
-            ->andWhere('b.done = 0')
-            ->setParameter('cid', $contest->getCid());
+                ->select('b.balloonid', 't.name', 't.location', 'p.name AS pname')
+                ->from(Balloon::class, 'b')
+                ->leftJoin('b.submission', 's')
+                ->leftJoin('s.problem', 'p')
+                ->leftJoin('s.contest', 'co')
+                ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'co.cid = cp.contest AND p.probid = cp.problem')
+                ->leftJoin('s.team', 't')
+                ->andWhere('co.cid = :cid')
+                ->andWhere('b.done = 0')
+                ->setParameter('cid', $contest->getCid());
 
             $freezetime = $contest->getFreezeTime();
             if ($freezetime !== null && !(bool)$this->config->get('show_balloons_postfreeze')) {

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -419,7 +419,7 @@ class DOMJudgeService
             }
         }
 
-        if ($this->checkrole('balloon')) {
+        if ($this->checkrole('balloon') && $contest) {
             $balloonsQuery = $this->em->createQueryBuilder()
                 ->select('b.balloonid', 't.name', 't.location', 'p.name AS pname')
                 ->from(Balloon::class, 'b')


### PR DESCRIPTION
I think this method of solving is actually wrong as we normally have another behaviour.

| #contests | Cookie selected | Normally shown      | Current behaviour balloonspage |
|-----------|-----------------|---------------------|--------------------------------|
| 0         | -1              | Nothing             | Same                           |
| 2         | 1               | All of contest 1    | Same                           |
| 2         | -1              | All of all contests | **Nothing**                      |

I can see the usecase for having 2 contests like the PacNW situation with divisions where you would still want to hand out balloons to both contests so I think we should refactor to also have the same behavior here (when selectedContest=-1 -> display everything from all active contests).