### PR TITLE
Implement optimization problems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - /var/lib/mysql
   domjudge:
-    image: docker.io/domjudge/domjudge-contributor
+    image: as6325400/domjudge-contributor:8.3.1
     hostname: domjudge-contributor
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -244,6 +244,11 @@
                 2: always
             regex: /^\d+$/
             error_message: A value between 0 and 2 is required.
+        -   name: show_test_results
+            type: bool
+            default_value: false
+            public: true
+            description: Show what kinds of testcases to user?
         -   name: show_sample_output
             type: bool
             default_value: false

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1432,7 +1432,6 @@ function judge(array $judgeTask): bool
         $runtime = @$metadata[$metadata['time-used']];
     }
 
-    logmsg(LOG_INFO, '[DEBUG] compareMeta = '.var_export($compareMeta, true));
     if (isset($compareMeta['opt-score'])) {
        $optscore = @$compareMeta['opt-score'];
     }

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1424,10 +1424,17 @@ function judge(array $judgeTask): bool
 
     // Try to read metadata from file
     $runtime = null;
+    $optscore = null;
     $metadata = read_metadata($testcasedir . '/program.meta');
+    $compareMeta = read_metadata($testcasedir.'/compare.meta');
 
     if (isset($metadata['time-used'])) {
         $runtime = @$metadata[$metadata['time-used']];
+    }
+
+    logmsg(LOG_INFO, '[DEBUG] compareMeta = '.var_export($compareMeta, true));
+    if (isset($compareMeta['opt-score'])) {
+       $optscore = @$compareMeta['opt-score'];
     }
 
     if ($result === 'compare-error') {
@@ -1446,6 +1453,7 @@ function judge(array $judgeTask): bool
     $new_judging_run = [
         'runresult' => urlencode($result),
         'runtime' => urlencode((string)$runtime),
+        'optscore'  => urlencode((string)$optscore),
         'output_run'   => rest_encode_file($testcasedir . '/program.out', $output_storage_limit),
         'output_error' => rest_encode_file($testcasedir . '/program.err', $output_storage_limit),
         'output_system' => rest_encode_file($testcasedir . '/system.out', $output_storage_limit),

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -233,6 +233,19 @@ if [ $COMBINED_RUN_COMPARE -eq 0 ]; then
 		-f $SCRIPTFILELIMIT -s $SCRIPTFILELIMIT -M compare.meta -- \
 		"$COMPARE_SCRIPT" testdata.in testdata.out feedback/ $COMPARE_ARGS < program.out \
 				  >compare.tmp 2>&1
+	
+	# match optscore 
+	if grep -q '^OPT_SCORE=' compare.tmp ; then
+		score="$(grep -m1 '^OPT_SCORE=' compare.tmp | cut -d= -f2-)"
+		case "$score" in
+				''|*[!0-9.-]*|*.*.*|*.-*)
+						echo "Invalid OPT_SCORE value: $score" >&2
+						;;
+				*)
+						echo "opt-score: $score" >> compare.meta
+						;;
+		esac
+	fi
 fi
 
 # Make sure that all feedback files are owned by the current

--- a/webapp/migrations/Version20250517062145.php
+++ b/webapp/migrations/Version20250517062145.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250517062145 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest ADD similarity_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Use similarity-based scoring instead of exact match\', ADD similarity_order VARCHAR(10) DEFAULT \'asc\' NOT NULL COMMENT \'Order to apply for similarity-based scoring: asc or desc\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest DROP similarity_as_score_tiebreaker, DROP similarity_order');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250517084703.php
+++ b/webapp/migrations/Version20250517084703.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250517084703 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest ADD opt_score_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Use objective-score–based ranking instead of exact match\', ADD opt_score_order VARCHAR(10) DEFAULT \'asc\' NOT NULL COMMENT \'Order to apply for objective score: asc(smaller-better) or desc(larger-better)\', DROP similarity_as_score_tiebreaker, DROP similarity_order');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest ADD similarity_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Use similarity-based scoring instead of exact match\', ADD similarity_order VARCHAR(10) DEFAULT \'asc\' NOT NULL COMMENT \'Order to apply for similarity-based scoring: asc or desc\', DROP opt_score_as_score_tiebreaker, DROP opt_score_order');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250517085220.php
+++ b/webapp/migrations/Version20250517085220.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250517085220 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest CHANGE opt_score_as_score_tiebreaker opt_score_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Use optimization score ranking instead of exact match\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contest CHANGE opt_score_as_score_tiebreaker opt_score_as_score_tiebreaker TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'Use objective-score–based ranking instead of exact match\'');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250517145253.php
+++ b/webapp/migrations/Version20250517145253.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250517145253 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run ADD optscore DOUBLE PRECISION DEFAULT NULL COMMENT \'optimization score\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE judging_run DROP optscore');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250519064616.php
+++ b/webapp/migrations/Version20250519064616.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250519064616 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache ADD optscore_max_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (restricted audience)\', ADD optscore_max_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (public audience)\', ADD optscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (restricted audience)\', ADD optscore_min_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (public audience)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache DROP optscore_max_restricted, DROP optscore_max_public, DROP optscore_min_restricted, DROP optscore_min_public');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250519122129.php
+++ b/webapp/migrations/Version20250519122129.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250519122129 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache CHANGE optscore_max_restricted optscore_max_restricted DOUBLE PRECISION DEFAULT \'0\' COMMENT \'Max optscore (restricted audience)\', CHANGE optscore_max_public optscore_max_public DOUBLE PRECISION DEFAULT \'0\' COMMENT \'Max optscore (public audience)\', CHANGE optscore_min_restricted optscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' COMMENT \'Min optscore (restricted audience)\', CHANGE optscore_min_public optscore_min_public DOUBLE PRECISION DEFAULT \'0\' COMMENT \'Min optscore (public audience)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scorecache CHANGE optscore_max_restricted optscore_max_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (restricted audience)\', CHANGE optscore_max_public optscore_max_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (public audience)\', CHANGE optscore_min_restricted optscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (restricted audience)\', CHANGE optscore_min_public optscore_min_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (public audience)\'');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250519130014.php
+++ b/webapp/migrations/Version20250519130014.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250519130014 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE rankcache ADD totaloptscore_max_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Total max optscore (restricted audience)\', ADD optscore_max_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (public audience)\', ADD optscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (restricted audience)\', ADD optscore_min_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (public audience)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE rankcache DROP totaloptscore_max_restricted, DROP optscore_max_public, DROP optscore_min_restricted, DROP optscore_min_public');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/migrations/Version20250519134327.php
+++ b/webapp/migrations/Version20250519134327.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250519134327 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE rankcache ADD totaloptscore_max_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Total max optscore (public audience)\', ADD totaloptscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Total min optscore (restricted audience)\', ADD totaloptscore_min_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Total min optscore (public audience)\', DROP optscore_max_public, DROP optscore_min_restricted, DROP optscore_min_public');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE rankcache ADD optscore_max_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Max optscore (public audience)\', ADD optscore_min_restricted DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (restricted audience)\', ADD optscore_min_public DOUBLE PRECISION DEFAULT \'0\' NOT NULL COMMENT \'Min optscore (public audience)\', DROP totaloptscore_max_public, DROP totaloptscore_min_restricted, DROP totaloptscore_min_public');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -972,7 +972,7 @@ class JudgehostController extends AbstractFOSRestController
                 $judgingRunOutput->setTeamMessage(base64_decode($teamMessage));
             }
 
