### PR TITLE
Update broken link to problem package format

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh admin
-      - uses: php-actions/phpstan@v3
+      - uses: php-actions/phpstan@v3.0.2
         with:
           configuration: phpstan.dist.neon
           path: webapp/src webapp/tests

--- a/doc/manual/problem-format.rst
+++ b/doc/manual/problem-format.rst
@@ -54,4 +54,4 @@ problem by uploading a zip file that contains only testcase files. Any jury
 solutions present will be automatically submitted when ``allow_submit`` is
 ``1`` and there's a team associated with the uploading user.
 
-.. _ICPC problem package specification: https://icpc.io/problem-package-format/spec/problem_package_format
+.. _ICPC problem package specification: https://icpc.io/problem-package-format/spec/legacy-icpc


### PR DESCRIPTION
Also point to the legacy ICPC version for now. A new version is planned to be released in September around the ICPC World Finals in Astana, but until that's finalized, point to what we're actually (roughly) implementing currently.

(cherry picked from commit 11fe36fd45e0cb1d4bd7e25e1a653279f35e105e)

Closing: https://github.com/DOMjudge/domjudge/issues/2869