### PR TITLE
Don't try to update aborted judgings

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1049,6 +1049,12 @@ class JudgehostController extends AbstractFOSRestController
             // Only update if the current result is different from what we had before.
             // This should only happen when the old result was NULL.
             if ($oldResult !== $result) {
+                if ($oldResult === 'aborted') {
+                    // This judging was cancelled while we worked on it,
+                    // probably as part of a cancelled rejudging.
+                    // Throw away our work, and return that we're done.
+                    return false;
+                }
                 if ($oldResult !== null) {
                     throw new BadMethodCallException('internal bug: the evaluated result changed during judging');
                 }


### PR DESCRIPTION
This (typically?) happens while cancelling a rejudging while there are judgedaemons actively judging. Fixes errors like
```
[Nov 23 13:34:53.075] judgedaemon[526392]: warning: Error while executing curl POST to url http://localhost/domjudge/api/judgehosts/add-judging-run/tiger-1/1555747: http status code: 500, request size = 67745, response: array (
  'code' => 500,
  'message' => 'internal bug: the evaluated result changed during judging',
  'class' => 'BadMethodCallException',
  'trace' =>
  array (
    0 =>
    array (
      'namespace' => '',
      'short_class' => '',
      'class' => '',
      'type' => '',
      'function' => '',
      'file' => '/home/jaap/domjudge/git/domjudge/webapp/src/Controller/API/JudgehostController.php',
      'line' => 1053,
      'args' =>
      array (
      ),
    ),
...
```