-            if ($optScore !== null) {
+            if ($optScore !== null and $optScore !== '') {
                 $judgingRun->setOptScore((float)$optScore);
             }
 

--- a/webapp/src/Controller/API/ScoreboardController.php
+++ b/webapp/src/Controller/API/ScoreboardController.php
@@ -180,6 +180,11 @@ class ScoreboardController extends AbstractApiController
                     numSolved: $teamScore->numPoints,
                     totalRuntime: $teamScore->totalRuntime,
                 );
+            } else if($contest->getOptScoreAsScoreTiebreaker()) {
+                $score = new Score(
+                    numSolved: $teamScore->numPoints,
+                    optMaxScore: $teamScore->$totalOptscore,
+                );
             } else {
                 $score = new Score(
                     numSolved: $teamScore->numPoints,

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -282,10 +282,10 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
     private bool $runtime_as_score_tiebreaker = false;
 
     #[ORM\Column(
-        options: ['comment' => 'Use similarity-based scoring instead of exact match', 'default' => 0]
+    options: ['comment' => 'Use optimization score ranking instead of exact match', 'default' => 0]
     )]
     #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
-    private bool $similarity_as_score_tiebreaker = false;
+    private bool $opt_score_as_score_tiebreaker = false;
 
     #[ORM\Column(
         type: 'string',
@@ -293,11 +293,11 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
         nullable: false,
         options: [
             'default' => 'asc',
-            'comment' => 'Order to apply for similarity-based scoring: asc or desc'
+            'comment' => 'Order to apply for objective score: asc(smaller-better) or desc(larger-better)'
         ]
     )]
     #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
-    private ?string $similarity_order = null;
+    private string $opt_score_order = 'asc';
 
     #[ORM\Column(
         options: ['comment' => 'Is this contest visible for the public?', 'default' => 1]
@@ -785,26 +785,26 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
         return $this->runtime_as_score_tiebreaker;
     }
 
-    public function setSimilarityAsScoreTiebreaker(bool $similarityAsScoreTiebreaker): Contest
+    public function setOptScoreAsScoreTiebreaker(bool $optScoreAsScoreTiebreaker): Contest
     {
-        $this->similarity_as_score_tiebreaker = $similarityAsScoreTiebreaker;
+        $this->opt_score_as_score_tiebreaker = $optScoreAsScoreTiebreaker;
         return $this;
     }
 
-    public function getSimilarityAsScoreTiebreaker(): bool
+    public function getOptScoreAsScoreTiebreaker(): bool
     {
-        return $this->similarity_as_score_tiebreaker;
+        return $this->opt_score_as_score_tiebreaker;
     }
 
-    public function setSimilarityOrder(?string $order): Contest
+    public function setOptScoreOrder(string $order): Contest
     {
-        $this->similarity_order = $order;
+        $this->opt_score_order = $order;
         return $this;
     }
 
-    public function getSimilarityOrder(): ?string
+    public function getOptScoreOrder(): string
     {
-        return $this->similarity_order;
+        return $this->opt_score_order;
     }
 
     public function setMedalsEnabled(bool $medalsEnabled): Contest
@@ -1342,10 +1342,10 @@ class Contest extends BaseApiEntity implements AssetEntityInterface
             }
         }
 
-        if ($this->runtime_as_score_tiebreaker && $this->similarity_as_score_tiebreaker) {
-            $context->buildViolation('You cannot enable both runtime and similarity scoring at the same time.')
-                ->atPath('similarityAsScoreTiebreaker')
-                ->addViolation();
+        if ($this->runtime_as_score_tiebreaker && $this->opt_score_as_score_tiebreaker) {
+            $context->buildViolation('Cannot enable both runtime and optimization score tiebreakers at the same time.')
+                    ->atPath('optScoreAsScoreTiebreaker')
+                    ->addViolation();
         }
 
         /** @var ContestProblem $problem */

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -179,6 +179,21 @@ class Judging extends BaseApiEntity implements ExternalRelationshipEntityInterfa
         return $max;
     }
 
