### PR TITLE
Improve source diff viewer.

### DIFF
--- a/webapp/templates/jury/partials/submission_diff.html.twig
+++ b/webapp/templates/jury/partials/submission_diff.html.twig
@@ -1,5 +1,4 @@
 {% if files | length > 1 or oldFiles | length > 1 %}
-
     <table class="table table-sm table-striped file-diff-table">
         <tr>
             <th class="diff-add">Files added</th>
@@ -19,9 +18,9 @@
         </tr>
     </table>
 {% endif %}
+
 <ul class="nav nav-tabs source-tab-nav">
     {%- for filePair in oldFileStats.changedfiles %}
-
         <li class="nav-item">
             <a class="nav-link {% if loop.first %}active{% endif %}" data-bs-toggle="tab"
                href="#diff-{{ filePair.1.submitfileid }}" role="tab">{{ filePair.0.filename }}</a>
@@ -31,11 +30,22 @@
 </ul>
 <div class="tab-content source-tab">
     {%- for filePair in oldFileStats.changedfiles %}
+        <div class="mb-1">
+            <a class="btn btn-secondary btn-sm"
+               href="{{ path('jury_submission_source', {submission: submission.submitid, fetch: filePair.1.rank}) }}">
+                <i class="fas fa-download"></i> Download
+            </a>
+            {% if allowEdit %}
+                <a class="btn btn-secondary btn-sm"
+                   href="{{ path('jury_submission_edit_source', {submission: submission.submitid, rank: filePair.1.rank}) }}">
+                    <i class="fas fa-pencil-alt"></i> Edit
+                </a>
+            {% endif %}
+        </div>
 
         <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="diff-{{ filePair.1.submitfileid }}"
              role="tabpanel">
             {{ showDiff("diff" ~  filePair.1.submitfileid, filePair.0, filePair.1) }}
         </div>
     {%- endfor %}
-
 </div>

--- a/webapp/templates/jury/submission_source.html.twig
+++ b/webapp/templates/jury/submission_source.html.twig
@@ -25,71 +25,60 @@
             )
         {% endif %}
 
-    </h1>
-
-    {%- if submission.entryPoint %}
-
-        <p><b>Entry point</b>: {{ submission.entryPoint }}</p>
-    {%- endif %}
-
-    {%- if oldSubmission is not null %}
-
-        <p><a href="#diff">Go to diff to previous submission</a></p>
-    {%- endif %}
-
-    {%- if submission.originalSubmission %}
-
-        <p><a href="#origdiff">Go to diff to original submission</a></p>
-    {%- endif %}
-
-    <ul class="nav nav-tabs source-tab-nav">
-        {%- for file in files %}
-
-            <li class="nav-item">
-                <a class="nav-link {% if loop.first %}active{% endif %}" data-bs-toggle="tab"
-                   href="#source-{{ file.rank }}" role="tab">{{ file.filename }}</a>
-            </li>
-        {%- endfor %}
-
-    </ul>
-    <div class="tab-content source-tab">
-        {%- for file in files %}
-
-            <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="source-{{ file.rank }}"
-                 role="tabpanel">
-                <div class="mb-1">
-                    <a class="btn btn-secondary btn-sm"
-                       href="{{ path('jury_submission_source', {submission: submission.submitid, fetch: file.rank}) }}">
-                        <i class="fas fa-download"></i> Download
-                    </a>
-                    {% if allowEdit %}
-                        <a class="btn btn-secondary btn-sm"
-                           href="{{ path('jury_submission_edit_source', {submission: submission.submitid, rank: file.rank}) }}">
-                            <i class="fas fa-pencil-alt"></i> Edit
-                        </a>
-                    {% endif %}
-                </div>
-
-                {{ file.sourcecode | codeEditor(file.rank, submission.language.editorLanguage) }}
-            </div>
-        {%- endfor %}
-
-    </div>
-
-    {%- if oldSubmission is not null %}
-
-        <h2 id="diff" class="mt-3">
-            Diff to submission
+        {% if oldSubmission %}
+            and diff to previous submission
             <a href="{{ path('jury_submission', {submitId: oldSubmission.submitid}) }}">
                 s{{ oldSubmission.submitid }}
             </a>
-        </h2>
+        {% endif %}
+    </h1>
 
+    {%- if submission.entryPoint %}
+        <p><b>Entry point</b>: {{ submission.entryPoint }}</p>
+    {%- endif %}
+
+    {%- if submission.originalSubmission %}
+        <p><a href="#origdiff">Go to diff to original submission</a></p>
+    {%- endif %}
+
+    {% if not oldSubmission %}
+        <ul class="nav nav-tabs source-tab-nav">
+            {%- for file in files %}
+                <li class="nav-item">
+                    <a class="nav-link {% if loop.first %}active{% endif %}" data-bs-toggle="tab"
+                       href="#source-{{ file.rank }}" role="tab">{{ file.filename }}</a>
+                </li>
+            {%- endfor %}
+
+        </ul>
+        <div class="tab-content source-tab">
+            {%- for file in files %}
+                <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="source-{{ file.rank }}"
+                     role="tabpanel">
+                    <div class="mb-1">
+                        <a class="btn btn-secondary btn-sm"
+                           href="{{ path('jury_submission_source', {submission: submission.submitid, fetch: file.rank}) }}">
+                            <i class="fas fa-download"></i> Download
+                        </a>
+                        {% if allowEdit %}
+                            <a class="btn btn-secondary btn-sm"
+                               href="{{ path('jury_submission_edit_source', {submission: submission.submitid, rank: file.rank}) }}">
+                                <i class="fas fa-pencil-alt"></i> Edit
+                            </a>
+                        {% endif %}
+                    </div>
+
+                    {{ file.sourcecode | codeEditor(file.rank, submission.language.editorLanguage) }}
+                </div>
+            {%- endfor %}
+        </div>
+    {% endif %}
+
+    {%- if oldSubmission is not null %}
         {%- include 'jury/partials/submission_diff.html.twig' with {oldSubmission: oldSubmission, oldFiles: oldFiles, oldFileStats: oldFileStats} %}
     {%- endif %}
 
     {%- if originalSubmission is not null %}
-
         <h2 id="origdiff" class="mt-3">
             Diff to original submission
             <a href="{{ path('jury_submission', {submitId: originalSubmission.submitid}) }}">


### PR DESCRIPTION
When viewing a submission from a team who previously submitted to the same problem, we originally displayed a short unified diff below the source.

When we switched to Monaco, we did replace it view a Monaco diff editor which will display the full source (either inline or side by side). That caused us to display the source twice.

Now, if there is a previous submission, we only display the diff editor. New files are still downloadable and editable.


----

Example:

![image](https://github.com/user-attachments/assets/e6e23074-852d-4bc1-b203-0ee73fcb64d4)
