### PR TITLE
Limit the labels on the x-axis

### DIFF
--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -381,7 +381,7 @@ var submissions = [
 var contest_duration_minutes = Math.ceil(({{ current_contest.endtime }} - {{ current_contest.starttime }}) / 60);
 
 submission_stats.forEach(stat => {
-  stat.values = Array.from({ length: contest_duration_minutes }, (_, i) => [i, 0]);
+  stat.values = Array.from({ length: contest_duration_minutes + 1 }, (_, i) => [i, 0]);
 });
 
 const statMap = submission_stats.reduce((map, stat) => {
@@ -397,13 +397,20 @@ submissions.forEach(submission => {
   }
 });
 
-for (let minute = 0; minute < contest_duration_minutes; minute++) {
+for (let minute = 0; minute <= contest_duration_minutes; minute++) {
   let this_minute_submission_nums = 0;
   submission_stats.forEach(stat => {
     this_minute_submission_nums += stat.values[minute][1];
   });
   max_submissions_per_minute = Math.max(max_submissions_per_minute, this_minute_submission_nums);
 }
+
+// Pick a nice round tickDelta and tickValues
+var tickDelta = 15;
+while (contest_duration_minutes / tickDelta > 15) {
+  tickDelta *= 2;
+}
+var tickValues = Array.from({ length: Math.ceil(contest_duration_minutes / tickDelta) + 1 }, (_, i) => i * tickDelta);
 
 nv.addGraph(function() {
   var chart = nv.models.multiBarChart()
@@ -417,11 +424,13 @@ nv.addGraph(function() {
       .y(function(d) { return d[1] })   //...in case your data is formatted differently.
       .showYAxis(true)        //Show the y-axis
       .showXAxis(true)        //Show the x-axis
+      .reduceXTicks(false)
       ;
   chart.xAxis     //Chart x-axis settings
       .axisLabel('Contest Time(minutes)')
+      .ticks(tickValues.length)
+      .tickValues(tickValues)
       .tickFormat(d3.format('d'));
-
   chart.yAxis     //Chart y-axis settings
       .axisLabel('Total Submissions')
       .tickFormat(d3.format('d'));


### PR DESCRIPTION
## Old PR
https://github.com/DOMjudge/domjudge/pull/2727

## Change
Since the `forceX` method is no longer available after using `multibarchart`, it causes the x-axis labels to be misaligned, and I can't set the competition end time as the final label. Therefore, I force interpolation to fill in the x-axis labels (I haven't thought of a better solution yet).

In addition to 0 and the end time, I will insert 9 additional points. This should handle all competitions where the duration is a multiple of 10.


## Next

Additionally, according to the last PR, the data size of the table uses `min(minutes, 300)`. How should I create the labels in this case? For example, if there is a competition that lasts for a week, should the unit of my labels still be in minutes?