+    public function getSumOptScore(): ?float
+    {   
+        if ($this->runs->isEmpty()) {
+            return null;
+        }
+        $sum = 0;
+        foreach ($this->runs as $run) {
+            if ($run->getOptscore() === null) {
+                return null;
+            }
+            $sum      += $run->getOptscore();
+        }
+        return $sum;
+    }
+
     public function getSumRuntime(): float
     {
         $sum = 0;

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -51,6 +51,13 @@ class JudgingRun extends BaseApiEntity
     private ?float $runtime = null;
 
     #[ORM\Column(
+        nullable: true,
+        options: ['comment' => 'optimization score']
+    )]
+    #[Serializer\Exclude]
+    private ?float $optscore = null;
+
+    #[ORM\Column(
         type: 'decimal',
         precision: 32,
         scale: 9,
@@ -149,6 +156,20 @@ class JudgingRun extends BaseApiEntity
     public function getRuntime(): ?float
     {
         return Utils::roundedFloat($this->runtime);
+    }
+
+    public function setOptscore(float $optscore): JudgingRun
+    {
+        $this->optscore = $optscore;
+        return $this;
+    }
+
+    #[Serializer\VirtualProperty]
+    #[Serializer\SerializedName('opt_score')]
+    #[Serializer\Type('float')]
+    public function getOptscore(): ?float
+    {
+        return Utils::roundedFloat($this->optscore);
     }
 
     public function setEndtime(string|float $endtime): JudgingRun

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -184,6 +184,28 @@ class RankCache
         return $this->totaloptscore_min_public;
     }
 
+    public function getTotalOptscore(bool $restricted): float
+    {
+        if ($this->contest->getOptScoreOrder() == 'asc') return $restricted
+                        ? $this->getTotalOptscoreMinRestricted()
+                        : $this->getTotalOptscoreMinPublic();
+        else return $restricted
+                        ? $this->getTotalOptscoreMaxRestricted()
+                        : $this->getTotalOptscoreMaxPublic();
+    }
+
+    public function getTotalOptscoreRestricted(): float
+    {
+        if ($this->contest->getOptScoreOrder() == 'asc') return $this->getTotalOptscoreMinRestricted();
+        else return $this->getTotalOptscoreMaxRestricted();
+    }
+
+    public function getTotalOptscorePublic(): float
+    {
+        if ($this->contest->getOptScoreOrder() == 'asc') return $this->getTotalOptscoreMinPublic();
+        else return $this->getTotalOptscoreMaxPublic();
+    }
+
     public function setContest(?Contest $contest = null): RankCache
     {
         $this->contest = $contest;

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -55,14 +55,14 @@ class RankCache
     #[ORM\Column(options: ['comment' => 'Total max optscore (restricted audience)', 'default' => 0])]
     private float $totaloptscore_max_restricted = 0;
 
-    #[ORM\Column(options: ['comment' => 'Max optscore (public audience)', 'default' => 0])]
-    private float $optscore_max_public = 0;
+    #[ORM\Column(options: ['comment' => 'Total max optscore (public audience)', 'default' => 0])]
+    private float $totaloptscore_max_public = 0;
 
-    #[ORM\Column(options: ['comment' => 'Min optscore (restricted audience)', 'default' => 0])]
-    private float $optscore_min_restricted = 0;
+    #[ORM\Column(options: ['comment' => 'Total min optscore (restricted audience)', 'default' => 0])]
+    private float $totaloptscore_min_restricted = 0;
 
-    #[ORM\Column(options: ['comment' => 'Min optscore (public audience)', 'default' => 0])]
-    private float $optscore_min_public = 0;
+    #[ORM\Column(options: ['comment' => 'Total min optscore (public audience)', 'default' => 0])]
+    private float $totaloptscore_min_public = 0;
 
     #[ORM\Id]
     #[ORM\ManyToOne]
@@ -151,37 +151,37 @@ class RankCache
         return $this->totaloptscore_max_restricted;
     }
 
-    public function setOptscoreMaxPublic(float $optscoreMaxPublic): RankCache
+    public function setTotalOptscoreMaxPublic(float $totalOptscoreMaxPublic): RankCache
     {
-        $this->optscore_max_public = $optscoreMaxPublic;
+        $this->totaloptscore_max_public = $totalOptscoreMaxPublic;
         return $this;
     }
 
-    public function getOptscoreMaxPublic(): float
+    public function getTotalOptscoreMaxPublic(): float
     {
-        return $this->optscore_max_public;
+        return $this->totaloptscore_max_public;
     }
 
-    public function setOptscoreMinRestricted(float $optscoreMinRestricted): RankCache
+    public function setTotalOptscoreMinRestricted(float $totalOptscoreMinRestricted): RankCache
     {
-        $this->optscore_min_restricted = $optscoreMinRestricted;
+        $this->totaloptscore_min_restricted = $totalOptscoreMinRestricted;
         return $this;
     }
 
-    public function getOptscoreMinRestricted(): float
+    public function getTotalOptscoreMinRestricted(): float
     {
-        return $this->optscore_min_restricted;
+        return $this->totaloptscore_min_restricted;
     }
 
-    public function setOptscoreMinPublic(float $optscoreMinPublic): RankCache
+    public function setTotalOptscoreMinPublic(float $totalOptscoreMinPublic): RankCache
     {
-        $this->optscore_min_public = $optscoreMinPublic;
+        $this->totaloptscore_min_public = $totalOptscoreMinPublic;
         return $this;
     }
 
-    public function getOptscoreMinPublic(): float
+    public function getTotalOptscoreMinPublic(): float
     {
-        return $this->optscore_min_public;
+        return $this->totaloptscore_min_public;
     }
 
     public function setContest(?Contest $contest = null): RankCache

