### PR TITLE
Create verdict groups that selectively can be used

### DIFF
--- a/etc/verdicts.php
+++ b/etc/verdicts.php
@@ -4,12 +4,24 @@
 // CCS specification (and a few more common ones) at:
 // https://ccs-specs.icpc.io/2021-11/ccs_system_requirements#judge-responses
 return [
-    'compiler-error'     => 'CE',
-    'memory-limit'       => 'MLE',
-    'output-limit'       => 'OLE',
-    'run-error'          => 'RTE',
-    'timelimit'          => 'TLE',
-    'wrong-answer'       => 'WA',
-    'no-output'          => 'NO',
-    'correct'            => 'AC',
+    'final' => [
+        'compiler-error'     => 'CE',
+        'memory-limit'       => 'MLE',
+        'output-limit'       => 'OLE',
+        'run-error'          => 'RTE',
+        'timelimit'          => 'TLE',
+        'wrong-answer'       => 'WA',
+        'no-output'          => 'NO',
+        'correct'            => 'AC',
+    ],
+    'error' => [
+        'aborted'            => 'JE',
+        'import-error'       => 'IE',
+    ],
+    'in_progress' => [
+        'judging'            => 'JU',
+        'pending'            => 'JU',
+        'queued'             => 'JU',
+    ],
+    // The 'external' group is defined in configuration.
 ];

--- a/webapp/src/Controller/API/JudgementController.php
+++ b/webapp/src/Controller/API/JudgementController.php
@@ -44,9 +44,7 @@ class JudgementController extends AbstractRestController implements QueryObjectT
     ) {
         parent::__construct($entityManager, $DOMJudgeService, $config, $eventLogService);
 
-        $verdicts = $this->dj->getVerdicts();
-        $verdicts['aborted'] = 'JE'; /* happens for aborted judgings */
-        $this->verdicts = $verdicts;
+        $this->verdicts = $this->dj->getVerdicts(['final', 'error']);
     }
 
     /**

--- a/webapp/src/Controller/API/JudgementTypeController.php
+++ b/webapp/src/Controller/API/JudgementTypeController.php
@@ -85,7 +85,7 @@ class JudgementTypeController extends AbstractApiController
      */
     protected function getJudgementTypes(array $filteredOn = null): array
     {
-        $verdicts = $this->dj->getVerdicts(mergeExternal: true);
+        $verdicts = $this->dj->getVerdicts(['final', 'external']);
 
         $result = [];
         foreach ($verdicts as $name => $label) {

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -241,9 +241,8 @@ class RejudgingController extends BaseController
         }
         $todo = $this->rejudgingService->calculateTodo($rejudging)['todo'];
 
-        $verdicts = $this->dj->getVerdicts();
+        $verdicts = $this->dj->getVerdicts(['final', 'error']);
         $verdicts[''] = 'JE'; /* happens for aborted judgings */
-        $verdicts['aborted'] = 'JE'; /* happens for aborted judgings */
 
         $used         = [];
         $verdictTable = [];

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -83,9 +83,7 @@ class ShadowDifferencesController extends BaseController
         $this->requestStack->getSession()->save();
 
         $contest  = $this->dj->getCurrentContest();
-        $verdicts = array_merge(['judging' => 'JU'], $this->dj->getVerdicts(mergeExternal: true));
-
-        $verdicts['import-error'] = 'IE';
+        $verdicts = $this->dj->getVerdicts(['final', 'error', 'external', 'in_progress']);
 
         $used         = [];
         $verdictTable = [];

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -138,9 +138,7 @@ class SubmissionController extends BaseController
         // Load preselected filters
         $filters = $this->dj->jsonDecode((string)$this->dj->getCookie('domjudge_submissionsfilter') ?: '[]');
 
-        $results = array_keys($this->dj->getVerdicts());
-        $results[] = 'judging';
-        $results[] = 'queued';
+        $results = array_keys($this->dj->getVerdicts(['final', 'in_progress']));
 
         $data = [
             'refresh' => $refresh,

--- a/webapp/src/Form/Type/SubmissionsFilterType.php
+++ b/webapp/src/Form/Type/SubmissionsFilterType.php
@@ -115,10 +115,7 @@ class SubmissionsFilterType extends AbstractType
             "attr" => ["data-filter-field" => "team-id"],
         ]);
 
-        $verdicts = array_keys($this->dj->getVerdicts());
-        $verdicts[] = "judging";
-        $verdicts[] = "queued";
-        $verdicts[] = "import-error";
+        $verdicts = array_keys($this->dj->getVerdicts(['final', 'error', 'in_progress']));
         $builder->add("result", ChoiceType::class, [
             "label" => "Filter on result(s)",
             "multiple" => true,

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1485,14 +1485,19 @@ class DOMJudgeService
     /**
      * @return array<string, string>
      */
-    public function getVerdicts(bool $mergeExternal = false): array
+    public function getVerdicts(array $groups = ['final']): array
     {
         $verdictsConfig = $this->getDomjudgeEtcDir() . '/verdicts.php';
-        $verdicts       = include $verdictsConfig;
+        $verdictGroups  = include $verdictsConfig;
 
-        if ($mergeExternal) {
-            foreach ($this->config->get('external_judgement_types') as $id => $name) {
-                $verdicts[$name] = $id;
+        $verdicts = [];
+        foreach( $groups as $group ) {
+            if ( $group === 'external' ) {
+                foreach ($this->config->get('external_judgement_types') as $id => $name) {
+                    $verdicts[$name] = $id;
+                }
+            } else {
+                $verdicts = array_merge($verdicts, $verdictGroups[$group]);
             }
         }
 

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -267,7 +267,7 @@ class ExternalContestSourceService
     public function import(bool $fromStart, array $eventsToSkip, ?callable $progressReporter = null): bool
     {
         // We need the verdicts to validate judgement-types.
-        $this->verdicts = $this->dj->getVerdicts(mergeExternal: true);
+        $this->verdicts = $this->dj->getVerdicts(['final', 'external']);
 
         if (!$this->isValidContestSource()) {
             throw new LogicException('The contest source is not valid');
@@ -797,7 +797,7 @@ class ExternalContestSourceService
             $customVerdicts = $this->config->get('external_judgement_types');
             $customVerdicts[$verdict] = str_replace(' ', '-', $data->name);
             $this->config->saveChanges(['external_judgement_types' => $customVerdicts], $this->eventLog, $this->dj);
-            $this->verdicts = $this->dj->getVerdicts(mergeExternal: true);
+            $this->verdicts = $this->dj->getVerdicts(['final', 'external']);
             $penalty = true;
             $solved = false;
             $this->logger->warning('Judgement type %s not found locally, importing as external verdict', [$verdict]);


### PR DESCRIPTION
Instead of manually adding various verdicts to the list in different places. This is not completely equivalent to before, but the changes should be fine. The original behaviour of calling `getVerdicts` without arguments is unchanged and `getVerdicts(mergeExternal: true)` maps to `getVerdicts(['final', 'external'])`.