### PR TITLE
Associate internal error with judging run if available.

### DIFF
--- a/webapp/migrations/Version20250302114442.php
+++ b/webapp/migrations/Version20250302114442.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250302114442 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Associate internal errors with judging run if possible.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE internal_error ADD runid INT UNSIGNED DEFAULT NULL COMMENT \'Run ID\'');
+        $this->addSql('ALTER TABLE internal_error ADD CONSTRAINT FK_518727D8A5788799 FOREIGN KEY (runid) REFERENCES judging_run (runid) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_518727D8A5788799 ON internal_error (runid)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE internal_error DROP FOREIGN KEY FK_518727D8A5788799');
+        $this->addSql('DROP INDEX IDX_518727D8A5788799 ON internal_error');
+        $this->addSql('ALTER TABLE internal_error DROP runid');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -729,6 +729,7 @@ class JudgehostController extends AbstractFOSRestController
         $judging = null;
         $judgingId = null;
         $cid = null;
+        $judgingRun = null;
         if ($judgeTaskId) {
             /** @var JudgeTask $judgeTask */
             $judgeTask = $this->em->getRepository(JudgeTask::class)->findOneBy(['judgetaskid' => $judgeTaskId]);
@@ -738,6 +739,7 @@ class JudgehostController extends AbstractFOSRestController
                 $judging = $this->em->getRepository(Judging::class)->findOneBy(['judgingid' => $judgingId]);
                 $cid = $judging->getContest()->getCid();
             }
+            $judgingRun = $this->em->getRepository(JudgingRun::class)->findOneBy(['judgetaskid' => $judgeTaskId]);
         }
 
         $disabled = Utils::jsonDecode($disabled);
@@ -796,6 +798,9 @@ class JudgehostController extends AbstractFOSRestController
             ->setJudgehostlog($judgehostlog)
             ->setTime(Utils::now())
             ->setDisabled($disabled);
+        if ($judgingRun) {
+            $error->setJudgingRun($judgingRun);
+        }
         $this->em->persist($error);
         // Even if there are no remaining judge tasks for this judging open (which is covered by the transaction below),
         // we need to mark this judging as internal error.

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -69,6 +69,10 @@ class InternalError
     #[ORM\JoinColumn(name: 'judgingid', referencedColumnName: 'judgingid', onDelete: 'SET NULL')]
     private ?Judging $judging = null;
 
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'runid', referencedColumnName: 'runid', onDelete: 'SET NULL')]
+    private ?JudgingRun $judgingRun = null;
+
     /**
      * @var Collection<int, Judging>
      */
@@ -181,5 +185,16 @@ class InternalError
     public function getAffectedJudgings(): Collection
     {
         return $this->affectedJudgings;
+    }
+
+    public function getJudgingRun(): ?JudgingRun
+    {
+        return $this->judgingRun;
+    }
+
+    public function setJudgingRun(?JudgingRun $judgingRun = null): InternalError
+    {
+        $this->judgingRun = $judgingRun;
+        return $this;
     }
 }

--- a/webapp/templates/jury/internal_error.html.twig
+++ b/webapp/templates/jury/internal_error.html.twig
@@ -43,6 +43,35 @@
                         </td>
                     </tr>
                 {% endif %}
+                {% if internalError.judgingRun is not null %}
+                    <tr>
+                        <th>Related judging run / testcase</th>
+                        <td>
+                            {% set tc = internalError.judgingRun.testcase %}
+                            <ul>
+                                <li>
+                                    <a href="{{ path('jury_submission_by_judging', {jid: internalError.judging.judgingid}) }}#run-{{ tc.rank }}">
+                                        tc{{ tc.testcaseid }}
+                                    </a>
+                                </li>
+                                <li>
+                                    rank: {{ tc.rank }}
+                                </li>
+                                {% if tc.description is not empty %}
+                                    <li>
+                                        description: {{ tc.description }}
+                                    </li>
+                                {% endif %}
+                                <li>
+                                    original filename: <code>{{ tc.origInputFilename }}.in</code>
+                                </li>
+                                <li>
+                                    testcase group: {{ (tc.sample) ? 'sample' : 'secret' }}
+                                </li>
+                            </ul>
+                        </td>
+                    </tr>
+                {% endif %}
                 {% if internalError.affectedJudgings is not null %}
                     <tr>
                         <th>Additional affected judgings</th>


### PR DESCRIPTION
In this case, display relevant information for corresponding test case and link to specific run on the submission page.

-----

Example:

![image](https://github.com/user-attachments/assets/4197ea78-f540-4277-9b0d-8c3fe5189827)
