### PR TITLE
Allow null `display_name` when importing `teams.json`, fixes #2666

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -1012,7 +1012,7 @@ class ImportExportService
                     'label' => $team['label'] ?? null,
                     'categoryid' => $team['group_ids'][0] ?? null,
                     'name' => $team['name'] ?? '',
-                    'display_name' => $team['display_name'] ?? '',
+                    'display_name' => $team['display_name'] ?? null,
                     'publicdescription' => $team['public_description'] ?? $team['members'] ?? '',
                     'location' => $team['location']['description'] ?? null,
                 ],


### PR DESCRIPTION
In the method `ImportExportService::importTeamsJson`, use `null` instead of the empty string as default `display_name`, so that it does not override the team name as explained in #2666.

I have tested it and it actually solves #2666.