### PR TITLE
Add pagination to submission lists

### DIFF
--- a/webapp/composer.json
+++ b/webapp/composer.json
@@ -67,6 +67,7 @@
 		"friendsofsymfony/rest-bundle": "^3.5",
 		"ircmaxell/password-compat": "*",
 		"jms/serializer-bundle": "^5.2",
+		"knplabs/knp-paginator-bundle": "^6.6",
 		"league/commonmark": "^2.3",
 		"mbostock/d3": "^3.5",
 		"nelmio/api-doc-bundle": "^4.11",

--- a/webapp/composer.lock
+++ b/webapp/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95d8ad1aada125b0c8078f1dccb08998",
+    "content-hash": "6401b4bdcb1db7464a2e9e4bcbf894b2",
     "packages": [
         {
             "name": "apalfrey/select2-bootstrap-5-theme",
@@ -2451,6 +2451,167 @@
                 }
             ],
             "time": "2023-12-12T15:33:15+00:00"
+        },
+        {
+            "name": "knplabs/knp-components",
+            "version": "v5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/knp-components.git",
+                "reference": "a1ccc001fd243670ca1e970356027a53d6fca2af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/a1ccc001fd243670ca1e970356027a53d6fca2af",
+                "reference": "a1ccc001fd243670ca1e970356027a53d6fca2af",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/event-dispatcher-contracts": "^3.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.8"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.8 || ^4.0",
+                "doctrine/mongodb-odm": "^2.5.5",
+                "doctrine/orm": "^2.13 || ^3.0",
+                "doctrine/phpcr-odm": "^1.8 || ^2.0",
+                "ext-pdo_sqlite": "*",
+                "jackalope/jackalope-doctrine-dbal": "^1.12 || ^2.0",
+                "phpunit/phpunit": "^10.5 || ^11.3",
+                "propel/propel1": "^1.7",
+                "ruflin/elastica": "^7.0",
+                "solarium/solarium": "^6.0",
+                "symfony/http-foundation": "^5.4.38 || ^6.4.4 || ^7.0",
+                "symfony/http-kernel": "^5.4.38 || ^6.4.4 || ^7.0",
+                "symfony/property-access": "^5.4.38 || ^6.4.4 || ^7.0"
+            },
+            "suggest": {
+                "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",
+                "doctrine/mongodb-odm": "to allow usage pagination with Doctrine ODM MongoDB",
+                "doctrine/orm": "to allow usage pagination with Doctrine ORM",
+                "doctrine/phpcr-odm": "to allow usage pagination with Doctrine ODM PHPCR",
+                "propel/propel1": "to allow usage pagination with Propel ORM",
+                "ruflin/elastica": "to allow usage pagination with ElasticSearch Client",
+                "solarium/solarium": "to allow usage pagination with Solarium Client",
+                "symfony/http-foundation": "to retrieve arguments from Request",
+                "symfony/property-access": "to allow sorting arrays"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Knp\\Component\\": "src/Knp/Component"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "https://knplabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/KnpLabs/knp-components/contributors"
+                }
+            ],
+            "description": "Knplabs component library",
+            "homepage": "https://github.com/KnpLabs/knp-components",
+            "keywords": [
+                "components",
+                "knp",
+                "knplabs",
+                "pager",
+                "paginator"
+            ],
+            "support": {
+                "issues": "https://github.com/KnpLabs/knp-components/issues",
+                "source": "https://github.com/KnpLabs/knp-components/tree/v5.1.0"
+            },
+            "time": "2024-09-20T12:03:01+00:00"
+        },
+        {
+            "name": "knplabs/knp-paginator-bundle",
+            "version": "v6.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/KnpPaginatorBundle.git",
+                "reference": "1a00f88149d25418bd99d8954eba951f04cc3acf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/KnpPaginatorBundle/zipball/1a00f88149d25418bd99d8954eba951f04cc3acf",
+                "reference": "1a00f88149d25418bd99d8954eba951f04cc3acf",
+                "shasum": ""
+            },
+            "require": {
+                "knplabs/knp-components": "^4.4 || ^5.0",
+                "php": "^8.1",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0",
+                "symfony/http-foundation": "^6.4 || ^7.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
+                "symfony/routing": "^6.4 || ^7.0",
+                "symfony/translation": "^6.4 || ^7.0",
+                "twig/twig": "^3.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^10.5 || ^11.3",
+                "symfony/expression-language": "^6.4 || ^7.0",
+                "symfony/templating": "^6.4 || ^7.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Knp\\Bundle\\PaginatorBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "https://knplabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/KnpLabs/KnpPaginatorBundle/contributors"
+                }
+            ],
+            "description": "Paginator bundle for Symfony to automate pagination and simplify sorting and other features",
+            "homepage": "https://github.com/KnpLabs/KnpPaginatorBundle",
+            "keywords": [
+                "bundle",
+                "knp",
+                "knplabs",
+                "pager",
+                "pagination",
+                "paginator",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/KnpLabs/KnpPaginatorBundle/issues",
+                "source": "https://github.com/KnpLabs/KnpPaginatorBundle/tree/v6.6.1"
+            },
+            "time": "2024-10-07T16:11:50+00:00"
         },
         {
             "name": "league/commonmark",
@@ -9006,6 +9167,101 @@
                 }
             ],
             "time": "2024-11-13T13:31:12+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v6.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "bee9bfabfa8b4045a66bf82520e492cddbaffa66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/bee9bfabfa8b4045a66bf82520e492cddbaffa66",
