### PR TITLE
Fix migration for executable zipfile

### DIFF
--- a/webapp/migrations/Version20210407120356.php
+++ b/webapp/migrations/Version20210407120356.php
@@ -63,7 +63,7 @@ final class Version20210407120356 extends AbstractMigration
                 );
             }
 
-            $this->connection->executeStatement('ALTER TABLE `executable` DROP COLUMN `zipfile`');
+            $this->addSql('ALTER TABLE `executable` DROP COLUMN `zipfile`');
         }
     }
 


### PR DESCRIPTION
By doing the ALTER on the connection directly Doctrine didn't recognize it and re-added the column. We need to use `addSql`.