### PR TITLE
Always push logs, even on failure.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           dest: '/tmp/docker-logs'
       - name: Upload all logs/artifacts
-        if: ${{ !cancelled() }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: Logs


### PR DESCRIPTION
Having logs for failures is great for debugging. Especially when an issue cannot be reproduced locally.