### PR TITLE
Fix judgehost check if its enabled

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -768,7 +768,7 @@ while (true) {
             $judgehosts = request('judgehosts', 'GET');
             if ($judgehosts !== null) {
                 $judgehosts = dj_json_decode($judgehosts);
-                $judgehost = array_filter($judgehosts, fn($j) => $j['hostname'] === $myhost);
+                $judgehost = array_values(array_filter($judgehosts, fn($j) => $j['hostname'] === $myhost))[0];
                 if (!isset($judgehost['enabled']) || !$judgehost['enabled']) {
                     logmsg(LOG_WARNING, "Judgehost needs to be enabled in web interface.");
                 }


### PR DESCRIPTION
array_filter would only filter out the other judgehosts but still return an array of judgehost objects. By selecting the first (and only item) we can now get the `enabled` property and properly check.

```
array(1) {
  [1]=>
  array(5) {
    ["id"]=>
    string(1) "2"
    ["hostname"]=>
    string(8) "judgehost"
    ["enabled"]=>
    bool(true)
    ["polltime"]=>
    string(20) "1728821560.017400000"
    ["hidden"]=>
    bool(false)
  }
}
```

There is probably a more elegant fix for this but this should work as a quick fix.