--- a/webapp/src/Entity/RankCache.php
+++ b/webapp/src/Entity/RankCache.php
@@ -52,6 +52,18 @@ class RankCache
     #[ORM\Column(options: ['comment' => 'Total runtime in milliseconds (public)', 'default' => 0])]
     private int $totalruntime_public = 0;
 
+    #[ORM\Column(options: ['comment' => 'Total max optscore (restricted audience)', 'default' => 0])]
+    private float $totaloptscore_max_restricted = 0;
+
+    #[ORM\Column(options: ['comment' => 'Max optscore (public audience)', 'default' => 0])]
+    private float $optscore_max_public = 0;
+
+    #[ORM\Column(options: ['comment' => 'Min optscore (restricted audience)', 'default' => 0])]
+    private float $optscore_min_restricted = 0;
+
+    #[ORM\Column(options: ['comment' => 'Min optscore (public audience)', 'default' => 0])]
+    private float $optscore_min_public = 0;
+
     #[ORM\Id]
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
@@ -126,6 +138,50 @@ class RankCache
     public function getTotalruntimePublic(): int
     {
         return $this->totalruntime_public;
+    }
+
+    public function setTotaloptscoreMaxRestricted(float $totaloptscoreMaxRestricted): RankCache
+    {
+        $this->totaloptscore_max_restricted = $totaloptscoreMaxRestricted;
+        return $this;
+    }
+
+    public function getTotaloptscoreMaxRestricted(): float
+    {
+        return $this->totaloptscore_max_restricted;
+    }
+
+    public function setOptscoreMaxPublic(float $optscoreMaxPublic): RankCache
+    {
+        $this->optscore_max_public = $optscoreMaxPublic;
+        return $this;
+    }
+
+    public function getOptscoreMaxPublic(): float
+    {
+        return $this->optscore_max_public;
+    }
+
+    public function setOptscoreMinRestricted(float $optscoreMinRestricted): RankCache
+    {
+        $this->optscore_min_restricted = $optscoreMinRestricted;
+        return $this;
+    }
+
+    public function getOptscoreMinRestricted(): float
+    {
+        return $this->optscore_min_restricted;
+    }
+
+    public function setOptscoreMinPublic(float $optscoreMinPublic): RankCache
+    {
+        $this->optscore_min_public = $optscoreMinPublic;
+        return $this;
+    }
+
+    public function getOptscoreMinPublic(): float
+    {
+        return $this->optscore_min_public;
     }
 
     public function setContest(?Contest $contest = null): RankCache

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -58,6 +58,30 @@ class ScoreCache
     private int $runtime_restricted = 0;
 
     #[ORM\Column(options: [
+        'comment' => 'Max optscore (restricted audience)',
+        'default' => 0,
+    ])]
+    private float $optscore_max_restricted = 0;
+
+    #[ORM\Column(options: [
+        'comment' => 'Max optscore (public audience)',
+        'default' => 0,
+    ])]
+    private float $optscore_max_public = 0;
+
+    #[ORM\Column(options: [
+        'comment' => 'Min optscore (restricted audience)',
+        'default' => 0,
+    ])]
+    private float $optscore_min_restricted = 0;
+
+    #[ORM\Column(options: [
+        'comment' => 'Min optscore (public audience)',
+        'default' => 0,
+    ])]
+    private float $optscore_min_public = 0;
+
+    #[ORM\Column(options: [
         'comment' => 'Number of submissions made (public)',
         'unsigned' => true,
         'default' => 0,
@@ -162,6 +186,50 @@ class ScoreCache
     public function getRuntimeRestricted(): int
     {
         return $this->runtime_restricted;
+    }
+    
+    public function setOptScoreMaxRestricted(float $optscoreMaxRestricted): ScoreCache
+    {
+        $this->optscore_max_restricted = $optscoreMaxRestricted;
+        return $this;
+    }
+
+    public function getOptScoreMaxRestricted(): float
+    {
+        return $this->optscore_max_restricted;
+    }
+
+    public function setOptScoreMaxPublic(float $optscoreMaxPublic): ScoreCache
+    {
+        $this->optscore_max_public = $optscoreMaxPublic;
+        return $this;
+    }
+
+    public function getOptScoreMaxPublic(): float
+    {
+        return $this->optscore_max_public;
+    }
+
+    public function setOptScoreMinRestricted(float $optscoreMinRestricted): ScoreCache
+    {
+        $this->optscore_min_restricted = $optscoreMinRestricted;
+        return $this;
+    }
+
+    public function getOptScoreMinRestricted(): float
+    {
+        return $this->optscore_min_restricted;
+    }
+
+    public function setOptScoreMinPublic(float $optscoreMinPublic): ScoreCache
+    {
+        $this->optscore_min_public = $optscoreMinPublic;
+        return $this;
+    }
+
+    public function getOptScoreMinPublic(): float
+    {
+        return $this->optscore_min_public;
     }
 
     public function setSubmissionsPublic(int $submissionsPublic): ScoreCache

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -212,7 +212,7 @@ class ScoreCache
 
     public function getOptScoreMaxRestricted(): float
     {
-        return $this->optscore_max_restricted;
+        return $this->optscore_max_restricted ?? 0;
     }
 
     public function setOptScoreMaxPublic(float $optscoreMaxPublic): ScoreCache
@@ -223,7 +223,7 @@ class ScoreCache
 
     public function getOptScoreMaxPublic(): float
     {
-        return $this->optscore_max_public;
+        return $this->optscore_max_public ?? 0;
     }
 
     public function setOptScoreMinRestricted(float $optscoreMinRestricted): ScoreCache
@@ -234,7 +234,7 @@ class ScoreCache
 
     public function getOptScoreMinRestricted(): float
     {
-        return $this->optscore_min_restricted;
+        return $this->optscore_min_restricted ?? 0;
     }
 
     public function setOptScoreMinPublic(float $optscoreMinPublic): ScoreCache
