### PR TITLE
Code refactor for printing UI, API and client

### DIFF
--- a/submit/submit
+++ b/submit/submit
@@ -506,7 +506,7 @@ elif contests:
 languages: list = []
 problems: list = []
 if my_contest and baseurl:
-    if 'allow_submit' in my_contest and not my_contest['allow_submit']:
+    if not args.print and 'allow_submit' in my_contest and not my_contest['allow_submit']:
         warn_user('Submissions for contest (temporarily) disabled')
         exit(1)
     languages = read_languages()
@@ -610,23 +610,25 @@ for problem in problems:
 if not my_problem and not args.print:
     usage('No known problem specified or detected.')
 
-# Guess entry point if not already specified.
-if not entry_point and my_language['entry_point_required']:
-    if my_language['name'] == 'Java':
-        entry_point = filebase
-    elif my_language['name'] == 'Kotlin':
-        entry_point = kotlin_base_entry_point(filebase) + "Kt"
-    elif my_language['name'] == 'Python 3':
-        entry_point = filebase + "." + ext
+if not args.print:
+    # Guess entry point if not already specified.
+    if not entry_point and my_language['entry_point_required']:
+        if my_language['name'] == 'Java':
+            entry_point = filebase
+        elif my_language['name'] == 'Kotlin':
+            entry_point = kotlin_base_entry_point(filebase) + "Kt"
+        elif my_language['name'] == 'Python 3':
+            entry_point = filebase + "." + ext
 
-if not entry_point and my_language['entry_point_required']:
-    error('Entry point required but not specified nor detected.')
+    if not entry_point and my_language['entry_point_required']:
+        error('Entry point required but not specified nor detected.')
 
 logging.debug(f"contest is `{my_contest['shortname']}'")
 if not args.print:
     logging.debug(f"problem is `{my_problem['label']}'")
-logging.debug(f"language is `{my_language['name']}'")
-logging.debug(f"entry_point is `{entry_point or '<None>'}'")
+logging.debug(f"language is `{my_language.get('name', '<None>')}'")
+if not args.print:
+    logging.debug(f"entry_point is `{entry_point or '<None>'}'")
 logging.debug(f"url is `{baseurl}'")
 
 if args.print:

--- a/webapp/src/Controller/API/PrintController.php
+++ b/webapp/src/Controller/API/PrintController.php
@@ -83,14 +83,10 @@ class PrintController extends AbstractFOSRestController
                 ->createQueryBuilder()
                 ->from(Language::class, "l")
                 ->select("l.langid")
-                ->andWhere("l.allowSubmit = 1")
                 ->andWhere("l.name = :name")
                 ->setParameter("name", $print->language)
                 ->getQuery()
                 ->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR);
-            if ($langid === null) {
-                throw new BadRequestHttpException("Programming language not found.");
-            }
         }
 
         $decodedFile = base64_decode($print->fileContents, true);

--- a/webapp/src/Controller/Jury/PrintController.php
+++ b/webapp/src/Controller/Jury/PrintController.php
@@ -62,17 +62,8 @@ class PrintController extends BaseController
             ]);
         }
 
-        /** @var Language[] $languages */
-        $languages = $this->em->createQueryBuilder()
-            ->from(Language::class, 'l')
-            ->select('l')
-            ->andWhere('l.allowSubmit = 1')
-            ->getQuery()
-            ->getResult();
-
         return $this->render('jury/print.html.twig', [
             'form' => $form,
-            'languages' => $languages,
         ]);
     }
 }

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -190,13 +190,8 @@ class MiscController extends BaseController
             ]);
         }
 
-        $currentContest = $this->dj->getCurrentContest();
-        /** @var Language[] $languages */
-        $languages = $this->dj->getAllowedLanguagesForContest($currentContest);
-
         return $this->render('team/print.html.twig', [
             'form' => $form,
-            'languages' => $languages,
         ]);
     }
 

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -766,7 +766,7 @@ class DOMJudgeService
         $replaces = [
             '[file]' => escapeshellarg($filename),
             '[original]' => escapeshellarg($origname),
-            '[language]' => escapeshellarg($language),
+            '[language]' => escapeshellarg($language ?? ''),
             '[username]' => escapeshellarg($username),
             '[teamname]' => escapeshellarg($teamname ?? ''),
             '[teamid]' => escapeshellarg($teamid ?? ''),


### PR DESCRIPTION
This PR does two things.
1. The current UI allows us to select any available language for printing (including plain text) So I removed the code in the form that retrieves the available languages.

![jury](https://github.com/user-attachments/assets/b05601ea-d679-4224-9425-44f83b766d9f)
![team](https://github.com/user-attachments/assets/40bc0328-e4ee-47dd-89e6-01d61b53f608)

2. Make the API available in any available language (plain text if no language is available) and make appropriate modifications to the print client so that it can submit any language for printing.

But I think putting submitting and printing in one command is not a wise choice, which makes the code logic confusing.

Here is our implementation of a command line printing client that we used in a recent ICPC Regional for reference. If anyone thinks a separate print client implementation would be more appropriate, I can open another PR.

https://gist.github.com/cubercsl/809fcfdb65a7f88d6322cf0ab3505aa4