### PR TITLE
Fix default full name in self-registration form

### DIFF
--- a/webapp/src/Controller/SecurityController.php
+++ b/webapp/src/Controller/SecurityController.php
@@ -105,7 +105,7 @@ class SecurityController extends AbstractController
             $plainPass = $registration_form->get('plainPassword')->getData();
             $password  = $passwordHasher->hashPassword($user, $plainPass);
             $user->setPassword($password);
-            if ($user->getName() === null) {
+            if ((string)$user->getName() === '') {
                 $user->setName($user->getUsername());
             }
 


### PR DESCRIPTION
From the commit message:

> When the full name is not specified, the code is supposed to set it to the username. But that wasn't working because the code was checking for `null` but the full name is set to an empty string.
>
> Fix this by checking for either an empty string or `null` (casting `null` to string returns an empty string).