@@ -245,7 +245,7 @@ class ScoreCache
 
     public function getOptScoreMinPublic(): float
     {
-        return $this->optscore_min_public;
+        return $this->optscore_min_public ?? 0;
     }
 
     public function setSubmissionsPublic(int $submissionsPublic): ScoreCache
@@ -370,5 +370,21 @@ class ScoreCache
     public function getIsCorrect(bool $restricted): bool
     {
         return $restricted ? $this->getIsCorrectRestricted() : $this->getIsCorrectPublic();
+    }
+
+    public function getMaxOptscore(bool $restricted): float
+    {
+        return $restricted ? $this->getOptScoreMaxRestricted() : $this->getOptScoreMaxPublic();
+    }
+
+    public function getMinOptscore(bool $restricted): float
+    {
+        return $restricted ? $this->getOptScoreMinRestricted() : $this->getOptScoreMinPublic();
+    }
+
+    public function getOptscore(bool $restricted): float
+    {
+        if ($this->contest->getOptScoreOrder() == 'asc') return $this->getMinOptscore($restricted);
+        else return $this->getMaxOptscore($restricted);
     }
 }

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -57,29 +57,45 @@ class ScoreCache
     ])]
     private int $runtime_restricted = 0;
 
-    #[ORM\Column(options: [
-        'comment' => 'Max optscore (restricted audience)',
-        'default' => 0,
-    ])]
-    private float $optscore_max_restricted = 0;
+    #[ORM\Column(
+        type: 'float',
+        nullable: true,
+        options: [
+            'comment' => 'Max optscore (restricted audience)',
+            'default' => 0,
+        ]
+    )]
+    private ?float $optscore_max_restricted = null;
 
-    #[ORM\Column(options: [
-        'comment' => 'Max optscore (public audience)',
-        'default' => 0,
-    ])]
-    private float $optscore_max_public = 0;
+    #[ORM\Column(
+        type: 'float',
+        nullable: true,
+        options: [
+            'comment' => 'Max optscore (public audience)',
+            'default' => 0,
+        ]
+    )]
+    private ?float $optscore_max_public = null;
 
-    #[ORM\Column(options: [
-        'comment' => 'Min optscore (restricted audience)',
-        'default' => 0,
-    ])]
-    private float $optscore_min_restricted = 0;
+    #[ORM\Column(
+        type: 'float',
+        nullable: true,
+        options: [
+            'comment' => 'Min optscore (restricted audience)',
+            'default' => 0,
+        ]
+    )]
+    private ?float $optscore_min_restricted = null;
 
-    #[ORM\Column(options: [
-        'comment' => 'Min optscore (public audience)',
-        'default' => 0,
-    ])]
-    private float $optscore_min_public = 0;
+    #[ORM\Column(
+        type: 'float',
+        nullable: true,
+        options: [
+            'comment' => 'Min optscore (public audience)',
+            'default' => 0,
+        ]
+    )]
+    private ?float $optscore_min_public = null;
 
     #[ORM\Column(options: [
         'comment' => 'Number of submissions made (public)',

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -101,6 +101,23 @@ class ContestType extends AbstractExternalIdEntityType
             ],
             'help' => 'Enable this to show runtimes in seconds on scoreboard and use them as tiebreaker instead of penalty. The runtime of a submission is the maximum over all testcases.',
         ]);
+        $builder->add('similarityAsScoreTiebreaker', ChoiceType::class, [
+            'expanded' => true,
+            'choices' => [
+                'Yes' => true,
+                'No' => false,
+            ],
+            'help' => 'Enable this to score submissions based on output similarity.',
+        ]);
+        $builder->add('similarityOrder', ChoiceType::class, [
+            'label'    => 'Similarity scoring order',
+            'choices'  => [
+                'Smaller is better (asc)' => 'asc',
+                'Larger is better (desc)' => 'desc',
+            ],
+            'required' => false,
+            'disabled' => false,
+        ]);
         $builder->add('medalsEnabled', ChoiceType::class, [
             'expanded' => true,
             'choices' => [

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -101,22 +101,18 @@ class ContestType extends AbstractExternalIdEntityType
             ],
             'help' => 'Enable this to show runtimes in seconds on scoreboard and use them as tiebreaker instead of penalty. The runtime of a submission is the maximum over all testcases.',
         ]);
