### PR TITLE
Apply base64 encoding to compilation output

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -431,7 +431,7 @@ class JudgehostController extends AbstractFOSRestController
                             ->setJudging($judging)
                             ->setContest($judging->getContest())
                             ->setDescription('Compilation results are different for j' . $judging->getJudgingid())
-                            ->setJudgehostlog('New compilation output: ' . $output_compile)
+                            ->setJudgehostlog(base64_encode('New compilation output: ' . $output_compile))
                             ->setTime(Utils::now())
                             ->setDisabled($disabled);
                         $this->em->persist($error);


### PR DESCRIPTION
In other places, the logs are nicely base64 encoded and the twig template applies a base64 decoding
(`webapp/templates/jury/internal_error.html.twig`) to render the judgehost logs. This seems to be missed on this place.

Fixes issue #2456.