### PR TITLE
Run Unit tests for all branches again

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -46,7 +46,7 @@ jobs:
       image: pipelinecomponents/php-codesniffer:latest
     strategy:
       matrix:
-        PHPVERSION: ["8.1", "8.2", "8.3"]
+        PHPVERSION: ["8.1", "8.2", "8.3", "8.4"]
     steps:
       - run: apk add git
       - uses: actions/checkout@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup composer dependencies
         run: .github/jobs/composer_setup.sh
-      - uses: php-actions/phpstan@v3
+      - name: Show the phpstan version
+        run: webapp/vendor/phpstan/phpstan/phpstan --version
+      - uses: php-actions/phpstan@v3.0.2
         with:
           configuration: webapp/phpstan.dist.neon
           path: webapp/src webapp/tests

--- a/gitlab/ci/template.yml
+++ b/gitlab/ci/template.yml
@@ -50,7 +50,7 @@
     - /bin/true
   parallel:
     matrix:
-      - PHPVERSION: ["8.1","8.2","8.3"]
+      - PHPVERSION: ["8.1","8.2","8.3", "8.4"]
         TEST: ["E2E","Unit"]
         CRAWL_SHADOW_MODE: ["0","1"]
 

--- a/gitlab/ci/unit.yml
+++ b/gitlab/ci/unit.yml
@@ -29,21 +29,12 @@
         - unit-tests.xml
 
 run unit tests:
-  only:
-    - main
-    - /^[0-9].[0-9]$/
   extends: [.mariadb_job,.phpsupported_job,.unit_job]
 
 run unit tests (PR):
-  except:
-    - main
-    - /^[0-9].[0-9]$/
   extends: [.mariadb_job,.phpsupported_job_pr,.unit_job]
 
 run unit tests (MySQL):
-  only:
-    - main
-    - /^[0-9].[0-9]$/
   extends: [.mysql_job,.unit_job]
   parallel:
     matrix:

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -50,7 +50,7 @@ class JuryMiscController extends BaseController
     public function indexAction(ConfigurationService $config): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {
-            $innodbSnapshotIsolation = $this->em->getConnection()->query('SHOW VARIABLES LIKE "innodb_snapshot_isolation"')->fetchAssociative();
+            $innodbSnapshotIsolation = $this->em->getConnection()->executeQuery('SHOW VARIABLES LIKE "innodb_snapshot_isolation"')->fetchAssociative();
             if ($innodbSnapshotIsolation && $innodbSnapshotIsolation['Value'] === 'ON') {
                 $this->addFlash('danger', 'InnoDB snapshot isolation is enabled. Set --innodb_snapshot_isolation=OFF in your MariaDB configuration. See https://github.com/DOMjudge/domjudge/issues/2848 for more information.');
             }


### PR DESCRIPTION
We limited because of the number of minutes but as we're close to migrating away from GitLab this is the easier fix for the current deprecation issue.

This does still not explain why some pushes to main trigger the failing job and some don't but I hope we get the result a bit earlier.