### PR TITLE
Fix setting external judgement types

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -772,7 +772,11 @@ class ExternalContestSourceService
             // Verdict not found, import it as a custom verdict; assume it has a penalty.
             $customVerdicts = $this->config->get('external_judgement_types');
             $customVerdicts[$verdict] = str_replace(' ', '-', $data->name);
-            $this->config->saveChanges(['external_judgement_types' => $customVerdicts], $this->eventLog, $this->dj);
+            $this->config->saveChanges(
+                array_merge($this->config->all(), ['external_judgement_types' => $customVerdicts]),
+                $this->eventLog,
+                $this->dj
+            );
             $this->verdicts = $this->config->getVerdicts(['final', 'external']);
             $penalty = true;
             $solved = false;


### PR DESCRIPTION
This used to reset some other config variables. By merging with all existing ones it doesn't do this anymore.