### PR TITLE
Fix 82 sql

### DIFF
--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -35,7 +35,8 @@
   script:
     - /bin/true
   services:
-    - name: mysql
+    - name: mysql:8.0
+      command: ["--default-authentication-plugin=mysql_native_password"]
       alias: sqlserver
 
 .mariadb_job:


### PR DESCRIPTION
The older image doesn't have the required SQL client tools. This is not relevant for the release itself as this is only needed for how the SQL container gets booted.