### PR TITLE
Use language name instead of id in language statistics overview.

### DIFF
--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -183,8 +183,8 @@ class StatisticsService
                 $misc['problem_stats']['teams_attempted'][$s->getProblem()->getProbId()][$team->getTeamId()] = $team->getTeamId();
 
                 static::setOrIncrement($misc['language_stats']['total_submissions'],
-                    $s->getLanguage()->getLangid());
-                $misc['language_stats']['teams_attempted'][$s->getLanguage()->getLangid()][$team->getTeamId()] = $team->getTeamId();
+                    $s->getLanguage()->getName());
+                $misc['language_stats']['teams_attempted'][$s->getLanguage()->getName()][$team->getTeamId()] = $team->getTeamId();
 
                 if ($s->getResult() != 'correct') {
                     continue;
@@ -197,9 +197,9 @@ class StatisticsService
                     $s->getProblem()->getProbId());
                 $misc['problem_stats']['teams_solved'][$s->getProblem()->getProbId()][$team->getTeamId()] = $team->getTeamId();
 
-                $misc['language_stats']['teams_solved'][$s->getLanguage()->getLangid()][$team->getTeamId()] = $team->getTeamId();
+                $misc['language_stats']['teams_solved'][$s->getLanguage()->getName()][$team->getTeamId()] = $team->getTeamId();
                 static::setOrIncrement($misc['language_stats']['total_solutions'],
-                    $s->getLanguage()->getLangid());
+                    $s->getLanguage()->getName());
 
                 if ($lastSubmission == null || $s->getSubmitTime() > $lastSubmission->getSubmitTime()) {
                     $lastSubmission = $s;

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -54,26 +54,6 @@ $(function() {
           # Submissions: {{ misc.total_submissions }}<br>
           # Accepted Submissions: {{ misc.total_accepted }} <span class="text-muted">(~{{ (misc.total_submissions>0 ? (misc.total_accepted/misc.total_submissions)*100:0)|number_format(0) }}%)</span><br>
           # of Teams: {{ misc.num_teams }}<br>
-
-<!--
-          # of Teams solving n problems<br>
-          <table class="table table-sm">
-            <thead>
-              <tr>
-                {% for x in range(0, problems|length) %}
-                <th>{{x}}</th>
-                {% endfor %}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                {% for n in range(0, problems|length ) %}
-                <td>{{ misc['teams_solved_n_problems'][n]|default(' ') }}</td>
-                {% endfor %}
-              </tr>
-            </tbody>
-          </table>
--->
         </div>
       </div>
     </div>
@@ -350,7 +330,7 @@ nv.addGraph(function() {
     d3.selectAll('#graph_problems .nv-bar').each(function(d) {
       if (d.value === 0) {
         d3.select(this).attr('height', 0);
-        d3.select(this).attr('y', chart.yAxis.scale()(0)); 
+        d3.select(this).attr('y', chart.yAxis.scale()(0));
       }
     });
   });


### PR DESCRIPTION
Example:

![image](https://github.com/user-attachments/assets/6389f430-0a90-4d08-90ab-5230205fb9ce)
