### PR TITLE
Close form before starting the other one.

### DIFF
--- a/webapp/templates/jury/executable.html.twig
+++ b/webapp/templates/jury/executable.html.twig
@@ -135,8 +135,8 @@
                 {{ form_widget(form) }}
             </div>
         </div>
-        {{ form_end(form) }}
     {% endif %}
+    {{ form_end(form) }}
 
     {% if is_granted('ROLE_ADMIN') %}
         <hr>


### PR DESCRIPTION
We never closed the first form (when there are no files) as we enter the first branch but the second branch had the closing tag for the form. Solved by moving that tag outside of the branches.

Closes #2272