### PR TITLE
Introduce the concept of sort keys.

### DIFF
--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -37,14 +37,14 @@ GNU/Linux, or one of its derivative distributions like Ubuntu::
 
   sudo apt install libcgroup-dev make acl zip unzip pv mariadb-server apache2 \
         php php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
-        php-curl php-json php-xml php-zip composer ntp python3-yaml
+        php-curl php-json php-xml php-zip composer ntp python3-yaml php-bcmath
 
 The following command can be used on Fedora, and related distributions like
 Red Hat Enterprise Linux and Rocky Linux (before V9)::
 
   sudo dnf install libcgroup-devel make acl zip unzip pv mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd php-fpm \
-        php-xml php-zip composer chronyd python3-pyyaml
+        php-xml php-zip composer chronyd python3-pyyaml php-bcmath
 
 `nginx` can be used as an alternate web server.
 

--- a/webapp/composer.json
+++ b/webapp/composer.json
@@ -40,6 +40,7 @@
 	],
 	"require": {
 		"php": "^8.1.0",
+		"ext-bcmath": "*",
 		"ext-ctype": "*",
 		"ext-curl": "*",
 		"ext-fileinfo": "*",

--- a/webapp/composer.lock
+++ b/webapp/composer.lock
@@ -12843,6 +12843,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1.0",
+        "ext-bcmath": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",

--- a/webapp/migrations/Version20250309122806.php
+++ b/webapp/migrations/Version20250309122806.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250309122806 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sort keys to rankcache, allowing us to support different scoring functions efficiently and elegantly';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE rankcache ADD sort_key_public TEXT DEFAULT \'\' NOT NULL COMMENT \'Opaque sort key for public audience.\', ADD sort_key_restricted TEXT DEFAULT \'\' NOT NULL COMMENT \'Opaque sort key for restricted audience.\'');
+        $this->addSql('CREATE INDEX sortKeyPublic ON rankcache (sort_key_public)');
+        $this->addSql('CREATE INDEX sortKeyRestricted ON rankcache (sort_key_restricted)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX sortKeyPublic ON rankcache');
+        $this->addSql('DROP INDEX sortKeyRestricted ON rankcache');
+        $this->addSql('ALTER TABLE rankcache DROP sort_key_public, DROP sort_key_restricted');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -412,7 +412,7 @@ class ImportExportController extends BaseController
         $filter           = new Filter();
         $filter->categories = $categoryIds;
         $scoreboard = $this->scoreboardService->getScoreboard($contest, true, $filter);
-        $teams      = $scoreboard->getTeams();
+        $teams      = $scoreboard->getTeamsInDescendingOrder();
 
         $teamNames = [];
         foreach ($teams as $team) {

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace App\Entity;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -18,6 +19,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['cid', 'points_public', 'totaltime_public', 'totalruntime_public'], name: 'order_public')]
 #[ORM\Index(columns: ['cid'], name: 'cid')]
 #[ORM\Index(columns: ['teamid'], name: 'teamid')]
+#[ORM\Index(columns: ['sort_key_public'], name: 'sortKeyPublic')]
+#[ORM\Index(columns: ['sort_key_restricted'], name: 'sortKeyRestricted')]
 class RankCache
 {
     #[ORM\Column(options: [
@@ -61,6 +64,20 @@ class RankCache
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'teamid', referencedColumnName: 'teamid', onDelete: 'CASCADE')]
     private Team $team;
