### PR TITLE
Preserve information whether attachments are executable.

### DIFF
--- a/webapp/migrations/Version20240917113927.php
+++ b/webapp/migrations/Version20240917113927.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240917113927 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adding executable bit to problem attachments.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE problem_attachment_content ADD is_executable TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Whether this file gets an executable bit.\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE problem_attachment_content DROP is_executable');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/ProblemAttachmentContent.php
+++ b/webapp/src/Entity/ProblemAttachmentContent.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
 
 #[ORM\Entity]
 #[ORM\Table(options: [
@@ -24,6 +25,10 @@ class ProblemAttachmentContent
 
     #[ORM\Column(type: 'blobtext', options: ['comment' => 'Attachment content'])]
     private string $content;
+
+    #[ORM\Column(options: ['comment' => 'Whether this file gets an executable bit.', 'default' => 0])]
+    #[Serializer\Exclude]
+    private bool $isExecutable = false;
 
     public function getAttachment(): ProblemAttachment
     {
@@ -47,5 +52,16 @@ class ProblemAttachmentContent
         $this->content = $content;
 
         return $this;
+    }
+
+    public function setIsExecutable(bool $isExecutable): ProblemAttachmentContent
+    {
+        $this->isExecutable = $isExecutable;
+        return $this;
+    }
+
+    public function isExecutable(): bool
+    {
+        return $this->isExecutable;
     }
 }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -892,6 +892,14 @@ class DOMJudgeService
             foreach ($problem->getProblem()->getAttachments() as $attachment) {
                 $filename = sprintf('%s/attachments/%s', $problem->getShortname(), $attachment->getName());
                 $zip->addFromString($filename, $attachment->getContent()->getContent());
+                if ($attachment->getContent()->isExecutable()) {
+                    // 100755 = regular file, executable
+                    $zip->setExternalAttributesName(
+                        $filename,
+                        ZipArchive::OPSYS_UNIX,
+                        octdec('100755') << 16
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
This is relevant for testing tools which are often uploaded as attachments for interactive problems. When we download the samples (via the web interface or API), we should mark these files as executable iff they were executable when uploading.