### PR TITLE
Improve scoreboard zip route

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -1038,8 +1038,8 @@ class ContestController extends BaseController
         return $this->redirectToRoute('jury_contest', ['contestId' => $contestId]);
     }
 
-    #[Route(path: '/{contestId<\d+>}/scoreboard-zip/{type<public|unfrozen>}/contest.zip', name: 'jury_scoreboard_data_zip')]
-    public function publicScoreboardDataZipAction(
+    #[Route(path: '/{contestId<\d+>}/{type<public|unfrozen>}-scoreboard.zip', name: 'jury_scoreboard_data_zip')]
+    public function scoreboardDataZipAction(
         int $contestId,
         string $type,
         RequestStack $requestStack,

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -89,7 +89,7 @@ class PublicController extends BaseController
         return $this->render('public/scoreboard.html.twig', $data, $response);
     }
 
-    #[Route(path: '/scoreboard-zip/contest.zip', name: 'public_scoreboard_data_zip')]
+    #[Route(path: '/scoreboard.zip', name: 'public_scoreboard_data_zip')]
     public function scoreboardDataZipAction(
         RequestStack $requestStack,
         Request $request,

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1557,7 +1557,7 @@ class DOMJudgeService
         }
         $zip->close();
 
-        return Utils::streamZipFile($tempFilename, 'contest.zip');
+        return Utils::streamZipFile($tempFilename, 'scoreboard.zip');
     }
 
     private function allowJudge(ContestProblem $problem, Submission $submission, Language $language, bool $manualRequest): bool


### PR DESCRIPTION
Simplify some routes and consistently use `scoreboard.zip` for downloaded file instead of `contest.zip`.