### PR TITLE
Extend bats test for new debian versions

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -67,9 +67,9 @@ repo-remove () {
     assert_line "checking for gcc... no"
     assert_line "checking for cc... no"
     assert_line "checking for cl.exe... no"
-    assert_line "configure: error: in \`${test_path}':"
+    assert_regex "configure: error: in .${test_path}':"
     assert_line 'configure: error: no acceptable C compiler found in $PATH'
-    assert_line "See \`config.log' for more details"
+    assert_regex "See [\`']config.log' for more details"
 }
 
 compiler_assertions () {


### PR DESCRIPTION
Debian testing started using different quotes in the generated configure scripts.

Kinda annoying but changing everything to a regex or only checking for parts of the string is also ugly.