### PR TITLE
Prevent the github action to take forever.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     container:
       image: domjudge/gitlabci:24.04
       options: --privileged --cgroupns=host --init

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   runpipe:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     container:
       image: domjudge/gitlabci:24.04
       options: --privileged --cgroupns=host --init


### PR DESCRIPTION
Default seems to be 6h: https://github.com/DOMjudge/domjudge/actions/runs/11977011821/job/33393963766?pr=2832