### PR TITLE
Fix error handling / messaging on import validation errors.

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -268,7 +268,7 @@ class ImportExportService
             $messages = [];
             /** @var ConstraintViolationInterface $error */
             foreach ($errors as $error) {
-                $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
             }
 
             $errorMessage = sprintf("Contest has errors:\n\n%s", implode("\n", $messages));
@@ -547,7 +547,7 @@ class ImportExportService
                 );
                 continue;
             }
-        
+
             if (!$skip && $rank - $skippedTeams <= $contest->getGoldMedals()) {
                 $awardString = 'Gold Medal';
                 $lowestMedalPoints = $teamScore->numPoints;
@@ -791,10 +791,13 @@ class ImportExportService
                 $messages = [];
                 /** @var ConstraintViolationInterface $error */
                 foreach ($errors as $error) {
-                    $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                    $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                 }
 
-                $message .= sprintf("Group at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                $message .= sprintf("Group at index %d (%s) has errors:\n%s\n\n",
+                    $index,
+                    json_encode($groupItem),
+                    implode("\n", $messages));
                 $anyErrors = true;
             } else {
                 $allCategories[] = $teamCategory;
@@ -810,7 +813,7 @@ class ImportExportService
         }
 
         if ($anyErrors) {
-            return 0;
+            return -1;
         }
 
         foreach ($allCategories as $category) {
@@ -898,10 +901,13 @@ class ImportExportService
                 $messages = [];
                 /** @var ConstraintViolationInterface $error */
                 foreach ($errors as $error) {
-                    $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                    $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                 }
 
-                $message .= sprintf("Organization at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                $message .= sprintf("Organization at index %d (%s) has errors:\n%s\n\n",
+                    $index,
+                    json_encode($organizationItem),
+                    implode("\n", $messages));
                 $anyErrors = true;
             } else {
                 $allOrganizations[] = $teamAffiliation;
@@ -917,7 +923,7 @@ class ImportExportService
         }
 
         if ($anyErrors) {
-            return 0;
+            return -1;
         }
 
         foreach ($allOrganizations as $organization) {
@@ -1146,10 +1152,13 @@ class ImportExportService
                         $messages = [];
                         /** @var ConstraintViolationInterface $error */
                         foreach ($errors as $error) {
-                            $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                            $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                         }
 
-                        $message .= sprintf("Organization for team at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                        $message .= sprintf("Organization for team at index %d (%s) has errors:\n%s\n\n",
+                            $index,
+                            json_encode($teamItem),
+                            implode("\n", $messages));
                         $anyErrors = true;
                     } else {
                         $createdAffiliations[] = $teamAffiliation;
@@ -1169,10 +1178,13 @@ class ImportExportService
                         $messages = [];
                         /** @var ConstraintViolationInterface $error */
                         foreach ($errors as $error) {
-                            $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                            $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                         }
 
-                        $message .= sprintf("Organization for team at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                        $message .= sprintf("Organization for team at index %d (%s) has errors:\n%s\n\n",
+                            $index,
+                            json_encode($teamItem),
+                            implode("\n", $messages));
                         $anyErrors = true;
                     } else {
                         $createdAffiliations[] = $teamAffiliation;
@@ -1195,10 +1207,13 @@ class ImportExportService
                         $messages = [];
                         /** @var ConstraintViolationInterface $error */
                         foreach ($errors as $error) {
-                            $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                            $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                         }
 
-                        $message .= sprintf("Group for team at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                        $message .= sprintf("Group for team at index %d (%s) has errors:\n%s\n\n",
+                            $index,
+                            json_encode($teamItem),
+                            implode("\n", $messages));
                         $anyErrors = true;
                     } else {
                         $createdCategories[] = $teamCategory;
@@ -1244,10 +1259,13 @@ class ImportExportService
                 $messages = [];
                 /** @var ConstraintViolationInterface $error */
                 foreach ($errors as $error) {
-                    $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                    $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                 }
 
-                $message .= sprintf("Team at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                $message .= sprintf("Team at index %d (%s) has errors:\n%s\n\n",
+                    $index,
+                    json_encode($teamItem),
+                    implode("\n", $messages));
                 $anyErrors = true;
             } else {
                 $allTeams[] = $team;
@@ -1265,7 +1283,7 @@ class ImportExportService
         }
 
         if ($anyErrors) {
-            return 0;
+            return -1;
         }
 
         foreach ($createdAffiliations as $affiliation) {
@@ -1348,10 +1366,13 @@ class ImportExportService
                     $messages = [];
                     /** @var ConstraintViolationInterface $error */
                     foreach ($errors as $error) {
-                        $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                        $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                     }
 
-                    $message .= sprintf("Team for user at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                    $message .= sprintf("Team for user at index %d (%s) has errors:\n%s\n\n",
+                        $index,
+                        json_encode($accountItem),
+                        implode("\n", $messages));
                     $anyErrors = true;
                 } else {
                     $newTeams[] = [
@@ -1397,10 +1418,13 @@ class ImportExportService
                 $messages = [];
                 /** @var ConstraintViolationInterface $error */
                 foreach ($errors as $error) {
-                    $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+                    $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
                 }
 
-                $message .= sprintf("User at index %d has errors:\n\n%s\n", $index, implode("\n", $messages));
+                $message .= sprintf("User at index %d (%s) has errors:\n%s\n\n",
+                    $index,
+                    json_encode($accountItem),
+                    implode("\n", $messages));
                 $anyErrors = true;
             } else {
                 $allUsers[] = $user;
@@ -1412,7 +1436,7 @@ class ImportExportService
         }
 
         if ($anyErrors) {
-            return 0;
+            return -1;
         }
 
         foreach ($allUsers as $user) {

--- a/webapp/tests/Unit/Service/ImportExportServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportExportServiceTest.php
@@ -105,7 +105,7 @@ class ImportExportServiceTest extends BaseTestCase
                 'start-time'               => '2020-01-01T12:34:56+02:00',
                 'scoreboard-freeze-length' => '30:00',
             ],
-            "Contest has errors:\n\nname: This value should not be blank.\nshortname: This value should not be blank."
+            "Contest has errors:\n\n  • `name`: This value should not be blank.\n  • `shortname`: This value should not be blank."
         ];
     }
 
