### PR TITLE
Fix fallthrough logic for cgroup version detection

### DIFF
--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -18,7 +18,7 @@ cgroup_error_and_usage () {
     exit 1
 }
 
-# Check whether cgroup v2 is available.
+# Check whether cgroup v2 is enabled.
 fs_type=$(awk '$2 == "/sys/fs/cgroup" {print $3}' /proc/mounts)
 if [ "$fs_type" = "cgroup2" ]; then
     kernel_version=$(uname -r)
@@ -34,25 +34,26 @@ You can try using cgroup V1 by adding systemd.unified_cgroup_hierarchy=0 to the 
     if ! echo "+cpuset" >> /sys/fs/cgroup/cgroup.subtree_control; then
         cgroup_error_and_usage "Error: Cannot add +cpuset to cgroup.subtree_control; check kernel params. Unable to continue."
     fi
-fi
 
-# Trying cgroup V1:
+else # Trying cgroup V1:
 
-for i in cpuset memory; do
-    mkdir -p $CGROUPBASE/$i
-    if [ ! -d $CGROUPBASE/$i/ ]; then
-        if ! mount -t cgroup -o$i $i $CGROUPBASE/$i/; then
-            cgroup_error_and_usage "Error: Can not mount $i cgroup. Probably cgroup support is missing from running kernel. Unable to continue."
+    for i in cpuset memory; do
+        mkdir -p $CGROUPBASE/$i
+        if [ ! -d $CGROUPBASE/$i/ ]; then
+            if ! mount -t cgroup -o$i $i $CGROUPBASE/$i/; then
+                cgroup_error_and_usage "Error: Can not mount $i cgroup. Probably cgroup support is missing from running kernel. Unable to continue."
+            fi
         fi
+        mkdir -p $CGROUPBASE/$i/domjudge
+    done
+
+    if [ ! -f $CGROUPBASE/memory/memory.limit_in_bytes ] || [ ! -f $CGROUPBASE/memory/memory.memsw.limit_in_bytes ]; then
+        cgroup_error_and_usage "Error: cgroup support missing memory features in running kernel. Unable to continue."
     fi
-    mkdir -p $CGROUPBASE/$i/domjudge
-done
 
-if [ ! -f $CGROUPBASE/memory/memory.limit_in_bytes ] || [ ! -f $CGROUPBASE/memory/memory.memsw.limit_in_bytes ]; then
-    cgroup_error_and_usage "Error: cgroup support missing memory features in running kernel. Unable to continue."
-fi
+    chown -R $JUDGEHOSTUSER $CGROUPBASE/*/domjudge
 
-chown -R $JUDGEHOSTUSER $CGROUPBASE/*/domjudge
+    cat $CGROUPBASE/cpuset/cpuset.cpus > $CGROUPBASE/cpuset/domjudge/cpuset.cpus
+    cat $CGROUPBASE/cpuset/cpuset.mems > $CGROUPBASE/cpuset/domjudge/cpuset.mems
 
-cat $CGROUPBASE/cpuset/cpuset.cpus > $CGROUPBASE/cpuset/domjudge/cpuset.cpus
-cat $CGROUPBASE/cpuset/cpuset.mems > $CGROUPBASE/cpuset/domjudge/cpuset.mems
+fi # cgroup V1


### PR DESCRIPTION
Only one of cgroup V1 or V2 can be enabled at a time, so it doesn't make sense to have fallthrough behaviour from V2 to V1. Instead of adding an `exit 0` at the end of the V2 case, add an `else` so that it is clearer that these are two mutually exclusive cases.

Fixes a0728be789071466e87f417066c73c7cf1098a03