-        $builder->add('similarityAsScoreTiebreaker', ChoiceType::class, [
+        $builder->add('optScoreAsScoreTiebreaker', ChoiceType::class, [
             'expanded' => true,
-            'choices' => [
-                'Yes' => true,
-                'No' => false,
-            ],
-            'help' => 'Enable this to score submissions based on output similarity.',
+            'choices'  => ['Yes' => true, 'No' => false],
+            'help'     => 'Enable this to rank submissions by optimization score instead of penalty.',
         ]);
-        $builder->add('similarityOrder', ChoiceType::class, [
-            'label'    => 'Similarity scoring order',
+        $builder->add('optScoreOrder', ChoiceType::class, [
+            'label'    => 'optimization score ranking order',
             'choices'  => [
                 'Smaller is better (asc)' => 'asc',
                 'Larger is better (desc)' => 'desc',
             ],
             'required' => false,
-            'disabled' => false,
         ]);
         $builder->add('medalsEnabled', ChoiceType::class, [
             'expanded' => true,

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -114,6 +114,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('entityIdBadge', $this->entityIdBadge(...), ['is_safe' => ['html']]),
             new TwigFilter('medalType', $this->awards->medalType(...)),
             new TwigFilter('numTableActions', $this->numTableActions(...)),
+            new TwigFilter('formatOptScore', $this->formatOptScore(...)),
         ];
     }
 
@@ -1221,5 +1222,29 @@ EOF;
             $maxNumActions = max($maxNumActions, count($item['actions'] ?? []));
         }
         return $maxNumActions;
+    }
+
+    /**
+     * Format the given optScore:
+     * - If it's an integer, display without decimal places
+     * - Otherwise, display up to the specified number of decimal places
+     *
+     * @param float|null $optScore     The value to format (nullable)
+     * @param int        $maxDecimals  Maximum number of decimal places to show (default = 3)
+     * @return string                  Formatted string representation of the score
+     */
+    protected function formatOptScore(?float $optScore, int $maxDecimals = 3): string
+    {
+        if ($optScore === null) {
+            return '-';
+        }
+
+        // If the value is an integer, format without decimal places
+        if ($optScore == floor($optScore)) {
+            return number_format($optScore, 0, '.', '');
+        }
+
+        // Otherwise, format with specified decimal precision
+        return number_format($optScore, $maxDecimals, '.', '');
     }
 }

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -158,7 +158,8 @@ class Scoreboard
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
                 $penalty,
-                $scoreRow->getRuntime($this->restricted)
+                $scoreRow->getRuntime($this->restricted),
+                $scoreRow->getOptscore($this->restricted)
             );
 
             if ($scoreRow->getIsCorrect($this->restricted)) {
@@ -169,6 +170,7 @@ class Scoreboard
                 $this->scores[$teamId]->solveTimes[] = $solveTime;
                 $this->scores[$teamId]->totalTime += $solveTime + $penalty;
                 $this->scores[$teamId]->totalRuntime += $scoreRow->getRuntime($this->restricted);
+                $this->scores[$teamId]->totalOptscore += $scoreRow->getOptscore($this->restricted);
             }
         }
 
@@ -216,7 +218,7 @@ class Scoreboard
                 $problemId = $contestProblem->getProbid();
                 // Provide default scores when nothing submitted for this team + problem yet
                 if (!isset($this->matrix[$teamId][$problemId])) {
-                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
+                    $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0, 0);
                 }
 
                 $problemMatrixItem = $this->matrix[$teamId][$problemId];
@@ -457,5 +459,14 @@ class Scoreboard
     public function getRuntimeAsScoreTiebreaker(): bool
     {
         return $this->contest->getRuntimeAsScoreTiebreaker();
+    }
+
+    /**
+     * Determine whether to order by optscore instead of solvetime
+     * @return bool
+     */
+    public function getOptScoreAsScoreTiebreaker(): bool
+    {
+        return $this->contest->getOptScoreAsScoreTiebreaker();
     }
 }

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -292,6 +292,14 @@ class Scoreboard
             if ($a->totalRuntime != $b->totalRuntime) {
                 return $a->totalRuntime <=> $b->totalRuntime;
             }
+        } else if ($this->getOptscoreAsScoreTiebreaker()) {
+            if ($a->totalRuntime != $b->totalRuntime) {
+                if ($this->getOptScoreOrder() === "asc") {
+                    return $a->totalOptscore <=> $b->totalOptscore;
+                } else {
+                    return $b->totalOptscore <=> $a->totalOptscore;
+                }
+            }
         } else { // solvetime ordering
             if ($a->totalTime != $b->totalTime) {
                 return $a->totalTime <=> $b->totalTime;
@@ -468,5 +476,14 @@ class Scoreboard
     public function getOptScoreAsScoreTiebreaker(): bool
     {
         return $this->contest->getOptScoreAsScoreTiebreaker();
+    }
+
+    /**
+     * Determine order by optscore 
+     * @return string
+     */
+    public function getOptScoreOrder(): string
+    {
+        return $this->contest->getOptScoreOrder();
     }
 }

--- a/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
+++ b/webapp/src/Utils/Scoreboard/ScoreboardMatrixItem.php
@@ -11,6 +11,7 @@ class ScoreboardMatrixItem
         public int $numSubmissionsPending,
         public float|string $time,
         public int $penaltyTime,
-        public int $runtime
+        public int $runtime,
+        public float|null $optscore
     ) {}
 }

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -46,6 +46,7 @@ class SingleTeamScoreboard extends Scoreboard
             $teamScore->numPoints += $this->rankCache->getPointsRestricted();
             $teamScore->totalTime += $this->rankCache->getTotaltimeRestricted();
             $teamScore->totalRuntime += $this->rankCache->getTotalruntimeRestricted();
+            $teamScore->totalOptscore +=  $this->rankCache->getTotalOptscoreRestricted();
         }
         $teamScore->rank = $this->teamRank;
 
@@ -69,7 +70,8 @@ class SingleTeamScoreboard extends Scoreboard
                 $scoreRow->getPending($this->restricted),
                 $scoreRow->getSolveTime($this->restricted),
                 $penalty,
-                $scoreRow->getRuntime($this->restricted)
+                $scoreRow->getRuntime($this->restricted),
+                $scoreRow->getOptscore($this->restricted)
             );
         }
 
@@ -79,7 +81,7 @@ class SingleTeamScoreboard extends Scoreboard
             $teamId    = $this->team->getTeamid();
             $problemId = $contestProblem->getProbid();
             if (!isset($this->matrix[$teamId][$problemId])) {
-                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0);
+                $this->matrix[$teamId][$problemId] = new ScoreboardMatrixItem(false, false, 0, 0, 0, 0, 0, 0);
             }
         }
     }

--- a/webapp/src/Utils/Scoreboard/TeamScore.php
+++ b/webapp/src/Utils/Scoreboard/TeamScore.php
@@ -13,6 +13,7 @@ class TeamScore
     public int $rank = 0;
     public int $totalTime;
     public int $totalRuntime = 0;
