### PR TITLE
Do not force square affiliation logos

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -236,8 +236,8 @@ del {
 }
 
 img.affiliation-logo {
-    height: 32px;
-    width: 32px;
+    max-height: 32px;
+    max-width: 32px;
     padding-left: 2px;
 }
 


### PR DESCRIPTION
According to the spec, they should be 64x64. We warn on import if they are not, but if we import different sized icons they get stretched. Instead, assume logos of at least 32px in width OR 32px in height and scale them such they are contained in the defined 32x32px reserved space.

Before: 
![before](https://github.com/user-attachments/assets/b47b8bae-af22-4601-8df4-884bbc6dad44)

After:
![after](https://github.com/user-attachments/assets/8a86bc25-c496-48e7-a114-550fbe1771d2)
