### PR TITLE
add Paste code to submit feature

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -201,6 +201,14 @@
 -   category: Display
     description: Options related to the DOMjudge user interface.
     items:
+        -   name: default_submission_code_mode
+            type: int
+            default_value: 0
+            public: true
+            description: Select the default submission method for the team
+            options:
+                0: Paste
+                1: Upload
         -   name: output_display_limit
             type: int
             default_value: 2000

--- a/webapp/src/Form/Type/SubmitProblemPasteType.php
+++ b/webapp/src/Form/Type/SubmitProblemPasteType.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+namespace App\Form\Type;
+
+use App\Entity\Language;
+use App\Entity\Problem;
+use App\Service\ConfigurationService;
+use App\Service\DOMJudgeService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+class SubmitProblemPasteType extends AbstractType
+{
+    public function __construct(
+        protected readonly DOMJudgeService $dj,
+        protected readonly ConfigurationService $config,
+        protected readonly EntityManagerInterface $em
+    ) {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $user = $this->dj->getUser();
+        $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
+
+        $builder->add('code_content', HiddenType::class, [
+            'required' => true,
+        ]);
+        $problemConfig = [
+            'class' => Problem::class,
+            'query_builder' => fn(EntityRepository $er) => $er->createQueryBuilder('p')
+                ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
+                ->select('p', 'cp')
+                ->andWhere('cp.allowSubmit = 1')
+                ->setParameter('contest', $contest)
+                ->addOrderBy('cp.shortname'),
+            'choice_label' => fn(Problem $problem) => sprintf(
+                '%s - %s',
+                $problem->getContestProblems()->first()->getShortName(),
+                $problem->getName()
+            ),
+            'placeholder' => 'Select a problem',
+        ];
+        $builder->add('problem', EntityType::class, $problemConfig);
+
+        $builder->add('language', EntityType::class, [
+            'class' => Language::class,
+            'query_builder' => fn(EntityRepository $er) => $er
+                ->createQueryBuilder('l')
+                ->andWhere('l.allowSubmit = 1'),
+            'choice_label' => 'name',
+            'placeholder' => 'Select a language',
+        ]);
+
+        $builder->add('entry_point', TextType::class, [
+            'label' => 'Entry point',
+            'required' => false,
+            'help' => 'The entry point for your code.',
+            'row_attr' => ['data-entry-point' => ''],
+            'constraints' => [
+                new Callback(function ($value, ExecutionContextInterface $context) {
+                    /** @var Form $form */
+                    $form = $context->getRoot();
+                    /** @var Language $language */
+                    $language = $form->get('language')->getData();
+                    if ($language && $language->getRequireEntryPoint() && empty($value)) {
+                        $message = sprintf(
+                            '%s required, but not specified',
+                            $language->getEntryPointDescription() ?: 'Entry point'
+                        );
+                        $context
+                            ->buildViolation($message)
+                            ->atPath('entry_point')
+                            ->addViolation();
+                    }
+                }),
+            ]
+        ]);
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($problemConfig) {
+            $data = $event->getData();
+            if (isset($data['problem'])) {
+                $problemConfig += ['row_attr' => ['class' => 'd-none']];
+                $event->getForm()->add('problem', EntityType::class, $problemConfig);
+            }
+        });
+    }
+}

--- a/webapp/templates/base.html.twig
+++ b/webapp/templates/base.html.twig
@@ -14,6 +14,8 @@
     <script src="{{ asset("js/bootstrap.bundle.min.js") }}"></script>
 
     <script src="{{ asset("js/domjudge.js") }}"></script>
+    <script src="{{ asset('js/ace/ace.js') }}"></script>
+    
     {% for file in customAssetFiles('js') %}
         <script src="{{ asset('js/custom/' ~ file) }}"></script>
     {% endfor %}

--- a/webapp/templates/team/submit_modal.html.twig
+++ b/webapp/templates/team/submit_modal.html.twig
@@ -19,21 +19,64 @@
                     {% include 'partials/alert.html.twig' with {'type': 'danger', 'message': 'Submissions (temporarily) disabled.'} %}
                 </div>
             {% else %}
-                {{ form_start(form) }}
+                {% set active_tab = defaultSubmissionCodeMode == 0 ? 'paste' : 'upload' %}
+
+                <!-- Bootstrap Nav Tabs for Switching -->
                 <div class="modal-body">
