### PR TITLE
Fix event feed last event ID lookup.

### DIFF
--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -655,8 +655,8 @@ class ContestController extends AbstractRestController
         $response->headers->set('Content-Type', 'application/x-ndjson');
         $response->setCallback(function () use ($format, $cid, $contest, $request, $since_id, $types, $strict, $stream, $metadataFactory, $kernel) {
             $lastUpdate = 0;
-            $lastIdSent = max(0, $since_id); // Don't try to look for event_id=0
-            $lastIdExists = $since_id === -1;
+            $lastIdSent = max(0, $since_id);
+            $lastIdExists = $since_id !== -1; // Don't try to look for event_id=0
             $typeFilter = false;
             if ($types) {
                 $typeFilter = explode(',', $types);


### PR DESCRIPTION
This has been added in https://github.com/DOMjudge/domjudge/commit/ef8c832e63ff4c2538b595ca91bd4389d9e59387

The first `eventid` will be 1. If the event feed reading client does not pass in a `since_token` or `since_id`, we set `since_id` to `-1` to signal start reading from the beginning. In that case there is no previous event that can be expected to exist.

This was also reported as broken in a side comment of https://github.com/DOMjudge/domjudge/issues/2728