### PR TITLE
fix verification_required type error

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -369,7 +369,7 @@ class PublicController extends BaseController
             }
         }
 
-        $verificationRequired = $this->config->get('verification_required');
+        $verificationRequired = (bool)$this->config->get('verification_required');
 
         foreach ($submissions as $submission) {
             $teamKey = 'team-' . $submission->getTeam()->getExternalid();


### PR DESCRIPTION
In my development environment, I encountered an error when clicking the scoreboard. The `submissionVerdict` method was expecting a boolean value for the `$verificationRequired` parameter, but an integer value was being passed instead.

Part of #2427 


```
App\Controller\PublicController::submissionVerdict(): Argument #3 ($verificationRequired) must be of type bool, int given, called in /opt/domjudge/webapp/src/Controller/PublicController.php on line 386
```

![image](https://github.com/user-attachments/assets/e185c108-bd5c-4afa-af32-08b485fb3525)

