### PR TITLE
Only get freezedata on found contests

### DIFF
--- a/webapp/src/Controller/API/ContestController.php
+++ b/webapp/src/Controller/API/ContestController.php
@@ -364,7 +364,7 @@ class ContestController extends AbstractRestController
 
         $hasAccess = $this->dj->checkrole('jury') ||
             $this->dj->checkrole('api_reader') ||
-            $contest->getFreezeData()->started();
+            $contest?->getFreezeData()->started();
 
         if (!$hasAccess) {
             throw new AccessDeniedHttpException();


### PR DESCRIPTION
We can't do a normal $contest==null check as that might leak information if someone doesn't have access.

Found by: https://github.com/TNO-S3/WuppieFuzz