### PR TITLE
do not display anything for 0 attempts.

### DIFF
--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -345,6 +345,15 @@ nv.addGraph(function() {
   d3.select('#graph_problems svg')
       .datum(problem_stats)
       .call(chart);
+  // Hide bars with 0 height after rendering
+  chart.dispatch.on('renderEnd', function() {
+    d3.selectAll('#graph_problems .nv-bar').each(function(d) {
+      if (d.value === 0) {
+        d3.select(this).attr('height', 0);
+        d3.select(this).attr('y', chart.yAxis.scale()(0)); 
+      }
+    });
+  });
   nv.utils.windowResize(chart.update);
   return chart;
 });


### PR DESCRIPTION
## issue
https://github.com/DOMjudge/domjudge/issues/2528

## display
<img width="528" alt="截圖 2024-10-25 上午11 19 24" src="https://github.com/user-attachments/assets/dac2efcf-77eb-4f8a-8a53-f1984bb1e85b">
<img width="599" alt="截圖 2024-10-25 上午11 25 25" src="https://github.com/user-attachments/assets/10b44615-3942-43ff-9e08-1bbd5f68cd06">

## Implement
Forcing the height to 0 after the chart rendering finishes may not be the most elegant solution, but I believe it's workable. Additionally, it involves minimal code changes.