### PR TITLE
Use "accepted" contest pdf name in import-contest script

### DIFF
--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -117,7 +117,7 @@ def import_contest_banner(cid: str):
 def import_contest_problemset_document(cid: str):
     """Import the contest problemset document"""
 
-    files = ['contest.pdf', 'contest-web.pdf', 'contest.html', 'contest.txt']
+    files = ['problemset.pdf', 'contest.pdf', 'contest-web.pdf', 'contest.html', 'contest.txt']
 
     text_file = None
     for file in files:


### PR DESCRIPTION
This seems to be the consensus in #2483 but was not implemented (yet).

Closes #2483 