### PR TITLE
Assume no configuration target as new default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,12 @@ AC_SUBST(DOMJUDGE_VERSION, $PACKAGE_VERSION)
 AC_DEFINE_UNQUOTED(DOMJUDGE_VERSION, "$PACKAGE_VERSION",
 [DOMjudge version number (alias for PACKAGE_VERSION)])
 
-AC_SUBST(DOMSERVER_BUILD_ENABLED,yes)
+AC_SUBST(DOMSERVER_BUILD_ENABLED,no)
 AC_ARG_ENABLE([domserver-build],AS_HELP_STRING([--enable-domserver-build],
 [configure and build the domserver (default: yes).]),
 [if test "x$enableval" = xno ; then AC_SUBST(DOMSERVER_BUILD_ENABLED,no) fi])
 
-AC_SUBST(JUDGEHOST_BUILD_ENABLED,yes)
+AC_SUBST(JUDGEHOST_BUILD_ENABLED,no)
 AC_ARG_ENABLE([judgehost-build],AS_HELP_STRING([--enable-judgehost-build],
 [configure and build the judgehost (default: yes).]),
 [if test "x$enableval" = xno ; then AC_SUBST(JUDGEHOST_BUILD_ENABLED,no) fi])
@@ -387,6 +387,12 @@ if test "x$BASEURL_UNCONFIGURED" = x1 ; then
    echo "Warning: base URL is unconfigured; generating team documentation will"
    echo "not work out of the box!"
    echo "Rerun configure with option '--with-baseurl=BASEURL' to correct this."
+   echo ""
+fi
+if test "x$JUDGEHOST_BUILD_ENABLED" = xno && test "x$DOMSERVER_BUILD_ENABLED" = xno ; then
+   echo "Warning: neither --enable-domserver-build nor --enable-judgehost-build provided."
+   echo "You probably want to rerun with either one (or both). This behaviour has changed"
+   echo "in DOMjudge 9.0."
    echo ""
 fi
 fi # !QUIET

--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -65,7 +65,7 @@ After installing the required software as described above, run configure.
 In this example to install DOMjudge in the directory ``domjudge`` under
 `/opt`::
 
-  ./configure --prefix=/opt/domjudge
+  ./configure --enable-domserver-build --prefix=/opt/domjudge
   make domserver
   sudo make install-domserver
 

--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -64,7 +64,7 @@ for instructions to build from git sources.
 After installing the software listed above, run configure. In this
 example to install DOMjudge in the directory ``domjudge`` under `/opt`::
 
-  ./configure --prefix=/opt/domjudge
+  ./configure --enable-judgehost-build --prefix=/opt/domjudge
   make judgehost
   sudo make install-judgehost
 

--- a/doc/manual/quick-install.rst
+++ b/doc/manual/quick-install.rst
@@ -15,7 +15,7 @@ DOMserver
  * Make sure PHP works for the web server and command line scripts.
 
  * Extract the `source tarball <https://www.domjudge.org/download>`_ and run
-   ``./configure --with-baseurl=<url> && make domserver``.
+   ``./configure --enable-domserver-build --with-baseurl=<url> && make domserver``.
  * Run ``sudo make install-domserver`` to install the system.
 
  * Install the MySQL database using e.g.
@@ -53,7 +53,7 @@ DOMserver
 Judgehosts
 ----------
  * Extract the `source tarball <https://www.domjudge.org/download>`_ and run
-   ``./configure --with-baseurl=<url> && make judgehost``.
+   ``./configure --enable-judgehost-build --with-baseurl=<url> && make judgehost``.
  * Run ``sudo make install-judgehost`` to install the system.
 
  * Create one or more unprivileged users:


### PR DESCRIPTION
We already allowed skipping certain checks for compilers etc. but only if someone is aware of the option. Changing this now for the next major release. Not sure what the rest thinks?

This will most likely fight with https://github.com/DOMjudge/domjudge/pull/2975 so I rather get that one merged first.