### PR TITLE
No need to declare implementing `Stringable`.

### DIFF
--- a/webapp/src/Config/OptionalFileResource.php
+++ b/webapp/src/Config/OptionalFileResource.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
  * @see FileResource
  * @see FileExistenceResource
  */
-class OptionalFileResource implements SelfCheckingResourceInterface, Stringable
+class OptionalFileResource implements SelfCheckingResourceInterface
 {
     private readonly bool $exists;
 


### PR DESCRIPTION
It's already part of the `ResourceInterface` which is one of the super classes.