### PR TITLE
Allow setting password explicitly in `console domjudge:reset-user-password`

### DIFF
--- a/webapp/src/Command/ResetUserPasswordCommand.php
+++ b/webapp/src/Command/ResetUserPasswordCommand.php
@@ -33,6 +33,11 @@ class ResetUserPasswordCommand extends Command
                 'username',
                 InputArgument::REQUIRED,
                 'The username of the user to reset the password of'
+            )
+            ->addArgument(
+                'password',
+                InputArgument::OPTIONAL,
+                'The new password; if not provided a random password is generated'
             );
     }
 
@@ -50,7 +55,7 @@ class ResetUserPasswordCommand extends Command
             return Command::FAILURE;
         }
 
-        $password = Utils::generatePassword();
+        $password = $input->getArgument('password') ?? Utils::generatePassword();
 
         $user->setPassword(
             $this->passwordHasher->hashPassword($user, $password)


### PR DESCRIPTION
This can be useful for example to reset the admin password to what's in `etc/initial_admin_password.secret`.