### PR TITLE
Record validator metadata.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1489,6 +1489,7 @@ function judge(array $judgeTask): bool
             'output_diff' => rest_encode_file($passdir . '/feedback/judgemessage.txt', $output_storage_limit),
             'hostname' => $myhost,
             'testcasedir' => $testcasedir,
+            'compare_metadata' => rest_encode_file($passdir . '/compare.meta', false),
         ];
 
         if (file_exists($passdir . '/feedback/teammessage.txt')) {

--- a/webapp/migrations/Version20250302070928.php
+++ b/webapp/migrations/Version20250302070928.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250302070928 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add metadata for the validator.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run_output ADD validator_metadata LONGBLOB DEFAULT NULL COMMENT \'Judging metadata of the validator(DC2Type:blobtext)\', CHANGE metadata metadata LONGBLOB DEFAULT NULL COMMENT \'Judging metadata of the run(DC2Type:blobtext)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run_output DROP validator_metadata, CHANGE metadata metadata LONGBLOB DEFAULT NULL COMMENT \'Judging metadata(DC2Type:blobtext)\'');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -383,7 +383,7 @@ class SubmissionController extends BaseController
                 ->join('t.content', 'tc')
                 ->leftJoin('t.judging_runs', 'jr', Join::WITH, 'jr.judging = :judging')
                 ->leftJoin('jr.output', 'jro')
-                ->select('t', 'jr', 'tc.image_thumb AS image_thumb', 'jro.metadata')
+                ->select('t', 'jr', 'tc.image_thumb AS image_thumb', 'jro.metadata', 'jro.validatorMetadata')
                 ->andWhere('t.problem = :problem')
                 ->setParameter('judging', $selectedJudging)
                 ->setParameter('problem', $submission->getProblem())

--- a/webapp/src/Entity/JudgingRunOutput.php
+++ b/webapp/src/Entity/JudgingRunOutput.php
@@ -64,9 +64,16 @@ class JudgingRunOutput
     #[ORM\Column(
         type: 'blobtext',
         nullable: true,
-        options: ['comment' => 'Judging metadata']
+        options: ['comment' => 'Judging metadata of the run']
     )]
     private ?string $metadata = null;
+
+    #[ORM\Column(
+        type: 'blobtext',
+        nullable: true,
+        options: ['comment' => 'Judging metadata of the validator']
+    )]
+    private ?string $validatorMetadata = null;
 
     public function setRun(JudgingRun $run): JudgingRunOutput
     {
@@ -142,6 +149,17 @@ class JudgingRunOutput
     public function setMetadata(?string $metadata): self
     {
         $this->metadata = $metadata;
+        return $this;
+    }
+
+    public function getValidatorMetadata(): string
+    {
+        return $this->validatorMetadata;
+    }
+
+    public function setValidatorMetadata(?string $validatorMetadata): self
+    {
+        $this->validatorMetadata = $validatorMetadata;
         return $this;
     }
 }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1228,16 +1228,31 @@ EOF;
             return '';
         }
         $metadata = Utils::parseMetadata($metadata);
-        return '<span style="display:inline; margin-left: 5px;">'
-            . '<i class="fas fa-stopwatch" title="runtime"></i> '
-            . $metadata['cpu-time'] . 's CPU, '
-            . $metadata['wall-time'] . 's wall, '
-            . '<i class="fas fa-memory" title="RAM"></i> '
-            . Utils::printsize((int)($metadata['memory-bytes'])) . ', '
-            . '<i class="far fa-question-circle" title="exit-status"></i> '
-            . 'exit-code: ' . $metadata['exitcode']
-            . (($metadata['signal'] ?? -1) > 0 ? ' signal: ' . $metadata['signal'] : '')
-            . '</span>';
+        $result = '<span style="display:inline; margin-left: 5px;">';
+
+        if (isset($metadata['cpu-time']) || isset($metadata['wall-time'])) {
+            $result .= '<i class="fas fa-stopwatch" title="runtime"></i> ';
+        }
+
+        if (isset($metadata['cpu-time'])) {
+            $result .= $metadata['cpu-time'] . 's CPU, ';
+        }
+        if (isset($metadata['wall-time'])) {
+            $result .= $metadata['wall-time'] . 's wall, ';
+        }
+        if (isset($metadata['memory-bytes'])) {
+            $result .= '<i class="fas fa-memory" title="RAM"></i> '
+                . Utils::printsize((int)($metadata['memory-bytes'])) . ', ';
+        }
+        if (isset($metadata['exitcode'])) {
+            $result .= '<i class="far fa-question-circle" title="exit-status"></i> '
+                . 'exit-code: ' . $metadata['exitcode'];
+        }
+        if (isset($metadata['signal'])) {
+            $result .= ' signal: ' . $metadata['signal'];
+        }
+        $result .= '</span>';
+        return $result;
     }
 
     public function printWarningContent(ExternalSourceWarning $warning): string

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -822,6 +822,21 @@
 {{  runsOutput[runIdx].team_message }}</pre>
                             {%  endif %}
                         {% endif %}
+
+                        {% if runsOutput[runIdx].validatorMetadata is not empty %}
+                            <hr/>
+                            <h5>Validator metadata</h5>
+                            {{ runsOutput[runIdx].validatorMetadata | printMetadata }}
+                            <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse"
+                                    data-bs-target="#collapseValMeta-{{ runIdx }}"
+                                    aria-expanded="false">
+                                show complete validator metadata
+                            </button>
+                            <div class="collapse" id="collapseValMeta-{{ runIdx }}">
+                                <div class="card card-body output_text">{{ runsOutput[runIdx].validatorMetadata  }}</div>
+                            </div>
+
+                        {% endif %}
                     {% endif %}
 
                     </div>


### PR DESCRIPTION
This can be especially useful when the validator takes more resources than expected or is misbehaving in other ways.

Example:

![image](https://github.com/user-attachments/assets/a6c52fcb-f265-43b9-8f50-e8b8b6f8c9fa)

and

![image](https://github.com/user-attachments/assets/51fb6d1b-9530-43b5-bc9a-22a241961e41)
