### PR TITLE
Change URL parameter name to fix autowiring

### DIFF
--- a/webapp/src/Controller/Jury/AnalysisController.php
+++ b/webapp/src/Controller/Jury/AnalysisController.php
@@ -82,7 +82,7 @@ class AnalysisController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/team/{teamid}', name: 'analysis_team')]
+    #[Route(path: '/team/{team}', name: 'analysis_team')]
     public function teamAction(Team $team): Response
     {
         $contest = $this->dj->getCurrentContest();


### PR DESCRIPTION
The autowiring works if the URL parameter and function parameter have the same name `team`.

fixes #2864