### PR TITLE
Convert whitesmoke to hex before parsing it

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1134,9 +1134,9 @@ EOF;
 
     public function problemBadge(ContestProblem $problem, bool $grayedOut = false): string
     {
-        $rgb        = Utils::convertToHex($problem->getColor() ?? '#ffffff');
+        $rgb = Utils::convertToHex($problem->getColor() ?? '#ffffff');
         if ($grayedOut) {
-            $rgb = 'whitesmoke';
+            $rgb = Utils::convertToHex('whitesmoke');
         }
         $background = Utils::parseHexColor($rgb);
 
@@ -1164,9 +1164,9 @@ EOF;
 
     public function problemBadgeMaybe(ContestProblem $problem, ScoreboardMatrixItem $matrixItem): string
     {
-        $rgb        = Utils::convertToHex($problem->getColor() ?? '#ffffff');
+        $rgb = Utils::convertToHex($problem->getColor() ?? '#ffffff');
         if (!$matrixItem->isCorrect) {
-            $rgb = 'whitesmoke';
+            $rgb = Utils::convertToHex('whitesmoke');
         }
         $background = Utils::parseHexColor($rgb);
 


### PR DESCRIPTION
This fixes many deprecation errors on the mobile scoreboard.