### PR TITLE
Fix #2701: Do not show shortcut box when modifier key is pressed

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -834,6 +834,10 @@ function initializeKeyboardShortcuts() {
         if (keysCookie != 1 && keysCookie != "") {
             return;
         }
+        // Do not trigger shortcuts if user is pressing Ctrl/Alt/Option/Meta key.
+        if (e.altKey || e.ctrlKey || e.metaKey) {
+            return;
+        }
         // Check if the user is not typing in an input field.
         if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
             return;

--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -905,38 +905,40 @@ function initializeKeyboardShortcuts() {
                 if (e.key >= '0' && e.key <= '9') {
                     sequence += e.key;
                     box.text(type + sequence);
-                } else if (e.key === 'Enter') {
-                    ignore = false;
-                    switch (type) {
-                        case 's':
-                            type = 'submissions';
-                            break;
-                        case 't':
-                            type = 'teams';
-                            break;
-                        case 'p':
-                            type = 'problems';
-                            break;
-                        case 'c':
-                            type = 'clarifications';
-                            break;
-                        case 'j':
-                            window.location = domjudge_base_url + '/jury/submissions/by-judging-id/' + sequence;
-                            return;
-                    }
-                    var redirect_to = domjudge_base_url + '/jury/' + type;
-                    if (sequence) {
-                        redirect_to += '/' + sequence;
-                    }
-                    window.location = redirect_to;
                 } else {
                     ignore = false;
                     if (box) {
                         box.remove();
                     }
+                    // We want to reset the `sequence` variable before redirecting, but then we do need to save the value typed by the user
+                    var typedSequence = sequence;
                     sequence = '';
                     $body.off('keydown');
                     $body.on('keydown', oldFunc);
+                    if (e.key === 'Enter') {
+                        switch (type) {
+                            case 's':
+                                type = 'submissions';
+                                break;
+                            case 't':
+                                type = 'teams';
+                                break;
+                            case 'p':
+                                type = 'problems';
+                                break;
+                            case 'c':
+                                type = 'clarifications';
+                                break;
+                            case 'j':
+                                type = 'submissions/by-judging-id';
+                                break;
+                        }
+                        var redirect_to = domjudge_base_url + '/jury/' + type;
+                        if (typedSequence) {
+                            redirect_to += '/' + typedSequence;
+                        }
+                        window.location = redirect_to;
+                    }
                 }
             });
         }


### PR DESCRIPTION
The fix itself (first commit) was quite easy to add :smile:

While I was at it, I also implemented an additional quality-of-life feature, for the following scenario:
- Use keyboard shortcuts to navigate to a specific entity (e.g. `s42` for submission with ID 42)
- Use the browser back button (or mouse button 4)
It used to be the case that the "shortcut box" would stay visible. With the second commit, I make sure that the shortcut state is reset before performing the redirect, to make sure that it does not linger when moving back to the previous page.

<details>
<summary>Tested locally with this diff, see #1072 and #2588</summary>

```diff
diff --git a/judge/create_cgroups.in b/judge/create_cgroups.in
index 56d1338a3..a36eb8c00 100755
--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -16,8 +16,9 @@ cgroup_error_and_usage () {
        On modern distros (e.g. Debian bullseye and Ubuntu Jammy Jellyfish) which have cgroup v2 enabled by default,
        you need to add 'systemd.unified_cgroup_hierarchy=0' as well.
     2. Run update-grub
-    3. Reboot" >&2
-    exit 1
+    3. Reboot
+    (ignoring for now, hehe)" >&2
+    exit 0
 }
 
 for i in cpuset memory; do
```

</details>