### PR TITLE
`createQueryBuilder` doesn't take any arguments, so remove it.

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1648,7 +1648,7 @@ class DOMJudgeService
                 return $languages->toArray();
             }
         }
-        return $this->em->createQueryBuilder(Language::class)
+        return $this->em->createQueryBuilder()
             ->select('l')
             ->from(Language::class, 'l')
             ->where('l.allowSubmit = 1')


### PR DESCRIPTION
`Language::class` is referenced in `from` clause.