### PR TITLE
Allow refreshing the scoreboard cache to take more than 30s.

### DIFF
--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -613,6 +613,8 @@ class ScoreboardService
      */
     public function refreshCache(Contest $contest, ?callable $progressReporter = null): void
     {
+        ini_set('max_execution_time', 300);
+
         $this->dj->auditlog('contest', $contest->getCid(), 'refresh scoreboard cache');
 
         if ($progressReporter === null) {


### PR DESCRIPTION
Refreshing the cache can take a while, especially with lots of teams in dev mode.