### PR TITLE
import-script: Upload problemset by default if it exists.

### DIFF
--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -126,7 +126,7 @@ def import_contest_problemset_document(cid: str):
             break
 
     if text_file:
-        if dj_utils.confirm(f'Import {text_file} for contest?', False):
+        if dj_utils.confirm(f'Import {text_file} for contest?', True):
             dj_utils.upload_file(f'contests/{cid}/problemset', 'problemset', text_file)
             print('Contest problemset imported.')
         else:


### PR DESCRIPTION
There is no reason why you wouldn't want to make the full problem text available.

This is in line with other questions, so that you typically just have to press Enter for the default option after doing an initial import.