### PR TITLE
When cancelling a rejudging, also delete the corresponding queue tasks.

### DIFF
--- a/webapp/src/Service/RejudgingService.php
+++ b/webapp/src/Service/RejudgingService.php
@@ -335,6 +335,8 @@ class RejudgingService
                             SET result = :aborted
                             WHERE judgingid = :judgingid
                             AND result IS NULL', ['aborted' => 'aborted', 'judgingid' => $submission['judgingid']]);
+                $this->em->getConnection()->executeQuery(
+                    'DELETE FROM queuetask WHERE judgingid = :judgingid', ['judgingid' => $submission['judgingid']]);
             } else {
                 $error = "Unknown action '$action' specified.";
                 throw new BadMethodCallException($error);


### PR DESCRIPTION
Previously, when you did a large rejudging (say of a whole contest), abort it immediately, you would have a lot of queuetasks where each queue task doesn't have any remaining judge task to process. The judgedaemon would process these one at a time and assume there is no work to be done and sleep until processing the next one, so it would take hours to clean up the queue. We should address that behavior separately.