### PR TITLE
Fix reltime to seconds parsing

### DIFF
--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -167,6 +167,8 @@ class Utils
 
     final public const DAY_IN_SECONDS = 60*60*24;
 
+    final public const RELTIME_REGEX = '/^(-)?(\d+):(\d{2}):(\d{2})(?:\.(\d{3}))?$/';
+
     /**
      * Returns the milliseconds part of a time stamp truncated at three digits.
      */
@@ -191,12 +193,12 @@ class Utils
     }
 
     /**
-     * Prints a time diff as relative time as (-)?(h)*h:mm:ss(.uuu)?
-     * (with millis if $floored is false).
+     * Prints a time diff as relative time as ([-+])?(h)*h:mm:ss(.uuu)?
+     * (with millis if $floored is false and with + sign only if $includePlus is true).
      */
-    public static function relTime(float $seconds, bool $floored = false): string
+    public static function relTime(float $seconds, bool $floored = false, bool $includePlus = false): string
     {
-        $sign = ($seconds < 0) ? '-' : '';
+        $sign = ($seconds < 0) ? '-' : ($includePlus ? '+' : '');
         $seconds = abs($seconds);
         $hours = (int)($seconds / 3600);
         $minutes = (int)(($seconds - $hours*3600)/60);
@@ -204,6 +206,17 @@ class Utils
         $seconds = $seconds - $hours*3600 - $minutes*60;
         return $sign . sprintf("%d:%02d:%02d", $hours, $minutes, $seconds)
             . ($floored ? '' : $millis);
+    }
+
+    public static function relTimeToSeconds(string $reltime): float
+    {
+        preg_match(self::RELTIME_REGEX, $reltime, $data);
+        $negative = ($data[1] === '-');
+        $modifier = $negative ? -1 : 1;
+        $seconds  = $modifier * (int)$data[2] * 3600
+                    + (int)$data[3] * 60
+                    + (float)sprintf('%d.%03d', $data[4], $data[5] ?? 0);
+        return $seconds;
     }
 
     /**

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -213,9 +213,10 @@ class Utils
         preg_match(self::RELTIME_REGEX, $reltime, $data);
         $negative = ($data[1] === '-');
         $modifier = $negative ? -1 : 1;
-        $seconds  = $modifier * (int)$data[2] * 3600
+        $seconds  = $modifier * (
+                      (int)$data[2] * 3600
                     + (int)$data[3] * 60
-                    + (float)sprintf('%d.%03d', $data[4], $data[5] ?? 0);
+                    + (float)sprintf('%d.%03d', $data[4], $data[5] ?? 0));
         return $seconds;
     }
 

--- a/webapp/tests/Unit/Utils/UtilsTest.php
+++ b/webapp/tests/Unit/Utils/UtilsTest.php
@@ -73,6 +73,14 @@ class UtilsTest extends TestCase
     }
 
     /**
+     * Test that the relTime function returns the plus sign
+     */
+    public function testRelTimeWithPlus(): void
+    {
+        self::assertEquals('+1:18:31.000', Utils::relTime(4711, includePlus: true));
+    }
+
+    /**
      * Test that the relTime function returns the correct data when using a
      * time with millisecond precision
      */
@@ -124,6 +132,30 @@ class UtilsTest extends TestCase
     public function testNegativeRelTimeWithMillisFloored(): void
     {
         self::assertEquals('-3:25:45', Utils::relTime(-12345.6789, true));
+    }
+
+    /**
+     * Test the relTimeToSeconds function with basic data.
+     */
+    public function testRelTimeToSeconds(): void
+    {
+        self::assertEquals(1*3600 + 2*60 + 3, Utils::relTimeToSeconds('1:02:03'));
+    }
+
+    /**
+     * Test the relTimeToSeconds function with millisecond precision.
+     */
+    public function testRelTimeToSecondsWithMillis(): void
+    {
+        self::assertEquals(10.123, Utils::relTimeToSeconds('0:00:10.123'));
+    }
+
+    /**
+     * Test the relTimeToSeconds function with negative reltime.
+     */
+    public function testRelTimeToSecondsWithNegative(): void
+    {
+        self::assertEquals(-(1*3600 + 2*60 + 3), Utils::relTimeToSeconds('-1:02:03'));
     }
 
     /**


### PR DESCRIPTION
Extracted the refactor and bug fix of #2946 to a separate PR. The change in the API spec is not included in this change: I will rebase the temporary fix on `main` after merging this.

In the original code, the modifier was only applied to the hours of the reltime string. Note that test `testRelTimeToSecondsWithNegative` fails without the fix commit:
```
Failed asserting that -3477.0 matches expected -3723.
```