### PR TITLE
Add simple script to force admin and judgehost passwords.

### DIFF
--- a/misc-tools/.gitignore
+++ b/misc-tools/.gitignore
@@ -5,3 +5,4 @@
 /dj_make_chroot_docker
 /dj_run_chroot
 /dj_judgehost_cleanup
+/force-passwords

--- a/misc-tools/Makefile
+++ b/misc-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/Makefile.global
 TARGETS =
 OBJECTS =
 
-SUBST_DOMSERVER = fix_permissions configure-domjudge import-contest
+SUBST_DOMSERVER = fix_permissions configure-domjudge import-contest force-passwords
 
 SUBST_JUDGEHOST = dj_make_chroot dj_run_chroot dj_make_chroot_docker \
                   dj_judgehost_cleanup

--- a/misc-tools/force-passwords.in
+++ b/misc-tools/force-passwords.in
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+import subprocess
+
+webappdir = '@domserver_webappdir@'
+etcdir = '@domserver_etcdir@'
+
+with open(f'{etcdir}/restapi.secret', 'r') as f:
+    while True:
+        line = f.readline()
+        if line.startswith('#'):
+            continue
+        tokens = line.split()
+        if len(tokens) == 4 and tokens[0] == 'default':
+            user = tokens[2]
+            password = tokens[3]
+            subprocess.run([webappdir + '/bin/console', 'domjudge:reset-user-password', user, password])    
+        break
+
+with open(f'{etcdir}/initial_admin_password.secret', 'r') as f:
+    password = f.readline().strip()
+    subprocess.run([webappdir + '/bin/console', 'domjudge:reset-user-password', 'admin', password]) 


### PR DESCRIPTION
This will read from restapi.secret and initial_admin_password.secret and reset the DB state to match these passwords.

This can be especially useful if you are importing a database from a previous contest and do not want to do update passwords manually.