### PR TITLE
Add warning about cgroup v1 force flag

### DIFF
--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -172,7 +172,8 @@ any other tasks on the same CPU core the judgedaemon is using:
 
 On modern distros (e.g. Debian bullseye and Ubuntu Jammy Jellyfish) which have
 cgroup v2 enabled by default, you need to add ``systemd.unified_cgroup_hierarchy=0``
-as well. Then run ``update-grub`` and reboot.
+as well. If you are running systemd v257, you also need to add `SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1`.
+Then run ``update-grub`` and reboot.
 After rebooting check that ``/proc/cmdline`` actually contains the
 added kernel options. On VM hosting providers such as Google Cloud or
 DigitalOcean, ``GRUB_CMDLINE_LINUX_DEFAULT`` may be overwritten


### PR DESCRIPTION
Systemd 257 (currently used on arch at least) stops users from booting if you don't set this flag. Although cgroup v2 support is on its way, we might want to warn current users.