### PR TITLE
Split display of problems in current and other contests.

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -75,16 +75,11 @@ class ProblemController extends BaseController
             ->groupBy('p.probid')
             ->getQuery()->getResult();
 
-        $badgeTitle = '';
-        $currentContest = $this->dj->getCurrentContest();
-        if ($currentContest !== null) {
-            $badgeTitle = 'in ' . $currentContest->getShortname();
-        }
         $table_fields = [
             'probid' => ['title' => 'ID', 'sort' => true, 'default_sort' => true],
             'externalid' => ['title' => 'external ID', 'sort' => true],
             'name' => ['title' => 'name', 'sort' => true],
-            'badges' => ['title' => $badgeTitle, 'sort' => false],
+            'badges' => ['title' => '', 'sort' => false],
             'num_contests' => ['title' => '# contests', 'sort' => true],
             'timelimit' => ['title' => 'time limit', 'sort' => true],
             'memlimit' => ['title' => 'memory limit', 'sort' => true],
@@ -107,7 +102,8 @@ class ProblemController extends BaseController
         }
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $problems_table   = [];
+        $problems_table_current = [];
+        $problems_table_other   = [];
         foreach ($problems as $row) {
             /** @var Problem $p */
             $p              = $row[0];
@@ -221,15 +217,20 @@ class ProblemController extends BaseController
                 'type' => ['value' => $type],
             ]);
 
-            // Save this to our list of rows
-            $problems_table[] = [
+            $data_to_add = [
                 'data' => $problemdata,
                 'actions' => $problemactions,
                 'link' => $this->generateUrl('jury_problem', ['probId' => $p->getProbid()]),
             ];
+            if ($badges) {
+                $problems_table_current[] = $data_to_add;
+            } else {
+                $problems_table_other[] = $data_to_add;
+            }
         }
         $data = [
-            'problems' => $problems_table,
+            'problems_current' => $problems_table_current,
+            'problems_other' => $problems_table_other,
             'table_fields' => $table_fields,
         ];
 

--- a/webapp/templates/jury/problems.html.twig
+++ b/webapp/templates/jury/problems.html.twig
@@ -10,9 +10,20 @@
 
 {% block content %}
 
-    <h1>Problems</h1>
+    {% if current_contest %}
+        <h1>Problems in contest {{ current_contest.name }}</h1>
+        {% if problems_current is empty %}
+            <em>There are no problems in this contest.</em>
+        {% endif %}
 
-    {{ macros.table(problems, table_fields) }}
+        {{ macros.table(problems_current, table_fields) }}
+    {% endif %}
+
+    {% if problems_other is not empty %}
+        <h1>Problems in other contests</h1>
+
+        {{ macros.table(problems_other, table_fields) }}
+    {% endif %}
 
     {% if is_granted('ROLE_ADMIN') %}
         <p>

--- a/webapp/tests/Unit/Controller/Jury/ProblemControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ProblemControllerTest.php
@@ -19,7 +19,7 @@ class ProblemControllerTest extends JuryControllerTestCase
     protected static string  $getIDFunc                = 'getProbid';
     protected static string  $className                = Problem::class;
     protected static array   $DOM_elements             = [
-        'h1'                            => ['Problems'],
+        'h1'                            => ['Problems in contest Demo contest'],
         'a.btn[title="Import problem"]' => ['admin' => [" Import problem"], 'jury' => []]
     ];
     protected static string  $identifyingEditAttribute = 'name';


### PR DESCRIPTION
This helps especially when there are many problems loaded.

-----

Before:

![image](https://github.com/user-attachments/assets/43871b47-230a-4265-96c4-68b9a07b5eaf)


After:

![image](https://github.com/user-attachments/assets/5d75fed4-0b37-419e-aeb4-554585ed7d07)
