### PR TITLE
preg_match_all always returns an array of arrays

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1023,8 +1023,8 @@ EOF;
         if (is_null($col)) {
             return $text;
         }
-        preg_match_all("/[0-9A-Fa-f]{2}/", $col, $m);
-        if (!count($m)) {
+        $ret = preg_match_all("/[0-9A-Fa-f]{2}/", $col, $m);
+        if (!($ret && count($m[0]))) {
             return $text;
         }
 


### PR DESCRIPTION
Even if we cannot match anything we will have an array containing an empty array. That array indicates that nothing was matched.

Hopefully this fixes what https://github.com/DOMjudge/domjudge/pull/2665 tried to do.