### PR TITLE
Only get freezedata on existing contests

### DIFF
--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -364,7 +364,7 @@ class ContestController extends AbstractRestController
 
         $hasAccess = $this->dj->checkrole('jury') ||
             $this->dj->checkrole('api_reader') ||
-            $contest->getFreezeData()->started();
+            $contest?->getFreezeData()->started();
 
         if (!$hasAccess) {
             throw new AccessDeniedHttpException();


### PR DESCRIPTION
This is a annoying case, we only check if the contests exists after we know if the user has access. This prevents us from disclosing data but does require this null check.

I did not check if it fixes the issue, but given the small change I expect we get away with this on visual inspection.

Should fix https://domjudge.sentry.io/issues/6155964196/?alert_rule_id=11022917&alert_type=issue&notification_uuid=d08175bd-ce4e-4e66-b1e3-49c72dfcef9e&project=6376669&referrer=slack