### PR TITLE
Installation fails without a Session

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -49,6 +49,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -627,6 +628,8 @@ class DOMJudgeService
         $request  = Request::create('/api' . $url, $method, $queryOrPostData, [], $files);
         if ($this->requestStack->getCurrentRequest() && $this->requestStack->getCurrentRequest()->hasSession()) {
             $request->setSession($this->requestStack->getSession());
+        } else {
+            $request->setSession(new Session());
         }
         $response = $this->httpKernel->handle($request, HttpKernelInterface::SUB_REQUEST);
 


### PR DESCRIPTION
It fixes my problem, but I'm not sure if there is not an underlying problem.

As we create a request it makes sense we also need a session, but does that session also need other things? I don't know enough about Symfony to be sure that this is besides a solution for my problem also the correct fix for the issue where no session is set.

I hope @nickygerritsen has some ideas?