### PR TITLE
Temporarily disable upload of unit tests

### DIFF
--- a/.github/workflows/upload-unit-tests.yml
+++ b/.github/workflows/upload-unit-tests.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          files: "tmp/artifacts/**/*.xml"
+      #- name: Publish Test Results
+      #  uses: EnricoMi/publish-unit-test-result-action@v2
+      #  with:
+      #    commit: ${{ github.event.workflow_run.head_sha }}
+      #    event_file: artifacts/Event File/event.json
+      #    event_name: ${{ github.event.workflow_run.event }}
+      #    files: "tmp/artifacts/**/*.xml"


### PR DESCRIPTION
Currently the last step fails and we always comment with 0 unit tests. I'll investigate this in the future but for now disabling the useless step is better.

After that we can have the discussion if we even want this comment as I know it's controversial.