### PR TITLE
Update issue templates to clarify intended usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-NOTE: If this is a _discussion starter_, you need any _installation help, or have a _question_ on how to accomplish something,
+NOTE: If this is a _discussion starter_, you need any _installation help_, or have a _question_ on how to accomplish something,
 rather post at [our discussion channel](https://www.domjudge.org/chat) or send an email to our
 [DOMjudge-devel mailinglist](https://www.domjudge.org/mailman/postorius/lists/domjudge-devel.domjudge.org/)
 instead of filing an issue here.
@@ -16,7 +16,7 @@ instead of filing an issue here.
 
 ### Description of the problem
 <!--
-Replace this line with a short description.
+Write here a short description.
 -->
 
 ### Your environment
@@ -29,7 +29,7 @@ Include details about your installation here.
 
 ### Steps to reproduce
 <!--
-Replace this with a description how we can reproduce your bug.
+Write here a description how we can reproduce your bug.
 1. Step 1
 1. Step 2
 1. Step 3
@@ -37,12 +37,12 @@ Replace this with a description how we can reproduce your bug.
 
 ### Expected behaviour
 <!--
-Replace this line with what you would expect to happen.
+Write here what you would expect to happen.
 -->
 
 ### Actual behaviour
 <!--
-Replace this line with what happens instead.
+Write here what happens instead.
 -->
 
 ### Any other information that you want to share?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,46 @@ assignees: ''
 
 ---
 
-NOTE: If this is a _discussion starter_, you need any _installation help_ or have a _question_ on how to accomplish something,
+<!--
+NOTE: If this is a _discussion starter_, you need any _installation help, or have a _question_ on how to accomplish something,
 rather post at [our discussion channel](https://www.domjudge.org/chat) or send an email to our
 [DOMjudge-devel mailinglist](https://www.domjudge.org/mailman/postorius/lists/domjudge-devel.domjudge.org/)
 instead of filing an issue here.
+-->
 
 ### Description of the problem
-> Replace this line with a short description.
+<!--
+Replace this line with a short description.
+-->
 
 ### Your environment
-> Include details about your installation here.
-> - DOMjudge version (e.g. 7.0.0 or a github commit hash)
-> - Operating system / Linux distribution and version (e.g. Ubuntu 18.04)
-> - Webserver (e.g. Apache or nginx)
+<!--
+Include details about your installation here.
+- DOMjudge version (e.g. 7.0.0 or a github commit hash)
+- Operating system / Linux distribution and version (e.g. Ubuntu 18.04)
+- Webserver (e.g. Apache or nginx)
+-->
 
 ### Steps to reproduce
-> Replace this with a description how we can reproduce your bug.
-> - Step 1
-> - Step 2
-> - Step 3
+<!--
+Replace this with a description how we can reproduce your bug.
+1. Step 1
+1. Step 2
+1. Step 3
+-->
 
 ### Expected behaviour
-> Replace this line with what you would expect to happen.
+<!--
+Replace this line with what you would expect to happen.
+-->
 
 ### Actual behaviour
-> Replace this line with what happens instead.
+<!--
+Replace this line with what happens instead.
+-->
 
 ### Any other information that you want to share?
-> Please include webserver, symfony and judgedaemon log snippets here as appropriate.
-> Screenshots may help in case of UI bugs.
+<!--
+Please include webserver, symfony and judgedaemon log snippets here as appropriate.
+Screenshots may help in case of UI bugs.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,8 @@ assignees: ''
 
 ---
 
-NOTE: If this is a _discussion starter_, you need any _installation help_ or have a _question_ on how to accomplish something,
+<!--
+NOTE: If this is a _discussion starter_, you need any _installation help, or have a _question_ on how to accomplish something,
 rather post at [our discussion channel](https://www.domjudge.org/chat) or send an email to our
 [DOMjudge-devel mailinglist](https://www.domjudge.org/mailman/postorius/lists/domjudge-devel.domjudge.org/).
 
@@ -15,17 +16,27 @@ Thank you for suggesting ways to improve DOMjudge. Before you file a feature
 request, it might be useful to discuss it first via the chat or mailing list
 linked above. We can then assess together whether there is
 not already a way to accomplish your goal with DOMjudge currently.
+-->
 
 ### Description of the enhancement request
-> Replace this line with a short description.
+<!--
+Replace this line with a short description.
+-->
 
 ### The goal you want to achieve
-> Please elaborate on the (larger, higher level) goal you want to achieve with this enhancement, so we have a good understanding what this feature would be useful for and how it fits in DOMjudge as a whole.
+<!--
+Please elaborate on the (larger, higher level) goal you want to achieve with this enhancement, so we have a good understanding what this feature would be useful for and how it fits in DOMjudge as a whole.
+-->
 
 ### Expected behaviour
-> Replace this line with what you would expect to happen.
-> Please describe the workflow how you want this feature to work with expected start URL
-> - Step 1
-> - Step 2
+<!--
+Replace this line with what you would expect to happen.
+Please describe the workflow how you want this feature to work with expected start URL
+1. Step 1
+2. Step 2
+-->
+
 ### Any other information that you want to share?
-> Screenshots may help in case of UI enhancements with annotated drawings.
+<!--
+Screenshots may help in case of UI enhancements with annotated drawings.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,12 +31,12 @@ Please elaborate on the (larger, higher level) goal you want to achieve with thi
 ### Expected behaviour
 <!--
 Replace this line with what you would expect to happen.
-Please describe the workflow how you want this feature to work with expected start URL
+For example describe the flow how you want this feature to work.
 1. Step 1
 2. Step 2
 -->
 
 ### Any other information that you want to share?
 <!--
-Screenshots may help in case of UI enhancements with annotated drawings.
+Screenshots with annotated drawings may help in case of UI enhancements.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-NOTE: If this is a _discussion starter_, you need any _installation help, or have a _question_ on how to accomplish something,
+NOTE: If this is a _discussion starter_, you need any _installation help_, or have a _question_ on how to accomplish something,
 rather post at [our discussion channel](https://www.domjudge.org/chat) or send an email to our
 [DOMjudge-devel mailinglist](https://www.domjudge.org/mailman/postorius/lists/domjudge-devel.domjudge.org/).
 
@@ -20,7 +20,7 @@ not already a way to accomplish your goal with DOMjudge currently.
 
 ### Description of the enhancement request
 <!--
-Replace this line with a short description.
+Write here a short description.
 -->
 
 ### The goal you want to achieve
@@ -30,7 +30,7 @@ Please elaborate on the (larger, higher level) goal you want to achieve with thi
 
 ### Expected behaviour
 <!--
-Replace this line with what you would expect to happen.
+Write here what you would expect to happen.
 For example describe the flow how you want this feature to work.
 1. Step 1
 2. Step 2


### PR DESCRIPTION
People are often not removing the boilerplate text and quoting their text, replicating the boilerplate quoted text.