@@ -501,7 +501,7 @@ EOF;
         // Remove the file, we don't need it anymore.
         unlink($fileName);
 
-        self::assertEquals(0, $importCount);
+        self::assertEquals(-1, $importCount);
         self::assertMatchesRegularExpression('/Only alphanumeric characters and _-@. are allowed/', $message);
 
         $postCount = $em->getRepository(User::class)->count([]);
@@ -870,8 +870,8 @@ EOF;
         // Remove the file, we don't need it anymore.
         unlink($fileName);
 
-        self::assertMatchesRegularExpression('/name: This value should not be blank./', $message);
-        self::assertEquals(0, $importCount);
+        self::assertMatchesRegularExpression('/.*`name`: This value should not be blank.*/', $message);
+        self::assertEquals(-1, $importCount);
 
         $postCount = $em->getRepository(Team::class)->count([]);
         self::assertEquals($preCount, $postCount);
@@ -908,8 +908,8 @@ EOF;
         // Remove the file, we don't need it anymore.
         unlink($fileName);
 
-        self::assertMatchesRegularExpression('/name: This value should not be blank./', $message);
-        self::assertEquals(0, $importCount);
+        self::assertMatchesRegularExpression('/.*`name`: This value should not be blank.*/', $message);
+        self::assertEquals(-1, $importCount);
 
         $postCount = $em->getRepository(Team::class)->count([]);
         self::assertEquals($preCount, $postCount);
@@ -1050,8 +1050,8 @@ EOF;
         // Remove the file, we don't need it anymore.
         unlink($fileName);
 
-        self::assertMatchesRegularExpression('/name: This value should not be blank/', $message);
-        self::assertEquals(0, $importCount);
+        self::assertMatchesRegularExpression('/.*`name`: This value should not be blank.*/', $message);
+        self::assertEquals(-1, $importCount);
 
         $postCount = $em->getRepository(TeamCategory::class)->count([]);
         self::assertEquals($preCount, $postCount);
@@ -1150,7 +1150,7 @@ EOF;
         unlink($fileName);
 
         self::assertMatchesRegularExpression('/ISO3166-1 alpha-3 values are allowed/', $message);
-        self::assertEquals(0, $importCount);
+        self::assertEquals(-1, $importCount);
 
         $postCount = $em->getRepository(TeamAffiliation::class)->count([]);
         self::assertEquals($preCount, $postCount);


### PR DESCRIPTION
Fixes #2705.

While we are at it, also improve the usefulness of the error messages.


Example:

![image](https://github.com/user-attachments/assets/1c0eb699-707e-41b0-b9b8-55622e2188c7)


Command line:
```
webapp/bin/console api:call -m POST -f json=../Downloads/organizations.json users/organizations
04:17:58 ERROR     [request] Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\BadRequestHttpException: "Error while adding organizations: Organization at index 36 ({"externalid":"U-3397","shortname":"","name":"Chalmers University of Technology","country":"SWE","icpc_id":null}) has errors:
  • `shortname`: This value should not be blank.

Organization at index 42 ({"externalid":"U-3758","shortname":"","name":"King's College London","country":"GBR","icpc_id":null}) has errors:
  • `shortname`: This value should not be blank.

Organization at index 67 ({"externalid":"U-8102","shortname":"","name":"University of Passau","country":"DEU","icpc_id":null}) has errors:
  • `shortname`: This value should not be blank.

" at UserController.php line 131 ["exception" => Symfony\Component\HttpKernel\Exception\BadRequestHttpException^ { …}]
```