### PR TITLE
Prevent import-examples to fail

### DIFF
--- a/.github/jobs/baseinstall.sh
+++ b/.github/jobs/baseinstall.sh
@@ -64,6 +64,7 @@ mysql_root "show databases"
 mysql_root "SELECT CURRENT_USER();"
 mysql_root "SELECT USER();"
 mysql_root "SELECT user,host FROM mysql.user"
+mysql_root "SET max_allowed_packet=1073741824"
 echo "unused:sqlserver:domjudge:domjudge:domjudge:3306" > /opt/domjudge/domserver/etc/dbpasswords.secret
 mysql_user "SELECT CURRENT_USER();"
 mysql_user "SELECT USER();"

--- a/.github/workflows/chroot-checks.yml
+++ b/.github/workflows/chroot-checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-chroot-arch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: domjudge/gitlabci:24.04
       options: --privileged --cgroupns=host --init

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -88,6 +88,13 @@ jobs:
         with:
           name: DB-dump
           path: /tmp/db.sql
+      - name: Get SQL logs
+        run: docker logs "${{ job.services.sqlserver.id }}"
+      - name: Collect docker logs on failure
+        if: ${{ !cancelled() }}
+        uses: jwalton/gh-docker-logs@v1
+        with:
+          dest: '/tmp/docker-logs'
       - name: Upload all logs/artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -96,6 +103,8 @@ jobs:
           path: |
             /var/log/nginx
             /opt/domjudge/domserver/webapp/var/log/*.log
+            /tmp/docker-logs
+            /tmp/artifacts
       - name: Verifying submissions
         shell: bash
         run: |


### PR DESCRIPTION
The mariadb images seems to now allow a smaller maximum packet by default. This resulted in problems for the boolfind problem which we didn't detect as all checks would still pass correctly.

We now also capture the SQL logs to detect this easier and increase the maximum packetsize (1G).

**When this is accepted I'll move the installation of the `docker.io` to the runner image and remove that line for a small speedup.**