### PR TITLE
Unset all auxiliary groups and simplify code

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -923,9 +923,7 @@ void setrestrictions()
 	/* Set group-id (must be root for this, so before setting user). */
 	if ( use_group ) {
 		if ( setgid(rungid) ) error(errno,"cannot set group ID to `%d'",rungid);
-		gid_t aux_groups[1];
-		aux_groups[0] = rungid;
-		if ( setgroups(1, aux_groups) ) error(errno,"cannot clear auxiliary groups");
+		if ( setgroups(0, NULL) ) error(errno,"cannot clear auxiliary groups");
 
 		verbose("using group ID `%d'",rungid);
 	}


### PR DESCRIPTION
Since `rungid` is already set as primary group, there's no reason to also set it as auxiliary group.

Tested by submitting https://github.com/DOMjudge/domjudge/blob/main/example_problems/hello/submissions/wrong_answer/test-permissions.sh and still seeing the `domjudge-run` group as primary group.

Closes #2589