### PR TITLE
Link from card on contests overview page to single contest page

### DIFF
--- a/webapp/templates/jury/contests.html.twig
+++ b/webapp/templates/jury/contests.html.twig
@@ -23,6 +23,7 @@
                         {% if contest.locked %}
                             <i class="fas fa-lock"></i>
                         {% endif %}
+                        <a class="fa-regular fa-folder-open" style="float: right; color: black" href={{ path('jury_contest', {'contestId': contest.cid}) }}></a>
                     </div>
                     <div class="card-body">
                         {% if not contest.starttimeEnabled and contest.finalizetime is not empty %}


### PR DESCRIPTION
The issue suggested using the header only but that felt a bit hard for people to find the link so the whole card is used now. The buttons in the card still work with their own links.

Fixes: #2462

```
<a href={{ path('jury_contest', {'contestId': contest.cid}) }}>
```

Is the only interesting piece, the rest is fixing indentation.