### PR TITLE
Fix team import when importing multiple teams with the same non-existing category or affiliation.

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -1127,7 +1127,9 @@ class ImportExportService
      */
     protected function importTeamData(array $teamData, ?string &$message, ?array &$saved = null): int
     {
+        /** @var TeamAffiliation[] $createdAffiliations */
         $createdAffiliations = [];
+        /** @var TeamCategory[] $createdCategories */
         $createdCategories   = [];
         $createdTeams        = [];
         $updatedTeams        = [];
@@ -1140,6 +1142,14 @@ class ImportExportService
             if (!empty($teamItem['team_affiliation']['shortname'])) {
                 // First look up if the affiliation already exists.
                 $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->findOneBy(['shortname' => $teamItem['team_affiliation']['shortname']]);
+                if (!$teamAffiliation) {
+                    foreach ($createdAffiliations as $createdAffiliation) {
+                        if ($createdAffiliation->getShortname() === $teamItem['team_affiliation']['shortname']) {
+                            $teamAffiliation = $createdAffiliation;
+                            break;
+                        }
+                    }
+                }
                 if (!$teamAffiliation) {
                     $teamAffiliation  = new TeamAffiliation();
                     $propertyAccessor = PropertyAccess::createPropertyAccessor();
@@ -1166,6 +1176,15 @@ class ImportExportService
                 }
             } elseif (!empty($teamItem['team_affiliation']['externalid'])) {
                 $teamAffiliation = $this->em->getRepository(TeamAffiliation::class)->findOneBy(['externalid' => $teamItem['team_affiliation']['externalid']]);
+                if (!$teamAffiliation) {
+                    foreach ($createdAffiliations as $createdAffiliation) {
+                        if ($createdAffiliation->getExternalid() === $teamItem['team_affiliation']['externalid']) {
+                            $teamAffiliation = $createdAffiliation;
+                            break;
+                        }
+                    }
+                }
+
                 if (!$teamAffiliation) {
                     $teamAffiliation = new TeamAffiliation();
                     $teamAffiliation
@@ -1196,6 +1215,14 @@ class ImportExportService
 
             if (!empty($teamItem['team']['categoryid'])) {
                 $teamCategory = $this->em->getRepository(TeamCategory::class)->findOneBy(['externalid' => $teamItem['team']['categoryid']]);
+                if (!$teamCategory) {
+                    foreach ($createdCategories as $createdCategory) {
+                        if ($createdCategory->getExternalid() === $teamItem['team']['categoryid']) {
+                            $teamCategory = $createdCategory;
+                            break;
+                        }
+                    }
+                }
                 if (!$teamCategory) {
                     $teamCategory = new TeamCategory();
                     $teamCategory

--- a/webapp/tests/Unit/Service/ImportExportServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportExportServiceTest.php
@@ -679,6 +679,7 @@ EOF;
 File_Version	2
 11	447047	24	¡i¡i¡	Lund University	LU	SWE	INST-42
 12	447837	25	Pleading not FAUlty	Friedrich-Alexander-University Erlangen-Nuremberg	FAU	DEU	INST-43
+13	447057	24	Another team from Lund	Lund University	LU	SWE	INST-42
 EOF;
 
         $expectedTeams = [
@@ -709,6 +710,20 @@ EOF;
                     'shortname' => 'FAU',
                     'name' => 'Friedrich-Alexander-University Erlangen-Nuremberg',
                     'country' => 'DEU',
+                ],
+            ], [
+                'externalid' => '13',
+                'icpcid' => '447057',
+                'label' => null,
+                'name' => 'Another team from Lund',
+                'category' => [
+                    'externalid' => '24',
+                ],
+                'affiliation' => [
+                    'externalid' => '42',
+                    'shortname' => 'LU',
+                    'name' => 'Lund University',
+                    'country' => 'SWE',
                 ],
             ],
         ];


### PR DESCRIPTION
This mostly happens with importing the `teams2.tsv` file, since we import both teams and categories at the same time. This is also why we didn't notice this yet, we use the JSON's.

Found by @mkfuron .