+                "reference": "bee9bfabfa8b4045a66bf82520e492cddbaffa66",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5|^3.0"
+            },
+            "conflict": {
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.18|^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v6.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-27T18:14:25+00:00"
         },
         {
             "name": "symfony/translation-contracts",

--- a/webapp/config/bundles.php
+++ b/webapp/config/bundles.php
@@ -18,4 +18,5 @@ return [
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
+    Knp\Bundle\PaginatorBundle\KnpPaginatorBundle::class => ['all' => true],
 ];

--- a/webapp/config/packages/knp_paginator.yaml
+++ b/webapp/config/packages/knp_paginator.yaml
@@ -1,0 +1,5 @@
+knp_paginator:
+    default_options:
+        default_limit: 50
+    template:
+        pagination: '@KnpPaginator/Pagination/bootstrap_v5_pagination.html.twig'

--- a/webapp/src/Controller/API/MetricsController.php
+++ b/webapp/src/Controller/API/MetricsController.php
@@ -102,7 +102,8 @@ class MetricsController extends AbstractFOSRestController
             /** @var Submission[] $submissions */
             [$submissions, $submissionCounts] = $this->submissionService->getSubmissionList(
                 [$contest->getCid() => $contest],
-                new SubmissionRestriction(visible: true)
+                new SubmissionRestriction(visible: true),
+                paginated: false
             );
             foreach ($submissionCounts as $kind => $count) {
                 if (!array_key_exists('submissions_' . $kind, $m)) {

--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -195,7 +195,8 @@ class LanguageController extends BaseController
         /** @var Submission[] $submissions */
         [$submissions, $submissionCounts] = $submissionService->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
-            new SubmissionRestriction(languageId: $language->getLangid())
+            new SubmissionRestriction(languageId: $language->getLangid()),
+            page: $request->query->getInt('submissions_page', 1),
         );
 
         $data = [

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -29,6 +29,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Exception;
+use Knp\Component\Pager\Pagination\PaginationInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -487,10 +488,11 @@ class ProblemController extends BaseController
             return $this->redirectToRoute('jury_problem', ['probId' => $probId]);
         }
 
-        /** @var Submission[] $submissions */
+        /** @var PaginationInterface<int, Submission> $submissions */
         [$submissions, $submissionCounts] = $submissionService->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
             new SubmissionRestriction(problemId: $problem->getProbid()),
+            page: $request->query->getInt('page', 1),
         );
 
         $type = '';

--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
+use Knp\Component\Pager\Pagination\PaginationInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -330,7 +331,7 @@ class RejudgingController extends BaseController
             $verdictTable[$originalVerdict->getResult()][$newVerdict->getResult()][] = $submitid;
         }
 
