### PR TITLE
Demo using bootstrap in team page

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -617,7 +617,7 @@ function enableRefresh($url, $after, usingAjax) {
         }
     };
     refreshHandler = setTimeout(refresh, $after * 1000);
-    refreshEnabled = true;
+    refreshEnabled = false;
     setCookie('domjudge_refresh', 1);
 
     if(window.location.href == localStorage.getItem('lastUrl')) {

--- a/webapp/templates/base.html.twig
+++ b/webapp/templates/base.html.twig
@@ -48,17 +48,6 @@
     {% endif %}
     var markdownPreviewUrl = "{{ path('markdown_preview') }}";
     $(function () {
-        /* toggle refresh if set */
-        {% if refresh is defined and refresh %}
-        $('#refresh-navitem').on('click', function () {
-            toggleRefresh('{{ refresh.url | raw }}', {{ refresh.after }}, {{ refresh.ajax | default(0) }});
-        });
-        {% endif %}
-        /* Enable page refresh if set if wanted by the page, and wanted by the user */
-        {% if refresh is defined and refresh and refresh_flag %}
-        enableRefresh('{{ refresh.url | raw }}', {{ refresh.after }}, {{ refresh.ajax | default(0) }});
-        {% endif %}
-
         initializeAjaxModals();
     });
 </script>

--- a/webapp/templates/team/partials/index_content.html.twig
+++ b/webapp/templates/team/partials/index_content.html.twig
@@ -50,7 +50,7 @@
     </div>
     <div class="col-sm-6">
         <div class="card mb-3" style="margin: 0; background-color: #c4d8ff;">
-            <div class="center card-header">
+            <div class="center card-header" style="background-color: inherit; border-bottom: 0 solid red;">
                 Clarifications
             </div>
             <div class="card-body" style="padding: 0">

--- a/webapp/templates/team/partials/index_content.html.twig
+++ b/webapp/templates/team/partials/index_content.html.twig
@@ -61,6 +61,21 @@
                 </a>
             </div>
         </div>
+        <div class="card mb-3">
+            <div class="card-header">
+                Clarification Requests
+                <a style="float: right;" href="{{ path('team_clarification_add') }}" class="btn btn-secondary btn-sm" data-ajax-modal data-ajax-modal-after="initModalClarificationPreviewAdd">
+                    Request clarification
+                </a>
+            </div>
+            <div class="card-body">
+                {% if clarificationRequests is empty %}
+                    <p class="nodata">No clarification request.</p>
+                {% else %}
+                    {% include 'team/partials/clarification_list.html.twig' with {clarifications: clarificationRequests} %}
+                {% endif %}
+            </div>
+        </div>
     </div>
 </div>
 <div>    

--- a/webapp/templates/team/partials/index_content.html.twig
+++ b/webapp/templates/team/partials/index_content.html.twig
@@ -8,18 +8,6 @@
     </h2>
 {% else %}
 
-    <div id="teamscoresummary">
-        {% set displayRank = not contest.freezeData.showFrozen %}
-        {% include 'partials/scoreboard_table.html.twig' with {displayRank: displayRank, jury: false, public: false} %}
-    </div>
-
-    <div class="mt-4" data-flash-messages>
-        {% include 'partials/messages.html.twig' %}
-        {% if not contest.allowSubmit %}
-            {% include 'partials/alert.html.twig' with {'type': 'danger', 'message': 'Submissions (temporarily) disabled.'} %}
-        {% endif %}
-    </div>
-
 <div class="row equal mt-3">
     <div class="col-sm-6">
         <div class="card mb-3">
@@ -30,8 +18,6 @@
                 {% include 'team/partials/submission_list.html.twig' %}
             </div>
         </div>
-    </div>
-    <div class="col-sm-6">
         <div class="card mb-3">
             <div class="card-header">
                 Clarifications
@@ -61,18 +47,32 @@
                 </a>
             </div>
         </div>
-        <div class="card mb-3">
+    </div>
+    <div class="col-sm-6">
+        <div class="card mb-3" style="margin: 0; background-color: #c4d8ff;">
+            <div class="center card-header">
+                Clarifications
+            </div>
+            <div class="card-body" style="padding: 0">
+                {% if clarifications is empty %}
+                    <p class="nodata">No clarifications.</p>
+                {% else %}
+                    {% include 'team/partials/clarification_list_suggested.html.twig' with {clarifications: clarifications} %}
+                {% endif %}
+            </div>
+        </div>
+        <div class="card mb-3" style="padding: 0; background-color: #c4d8ff;"">
             <div class="card-header">
                 Clarification Requests
                 <a style="float: right;" href="{{ path('team_clarification_add') }}" class="btn btn-secondary btn-sm" data-ajax-modal data-ajax-modal-after="initModalClarificationPreviewAdd">
                     Request clarification
                 </a>
             </div>
-            <div class="card-body">
+            <div class="card-body" style="padding: 0">
                 {% if clarificationRequests is empty %}
                     <p class="nodata">No clarification request.</p>
                 {% else %}
-                    {% include 'team/partials/clarification_list.html.twig' with {clarifications: clarificationRequests} %}
+                    {% include 'team/partials/clarification_list_suggested.html.twig' with {clarifications: clarificationRequests} %}
                 {% endif %}
             </div>
         </div>

--- a/webapp/templates/team/partials/index_content.html.twig
+++ b/webapp/templates/team/partials/index_content.html.twig
@@ -20,6 +20,50 @@
         {% endif %}
     </div>
 
+<div class="row equal mt-3">
+    <div class="col-sm-6">
+        <div class="card mb-3">
+            <div class="card-header">
+                Submissions
+            </div>
+            <div class="card-body">
+                {% include 'team/partials/submission_list.html.twig' %}
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6">
+        <div class="card mb-3">
+            <div class="card-header">
+                Clarifications
+            </div>
+            <div class="card-body">
+                {% if clarifications is empty %}
+                    <p class="nodata">No clarifications.</p>
+                {% else %}
+                    {% include 'team/partials/clarification_list.html.twig' with {clarifications: clarifications} %}
+                {% endif %}
+            </div>
+        </div>
+        <div class="card mb-3">
+            <div class="card-header">
+                Clarification Requests
+            </div>
+            <div class="card-body">
+                {% if clarificationRequests is empty %}
+                    <p class="nodata">No clarification request.</p>
+                {% else %}
+                    {% include 'team/partials/clarification_list.html.twig' with {clarifications: clarificationRequests} %}
+                {% endif %}
+            </div>
+            <div class="card-footer">
+                <a href="{{ path('team_clarification_add') }}" class="btn btn-secondary btn-sm" data-ajax-modal data-ajax-modal-after="initModalClarificationPreviewAdd">
+                    Request clarification
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+<div>    
     <div class="row">
         <div class="col">
             <h1 class="teamoverview">Submissions</h1>


### PR DESCRIPTION
Discussed with @nickygerritsen, a small demo on this idea. I think this looks a bit better and without it taking up valuable space.

I duplicated the old and the new stuff to show the difference, I think we can create more space by moving the `request clarification` button to the header. Not sure if we want to bring back the old color scheme? Next step would be to take away the clarification lists padding (and see if we have the same layout in the jury interface). 

![image](https://github.com/user-attachments/assets/215955bc-761c-4fa5-8514-018d4b082362)
