### PR TITLE
Judging timestamps

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -704,7 +704,7 @@ class ContestController extends BaseController
                         ->setJudgehost($judgehost)
                         ->setPriority(JudgeTask::PRIORITY_DEFAULT)
                         ->setTestcaseId($testcase->getTestcaseid())
-                        ->setTestcaseHash($testcase->getMd5sumInput() . '_' . $testcase->getMd5sumOutput());
+                        ->setTestcaseHash($testcase->getTestcaseHash());
                     $this->em->persist($judgeTask);
                     $cnt++;
                 }

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -377,7 +377,7 @@ class SubmissionController extends BaseController
         $runsOutstanding = false;
         $runs       = [];
         $runsOutput = [];
-        $sameTestcaseIds = true;
+        $sameTestcaseHashes = true;
         if ($selectedJudging || $externalJudgement) {
             $queryBuilder = $this->em->createQueryBuilder()
                 ->from(Testcase::class, 't')
@@ -414,9 +414,9 @@ class SubmissionController extends BaseController
                 ->getQuery()
                 ->getResult();
 
-            $judgingRunTestcaseIdsInOrder = $this->em->createQueryBuilder()
+            $judgingRunTestcaseHashesInOrder = $this->em->createQueryBuilder()
                 ->from(JudgeTask::class, 'jt')
-                ->select('jt.testcase_id')
+                ->select('jt.testcase_hash')
                 ->andWhere('jt.jobid = :judging')
                 ->setParameter('judging', $selectedJudging)
                 ->orderBy('jt.judgetaskid')
@@ -424,15 +424,15 @@ class SubmissionController extends BaseController
                 ->getScalarResult();
 
             $cnt = 0;
-            if (count($judgingRunTestcaseIdsInOrder) !== count($runResults)) {
-                $sameTestcaseIds = false;
+            if (count($judgingRunTestcaseHashesInOrder) !== count($runResults)) {
+                $sameTestcaseHashes = false;
             }
             foreach ($runResults as $runResult) {
                 /** @var Testcase $testcase */
                 $testcase = $runResult[0];
-                if (isset($judgingRunTestcaseIdsInOrder[$cnt])) {
-                    if ($testcase->getTestcaseid() != $judgingRunTestcaseIdsInOrder[$cnt]['testcase_id']) {
-                        $sameTestcaseIds = false;
+                if (isset($judgingRunTestcaseHashesInOrder[$cnt])) {
+                    if ($testcase->getTestcasehash() != $judgingRunTestcaseHashesInOrder[$cnt]['testcase_hash']) {
+                        $sameTestcaseHashes = false;
                     }
                 }
                 $cnt++;
@@ -571,7 +571,7 @@ class SubmissionController extends BaseController
             'runs' => $runs,
             'runsOutstanding' => $runsOutstanding,
             'judgehosts' => $judgehosts,
-            'sameTestcaseIds' => $sameTestcaseIds,
+            'sameTestcaseHashes' => $sameTestcaseHashes,
             'externalRuns' => $externalRuns,
             'runsOutput' => $runsOutput,
             'lastRuns' => $lastRuns,
@@ -710,7 +710,7 @@ class SubmissionController extends BaseController
             ->setJobId($jid->getJudgingid())
             ->setUuid($jid->getUuid())
             ->setTestcaseId($testcase->getTestcaseid())
-            ->setTestcaseHash($testcase->getMd5sumInput() . '_' . $testcase->getMd5sumOutput());
+            ->setTestcaseHash($testcase->getTestcaseHash());
         $this->em->persist($judgeTask);
         $this->em->flush();
         return $this->redirectToLocalReferrer($this->router, $request, $this->generateUrl('jury_submission', [

--- a/webapp/src/Entity/Testcase.php
+++ b/webapp/src/Entity/Testcase.php
@@ -161,6 +161,11 @@ class Testcase
         return $this->ranknumber;
     }
 
+    public function getTestcaseHash(): string
+    {
+        return $this->getMd5sumInput() . '_' . $this->getMd5sumOutput();
+    }
+
     /**
      * @param resource|string $description
      */

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1625,7 +1625,7 @@ class DOMJudgeService
                 $testcase->getTestcaseid()
             );
             $judgetaskInsertParams[':testcase_id' . $testcase->getTestcaseid()] = $testcase->getTestcaseid();
-            $judgetaskInsertParams[':testcase_hash' . $testcase->getTestcaseid()] = $testcase->getMd5sumInput() . '_' . $testcase->getMd5sumOutput();
+            $judgetaskInsertParams[':testcase_hash' . $testcase->getTestcaseid()] = $testcase->getTestcaseHash();
         }
         $judgetaskColumns = array_map(fn(string $column) => substr($column, 1), $judgetaskDefaultParamNames);
         $judgetaskInsertQuery = sprintf(

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -279,7 +279,7 @@
         </div>
     {% endif %}
 
-    {% if not sameTestcaseIds and selectedJudging is not null and selectedJudging.result is not empty %}
+    {% if not sameTestcaseHashes and selectedJudging is not null and selectedJudging.result is not empty %}
         <div class="alert alert-danger">The problem's testcases have changed since this judging has been performed. We recommend rejudging the whole problem.</div>
     {% endif %}
 

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -399,7 +399,8 @@
                             , on {{ judgehosts | printHosts }}
                             {%- if selectedJudging.starttime -%}
                                 {%- if selectedJudging.endtime -%}
-                                    , took <span title="started: {{ selectedJudging.starttime | printtime('H:i:s') }}, completed: {{ selectedJudging.endtime | printtime('H:i:s') }}">{{ selectedJudging.starttime | printHumanTimeDiff(selectedJudging.endtime) }}</span>
+                                    , started at <span title="{{ selectedJudging.starttime | printtime('Y-m-d H:i:s (T)') }}">{{ selectedJudging.starttime | printtime('H:i') }}</span>
+                                    , took <span title="completed: {{ selectedJudging.endtime | printtime('Y-m-d H:i:s (T)') }}">{{ selectedJudging.starttime | printHumanTimeDiff(selectedJudging.endtime) }}</span>
                                 {%- elseif selectedJudging.valid or selectedJudging.rejudging -%}
                                     &nbsp;[still judging - busy {{ selectedJudging.starttime | printtimediff }}]
                                 {%- else -%}


### PR DESCRIPTION
While we're at it, align title formatting with the format used in the title of the submission time.

The submission page shows a warning
```The problem's testcases have changed since this judging has been performed. We recommend rejudging the whole problem.```
but this warning does not cover all possible changes in the testcases (e.g. changing input / output files does not trigger this warning). Update to use the hashes to cover more cases.

Fixes #2764