+    public ?float $totalOptscore = null;
 
     public function __construct(public Team $team)
     {

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -20,6 +20,10 @@
         {{ form_row(form.allowSubmit) }}
         {{ form_row(form.processBalloons) }}
         {{ form_row(form.runtimeAsScoreTiebreaker) }}
+        {{ form_row(form.similarityAsScoreTiebreaker) }}
+        <div data-similarity-field>
+            {{ form_row(form.similarityOrder) }}
+        </div>
         {{ form_row(form.medalsEnabled) }}
         <div data-medals-field>
             {{ form_row(form.medalCategories) }}
@@ -157,5 +161,17 @@
 
         $('#contest_medalsEnabled_1, #contest_medalsEnabled_0').on('change', showHideMedals);
         showHideMedals();
+
+        function showHideSimilarity() {
+            if ($('#contest_similarityAsScoreTiebreaker_0').is(':checked')) { // Yes = index 0
+                $('[data-similarity-field]').show();
+            } else {
+                $('[data-similarity-field]').hide();
+            }
+        }
+
+        $('#contest_similarityAsScoreTiebreaker_0, #contest_similarityAsScoreTiebreaker_1')
+            .on('change', showHideSimilarity);
+        showHideSimilarity();
     })
 </script>

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -20,9 +20,9 @@
         {{ form_row(form.allowSubmit) }}
         {{ form_row(form.processBalloons) }}
         {{ form_row(form.runtimeAsScoreTiebreaker) }}
-        {{ form_row(form.similarityAsScoreTiebreaker) }}
-        <div data-similarity-field>
-            {{ form_row(form.similarityOrder) }}
+        {{ form_row(form.optScoreAsScoreTiebreaker) }}
+        <div data-opt-score-field>
+            {{ form_row(form.optScoreOrder) }}
         </div>
         {{ form_row(form.medalsEnabled) }}
         <div data-medals-field>
@@ -162,16 +162,15 @@
         $('#contest_medalsEnabled_1, #contest_medalsEnabled_0').on('change', showHideMedals);
         showHideMedals();
 
-        function showHideSimilarity() {
-            if ($('#contest_similarityAsScoreTiebreaker_0').is(':checked')) { // Yes = index 0
-                $('[data-similarity-field]').show();
+        function showHideOptScore() {
+            if ($('#contest_optScoreAsScoreTiebreaker_0').is(':checked')) {
+                $('[data-opt-score-field]').show();
             } else {
-                $('[data-similarity-field]').hide();
+                $('[data-opt-score-field]').hide();
             }
         }
-
-        $('#contest_similarityAsScoreTiebreaker_0, #contest_similarityAsScoreTiebreaker_1')
-            .on('change', showHideSimilarity);
-        showHideSimilarity();
+        $('#contest_optScoreAsScoreTiebreaker_0, #contest_optScoreAsScoreTiebreaker_1')
+            .on('change', showHideOptScore);
+        showHideOptScore();
     })
 </script>

--- a/webapp/templates/jury/partials/submission_graph.html.twig
+++ b/webapp/templates/jury/partials/submission_graph.html.twig
@@ -6,10 +6,12 @@
                 <span id="graphs" style="font-weight: bold;">testcase CPU times
                     <span style="font-weight: normal;">
                             {%- if selectedJudging.result != 'compiler-error' -%}
