### PR TITLE
Add page with language stats

### DIFF
--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -120,4 +120,25 @@ class AnalysisController extends AbstractController
             $this->stats->getProblemStats($contest, $problem, $view)
         );
     }
+
+    #[Route(path: '/languages', name: 'analysis_languages')]
+    public function languagesAction(
+        #[MapQueryParameter]
+        ?string $view = null
+    ): Response {
+        $contest = $this->dj->getCurrentContest();
+
+        if ($contest === null) {
+            return $this->render('jury/error.html.twig', [
+                'error' => 'No contest selected',
+            ]);
+        }
+
+        $filterKeys = array_keys(StatisticsService::FILTERS);
+        $view = $view ?: reset($filterKeys);
+
+        return $this->render('jury/analysis/languages.html.twig',
+            $this->stats->getLanguagesStats($contest, $view)
+        );
+    }
 }

--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Judging;
+use App\Entity\Language;
 use App\Entity\Problem;
 use App\Entity\Submission;
 use App\Entity\Team;
@@ -58,6 +59,7 @@ class StatisticsService
                 ->join('t.category', 'tc')
                 ->leftJoin('t.affiliation', 'a')
                 ->join('t.submissions', 'ts')
+                ->join('ts.language', 'l')
                 ->join('ts.judgings', 'j')
                 ->andWhere('j.valid = true')
                 ->join('ts.language', 'lang')
@@ -72,6 +74,7 @@ class StatisticsService
                 ->join('t.category', 'tc')
                 ->leftJoin('tc.contests', 'cc')
                 ->join('t.submissions', 'ts')
+                ->join('ts.language', 'l')
                 ->join('ts.judgings', 'j')
                 ->andWhere('j.valid = true')
                 ->join('ts.language', 'lang')
@@ -512,6 +515,86 @@ class StatisticsService
         $stats['maxBucketSizeIncorrect'] = $maxBucketSizeIncorrect;
 
         return $stats;
