### PR TITLE
hide “Deactivate now” button once deactivated

### DIFF
--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -1191,7 +1191,8 @@ class Contest extends BaseApiEntity implements
                     $showButton = $hasstarted && !$hasended && (empty($this->getFreezetime()) || $hasfrozen);
                     break;
                 case 'deactivate':
-                    $showButton = $hasended && (empty($this->getUnfreezetime()) || $hasunfrozen);
+                    $futureDeactivate = empty($this->getDeactivatetime()) || Utils::difftime((float)$this->getDeactivatetime(), $now) > 0;
+                    $showButton = $hasended && (empty($this->getUnfreezetime()) || $hasunfrozen) && $futureDeactivate;
                     break;
                 case 'freeze':
                     $showButton = $hasstarted && !$hasended && !$hasfrozen;


### PR DESCRIPTION
Fixes https://github.com/DOMjudge/domjudge/issues/2687

Use getDeactivatetime() to check whether the `Deactivate time` field is set, and decide accordingly whether to display the `Deactivate now` button.