### PR TITLE
Prevent indexing by search engines by default

### DIFF
--- a/etc/nginx-conf-inner.in
+++ b/etc/nginx-conf-inner.in
@@ -8,6 +8,9 @@ server_name _default_;
 # set max upload size to infinite since PHP has a setting for this
 client_max_body_size 0;
 
+# Prevent indexing by robots
+add_header X-Robots-Tag "none" always;
+
 # Variables used in the nginx configuration
 set $domjudgeRoot @domserver_webappdir@/public;
 # Set this to '' instead of /domjudge when running in the root of your system


### PR DESCRIPTION
Some search engines trigger the markdown-preview which is POST only so we would get sentry errors for this. That lead to the discussion that we don't want search engines to index DOMjudge instances without the user specifically choosing this.

Fixes: https://github.com/DOMjudge/domjudge/issues/2654