### PR TITLE
Fix saving new problems with statements

### DIFF
--- a/webapp/src/Controller/BaseController.php
+++ b/webapp/src/Controller/BaseController.php
@@ -561,7 +561,6 @@ abstract class BaseController extends AbstractController
                         return $response;
                     }
                 } else {
-                    $this->em->persist($entity);
                     $this->saveEntity($entity, null, true);
                 }
                 return $this->redirect($urlGenerator());


### PR DESCRIPTION
Fixes #2646.

We used to persist the entity both before and after calling the lifecycle callbacks ourselves, which would introduce weird behavior where Doctrine wanted to insert some rows twice. By not persisting before calling the callbacks ourselves, this issue goes away.