### PR TITLE
Fix highlighting of in-freeze submissions by introducing separate met…

### DIFF
--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -152,13 +152,14 @@ class Scoreboard
             );
 
             $this->matrix[$teamId][$probId] = new ScoreboardMatrixItem(
-                $scoreRow->getIsCorrect($this->restricted),
-                $scoreRow->getIsCorrect($this->restricted) && $scoreRow->getIsFirstToSolve(),
-                $scoreRow->getSubmissions($this->restricted),
-                $scoreRow->getPending($this->restricted),
-                $scoreRow->getSolveTime($this->restricted),
-                $penalty,
-                $scoreRow->getRuntime($this->restricted)
+                isCorrect: $scoreRow->getIsCorrect($this->restricted),
+                isFirst: $scoreRow->getIsCorrect($this->restricted) && $scoreRow->getIsFirstToSolve(),
+                numSubmissions: $scoreRow->getSubmissions($this->restricted),
+                numSubmissionsPending: $scoreRow->getPending($this->restricted),
+                time: $scoreRow->getSolveTime($this->restricted),
+                penaltyTime: $penalty,
+                runtime: $scoreRow->getRuntime($this->restricted),
+                numSubmissionsInFreeze: $scoreRow->getPending(false),
             );
 
             if ($scoreRow->getIsCorrect($this->restricted)) {
@@ -216,7 +217,14 @@ class Scoreboard
                 $problemId = $contestProblem->getProbid();
                 // Provide default scores when nothing submitted for this team + problem yet
                 if (!isset($this->matrix[$teamId][$problemId])) {
-                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
+                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(
+                        isCorrect: false,
+                        isFirst: false,
+                        numSubmissions: 0,
+                        numSubmissionsPending: 0,
+                        time: 0,
+                        penaltyTime: 0,
+                        runtime: 0);
                 }
 
                 $problemMatrixItem = $this->matrix[$teamId][$problemId];

--- a/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -11,6 +11,7 @@ class ScoreboardMatrixItem
         public int $numSubmissionsPending,
         public float|string $time,
         public int $penaltyTime,
-        public int $runtime
+        public int $runtime,
+        public ?int $numSubmissionsInFreeze = null,
     ) {}
 }

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -63,14 +63,14 @@ class SingleTeamScoreboard extends Scoreboard
             );
 
             $this->matrix[$scoreRow->getTeam()->getTeamid()][$scoreRow->getProblem()->getProbid()] = new ScoreboardMatrixItem(
-                $scoreRow->getIsCorrect($this->restricted),
-                $scoreRow->getIsCorrect($this->showRestrictedFts) && $scoreRow->getIsFirstToSolve(),
-                // When public scoreboard is frozen, also show "x + y tries" for jury
-                $scoreRow->getSubmissions($this->freezeData->showFrozen() ? false : $this->restricted),
-                $scoreRow->getPending($this->freezeData->showFrozen() ? false : $this->restricted),
-                $scoreRow->getSolveTime($this->restricted),
-                $penalty,
-                $scoreRow->getRuntime($this->restricted)
+                isCorrect: $scoreRow->getIsCorrect($this->restricted),
+                isFirst: $scoreRow->getIsCorrect($this->showRestrictedFts) && $scoreRow->getIsFirstToSolve(),
+                numSubmissions: $scoreRow->getSubmissions($this->restricted),
+                numSubmissionsPending: $scoreRow->getPending($this->restricted),
+                time: $scoreRow->getSolveTime($this->restricted),
+                penaltyTime: $penalty,
+                runtime: $scoreRow->getRuntime($this->restricted),
+                numSubmissionsInFreeze: $scoreRow->getPending(false),
             );
         }
 
@@ -80,7 +80,14 @@ class SingleTeamScoreboard extends Scoreboard
             $teamId    = $this->team->getTeamid();
             $problemId = $contestProblem->getProbid();
             if (!isset($this->matrix[$teamId][$problemId])) {
-                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
+                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(
+                    isCorrect: false,
+                    isFirst: false,
+                    numSubmissions: 0,
+                    numSubmissionsPending: 0,
+                    time: 0,
+                    penaltyTime: 0,
+                    runtime: 0);
             }
         }
     }

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -257,10 +257,8 @@
                     {% elseif matrixItem.numSubmissions > 0 %}
                         {% set scoreCssClass = 'score_incorrect' %}
                     {% endif %}
-                    {% if jury and showPending and matrixItem.numSubmissionsPending > 0 %}
-                        {% if scoreCssClass == 'score_pending' %}
-                            {% set scoreCssClass = scoreCssClass ~ ' score_incorrect' %}
-                        {% else %}
+                    {% if jury and showPending and matrixItem.numSubmissionsInFreeze > 0 %}
+                        {% if scoreCssClass != 'score_pending' %}
                             {% set scoreCssClass = scoreCssClass ~ ' score_pending' %}
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
…adata.

Previously, we did try to use the same metadata attribute in different scenarios and this was causing unrelated things to break (e.g. when having the triangles on the jury scoreboard, we would also incorrectly still show pending submissions in the scoreboard.json in the API).

Note that as a side effect, this will no longer show "x + y tries" for submissions that happened in the freeze on the jury scoreboard (as we did before we introduced the blue triangles).