### PR TITLE
fix(printing): regression in printing with UI

### DIFF
--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -181,7 +181,8 @@ class MiscController extends BaseController
             $ret = $this->dj->printUserFile(
                 $realfile,
                 $originalfilename,
-                $langid
+                $langid,
+                true
             );
 
             return $this->render('team/print_result.html.twig', [


### PR DESCRIPTION
Printing in team UI has no longer shown team id and name since 58a630ce9d4bcf2ed5e4f3351a1e742dcca7e633 as the new default parameters break the original behavior.

Originally reported at ICPC Asia East Regionals.