### PR TITLE
Fix building the team manual on debian trixie.

### DIFF
--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -46,13 +46,9 @@ else:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 
-# The sphinx_rtd_theme extension does not seem to work with older
-# versions (at least those in buster/bionic). We don't seem to need
-# it yet, so don't add it.
 extensions = [
     'sphinx.ext.ifconfig',
-#   'sphinx_rtd_theme',
-    'rst2pdf.pdfbuilder',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/manual/develop.rst
+++ b/doc/manual/develop.rst
@@ -40,7 +40,7 @@ already listed under
 :ref:`submit client <submit_client_requirements>` requirements)::
 
   sudo apt install autoconf automake bats \
-    python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
+    python3-sphinx python3-sphinx-rtd-theme fontconfig python3-yaml \
     latexmk texlive-latex-recommended texlive-latex-extra tex-gyre
 
 When this software is present, bootstrapping can be done by running

--- a/doc/manual/install-workstation.rst
+++ b/doc/manual/install-workstation.rst
@@ -84,7 +84,7 @@ When DOMjudge is configured and site-specific configuration set,
 the team manual can be generated with the command ``make docs``.
 The following should do it on a Debian-like system::
 
-  sudo apt install python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml
+  sudo apt install python3-sphinx python3-sphinx-rtd-theme fontconfig python3-yaml
   cd <INSTALL_PATH>/doc/
   make docs
 


### PR DESCRIPTION
This should still work on older versions as well that are not debian oldoldstable old.