### PR TITLE
Make output of import contest more readable.

### DIFF
--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -15,12 +15,13 @@ Part of the DOMjudge Programming Contest Jury System and licensed
 under the GNU GPL. See README and COPYING for details.
 '''
 
-import json
 from os import listdir
+from typing import List
+import json
 import os.path
 import re
+import subprocess
 import sys
-from typing import List
 import yaml
 
 sys.path.append('@domserver_libdir@')
@@ -213,19 +214,46 @@ if os.path.exists('problems.yaml') or os.path.exists('problems.json') or os.path
 
         confirmIndividually = dj_utils.confirm("Confirm individually for every problem", False)
         for problem in problems:
-            print(f'Preparing problem \'{problem}\'.')
+            print(f'\nPreparing problem \'{problem}\'.')
             if os.path.exists(f'{problem}.zip'):
                 os.unlink(f'{problem}.zip')
             if not os.path.isdir(problem) or not os.path.isfile(f'{problem}/problem.yaml'):
                 print('Problem directory not found or doesn\'t contain a problem.yaml.')
                 exit(3)
-            os.system(f'cd {problem} && zip -r \'../{problem}\' -- .timelimit *')
+            zip_command = f"zip -r '../{problem}' -- .timelimit *"
+            process = subprocess.Popen(zip_command, cwd=problem, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True)
+
+            lastLine = None
+            for line in process.stdout:
+                if lastLine:
+                    sys.stdout.write("\r" + " " * len(lastLine))
+                sys.stdout.write(f"\r{line.strip()}")
+                sys.stdout.flush()
+                lastLine = line
+
+            exit_code = process.wait()
+            if exit_code == 0:
+                if lastLine:
+                    sys.stdout.write("\r" + " " * len(lastLine) + "\r")
+            else:
+                print(f"\nZipping problem failed with exit code: {exit_code}")
 
             if ((not confirmIndividually) or dj_utils.confirm(f'Ready to import problem \'{problem}\' to problem={problem}. Continue?', True)):
                 print(f'Uploading problem \'{problem}\', please be patient, this may take a while.')
                 response = dj_utils.upload_file(
                     f'contests/{cid}/problems', 'zip', f'{problem}.zip', {'problem': problem})
-                print(json.dumps(response, indent=4))
+                if response and 'problem_id' in response:
+                    print(f'Problem imported with ID {response["problem_id"]}:')
+                    if 'messages' in response:
+                        messages = response['messages']
+                        types = {'info': '🛈 ', 'warning': '⚠️ ', 'danger': '🚨'}
+                        for t,e in types.items():
+                            if t in messages and messages[t]:
+                                print(f'  {e} {t.capitalize()}:')
+                                for message in messages[t]:
+                                    print(f'    - {message}')
+                else:
+                    print(json.dumps(response, indent=4))
     else:
         print('Skipping contest import.')
 else:


### PR DESCRIPTION
Print the output of `zip` line by line, overwriting the last line and removing all output of it on success.

Also pretty-print the JSON response on problem output.

That makes it much easier to see warnings or errors.

Fixes #2342.