### PR TITLE
Fix start of MySQL container

### DIFF
--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -36,7 +36,6 @@
     - /bin/true
   services:
     - name: mysql
-      command: ["--mysql-native-password", "--authentication_policy=mysql_native_password"]
       alias: sqlserver
 
 .mariadb_job:


### PR DESCRIPTION
The native password module used was deprecated with MySQL8 and doesn't work with MySQL9 anymore. It seems we don't need it anymore (I think we needed it because the mariadb-utils did not have support for caching_sha2_password yet), but the alternative is to keep using the MySQL8 container and not test for MySQL9.

Under the hood in the past we used to store the password as a hash in the mysql.user table and now it's stored in another way (https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password) which should also give better performance.

See: https://dba.stackexchange.com/a/209520
(cherry picked from commit 9c2bb9906c384e6b4292ec973cbcf2edb392dd79)