-                                | max:
-                                {{ selectedJudging.maxRuntime | number_format(3, '.', '') }}s
-                                | sum: {{ selectedJudging.sumRuntime | number_format(3, '.', '') }}s
-                            {% endif %}
+                                | max: {{ selectedJudging.maxRuntime | number_format(3, '.', '') }}s
+                                | sum: {{ selectedJudging.sumRuntime | number_format(3, '.', '') }}s&nbsp
+                                {%- if selectedJudging.SumOptScore is not null -%}
+                                    | <span>opt score:</span> {{ selectedJudging.SumOptScore | formatOptScore }}
+                                {%- endif %}
+                            {%- endif %}
                     </span>
                 </span>
             </div>

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -235,6 +235,8 @@
                 <td class="scorenc">{{ totalPoints }}</td>
                 {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
                     <td class="scorett">{{ "%0.3f s" | format(score.totalRuntime/1000.0) }}</td>
+                {% elseif contest.getOptScoreAsScoreTiebreaker() %}
+                    <td class="scorett">{{ score.totalOptscore | formatOptScore }}</td>
                 {% else %}
                     <td class="scorett">{{ totalTime }}</td>
                 {% endif %}
@@ -270,7 +272,9 @@
                     {% set time = '' %}
                     {% if matrixItem.isCorrect %}
                         {% set time = matrixItem.time %}
-                        {% if scoreboard.getRuntimeAsScoreTiebreaker() %}
+                        {% if scoreboard.getOptScoreAsScoreTiebreaker() %}
+                            {% set time = matrixItem.optscore %}
+                        {% elseif scoreboard.getRuntimeAsScoreTiebreaker() %}
                             {% set time = "%0.3f s" | format(matrixItem.runtime / 1000.0) %}
                         {% elseif scoreInSeconds %}
                             {% set time = time | scoreTime | printTimeRelative %}

--- a/webapp/templates/security/login.html.twig
+++ b/webapp/templates/security/login.html.twig
@@ -118,7 +118,7 @@ Use the form below to change login.' %}
             </form>
         </div>
 
-        <p class="mt-5 mb-3 small text-muted" id="dj_version">DOMjudge {{ DOMJUDGE_VERSION }}</p>
+        <p class="mt-5 mb-3 small text-muted" id="dj_version">DOMjudge DSxOOP-8.3.1</p>
     </div>
 </main>
 

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -35,19 +35,24 @@
                     {% endif %}
                 </div>
             {% endif %}
+            {% if judging.result != 'compiler-error' %}
+                <div class="d-flex flex-row">
+                    <div class="p-2">
+                        Result: {{ judging.result | printResult }}
+                    </div>
+                    {% if judging.result == 'correct' and judging.submission.contest.getRuntimeAsScoreTiebreaker() %}
+                        <div class="p-2">
+                            Max. Runtime: <b>{{ "%0.3f s" | format(judging.getMaxRuntime()) }}</b>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
 
-        {% if judging.result != 'compiler-error' %}
-            <div class="d-flex flex-row">
-                <div class="p-2">
-                    Result: {{ judging.result | printResult }}
-                </div>
-                {% if judging.result == 'correct' and judging.submission.contest.getRuntimeAsScoreTiebreaker() %}
-                    <div class="p-2">
-                        Max. Runtime: <b>{{ "%0.3f s" | format(judging.getMaxRuntime()) }}</b>
-                    </div>
-                {% endif %}
-            </div>
+        {% if showTestResults and judging.result != 'compiler-error' %}
+            <div class="p-2">
+                Testcase Runs: {{ testcasesruns | displayTestcaseResults(1) }}
+            <div>
         {% endif %}
 
         {% if allowDownload %}

--- a/webapp/templates/team/partials/submission.html.twig
+++ b/webapp/templates/team/partials/submission.html.twig
@@ -45,6 +45,11 @@
                             Max. Runtime: <b>{{ "%0.3f s" | format(judging.getMaxRuntime()) }}</b>
                         </div>
                     {% endif %}
+                    {% if judging.result == 'correct' and judging.submission.contest.getOptScoreAsScoreTiebreaker() %}
+                        <div class="p-2">
+                            Opt. Score: <b>{{ judging.SumOptScore  | formatOptScore }}</b>
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/webapp/templates/team/partials/submission_list.html.twig
+++ b/webapp/templates/team/partials/submission_list.html.twig
@@ -14,6 +14,9 @@
             {% if contest.getRuntimeAsScoreTiebreaker() %}
                 <th scope="col">runtime</th>
             {% endif %}
+            {% if contest.getOptScoreAsScoreTiebreaker() %}
+                <th scope="col">optscore</th>
+            {% endif %}
             {% if allowDownload %}
                 <th scope="col"></th>
             {% endif %}
@@ -73,6 +76,17 @@
                     <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
                         {% if link and submission.getResult()=='correct' %}
                             {{ "%0.3f s" | format(submission.judgings.first.getMaxRuntime()) }}
+                        {% else %}
+                            -
+                        {% endif %}
+                    </a>
+                </td>
+        {% endif %}
+        {% if contest.getOptScoreAsScoreTiebreaker() %}
+                <td>
+                    <a data-ajax-modal data-ajax-modal-after="markSeen" {% if link %}href="{{ link }}"{% endif %}>
+                        {% if link and submission.getResult()=='correct' %}
+                            {{ submission.judgings.first.SumOptScore | formatOptScore }}
                         {% else %}
                             -
                         {% endif %}


### PR DESCRIPTION
As part of a feature I needed for my class, I went ahead and implemented it myself. I'm not sure if this is something the DOMjudge team would be interested in adopting, but I thought I'd share it in case it can serve as a useful reference.

Issue: https://github.com/DOMjudge/domjudge/issues/2519

To use this feature, simply have the compare script output to stderr a line starting with `OPT_SCORE=`. Currently, I'm storing the value as a float, so both integers and decimals are supported.

![截圖 2025-05-21 晚上9 24 44](https://github.com/user-attachments/assets/4c128239-b3f2-4fa9-b4b6-590a09eef4e3)
![截圖 2025-05-21 晚上9 30 26](https://github.com/user-attachments/assets/505b2b5e-2f43-4ca2-9b31-c69c4a99083a)

On the judgehost side, the score for each testcase is recorded in the judging_run table and then propagated to scorecache and rankcache.

To enable using the optscore as a contest tiebreaker, go to the contest settings and set `"Opt score as score tiebreaker" `to yes. This will reveal two options:

- Larger is best
- Smaller is best

You can then configure whether a higher or lower score is considered better for optimization problems.

![截圖 2025-05-21 晚上9 22 30](https://github.com/user-attachments/assets/79881ac5-7137-474f-83b3-30f9ffe275dd)
![截圖 2025-05-21 晚上9 23 00](https://github.com/user-attachments/assets/b31346d3-c4ac-47e7-a0d9-fa0bd9bfdbb8)

Note: It is asserted that Runtime as score tiebreaker cannot be used at the same time as Opt score as score tiebreaker.
![截圖 2025-05-21 晚上9 45 46](https://github.com/user-attachments/assets/13a9c1c8-d868-4f4e-91db-b53d74fffd17)

In the team interface, if Opt score as score tiebreaker is enabled, the optscore will be shown in the submission list for each submission. For problems that do not report an optscore, a value of 0 will be shown on the scoreboard and - in the submission list.
![截圖 2025-05-21 晚上9 35 57](https://github.com/user-attachments/assets/3e920f46-4cbb-454a-ba69-bc9508249e0a)

Regardless of whether the tiebreaker setting is enabled, jury members will always be able to see the optscore for each submission.
![截圖 2025-05-21 晚上9 39 05](https://github.com/user-attachments/assets/23311111-f181-4675-bd8a-081d0a7e59f9)




Standard problems (without optimization scores) are unaffected by this feature.
![截圖 2025-05-21 晚上9 39 45](https://github.com/user-attachments/assets/c1ca13d9-395d-492a-ba2b-17f10dadb8d2)

This implementation is essentially a minimum viable product (MVP). I’m not sure if outputting OPT_SCORE= directly in the compare script is the best long-term approach, but it works well for now.

Since my class is actively using this judge system, I’ve implemented the changes on version 8.3.1. If this feature is of interest, I can port the code to the main branch.

I’ve also set up a live demo judge at: https://domjudge.as6325400.org/
problem: https://domjudge.as6325400.org/public/problems/4/statement

If you’d like to try it out, feel free to message me on Slack for a login account.