-        $viewTypes = [0 => 'newest', 1 => 'unverified', 2 => 'unjudged', 3 => 'diff', 4 => 'all'];
+        $viewTypes = [0 => 'unverified', 1 => 'unjudged', 2 => 'diff', 3 => 'all'];
         $defaultView = 'diff';
         $onlyAHandfulOfSubmissions = $rejudging->getSubmissions()->count() <= 5;
         if ($onlyAHandfulOfSubmissions) {
@@ -362,10 +363,11 @@ class RejudgingController extends BaseController
             $restrictions->result = $newverdict;
         }
 
-        /** @var Submission[] $submissions */
+        /** @var PaginationInterface<int, Submission> $submissions */
         [$submissions, $submissionCounts] = $submissionService->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
-            $restrictions
+            $restrictions,
+            page: $request->query->getInt('page', 1),
         );
 
         $repetitions = $this->em->createQueryBuilder()

--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -205,6 +205,7 @@ class ShadowDifferencesController extends BaseController
         [$submissions, $submissionCounts] = $this->submissions->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
             $restrictions,
+            page: $request->query->getInt('page', 1),
             showShadowUnverified: true
         );
 

--- a/webapp/src/Controller/Jury/TeamCategoryController.php
+++ b/webapp/src/Controller/Jury/TeamCategoryController.php
@@ -16,6 +16,7 @@ use App\Service\SubmissionService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Knp\Component\Pager\Pagination\PaginationInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -125,10 +126,11 @@ class TeamCategoryController extends BaseController
             throw new NotFoundHttpException(sprintf('Team category with ID %s not found', $categoryId));
         }
 
-        /** @var Submission[] $submissions */
+        /** @var PaginationInterface<int, Submission> $submissions */
         [$submissions, $submissionCounts] = $submissionService->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
-            new SubmissionRestriction(categoryId: $teamCategory->getCategoryid())
+            new SubmissionRestriction(categoryId: $teamCategory->getCategoryid()),
+            page: $request->query->getInt('page', 1),
         );
 
         $data = [

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -286,7 +286,11 @@ class TeamController extends BaseController
         }
         $restrictions->teamId = $teamId;
         [$submissions, $submissionCounts] =
-            $submissionService->getSubmissionList($this->dj->getCurrentContests(honorCookie: true), $restrictions);
+            $submissionService->getSubmissionList(
+                $this->dj->getCurrentContests(honorCookie: true),
+                $restrictions,
+                page: $request->query->getInt('page', 1),
+            );
 
         $data['restrictionText']    = $restrictionText;
         $data['submissions']        = $submissions;

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -171,7 +171,7 @@ class UserController extends BaseController
     }
 
     #[Route(path: '/{userId<\d+>}', name: 'jury_user')]
