### PR TITLE
Update components as registered in Coverity

### DIFF
--- a/coverity/components.tsv
+++ b/coverity/components.tsv
@@ -1,7 +1,7 @@
 Component name	Pattern	Ignore in analysis
 Included standard libraries	/usr/include/.*	Yes
-External JS libraries	/webapp/web/js/(ace/.*|flot/.*|jquery\..*\.js)	No
 Generated cache files in var	/webapp/var/cache/.*	Yes
 Generated doc build files	/doc/manual/build/.*	Yes
 Symfony external resources	/webapp/resources/.*	Yes
 External PHP libraries	/webapp/vendor/.*	Yes
+External JS libraries	/webapp/public/js/(monaco/.*|jquery\..*\.js)	Yes


### PR DESCRIPTION
- Replace ACE by Monaco editor
- JS libraries are under webapp/public/js since a while
- Flot library is long gone