### PR TITLE
Use Bash for all GitHub Actions CI jobs

### DIFF
--- a/.github/jobs/baseinstall.sh
+++ b/.github/jobs/baseinstall.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . .github/jobs/ci_settings.sh
 
@@ -13,7 +13,7 @@ export APP_ENV="${4:-prod}"
 
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
 
-set -eux
+set -euxo pipefail
 
 if [ -z "$phpversion" ]; then
 phpversion=$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION."\n";')

--- a/.github/jobs/chroot_checks.sh
+++ b/.github/jobs/chroot_checks.sh
@@ -3,7 +3,9 @@
 . .github/jobs/ci_settings.sh
 
 if [ -n "$1" ] && [ "$1" != "default" ]; then
-export ARCH="$1"
+    export ARCH_OPTION="-a $1"
+else
+    export ARCH_OPTION=""
 fi
 
 function finish() {
@@ -19,6 +21,8 @@ function finish() {
 FAILED=0
 
 trap finish EXIT
+
+set -euo pipefail
 
 DIR=$PWD
 section_start "Debug info"
@@ -44,7 +48,7 @@ cd /opt/domjudge/judgehost/bin || exit 1
 section_end chroot
 
 section_start "Show minimal chroot"
-./dj_make_chroot -a "$ARCH" | tee -a "$ARTIFACTS"/chroot.log
+./dj_make_chroot $ARCH_OPTION | tee -a "$ARTIFACTS"/chroot.log
 section_end
 
 section_start "Test chroot contents"

--- a/.github/jobs/composer_setup.sh
+++ b/.github/jobs/composer_setup.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eux
+set -euxo pipefail
 
 . .github/jobs/ci_settings.sh
 

--- a/.github/jobs/configure-checks/setup_configure_image.sh
+++ b/.github/jobs/configure-checks/setup_configure_image.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eux
+set -euxo pipefail
 
 distro_id=$(grep "^ID=" /etc/os-release)
 

--- a/.github/jobs/fix_pipelinecomponents_image.sh
+++ b/.github/jobs/fix_pipelinecomponents_image.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# We can't convert this script to bash as GHA doesn't have bash installed
+#
+# The current script doesn't use a piped command so the "benefit" of using
+# pipefail is not there over the hassle of maintaining another container.
 set -eux
 
 echo "Set plugin config for version detection"

--- a/.github/jobs/getapi.sh
+++ b/.github/jobs/getapi.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eux 
+set -euxo pipefail
 
 # Ignore the CLICS API strict mode
 sudo sed -i "s/'strict'/'ignore-clics'/g" /opt/domjudge/domserver/webapp/src/Controller/API/AbstractRestController.php

--- a/.github/jobs/unit-tests.sh
+++ b/.github/jobs/unit-tests.sh
@@ -2,6 +2,8 @@
 
 . .github/jobs/ci_settings.sh
 
+set -euo pipefail
+
 DIR="$PWD"
 
 export version=$1

--- a/.github/jobs/webstandard.sh
+++ b/.github/jobs/webstandard.sh
@@ -2,6 +2,8 @@
 
 . .github/jobs/ci_settings.sh
 
+set -euo pipefail
+
 DIR="$PWD"
 
 if [ "$#" -ne "2" ]; then


### PR DESCRIPTION
We didn't catch an error with an error being eaten away with a piped command. The benefits of being POSIX compliant are slim for the CI jobs.

The -o pipefail is added for al scripts (also if they don't use a `|` yet) and where we don't have set -eu yet this is added but not the -x to keep the looks the same.