-    public function viewAction(int $userId, SubmissionService $submissionService): Response
+    public function viewAction(Request $request, int $userId, SubmissionService $submissionService): Response
     {
         $user = $this->em->getRepository(User::class)->find($userId);
         if (!$user) {
@@ -182,6 +182,7 @@ class UserController extends BaseController
         [$submissions, $submissionCounts] = $submissionService->getSubmissionList(
             $this->dj->getCurrentContests(honorCookie: true),
             new SubmissionRestriction(userId: $user->getUserid()),
+            page: $request->query->getInt('page', 1),
         );
 
         return $this->render('jury/user.html.twig', [

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -89,7 +89,8 @@ class MiscController extends BaseController
             $this->em->clear();
             $data['submissions'] = $this->submissionService->getSubmissionList(
                 [$contest->getCid() => $contest],
-                new SubmissionRestriction(teamId: $teamId)
+                new SubmissionRestriction(teamId: $teamId),
+                paginated: false
             )[0];
 
             /** @var Clarification[] $clarifications */

--- a/webapp/src/DataTransferObject/SubmissionRestriction.php
+++ b/webapp/src/DataTransferObject/SubmissionRestriction.php
@@ -5,35 +5,42 @@ namespace App\DataTransferObject;
 class SubmissionRestriction
 {
     /**
-     * @param int|null    $rejudgingId         ID of a rejudging to filter on
-     * @param bool|null   $verified            If true, only return verified submissions
-     *                                         If false, only return unverified or unjudged submissions
-     * @param bool|null   $judged              If true, only return judged submissions
-     *                                         If false, only return unjudged submissions
-     * @param bool|null   $judging             If true, only return submissions currently being judged
-     *                                         If false, only return submssions which are already judged or still
-     *                                         need to be judged
-     * @param bool|null   $rejudgingDifference If true, only return judgings that differ from their
-     *                                         original result in final verdict. Vice versa if false
-     * @param int|null    $teamId              ID of a team to filter on
-     * @param int|null    $categoryId          ID of a category to filter on
-     * @param int|null    $problemId           ID of a problem to filter on
-     * @param string|null $languageId          ID of a language to filter on
-     * @param string|null $judgehost           Hostname of a judgehost to filter on
-     * @param string|null $oldResult           Result of old judging to filter on
-     * @param string|null $result              Result of current judging to filter on
-     * @param int|null    $userId              Filter on specific user
-     * @param bool|null   $visible             If true, only return submissions from visible teams
-     * @param bool|null   $externalDifference  If true, only return results with a difference with an
-     *                                         external system
-     *                                         If false, only return results without a difference with an
-     *                                         external system
-     * @param string|null $externalResult      Result in the external system
-     * @param bool|null   $externallyJudged    If true, only return externally judged submissions
-     *                                         If false, only return externally unjudged submissions
-     * @param bool|null   $externallyVerified  If true, only return verified submissions
-     *                                         If false, only return unverified or unjudged submissions
-     * @param bool|null   $withExternalId      If true, only return submissions with an external ID.
+     * @param int|null          $rejudgingId         ID of a rejudging to filter on
+     * @param bool|null         $verified            If true, only return verified submissions
+     *                                               If false, only return unverified or unjudged submissions
+     * @param bool|null         $judged              If true, only return judged submissions
+     *                                               If false, only return unjudged submissions
+     * @param bool|null         $judging             If true, only return submissions currently being judged
+     *                                               If false, only return submssions which are already judged or still
+     *                                               need to be judged
+     * @param bool|null         $rejudgingDifference If true, only return judgings that differ from their
+     *                                               original result in final verdict. Vice versa if false
+     * @param int|null          $teamId              ID of a team to filter on
+     * @param list<int>|null    $teamIds             ID's of teams to filter on
+     * @param int|null          $categoryId          ID of a category to filter on
+     * @param list<int>|null    $categoryIds         ID's of categories to filter on
+     * @param int|null          $affiliationId       ID of an affiliation to filter on
+     * @param list<int>|null    $affiliationIds      ID's of affiliations to filter on
+     * @param int|null          $problemId           ID of a problem to filter on
+     * @param list<int>|null    $problemIds          ID's of problems to filter on
+     * @param string|null       $languageId          ID of a language to filter on
+     * @param list<string>|null $languageIds         ID's of languages to filter on
+     * @param string|null       $judgehost           Hostname of a judgehost to filter on
+     * @param string|null       $oldResult           Result of old judging to filter on
+     * @param string|null       $result              Result of current judging to filter on
+     * @param list<string>|null $results             Results of current judging to filter on
+     * @param int|null          $userId              Filter on specific user
+     * @param bool|null         $visible             If true, only return submissions from visible teams
+     * @param bool|null         $externalDifference  If true, only return results with a difference with an
+     *                                               external system
+     *                                               If false, only return results without a difference with an
+     *                                               external system
+     * @param string|null       $externalResult      Result in the external system
+     * @param bool|null         $externallyJudged    If true, only return externally judged submissions
+     *                                               If false, only return externally unjudged submissions
+     * @param bool|null         $externallyVerified  If true, only return verified submissions
+     *                                               If false, only return unverified or unjudged submissions
+     * @param bool|null         $withExternalId      If true, only return submissions with an external ID.
      */
     public function __construct(
         public ?int $rejudgingId = null,
@@ -42,12 +49,19 @@ class SubmissionRestriction
         public ?bool $judging = null,
         public ?bool $rejudgingDifference = null,
         public ?int $teamId = null,
+        public ?array $teamIds = [],
         public ?int $categoryId = null,
+        public ?array $categoryIds = [],
+        public ?int $affiliationId = null,
+        public ?array $affiliationIds = [],
         public ?int $problemId = null,
+        public ?array $problemIds = [],
         public ?string $languageId = null,
+        public ?array $languageIds = [],
         public ?string $judgehost = null,
         public ?string $oldResult = null,
         public ?string $result = null,
+        public ?array $results = [],
         public ?int $userId = null,
         public ?bool $visible = null,
         public ?bool $externalDifference = null,

--- a/webapp/src/Form/Type/SubmissionsFilterType.php
+++ b/webapp/src/Form/Type/SubmissionsFilterType.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SubmissionsFilterType extends AbstractType
@@ -39,7 +40,7 @@ class SubmissionsFilterType extends AbstractType
             ->addOrderBy("p.name")
             ->getQuery()
             ->getResult();
-        $builder->add("problem-id", EntityType::class, [
+        $builder->add("problem_id", EntityType::class, [
             "multiple" => true,
             "label" => "Filter on problem(s)",
             "class" => Problem::class,
@@ -48,7 +49,7 @@ class SubmissionsFilterType extends AbstractType
             "choices" => $problems,
             "attr" => ["data-filter-field" => "problem-id"],
         ]);
-        $builder->add("language-id", EntityType::class, [
+        $builder->add("language_id", EntityType::class, [
             "multiple" => true,
             "label" => "Filter on language(s)",
             "class" => Language::class,
@@ -60,7 +61,7 @@ class SubmissionsFilterType extends AbstractType
                 ->orderBy("l.name"),
             "attr" => ["data-filter-field" => "language-id"],
         ]);
-        $builder->add("category-id", EntityType::class, [
+        $builder->add("category_id", EntityType::class, [
             "multiple" => true,
             "label" => "Filter on category(s)",
             "class" => TeamCategory::class,
@@ -71,7 +72,7 @@ class SubmissionsFilterType extends AbstractType
                 ->orderBy("tc.name"),
             "attr" => ["data-filter-field" => "category-id"],
         ]);
-        $builder->add("affiliation-id", EntityType::class, [
+        $builder->add("affiliation_id", EntityType::class, [
             "multiple" => true,
             "label" => "Filter on affiliation(s)",
             "class" => TeamAffiliation::class,
@@ -108,7 +109,7 @@ class SubmissionsFilterType extends AbstractType
         }
 
         $teams = $teamsQueryBuilder->getQuery()->getResult();
-        $builder->add("team-id", EntityType::class, [
+        $builder->add("team_id", EntityType::class, [
             "multiple" => true,
             "label" => "Filter on team(s)",
             "class" => Team::class,
@@ -127,7 +128,12 @@ class SubmissionsFilterType extends AbstractType
             "attr" => ["data-filter-field" => "result"],
         ]);
 
-        $builder->add("clear", ButtonType::class, [
+        $builder->add("apply", SubmitType::class, [
+            "label" => "Apply filters",
+
+        ]);
+
+        $builder->add("clear", SubmitType::class, [
             "label" => "Clear all filters",
             "attr" => ["class" => "btn-secondary"],
         ]);

--- a/webapp/src/Form/Type/SubmissionsFilterType.php
+++ b/webapp/src/Form/Type/SubmissionsFilterType.php
@@ -130,7 +130,6 @@ class SubmissionsFilterType extends AbstractType
 
         $builder->add("apply", SubmitType::class, [
             "label" => "Apply filters",
-
         ]);
 
         $builder->add("clear", SubmitType::class, [

--- a/webapp/symfony.lock
+++ b/webapp/symfony.lock
@@ -158,6 +158,9 @@
             "config/packages/jms_serializer.yaml"
         ]
     },
+    "knplabs/knp-paginator-bundle": {
+        "version": "v6.6.1"
+    },
     "laminas/laminas-code": {
         "version": "3.4.1"
     },
@@ -631,6 +634,19 @@
     },
     "symfony/string": {
         "version": "v5.2.3"
+    },
+    "symfony/translation": {
+        "version": "6.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.3",
+            "ref": "e28e27f53663cc34f0be2837aba18e3a1bef8e7b"
+        },
+        "files": [
+            "config/packages/translation.yaml",
+            "translations/.gitignore"
+        ]
     },
     "symfony/translation-contracts": {
         "version": "v1.1.6"

--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -7,6 +7,7 @@
     {{ parent() }}
     {{ macros.table_extrahead() }}
     {{ macros.toggle_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -99,14 +99,7 @@
                 {% set affilid = '' %}
             {% endif %}
 
-            <tr class="{% if not submission.valid %}ignore{% endif %}"
-                data-problem-id="{{ submission.problem.probid }}"
-                data-team-id="{{ submission.team.teamid }}"
-                data-category-id="{{ submission.team.category.categoryid }}"
-                data-affiliation-id="{{ affilid }}"
-                data-language-id="{{ submission.language.langid }}"
-                data-submission-id="{{ submission.submitid }}"
-                data-result="{{ submission | printValidJurySubmissionResult(false) }}">
+            <tr class="{% if not submission.valid %}ignore{% endif %}">
                 {% if showExternalResult and showExternalTestcases %}
                     <td class="{{ tdExtraClass }}">
                         <a href="{{ link }}">
@@ -291,4 +284,6 @@
 
         </tbody>
     </table>
+
+    {{ knp_pagination_render(submissions) }}
 {% endif %}

--- a/webapp/templates/jury/problem.html.twig
+++ b/webapp/templates/jury/problem.html.twig
@@ -7,6 +7,7 @@
     {{ parent() }}
     {{ macros.table_extrahead() }}
     {{ macros.toggle_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/rejudging.html.twig
+++ b/webapp/templates/jury/rejudging.html.twig
@@ -7,6 +7,7 @@
     {{ parent() }}
     {{ macros.table_extrahead() }}
     {{ macros.select2_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/shadow_differences.html.twig
+++ b/webapp/templates/jury/shadow_differences.html.twig
@@ -7,6 +7,7 @@
     {{ parent() }}
     {{ macros.table_extrahead() }}
     {{ macros.select2_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/submissions.html.twig
+++ b/webapp/templates/jury/submissions.html.twig
@@ -7,6 +7,7 @@
     {{ parent() }}
     {{ macros.table_extrahead() }}
     {{ macros.select2_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}
@@ -32,7 +33,18 @@
         </div>
         <div class="card mt-3{% if not hasFilters %} d-none{% endif %}" id="filter-card">
             <div class="card-body col-sm-6">
-                {{ form(form) }}
+                {{ form_start(form) }}
+                {{ form_row(form.problem_id) }}
+                {{ form_row(form.language_id) }}
+                {{ form_row(form.category_id) }}
+                {{ form_row(form.affiliation_id) }}
+                {{ form_row(form.team_id) }}
+                {{ form_row(form.result) }}
+                <div class="mb-3">
+                    {{ form_widget(form.apply) }}
+                    {{ form_widget(form.clear) }}
+                </div>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>
@@ -58,7 +70,7 @@
         </div>
     {% endif %}
 
-    <div data-ajax-refresh-target data-ajax-refresh-after="process_submissions_filter">
+    <div data-ajax-refresh-target>
         {%- include 'jury/partials/submission_list.html.twig' %}
     </div>
 
@@ -82,54 +94,6 @@
             $('#submissions_filter_clear').on('click', function () {
                 $('select[data-filter-field]').val([]).trigger('change');
             });
-
-            window.process_submissions_filter = function () {
-                var $trs = $('table.submissions-table > tbody tr');
-
-                var filters = [];
-
-                $('select[data-filter-field]').each(function () {
-                    var $filterField = $(this);
-                    if ($filterField.val().length) {
-                        filters.push({
-                            field: $filterField.data('filter-field'),
-                            values: $filterField.val()
-                        });
-                    }
-                });
-
-                var submissions_filter = {};
-                for (var i = 0; i < filters.length; i++) {
-                    submissions_filter[filters[i].field] = filters[i].values;
-                }
-
-                setCookie('domjudge_submissionsfilter', JSON.stringify(submissions_filter));
-
-                if (filters.length === 0) {
-                    $trs.show();
-                } else {
-                    $trs
-                        .hide()
-                        .filter(function () {
-                            var $tr = $(this);
-
-                            for (var i = 0; i < filters.length; i++) {
-                                var value = "" + $tr.data(filters[i].field);
-                                if (filters[i].values.indexOf(value) === -1) {
-                                    return false;
-                                }
-                            }
-
-                            return true;
-                        })
-                        .show();
-                }
-
-                $('table.submissions-table').find('[data-bs-toggle="tooltip"]').tooltip();
-            };
-
-            $('select[data-filter-field]').on('change', process_submissions_filter);
-            window.process_submissions_filter();
         });
     </script>
 {% endblock %}

--- a/webapp/templates/jury/team.html.twig
+++ b/webapp/templates/jury/team.html.twig
@@ -6,6 +6,7 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.table_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -6,6 +6,7 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.table_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/templates/jury/user.html.twig
+++ b/webapp/templates/jury/user.html.twig
@@ -6,6 +6,7 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.table_extrahead() }}
+    {{ knp_pagination_rel_links(submissions) }}
 {% endblock %}
 
 {% block content %}

--- a/webapp/tests/Unit/Controller/Jury/SubmissionControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/SubmissionControllerTest.php
@@ -33,7 +33,7 @@ class SubmissionControllerTest extends BaseTestCase
     public function provideViews(): Generator
     {
         foreach ([[], [SampleSubmissionsFixture::class]] as $fixtures) {
-            foreach (['all', 'unjudged', 'unverified', 'newest'] as $view) {
+            foreach (['all', 'unjudged', 'unverified'] as $view) {
                 yield [$view, $fixtures];
             }
         }

--- a/webapp/tests/Unit/Controller/Jury/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/UserControllerTest.php
@@ -84,9 +84,9 @@ class UserControllerTest extends JuryControllerTestCase
                                                                                                                   ['username' => 'usérname', 'name' => 'NonPrintable'],
                                                                                                                   ['username' => 'username⚠', 'name' => 'SpecialSymbol']],
                                                           'This value should not be blank.' => [['username' => '', 'name' => 'Empty']],
-                                                          'This is not a valid IP address.' => [['ipAddress' => '1.1.1'],
-                                                                                                ['ipAddress' => '256.1.1.1'],
-                                                                                                ['ipAddress' => '1.1.1.256'],
-                                                                                                ['ipAddress' => '1.1.1.1.1'],
-                                                                                                ['ipAddress' => '::g']]];
+                                                          'This value is not a valid IP address.' => [['ipAddress' => '1.1.1'],
+                                                                                                      ['ipAddress' => '256.1.1.1'],
+                                                                                                      ['ipAddress' => '1.1.1.256'],
+                                                                                                      ['ipAddress' => '1.1.1.1.1'],
+                                                                                                      ['ipAddress' => '::g']]];
 }

--- a/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
@@ -19,6 +19,7 @@ use App\Service\ScoreboardService;
 use App\Service\SubmissionService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
+use Knp\Component\Pager\PaginatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -79,7 +80,8 @@ class QueuetaskIntegrationTest extends KernelTestCase
             $dj,
             $this->config,
             self::getContainer()->get(EventLogService::class),
-            $this->scoreboardService
+            $this->scoreboardService,
+            self::getContainer()->get(PaginatorInterface::class)
         );
 
         // Create a contest, problems and teams for which to test the


### PR DESCRIPTION
Fixes #2511

Some notes:

- I used a well-known bundle that takes care of most of the things we want, so the changes are minimal.
- We paginate all submissions pages by default, but exclude the team interface and the prometheus metrics. The former should not have that many submissions and the latter needs all.
- The query parameter for pages is always `page`. We can't currently override this, see https://github.com/KnpLabs/KnpPaginatorBundle/issues/815.
- I changed the jury submissions filter form to a PHP/backend filter form. This requires you to press a new "Apply" button, but makes it such that filtering happens server side and thus pagination is honored. This also allowed us to get rid of quite a bit of javascript and code in the Twig (but some logic in the controller action came in return).
- I removed the "new" view type in two spots, since we don't need it anymore.
- A page contains 50 submissions, just like the "new" filter did before.
- We always show testcases for the main submissions page now, since we only show 50 submissions.
- I needed to add filters for restrictions with arrays of ID's. Those were trivial.
- I also added a filter for an array of results. That one is less trivial. I tested the "normal" results, judging and queued. import-error should also work, so I think we have all cases.

Screenshots:
![image](https://github.com/user-attachments/assets/dd8cd608-2d1f-4587-ac89-1605b0a15606)
![image](https://github.com/user-attachments/assets/ef728c07-54f4-43e1-b800-7c21518b5293)
