### PR TITLE
Skip C++ test for fedora

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -111,6 +111,10 @@ compile_assertions_finished () {
 }
 
 @test "Install GNU C only" {
+    if [ "$distro_id" = "ID=fedora" ]; then
+        # Fedora ships with a gcc with enough C++ support
+        skip
+    fi
     repo-remove clang g++
     repo-install gcc libcgroup-dev
     compiler_assertions gcc ''


### PR DESCRIPTION
Fedora 41 seems to ship with C++ support either in the package or via dependencies. Exclude it as a quick fix.