### PR TITLE
Fix pre-contest display when teams have no affiliations

### DIFF
--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -750,7 +750,8 @@ class ScoreboardService
             ->leftJoin('t.affiliation', 'affil')
             ->andWhere('cat.visible = 1')
             ->orderBy('cat.name')
-            ->addOrderBy('affil.name');
+            ->addOrderBy('affil.name')
+            ->addOrderBy('t.name');
 
         if (!$contest->isOpenToAllTeams()) {
             $queryBuilder

--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -67,14 +67,14 @@
                             <div class="card-body">
                                 <ul class="list-group list-group-flush">
                                     {% for affiliation in affiliations %}
-                                        {% if affiliation.color is null %}
+                                        {% if affiliation.color is not defined or affiliation.color is null %}
                                             {% set color = "#FFFFFF" %}
                                             {% set colorClass = "_FFFFFF" %}
                                         {% else %}
                                             {% set colorClass = affiliation.color | replace({"#": "_"}) %}
                                         {% endif %}
                                         <li class="list-group-item cl{{ colorClass }}">
-                                            {% if showFlags %}
+                                            {% if showFlags and affiliation.country is defined %}
                                                 {{ affiliation.country|countryFlag }}
                                             {% endif %}
                                             {% set affiliationLogo = affiliation.id | assetPath('affiliation') %}


### PR DESCRIPTION
The LOJ at NAC had issues displaying the pre-contest list of teams.