### PR TITLE
Warn when additional test cases have been added.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -378,6 +378,9 @@ class SubmissionController extends BaseController
                 ->getScalarResult();
 
             $cnt = 0;
+            if (count($judgingRunTestcaseIdsInOrder) !== count($runResults)) {
+                $sameTestcaseIds = false;
+            }
             foreach ($runResults as $runResult) {
                 /** @var Testcase $testcase */
                 $testcase = $runResult[0];


### PR DESCRIPTION
We already had a warning when testcases have been re-ordered or removed, but didn't catch the case where additional cases have been added to the end.

Fixes #2765.

Example:
![image](https://github.com/user-attachments/assets/a94aaf0d-4eef-45e5-952d-51d4d0911afe)
