### PR TITLE
Distclean should remove what `make clean` removes and configure artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ clean-l:
 # Remove Coverity scan data:
 	-rm -rf cov-int domjudge-scan.t* coverity-scan.tar.xz cov-submit-data-version.sh
 
-distclean-l: clean-autoconf
+distclean-l: clean-autoconf clean
 	-rm -f paths.mk
 
 maintainer-clean: inplace-uninstall


### PR DESCRIPTION
See: https://www.gnu.org/software/automake/manual/automake.html#Clean

Currently we would leave the `tex` output after a `make dist` which does get removed after `make clean` so `make distclean` was not a superset of `make clean`. Easiest way of achieving that is a recursive target on top. We remove nothing in that folder so I'm not sure if we want to set it lower in the subdirectories (what is the convention?).