### PR TITLE
Use /etc/os-release as alternative when lsb_release is not available

### DIFF
--- a/misc-tools/dj_make_chroot.in
+++ b/misc-tools/dj_make_chroot.in
@@ -34,6 +34,11 @@ RELEASE=""
 DEBIAN_ARCHLIST="amd64,arm64,armel,armhf,i386,mips,mips64el,mipsel,ppc64el,s390x"
 UBUNTU_ARCHLIST="amd64,arm64,armhf,i386,powerpc,ppc64el,s390x"
 
+if ! command -v lsb_release; then
+    echo "Please install `lsb_release`."
+    exit 1
+fi
+
 # If host system is Debian or Ubuntu, use its release and architecture by default
 if [ "$(lsb_release -i -s || true)" = 'Debian' ] || \
    [ "$(lsb_release -i -s || true)" = 'Ubuntu' ]; then


### PR DESCRIPTION
Extract the OS/release information

This is not 100% doable with /etc/os-release only. The Debian difference between Release & Codename is not shown in the official containers for example. See: https://hub.docker.com/_/debian

Closes: #2563.