### PR TITLE
Disallow negative numbers on the scoreboard.

### DIFF
--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -328,6 +328,8 @@ class ScoreboardService
         $runtimeJury     = PHP_INT_MAX;
         $runtimePubl     = PHP_INT_MAX;
 
+        $contestStartTime = $contest->getStarttime();
+
         foreach ($submissions as $submission) {
             /** @var Judging|ExternalJudgement|null $judging */
             if ($useExternalJudgements) {
@@ -402,6 +404,8 @@ class ScoreboardService
 
             // STEP 3:
             $absSubmitTime = (float)$submission->getSubmittime();
+            // Negative numbers don't make sense on the scoreboard, cap them to the contest start.
+            $absSubmitTime = max($absSubmitTime, $contestStartTime);
             $submitTime    = $contest->getContestTime($absSubmitTime);
 
             if ($judging->getResult() == Judging::RESULT_CORRECT) {


### PR DESCRIPTION
If submissions happen before contest start - realistically these can only happen for jury - they are moved up to the contest start and represented as 0.

(They also did break the scoreboard UI in the past with large negative numbers if you set up the contest a few days in advance)