### PR TITLE
Error when missing cgroup value memory.peak

### DIFF
--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -179,6 +179,12 @@ Optionally the timings can be made more stable by not letting the OS schedule
 any other tasks on the same CPU core the judgedaemon is using:
 ``GRUB_CMDLINE_LINUX_DEFAULT="quiet cgroup_enable=memory swapaccount=1 isolcpus=2"``
 
+On modern systems where cgroup v2 is available, DOMjudge will try to
+use that. This requires kernel versions 5.19 or 6.0 or later to
+support reporting peak memory usage. If not found, the system will try
+to fall back to cgroup v1, but this might require you to add
+``systemd.unified_cgroup_hierarchy=0`` to the boot options as well.
+
 You have now configured the system to use cgroups. To create
 the actual cgroups that DOMjudge will use you need to run::
 

--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -25,7 +25,8 @@ if [ "$fs_type" = "cgroup2" ]; then
     major=$(echo "$kernel_version" | cut -d '.' -f 1)
     minor=$(echo "$kernel_version" | cut -d '.' -f 2)
     if [ "$major" -lt 5 ] || { [ "$major" -eq 5 ] && [ "$minor" -lt 19 ]; }; then
-        echo "WARNING: Kernel ($kernel_version) is too old to record peak RAM usage" >&2
+        cgroup_error_and_usage "Error: kernel ($kernel_version) is too old to record peak RAM usage with cgroup V2.
+You can try using cgroup V1 by adding systemd.unified_cgroup_hierarchy=0 to the kernel params."
     fi
     if ! echo "+memory" >> /sys/fs/cgroup/cgroup.subtree_control; then
         cgroup_error_and_usage "Error: Cannot add +memory to cgroup.subtree_control; check kernel params. Unable to continue."
@@ -33,8 +34,9 @@ if [ "$fs_type" = "cgroup2" ]; then
     if ! echo "+cpuset" >> /sys/fs/cgroup/cgroup.subtree_control; then
         cgroup_error_and_usage "Error: Cannot add +cpuset to cgroup.subtree_control; check kernel params. Unable to continue."
     fi
-    exit 0
 fi
+
+# Trying cgroup V1:
 
 for i in cpuset memory; do
     mkdir -p $CGROUPBASE/$i

--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -504,7 +504,7 @@ void output_cgroup_stats_v2(double *cputime)
 	int64_t max_usage = 0;
 	ret = cgroup_get_value_int64(cg_controller, "memory.peak", &max_usage);
 	if ( ret == ECGROUPVALUENOTEXIST ) {
-		write_meta("internal-warning", "Kernel too old and does not support memory.peak");
+		error(ret, "kernel too old and does not support memory.peak");
 	} else if ( ret!=0 ) {
 		error(ret,"get cgroup value memory.peak");
 	}


### PR DESCRIPTION
This replaces the `memory.memsw.max_usage_in_bytes` value from cgroup v1. We always assume it's there so we should fail if it is not. Otherwise things silently degrade in a way they would not have before.

Addresses #2763