### PR TITLE
On clicking "Reset login status of all team users" also reset the API…

### DIFF
--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -373,9 +373,11 @@ class UserController extends BaseController
         $count = 0;
         foreach ($teamRole->getUsers() as $user) {
             /** @var User $user */
-            $user->setFirstLogin(null);
-            $user->setLastLogin(null);
-            $user->setLastIpAddress(null);
+            $user
+                ->setFirstLogin(null)
+                ->setLastLogin(null)
+                ->setLastApiLogin(null)
+                ->setLastIpAddress(null);
             $count++;
         }
         $this->em->flush();

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -250,7 +250,7 @@ class User extends BaseApiEntity implements
         return $this->getLastLogin() ? new DateTime(Utils::absTime($this->getLastLogin())) : null;
     }
 
-    public function setLastApiLogin(string|float $lastApiLogin): User
+    public function setLastApiLogin(string|float|null $lastApiLogin): User
     {
         $this->last_api_login = $lastApiLogin;
         return $this;


### PR DESCRIPTION
… login status.

Funnily enough, when we introduced the feature, the original issue has "API login" in the title: https://github.com/DOMjudge/domjudge/issues/1720

So I assume it was just an oversight.

It is definitely what we want to show the right status in Grafana.