-                    {{ form_row(form.code) }}
-                    <div class="alert d-none" id="files_selected"></div>
-                    {{ form_row(form.problem) }}
-                    {{ form_row(form.language) }}
-                    {{ form_row(form.entry_point) }}
+                    <ul class="nav nav-tabs container text-center" id="submissionTabs" role="tablist" style="width: 100%">
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link {% if active_tab == 'upload' %}active{% endif %}" id="upload-tab" data-bs-toggle="tab" href="#upload" role="tab" aria-controls="upload" aria-selected="{% if active_tab == 'upload' %}true{% else %}false{% endif %}">Upload File</a>
+                        </li>
+                        <li class="nav-item text-center" role="presentation">
+                            <a class="nav-link {% if active_tab == 'paste' %}active{% endif %}" id="paste-tab" data-bs-toggle="tab" href="#paste" role="tab" aria-controls="paste" aria-selected="{% if active_tab == 'paste' %}true{% else %}false{% endif %}">Paste Code</a>
+                        </li>
+                    </ul>
+                    <div class="tab-content" id="submissionTabsContent" style="margin-top: 20px;">
+                        <!-- File Upload Tab -->
+                        <div class="tab-pane fade {% if active_tab == 'upload' %}show active{% endif %}" id="upload" role="tabpanel" aria-labelledby="upload-tab">
+                            {{ form_start(formupload) }}
+                            {{ form_row(formupload.code) }}
+                            <div class="alert d-none" id="files_selected"></div>
+                            {{ form_row(formupload.problem) }}
+                            {{ form_row(formupload.language) }}
+                            {{ form_row(formupload.entry_point) }}
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="submit" class="btn btn-success">
+                                    <i class="fas fa-cloud-upload-alt"></i> Submit Upload
+                                </button>
+                            </div>
+                            {{ form_end(formupload) }}
+                        </div>
+
+                        <!-- Paste Code Tab -->
+                        <div class="tab-pane fade {% if active_tab == 'paste' %}show active{% endif %}" id="paste" role="tabpanel" aria-labelledby="paste-tab">
+                            {{ form_start(formpaste) }}
+                            {{ form_widget(formpaste.code_content) }}
+                            <label for="codeInput">Paste your code here:</label>
+                            <div class="editor-container">
+                                {{ "" | codeEditor(
+                                    "_team_submission_code",
+                                    "c_cpp",
+                                    true,
+                                    formpaste.code_content.vars.id,
+                                    null,
+                                    formpaste.language.vars.value
+                                ) }}
+                            </div>
+                                {{ form_row(formpaste.problem) }}
+                                {{ form_row(formpaste.language) }}
+                                {{ form_row(formpaste.entry_point) }}
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-paste"></i> Submit Paste
+                                </button>
+                            </div>
+                            {{ form_end(formpaste) }}
+                        </div>
+                    </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn-success btn">
-                        <i class="fas fa-cloud-upload-alt"></i> Submit
-                    </button>
-                </div>
-                {{ form_end(form) }}
             {% endif %}
         </div>
     </div>
@@ -80,4 +123,31 @@
             filesSelected.removeClass('d-none');
         });
     </script>
+    <style>
+        .container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); 
+            gap: 10px; 
+        }
+        
+        .text-center {
+            text-align: center;
+        }
+        
+        .editor-container {
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+            padding: 10px;
+            margin-top: 10px;
+            margin-bottom: 10px;
+            background-color: #fafafa;
+            max-height: 400px;
+            overflow: auto;
+        }
+        
+        .editor-container:hover {
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+        }
+    </style>
 </div>


### PR DESCRIPTION
## Modify the old PR
[Add two features: the ability to view the first failed test case and to copy and paste code directly.](https://github.com/DOMjudge/domjudge/pull/2696)

## Motivation:
As for the process of uploading code as files, I often find it a bit inconvenient. In online judges like Codeforces and Luogu, there are features allowing users to paste code directly. I believe this is a very convenient feature to have.


## Implementation:
1. A navigation tab is provided for users to choose between uploading a file or pasting code.
<p align="center">
  <img src="https://github.com/user-attachments/assets/0dbf903e-58ff-4b8c-b22e-60910fcd93ec" width="45%" />
  <img src="https://github.com/user-attachments/assets/3a6ba574-7bae-459d-8e8c-07b0a7fc1dce" width="45%" />
</p>
2. Configuration setting

![截圖 2024-09-22 凌晨2 57 34](https://github.com/user-attachments/assets/16888c0f-b683-460b-a481-e7f43380619f)


