### PR TITLE
Fix compiler error reporting for empty source file sets.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -394,9 +394,12 @@ class JudgehostController extends AbstractFOSRestController
                     if ($judging->getOutputCompile() === null) {
                         $judging
                             ->setOutputCompile($output_compile)
-                            ->setCompileMetadata(base64_decode($compileMetadata))
                             ->setResult(Judging::RESULT_COMPILER_ERROR)
                             ->setEndtime(Utils::now());
+
+                        if ($compileMetadata !== null) {
+                            $judging->setCompileMetadata(base64_decode($compileMetadata));
+                        }
                         $this->em->flush();
 
                         if ($judging->getValid()) {


### PR DESCRIPTION
Empty source file sets can happen with filtered file extensions, when you accept a submission and later trim down the list of filtered file extensions to a smaller set.

We also saw this during shadowing, but probably want to classify that as an import error.