+
+    #[ORM\Column(
+        type: 'text',
+        length: AbstractMySQLPlatform::LENGTH_LIMIT_TEXT,
+        options: ['comment' => 'Opaque sort key for public audience.', 'default' => '']
+    )]
+    private string $sortKeyPublic = '';
+
+    #[ORM\Column(
+        type: 'text',
+        length: AbstractMySQLPlatform::LENGTH_LIMIT_TEXT,
+        options: ['comment' => 'Opaque sort key for restricted audience.', 'default' => '']
+    )]
+    private string $sortKeyRestricted = '';
 
     public function setPointsRestricted(int $pointsRestricted): RankCache
     {
@@ -148,5 +165,27 @@ class RankCache
     public function getTeam(): Team
     {
         return $this->team;
+    }
+
+    public function setSortKeyPublic(string $sortKeyPublic): RankCache
+    {
+        $this->sortKeyPublic = $sortKeyPublic;
+        return $this;
+    }
+
+    public function getSortKeyPublic(): string
+    {
+        return $this->sortKeyPublic;
+    }
+
+    public function setSortKeyRestricted(string $sortKeyRestricted): RankCache
+    {
+        $this->sortKeyRestricted = $sortKeyRestricted;
+        return $this;
+    }
+
+    public function getSortKeyRestricted(): string
+    {
+        return $this->sortKeyRestricted;
     }
 }

