### PR TITLE
Remove legacy Docker compose links option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - .:${PWD}:cached
       - /chroot
-    links:
-      - mariadb:mariadb
     ports:
       - 12345:80
     privileged: true


### PR DESCRIPTION
This is not needed anyway.