+    }
+
+    /**
+     * @return array{
+     *     contest: Contest,
+     *     filters: array<string, string>,
+     *     view: string,
+     *     languages: array<string, array{
+     *          name: string,
+     *          teams: array<int, Team>,
+     *          team_count: int,
+     *          solved: int,
+     *          not_solved: int,
+     *          total: int,
+     *     }>
+     * }
+     */
+    public function getLanguagesStats(Contest $contest, string $view): array
+    {
+        /** @var Language[] $languages */
+        $languages = $this->em->getRepository(Language::class)
+            ->createQueryBuilder('l')
+            ->andWhere('l.allowSubmit = 1')
+            ->orderBy('l.name')
+            ->getQuery()
+            ->getResult();
+
+        $languageStats = [];
+
+        foreach ($languages as $language) {
+            $languageStats[$language->getLangid()] = [
+                'name' => $language->getName(),
+                'teams' => [],
+                'team_count' => 0,
+                'solved' => 0,
+                'not_solved' => 0,
+                'total' => 0,
+            ];
+        }
+
+        $teams = $this->getTeams($contest, $view);
+        foreach ($teams as $team) {
+            foreach ($team->getSubmissions() as $s) {
+                if ($s->getContest() != $contest) {
+                    continue;
+                }
+                if ($s->getSubmitTime() > $contest->getEndTime()) {
+                    continue;
+                }
+                if ($s->getSubmitTime() < $contest->getStartTime()) {
+                    continue;
+                }
+                if ($s->getSubmittime() > $contest->getFreezetime()) {
+                    continue;
+                }
+
+                $language = $s->getLanguage();
+
+                $languageStats[$language->getLangid()]['teams'][$team->getTeamid()] = $team;
+                $languageStats[$language->getLangid()]['total']++;
+                if ($s->getResult() === 'correct') {
+                    $languageStats[$language->getLangid()]['solved']++;
+                } else {
+                    $languageStats[$language->getLangid()]['not_solved']++;
+                }
+            }
+        }
+
+        foreach ($languageStats as &$languageStat) {
+            usort($languageStat['teams'], static fn(Team $a, Team $b) => ($a->getLabel() ?: $a->getExternalid()) <=> ($b->getLabel() ?: $b->getExternalid()));
+            $languageStat['team_count'] = count($languageStat['teams']);
+        }
+        unset($languageStat);
+
+        return [
+            'contest' => $contest,
+            'filters' => StatisticsService::FILTERS,
+            'view' => $view,
+            'languages' => $languageStats,
+        ];
     }
 
     /**

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1061,9 +1061,12 @@ EOF;
         return 'fas fa-file-' . $iconName;
     }
 
-    public function problemBadge(ContestProblem $problem): string
+    public function problemBadge(ContestProblem $problem, bool $grayedOut = false): string
     {
         $rgb        = Utils::convertToHex($problem->getColor() ?? '#ffffff');
+        if ($grayedOut) {
+            $rgb = 'whitesmoke';
+        }
         $background = Utils::parseHexColor($rgb);
 
         // Pick a border that's a bit darker.
@@ -1075,6 +1078,10 @@ EOF;
 
         // Pick the foreground text color based on the background color.
         $foreground = ($background[0] + $background[1] + $background[2] > 450) ? '#000000' : '#ffffff';
+        if ($grayedOut) {
+            $foreground = 'silver';
+            $border = 'linen';
+        }
         return sprintf(
             '<span class="badge problem-badge" style="background-color: %s; border: 1px solid %s"><span style="color: %s;">%s</span></span>',
             $rgb,

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -81,6 +81,10 @@ $(function() {
       <div class="card">
         <div class="card-header">
           Language Stats
+            <a href="{{ path('analysis_languages', {'view': view}) }}" class="btn btn-sm btn-outline-primary">
+                <i class="fas fa-list"></i>
+                Details
+            </a>
         </div>
         <div class="card-body">
           <svg style="height: 300px"></svg>

--- a/webapp/templates/jury/analysis/languages.html.twig
+++ b/webapp/templates/jury/analysis/languages.html.twig
@@ -28,15 +28,33 @@
                             </div>
                             <div class="card mt-2 mb-2 d-none" id="team-list-{{ langid }}">
                                 <div class="card-body">
-                                    <ul class="mb-0">
+                                    <table class="table table-striped table-hover">
+                                        <thead>
+                                        <tr>
+                                            <td colspan="2">Team</td>
+                                            <td>Number of solved problems in {{ language.name }}</td>
+                                            <td>Total attempts in {{ language.name }}</td>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
                                         {% for team in language.teams %}
-                                        <li>
-                                            <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">
-                                                {{ team.effectiveName }} {{ team | entityIdBadge('t') }}
-                                            </a>
-                                        </li>
+                                            <tr>
+                                                <td>
+                                                    <a href="{{ path('jury_team', {'teamId': team.team.teamid}) }}">
+                                                        {{ team.team | entityIdBadge('t') }}
+                                                    </a>
+                                                </td>
+                                                <td>
+                                                    <a href="{{ path('jury_team', {'teamId': team.team.teamid}) }}">
+                                                        {{ team.team.effectiveName }}
+                                                    </a>
+                                                </td>
+                                                <td>{{ team.solved }}</td>
+                                                <td>{{ team.total }}</td>
+                                            </tr>
                                         {% endfor %}
-                                    </ul>
+                                        </tbody>
+                                    </table>
                                 </div>
                             </div>
                         {% endif %}

--- a/webapp/templates/jury/analysis/languages.html.twig
+++ b/webapp/templates/jury/analysis/languages.html.twig
@@ -41,8 +41,22 @@
                             </div>
                         {% endif %}
                         <br/>
-                        <i class="fas fa-file-code fa-fw"></i> {{ language.total }} total submission{% if language.total != 1 %}s{% endif %}<br />
-                        <i class="fas fa-check fa-fw"></i> {{ language.solved }} submission{% if language.solved != 1 %}s{% endif %} solved problems<br />
+                        <i class="fas fa-file-code fa-fw"></i> {{ language.total }} total submission{% if language.total != 1 %}s{% endif %}
+                        for {{ language.problems_attempted_count }} problem{% if language.problems_attempted_count != 1 %}s{% endif %}:<br/>
+                        {% for problem in problems %}
+                            <a href="{{ path('jury_problem', {'probId': problem.probid}) }}">
+                                {{ problem | problemBadge(language.problems_attempted[problem.probid] is not defined) }}
+                            </a>
+                        {% endfor %}
+                        <br />
+                        <i class="fas fa-check fa-fw"></i> {{ language.solved }} submission{% if language.solved != 1 %}s{% endif %} solved problems
+                        for {{ language.problems_solved_count }} problem{% if language.problems_solved_count != 1 %}s{% endif %}:<br/>
+                        {% for problem in problems %}
+                            <a href="{{ path('jury_problem', {'probId': problem.probid}) }}">
+                                {{ problem | problemBadge(language.problems_solved[problem.probid] is not defined) }}
+                            </a>
+                        {% endfor %}
+                        <br />
                         <i class="fas fa-xmark fa-fw"></i> {{ language.not_solved }} submission{% if language.not_solved != 1 %}s{% endif %} did not solve a problem<br />
                     </div>
                 </div>

--- a/webapp/templates/jury/analysis/languages.html.twig
+++ b/webapp/templates/jury/analysis/languages.html.twig
@@ -1,0 +1,68 @@
+{% extends "jury/base.html.twig" %}
+
+{% block title %}Analysis - Languages in {{ current_contest.shortname | default('') }} - {{ parent() }}{% endblock %}
+
+{% block content %}
+    <h1>Language stats</h1>
+    {% include 'jury/partials/analysis_filter.html.twig' %}
+
+    <div class="row">
+        {% for langid, language in languages %}
+            <div class="col-12 mt-3">
+                <div class="card">
+                    <div class="card-header">
+                        {{ language.name }}
+                    </div>
+                    <div class="card-body">
+                        <i class="fas fa-users fa-fw"></i> {{ language.team_count }} team{% if language.team_count != 1 %}s{% endif %}
+                        {% if language.team_count > 0 %}
+                            <div class="btn-group" role="group">
+                                <input type="checkbox"
+                                       class="btn-check team-list-toggle"
+                                       id="team-list-toggle-{{ langid }}"
+                                       data-team-list-container="#team-list-{{ langid }}"
+                                       autocomplete="off" />
+                                <label for="team-list-toggle-{{ langid }}" class="btn-sm btn btn-outline-secondary">
+                                    <i class="fas fa-eye"></i> Show
+                                </label>
+                            </div>
+                            <div class="card mt-2 mb-2 d-none" id="team-list-{{ langid }}">
+                                <div class="card-body">
+                                    <ul class="mb-0">
+                                        {% for team in language.teams %}
+                                        <li>
+                                            <a href="{{ path('jury_team', {'teamId': team.teamid}) }}">
+                                                {{ team.effectiveName }} {{ team | entityIdBadge('t') }}
+                                            </a>
+                                        </li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                            </div>
+                        {% endif %}
+                        <br/>
+                        <i class="fas fa-file-code fa-fw"></i> {{ language.total }} total submission{% if language.total != 1 %}s{% endif %}<br />
+                        <i class="fas fa-check fa-fw"></i> {{ language.solved }} submission{% if language.solved != 1 %}s{% endif %} solved problems<br />
+                        <i class="fas fa-xmark fa-fw"></i> {{ language.not_solved }} submission{% if language.not_solved != 1 %}s{% endif %} did not solve a problem<br />
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}
+
+{% block extrafooter %}
+    <script>
+        $('.team-list-toggle').on('change', function () {
+            const $container = $($(this).data('team-list-container'));
+            const $label = $(this).parent().find('label');
+            if ($(this).is(':checked')) {
+                $container.removeClass('d-none');
+                $label.html('<i class="fas fa-eye-slash"></i> Hide');
+            } else {
+                $container.addClass('d-none');
+                $label.html('<i class="fas fa-eye"></i> Show');
+            }
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
As discussed before.

Screenshots:
<img width="1275" alt="Screenshot 2024-08-11 at 15 21 40" src="https://github.com/user-attachments/assets/4f06a227-84eb-4f05-ad72-41ab30c6fa1f">
<img width="1275" alt="Screenshot 2024-08-11 at 15 21 46" src="https://github.com/user-attachments/assets/1d9e000b-ba71-4c9c-b4bd-6fa8d025e4f5">

There is a button above the language graph to link to this page:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/c8ad5d7a-d5c7-4fa9-a03d-478664c2bca3">

I made it two columns next to each other first, but expanding the teams will make a lot of teams two lines, so I didn't do that  in the end.

Feedback on what to show or how to show it is welcome.