### PR TITLE
Change URL parameter name to fix autowiring

### DIFF
--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -171,7 +171,7 @@ $(function() {
             {% for t in teams %}
               {% set id=t.teamid %}
               <tr>
-                {% set link = path('analysis_team', {'teamid':id}) %}
+                {% set link = path('analysis_team', {'team':id}) %}
                 <td scope="row" style="text-align: right;"><a href="{{ link }}">{{ t | entityIdBadge('t') }}</a></td>
                 <td><a href="{{ link }}">{% if t.affiliation %}{{ t.affiliation.name }}{% else %}-{% endif %}</a></td>
                 <td class="truncate" style="max-width: 200px"><a href="{{ link }}">{{ t.effectiveName }}</a></td>


### PR DESCRIPTION
This has been fixed in #2865, but forgot to modify it in the template, which makes the entire analysis page failed to open.