--- a/webapp/src/Service/AwardService.php
+++ b/webapp/src/Service/AwardService.php
@@ -16,7 +16,7 @@ class AwardService
     {
         $group_winners = $problem_winners = $problem_shortname = [];
         $groups = [];
-        foreach ($scoreboard->getTeams() as $team) {
+        foreach ($scoreboard->getTeamsInDescendingOrder() as $team) {
             $teamid = $team->getExternalid();
             if ($scoreboard->isBestInCategory($team)) {
                 $catId = $team->getCategory()->getExternalid();

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -4,6 +4,7 @@ namespace App\Utils\Scoreboard;
 
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
+use App\Entity\RankCache;
 use App\Entity\ScoreCache;
 use App\Entity\Team;
 use App\Entity\TeamCategory;
@@ -26,21 +27,22 @@ class Scoreboard
     protected ?array $bestInCategoryData = null;
 
     /**
-     * @param Team[]           $teams
+     * @param Team[]           $teamsInDescendingOrder
      * @param TeamCategory[]   $categories
      * @param ContestProblem[] $problems
      * @param ScoreCache[]     $scoreCache
      */
     public function __construct(
-        protected readonly Contest $contest,
-        protected readonly array $teams,
-        protected readonly array $categories,
-        protected readonly array $problems,
-        protected readonly array $scoreCache,
+        protected readonly Contest    $contest,
+        protected readonly array      $teamsInDescendingOrder,
+        protected readonly array      $categories,
+        protected readonly array      $problems,
+        protected readonly array      $scoreCache,
+        protected readonly array      $rankCache,
         protected readonly FreezeData $freezeData,
-        bool $jury,
-        protected readonly int $penaltyTime,
-        protected readonly bool $scoreIsInSeconds
+        bool                          $jury,
+        protected readonly int        $penaltyTime,
+        protected readonly bool       $scoreIsInSeconds
     ) {
         $this->restricted = $jury || $freezeData->showFinal($jury);
 
@@ -59,9 +61,9 @@ class Scoreboard
     /**
      * @return Team[]
      */
-    public function getTeams(): array
+    public function getTeamsInDescendingOrder(): array
     {
-        return $this->teams;
+        return $this->teamsInDescendingOrder;
     }
 
     /**
@@ -122,10 +124,16 @@ class Scoreboard
         // Initialize summary
         $this->summary = new Summary($this->problems);
 
+        $teamToRankCache = [];
+        foreach ($this->rankCache as $rc) {
+            $teamToRankCache[$rc->getTeam()->getTeamid()] = $rc;
+        }
+
         // Initialize scores
         $this->scores = [];
-        foreach ($this->teams as $team) {
-            $this->scores[$team->getTeamid()] = new TeamScore($team);
+        foreach ($this->teamsInDescendingOrder as $team) {
+            $rankCacheForTeam = $teamToRankCache[$team->getTeamid()] ?? null;
+            $this->scores[$team->getTeamid()] = new TeamScore($team, $rankCacheForTeam, $this->restricted);
         }
     }
 
@@ -139,8 +147,8 @@ class Scoreboard
         foreach ($this->scoreCache as $scoreCell) {
             $teamId = $scoreCell->getTeam()->getTeamid();
             $probId = $scoreCell->getProblem()->getProbid();
-            // Skip this row if the team or problem is not known by us.
-            if (!array_key_exists($teamId, $this->teams) ||
+            // Skip this cell if the team or problem is not known by us.
+            if (!array_key_exists($teamId, $this->teamsInDescendingOrder) ||
                 !array_key_exists($probId, $this->problems)) {
                 continue;
             }
@@ -161,20 +169,7 @@ class Scoreboard
                 runtime: $scoreCell->getRuntime($this->restricted),
                 numSubmissionsInFreeze: $scoreCell->getPending(false),
             );
-
-            if ($scoreCell->getIsCorrect($this->restricted)) {
-                $solveTime      = Utils::scoretime($scoreCell->getSolveTime($this->restricted),
-                                                   $this->scoreIsInSeconds);
-                $contestProblem = $this->problems[$scoreCell->getProblem()->getProbid()];
-                $this->scores[$teamId]->numPoints += $contestProblem->getPoints();
-                $this->scores[$teamId]->solveTimes[] = $solveTime;
-                $this->scores[$teamId]->totalTime += $solveTime + $penalty;
-                $this->scores[$teamId]->totalRuntime += $scoreCell->getRuntime($this->restricted);
-            }
         }
-
-        // Now sort the scores using the scoreboard sort function.
-        uasort($this->scores, $this->scoreboardCompare(...));
 
         // Loop over all teams to calculate ranks and totals.
         $prevSortOrder  = -1;
@@ -193,7 +188,7 @@ class Scoreboard
 
             // Use previous team rank when scores are equal.
             if (isset($previousTeamId) &&
-                $this->scoreCompare($this->scores[$previousTeamId], $teamScore) == 0) {
+                $this->scores[$previousTeamId]->getSortKey($this->restricted) === $teamScore->getSortKey($this->restricted)) {
                 $teamScore->rank = $this->scores[$previousTeamId]->rank;
             } else {
                 $teamScore->rank = $rank;
@@ -247,93 +242,6 @@ class Scoreboard
         }
     }
 
-    /**
-     * Scoreboard sorting function. It uses the following
-     * criteria:
-     * - First, use the sortorder override from the team_category table
-     *   (e.g. score regular contestants always over spectators);
-     * - Then, use the scoreCompare function to determine the actual ordering
-     *   based on number of problems solved and the time it took;
-     * - If still equal, order on team name alphabetically.
-     */
-    protected function scoreboardCompare(TeamScore $a, TeamScore $b): int
-    {
-        // First order by our predefined sortorder based on category.
-        $a_sortorder = $a->team->getCategory()->getSortorder();
-        $b_sortorder = $b->team->getCategory()->getSortorder();
-        if ($a_sortorder != $b_sortorder) {
-            return $a_sortorder <=> $b_sortorder;
-        }
-
-        // Then compare scores.
-        $scoreCompare = $this->scoreCompare($a, $b);
-        if ($scoreCompare != 0) {
-            return $scoreCompare;
-        }
-
-        // Else, order by teamname alphabetically.
-        if ($a->team->getEffectiveName() != $b->team->getEffectiveName()) {
-            $collator = new Collator('en');
-            return $collator->compare($a->team->getEffectiveName(), $b->team->getEffectiveName());
-        }
-        // Undecided, should never happen in practice.
-        return 0;
-    }
-
-    /**
-     * Main score comparison function, called from the 'scoreboardCompare' wrapper
-     * above. Scores based on the following criteria:
-     * - highest points from correct solutions;
-     * - least amount of total time spent on these solutions; (or lowest total runtime)
-     * - the tie-breaker function below.
-     */
-    protected function scoreCompare(TeamScore $a, TeamScore $b): int
-    {
-        // More correctness points than someone else means higher rank.
-        if ($a->numPoints != $b->numPoints) {
-            return $b->numPoints <=> $a->numPoints;
-        }
-        // Else, less time spent means higher rank.
-        if ($this->getRuntimeAsScoreTiebreaker()) { // runtime ordering
-            if ($a->totalRuntime != $b->totalRuntime) {
-                return $a->totalRuntime <=> $b->totalRuntime;
-            }
-        } else { // solvetime ordering
-            if ($a->totalTime != $b->totalTime) {
-                return $a->totalTime <=> $b->totalTime;
-            }
-        }
-        // Else tie-breaker rule.
-        return static::scoreTiebreaker($a, $b);
-    }
-
-    /**
-     * Tie-breaker comparison function, called from the 'scoreCompare' function
-     * above. Scores based on the following criterion:
-     * - fastest submission time for latest correct problem
-     */
-    public static function scoreTiebreaker(TeamScore $a, TeamScore $b): int
-    {
-        $atimes = $a->solveTimes;
-        $btimes = $b->solveTimes;
-        rsort($atimes);
-        rsort($btimes);
-
-        if (isset($atimes[0]) && isset($btimes[0])) {
-            return $atimes[0] <=> $btimes[0];
-        }
-        if (!isset($atimes[0]) && !isset($btimes[0])) {
-            return 0;
-        }
-        if (!isset($atimes[0])) {
-            return -1;
-        }
-        if (!isset($btimes[0])) {
-            return 1;
-        }
-
-        throw new Exception('Unhandled tie breaker case.');
-    }
 
     /**
      * Return whether to show points for this scoreboard.

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -27,7 +27,7 @@ class SingleTeamScoreboard extends Scoreboard
         protected readonly Team $team,
         protected readonly int $teamRank,
         array $problems,
-        protected readonly ?RankCache $rankCache,
+        array $rankCache,
         array $scoreCache,
         FreezeData $freezeData,
         bool $showFtsInFreeze,
@@ -35,17 +35,22 @@ class SingleTeamScoreboard extends Scoreboard
         bool $scoreIsInSeconds
     ) {
         $this->showRestrictedFts = $showFtsInFreeze || $freezeData->showFinal();
-        parent::__construct($contest, [$team->getTeamid() => $team], [], $problems, $scoreCache, $freezeData, true,
+        parent::__construct($contest, [$team->getTeamid() => $team], [], $problems, $scoreCache, $rankCache, $freezeData, true,
             $penaltyTime, $scoreIsInSeconds);
     }
 
     protected function calculateScoreboard(): void
     {
+        $rankCacheForTeam = null;
+        if ($this->rankCache !== null && count($this->rankCache) > 0) {
+            $rankCacheForTeam = $this->rankCache[0];
+        }
+
         $teamScore = $this->scores[$this->team->getTeamid()];
-        if ($this->rankCache !== null) {
-            $teamScore->numPoints += $this->rankCache->getPointsRestricted();
-            $teamScore->totalTime += $this->rankCache->getTotaltimeRestricted();
-            $teamScore->totalRuntime += $this->rankCache->getTotalruntimeRestricted();
+        if ($rankCacheForTeam !== null) {
+            $teamScore->numPoints += $rankCacheForTeam->getPointsRestricted();
+            $teamScore->totalTime += $rankCacheForTeam->getTotaltimeRestricted();
+            $teamScore->totalRuntime += $rankCacheForTeam->getTotalruntimeRestricted();
         }
         $teamScore->rank = $this->teamRank;
 

--- a/webapp/src/Utils/Scoreboard/TeamScore.php
+++ b/webapp/src/Utils/Scoreboard/TeamScore.php
@@ -2,20 +2,39 @@
 
 namespace App\Utils\Scoreboard;
 
+use App\Entity\RankCache;
 use App\Entity\Team;
 
 class TeamScore
 {
     public int $numPoints = 0;
 
-    /** @var float[] */
-    public array $solveTimes = [];
     public int $rank = 0;
     public int $totalTime;
     public int $totalRuntime = 0;
 
-    public function __construct(public Team $team)
+    public function __construct(public Team $team, public ?RankCache $rankCache, bool $restricted)
     {
         $this->totalTime = $team->getPenalty();
+        if ($this->rankCache) {
+            if ($restricted) {
+                $this->numPoints = $rankCache->getPointsRestricted();
+                $this->totalTime += $rankCache->getTotaltimeRestricted();
+                $this->totalRuntime = $rankCache->getTotalruntimeRestricted();
+            } else {
+                $this->numPoints = $rankCache->getPointsPublic();
+                $this->totalTime += $rankCache->getTotaltimePublic();
+                $this->totalRuntime = $rankCache->getTotalruntimePublic();
+            }
+        }
+    }
+
+    public function getSortKey(bool $restricted): string
+    {
+        if ($this->rankCache === null) {
+            // Sorts teams without a rank last.
+            return '.';
+        }
+        return $restricted ? $this->rankCache->getSortKeyRestricted() : $this->rankCache->getSortKeyPublic();
     }
 }

--- a/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
@@ -411,7 +411,7 @@ class ScoreboardIntegrationTest extends KernelTestCase
         $matrix = $scoreboard->getMatrix();
         $teams = [];
         $probs = [];
-        foreach ($scoreboard->getTeams() as $team) {
+        foreach ($scoreboard->getTeamsInDescendingOrder() as $team) {
             $teams[$team->getTeamid()] = $team;
         }
         foreach ($scoreboard->getProblems() as $prob) {

--- a/webapp/tests/Unit/Service/ScoreboardServiceTest.php
+++ b/webapp/tests/Unit/Service/ScoreboardServiceTest.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\ScoreboardService;
+use Doctrine\Common\Collections\Order;
+use Exception;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ScoreboardServiceTest extends KernelTestCase
+{
+    public function testScoreKeyConversionInt(): void
+    {
+        self::assertEquals(
+            "00000000000000000000000.000000000",
+            ScoreboardService::convertToScoreKeyElement(0)
+        );
+
+        self::assertEquals(
+            "00000000000000000000001.000000000",
+            ScoreboardService::convertToScoreKeyElement(1)
+        );
+
+        self::assertEquals(
+            "00000000000000000000042.000000000",
+            ScoreboardService::convertToScoreKeyElement(42)
+        );
+
+        self::assertEquals(
+            "00000000000000000000666.000000000",
+            ScoreboardService::convertToScoreKeyElement(666)
+        );
+    }
+
+    public function testScoreKeyConversionIntAscending(): void
+    {
+        self::assertEquals(
+            "99999999999999999999999.000000000",
+            ScoreboardService::convertToScoreKeyElement(0, Order::Ascending)
+        );
+
+        self::assertEquals(
+            "99999999999999999999998.000000000",
+            ScoreboardService::convertToScoreKeyElement(1, Order::Ascending)
+        );
+
+        self::assertEquals(
+            "99999999999999999999957.000000000",
+            ScoreboardService::convertToScoreKeyElement(42, Order::Ascending)
+        );
+    }
+
+    public function testScoreKeyConversionBcmath(): void
+    {
+        self::assertEquals(
+            "00000000000000000000000.000000000",
+            ScoreboardService::convertToScoreKeyElement("0")
+        );
+
+        self::assertEquals(
+            "00000000000000000000000.123000000",
+            ScoreboardService::convertToScoreKeyElement("0.123")
+        );
+
+        self::assertEquals(
+            "00000000000000000000666.123456789",
+            ScoreboardService::convertToScoreKeyElement("666.123456789")
+        );
+    }
+
+    public function testScoreKeyConversionBcmathAscending(): void
+    {
+        self::assertEquals(
+            "99999999999999999999999.000000000",
+            ScoreboardService::convertToScoreKeyElement("0", Order::Ascending)
+        );
+
+        self::assertEquals(
+            "99999999999999999999998.877000000",
+            ScoreboardService::convertToScoreKeyElement("0.123", Order::Ascending)
+        );
+
+        self::assertEquals(
+            "99999999999999999999332.876543211",
+            ScoreboardService::convertToScoreKeyElement("666.123456789", Order::Ascending)
+        );
+    }
+
+    public function testScoreKeyNegativeInt(): void
+    {
+        $this->expectException(Exception::class);
+        ScoreboardService::convertToScoreKeyElement(-1);
+    }
+
+    public function testScoreKeyNegativeBcmath(): void
+    {
+        $this->expectException(Exception::class);
+        ScoreboardService::convertToScoreKeyElement("-0.123");
+    }
+
+    public function testTooLarge(): void
+    {
+        $this->expectException(Exception::class);
+        ScoreboardService::convertToScoreKeyElement("100000000000000000000000");
+    }
+
+    public function testEmptyTeams(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(0, 0, 0);
+        $teamB = ScoreboardService::getICPCScoreKey(0, 0, 0);
+        self::assertEquals($teamA, $teamB);
+    }
+
+    public function testEqualTeams(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        $teamB = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        self::assertEquals($teamA, $teamB);
+    }
+
+    public function testOneTeamEmpty(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(0, 0, 0);
+        $teamB = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        self::assertTrue($teamA < $teamB);
+    }
+
+    public function testOneTeamSolvedMore(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(1, 333, 210);
+        $teamB = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        self::assertTrue($teamA < $teamB);
+    }
+
+    public function testEqualExceptLast(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        $teamB = ScoreboardService::getICPCScoreKey(7, 666, 421);
+        self::assertTrue($teamA > $teamB);
+    }
+
+    public function testEqualExceptSecondLast(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        $teamB = ScoreboardService::getICPCScoreKey(7, 667, 420);
+        self::assertTrue($teamA > $teamB);
+    }
+
+    public function testEqualExceptFirst(): void
+    {
+        $teamA = ScoreboardService::getICPCScoreKey(7, 666, 420);
+        $teamB = ScoreboardService::getICPCScoreKey(8, 666, 420);
+        self::assertTrue($teamA < $teamB);
+    }
+}

--- a/webapp/tests/Unit/Utils/Scoreboard/ScoreboardTest.php
+++ b/webapp/tests/Unit/Utils/Scoreboard/ScoreboardTest.php
@@ -15,109 +15,6 @@ use Generator;
 class ScoreboardTest extends BaseBaseTestCase
 {
     /**
-     * Test that the scoreboard tiebreaker works with two teams without any scores.
-     */
-    public function testScoreTiebreakerEmptyTeams(): void
-    {
-        $teamA = new Team();
-        $teamB = new Team();
-        $scoreA = new TeamScore($teamA);
-        $scoreB = new TeamScore($teamB);
-
-        // Always test in both directions for symmetry.
-        $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
-        self::assertEquals(0, $tie);
-        $tie = Scoreboard::scoreTieBreaker($scoreB, $scoreA);
-        self::assertEquals(0, $tie);
-    }
-
-    /**
-     * Test that the scoreboard tiebreaker works with two teams with equal scores.
-     */
-    public function testScoreTiebreakerEqualTeams(): void
-    {
-        $teamA = new Team();
-        $teamB = new Team();
-        $scoreA = new TeamScore($teamA);
-        foreach ([6, 367, 2, 100] as $time) {
-            $scoreA->solveTimes[] = $time;
-        }
-        $scoreB = new TeamScore($teamB);
-        foreach ([100, 6, 2, 367] as $time) {
-            $scoreB->solveTimes[] = $time;
-        }
-
-        $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
-        self::assertEquals(0, $tie);
-        $tie = Scoreboard::scoreTieBreaker($scoreB, $scoreA);
-        self::assertEquals(0, $tie);
-    }
-
-    /**
-     * Test that the scoreboard tiebreaker works if only one team has scores.
-     */
-    public function testScoreTiebreakerOneTeamEmpty(): void
-    {
-        $teamA = new Team();
-        $teamB = new Team();
-        $scoreA = new TeamScore($teamA);
-        foreach ([6, 367, 2, 100] as $time) {
-            $scoreA->solveTimes[] = $time;
-        }
-        $scoreB = new TeamScore($teamB);
-
-        $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
-        self::assertEquals(1, $tie);
-        $tie = Scoreboard::scoreTieBreaker($scoreB, $scoreA);
-        self::assertEquals(-1, $tie);
-    }
-
-
-    /**
-     * Test that the scoreboard tiebreaker works if both teams have the same highest score.
-     */
-    public function testScoreTiebreakerHighestEqual(): void
-    {
-        $teamA = new Team();
-        $teamB = new Team();
-        $scoreA = new TeamScore($teamA);
-        foreach ([6, 367, 2, 100] as $time) {
-            $scoreA->solveTimes[] = $time;
-        }
-        $scoreB = new TeamScore($teamB);
-        foreach ([23, 150, 367] as $time) {
-            $scoreB->solveTimes[] = $time;
-        }
-
-        $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
-        self::assertEquals(0, $tie);
-        $tie = Scoreboard::scoreTieBreaker($scoreB, $scoreA);
-        self::assertEquals(0, $tie);
-    }
-
-    /**
-     * Test that the scoreboard tiebreaker works if scores are different.
-     */
-    public function testScoreTiebreakerUnequal(): void
-    {
-        $teamA = new Team();
-        $teamB = new Team();
-        $scoreA = new TeamScore($teamA);
-        foreach ([6, 367, 2, 100] as $time) {
-            $scoreA->solveTimes[] = $time;
-        }
-        $scoreB = new TeamScore($teamB);
-        foreach ([23, 150, 2] as $time) {
-            $scoreB->solveTimes[] = $time;
-        }
-
-        $tie = Scoreboard::scoreTieBreaker($scoreA, $scoreB);
-        self::assertEquals(1, $tie);
-        $tie = Scoreboard::scoreTieBreaker($scoreB, $scoreA);
-        self::assertEquals(-1, $tie);
-    }
-
-    /**
      * @dataProvider provideFreezeDataProgress
      */
     public function testScoreboardProgress(
@@ -134,7 +31,7 @@ class ScoreboardTest extends BaseBaseTestCase
         $em = self::getContainer()->get('doctrine')->getManager();
         $contest = $em->getRepository(Contest::class)->findOneBy(['name' => $reference]);
         $freezeData = new FreezeData($contest);
-        $scoreBoard = new Scoreboard($contest, [], [], [], [], $freezeData, false, 0, true);
+        $scoreBoard = new Scoreboard($contest, [], [], [], [], [], $freezeData, false, 0, true);
         self::assertEquals($scoreBoard->getProgress(), $progress);
     }
 


### PR DESCRIPTION
Progress towards https://github.com/DOMjudge/domjudge/issues/2525.

The basic idea is to replace a lot of scattered scoring logic (which
might become more complex when we introduce more scoring options such as
optimization problems) by encoding sufficient information within the
existing rank cache.

The information is encoded into a sort key that is designed to be sorted
descendingly. The sort key is a tuple (serialized as string into the
database) of fixed precision decimals. Each tuple uses 9 decimals and is
left padded with `0`s, enabling sorting via standard database query
operations. For ascendingly sorted tuple entries (e.g. penalty time),
values are subtracted from a very large constant - this ensures that
that the key can be sorted as a whole.

For example, with ICPC scoring, the top 3 teams from NWERC 2024 receive
these sort keys:
```
00000000000000000000013.000000000,99999999999999999998725.000000000,99999999999999999999711.000000000
00000000000000000000011.000000000,99999999999999999998918.000000000,99999999999999999999701.000000000
00000000000000000000011.000000000,99999999999999999998916.000000000,99999999999999999999706.000000000
```

This mechanism should facilitate the implementation of other planned
scoring methods, particularly partial scoring and optimization problems,
with reasonable complexity in the business logic.

We are using `bcmath` with fixed precision to avoid numerical precision
issues caused by the order of floating point operations.  While not
critical currently, this will be essential when handling non-integers,
such as those in optimization problems.

The new mechanism also caches some computations and thus improves
scoreboard computation efficiency.