### PR TITLE
Do not initialize maxruntime ticks

### DIFF
--- a/webapp/templates/jury/analysis/problem.html.twig
+++ b/webapp/templates/jury/analysis/problem.html.twig
@@ -16,11 +16,6 @@
 .card {
   height: 100%;
 }
-
-/* Don't show x-axis ticks/ticklines for max runtimes chart. */
-#maxruntime .nv-x.nv-axis .tick {
-  display: none;
-}
 </style>
 {% endblock %}
 
@@ -133,7 +128,10 @@ $(function(){
       chart.yAxis
         .tickFormat(d3.format('.3f'))
         .axisLabel('Runtime(in s)');
-      chart.xAxis.axisLabel("Judgings");
+      chart.xAxis
+        .ticks(0)
+        .tickValues([])
+        .axisLabel("Judgings");
       d3.select('#maxruntime svg')
           .datum(run_max_times)
           .call(chart);


### PR DESCRIPTION
Not initializing ticks seems like a better solution than hiding them in CSS. Visually equivalent, but does not create all the DOM elements for the ticks.