### PR TITLE
Fix the line break in the tooltips of public statistics

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -823,7 +823,7 @@ function setupPreviewClarification($input, $previewDiv, previewInitial) {
 }
 
 $(function () {
-    $('[data-toggle="tooltip"]').tooltip();
+    $('[data-bs-toggle="tooltip"]').tooltip();
 });
 
 function initializeKeyboardShortcuts() {

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -24,6 +24,14 @@ table tr a {
     color: inherit;
 }
 </style>
+<script>
+$(function() {
+    $('[data-bs-toggle="popover"]').popover({
+      trigger: 'hover',
+      html: true
+    })
+})
+</script>
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -36,7 +36,7 @@ table tr a {
           Contest Stats
         </div>
         <div class="card-body">
-          <abbr data-bs-toggle="popover" data-placement="bottom" data-bs-title="Misery Index" data-bs-content="
+          <abbr data-bs-toggle="popover" data-bs-placement="bottom" data-bs-title="Misery Index" data-bs-content="
             This is a measure of how 'bored' contestants are. It is the average number of
             people-minutes spent fruitlessly trying to solve problems at the end of the contest.
             <br>

--- a/webapp/templates/jury/entity_id_badge.html.twig
+++ b/webapp/templates/jury/entity_id_badge.html.twig
@@ -1,4 +1,4 @@
-<span class="badge text-bg-secondary id-badge" data-bs-toggle="tooltip" data-placement="top" title="{% if label is defined and label | length %}Label: {{ label }}, {% endif %}{% if externalId is not null %}External ID: {{ externalId }}, {% endif %}Internal ID: {{ idPrefix }}{{ id }}">
+<span class="badge text-bg-secondary id-badge" data-bs-toggle="tooltip" data-bs-placement="top" title="{% if label is defined and label | length %}Label: {{ label }}, {% endif %}{% if externalId is not null %}External ID: {{ externalId }}, {% endif %}Internal ID: {{ idPrefix }}{{ id }}">
     {% if label is defined and label | length %}
         {{ label }}
     {% elseif externalId is not null %}

--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -92,8 +92,8 @@
                                                             <div
                                                                 class="problem-stats-item {{ itemClass }}"
                                                                 data-bs-toggle="tooltip"
-                                                                data-placement="top"
-                                                                data-html="true"
+                                                                data-bs-placement="top"
+                                                                data-bs-html="true"
                                                                 title="Between {{ stat.start.timestamp | printtime(null, contest) }} and {{ stat.end.timestamp | printtime(null, contest) }}:<br/>{{ label }}">
                                                             </div>
                                                         {% endfor %}

--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -94,7 +94,7 @@
                                                                 data-bs-toggle="tooltip"
                                                                 data-placement="top"
                                                                 data-html="true"
-                                                                title="Between {{ stat.start.timestamp | printtime(null, contest) }} and {{ stat.end.timestamp | printtime(null, contest) }}:{{ '\n' }}{{ label }}">
+                                                                title="Between {{ stat.start.timestamp | printtime(null, contest) }} and {{ stat.end.timestamp | printtime(null, contest) }}:<br/>{{ label }}">
                                                             </div>
                                                         {% endfor %}
                                                     </div>


### PR DESCRIPTION
This PR fixes the line break in the tooltips of public statistics.

Bootstrap5 uses `data-bs-*` instead of `data-*`, so `data-html` should be replaced by `data-bs-html`. After that, <br/> can be shown as a line break correctly.

Also, all the tooltips should be initialized by js. This is already done in `domjudge.js`, but it's also outdated.

See also: https://getbootstrap.com/docs/5.0/migration/#javascript

Closes #2613.

Also, popover initialization was accidentally removed in d74c94f350f3cf35cc21fd3eec6607d2103e2f17, I have also revert this in this PR.

---
After fix, all tooltips in problemset statistics will be shown as below.

![image](https://github.com/user-attachments/assets/0c3bacba-e039-4486-b7ca-eb9a3fdd6be7)


