### PR TITLE
Fixes to API access endpoint and update some exposed properties

### DIFF
--- a/webapp/src/Controller/API/AccessController.php
+++ b/webapp/src/Controller/API/AccessController.php
@@ -100,9 +100,13 @@ class AccessController extends AbstractApiController
                         'name',
                         'formal_name',
                         'start_time',
+                        'countdown_pause_time',
                         'duration',
                         'scoreboard_freeze_duration',
+                        'scoreboard_thaw_time',
+                        'scoreboard_type',
                         'penalty_time',
+                        'banner',
                     ],
                 ),
                 new AccessEndpoint(
@@ -122,9 +126,8 @@ class AccessController extends AbstractApiController
                         'entry_point_required',
                         'entry_point_name',
                         'extensions',
-                        // TODO: we don't support these yet
-//                        'compiler.command',
-//                        'runner.command',
+                        'compiler',
+                        'runner',
                     ],
                 ),
                 new AccessEndpoint(
@@ -160,9 +163,24 @@ class AccessController extends AbstractApiController
                         'id',
                         'icpc_id',
                         'name',
+                        'label',
                         'display_name',
                         'organization_id',
                         'group_ids',
+                        'hidden',
+                        'location',
+                        'photo',
+                    ]
+                ),
+                new AccessEndpoint(
+                    type: 'accounts',
+                    properties: [
+                        'id',
+                        'username',
+                        'name',
+                        'type',
+                        'ip',
+                        'team_id',
                     ]
                 ),
                 new AccessEndpoint(
@@ -203,6 +221,19 @@ class AccessController extends AbstractApiController
                         'time',
                         'contest_time',
                         'run_time',
+                    ],
+                ),
+                new AccessEndpoint(
+                    type: 'clarifications',
+                    properties: [
+                        'id',
+                        'from_team_id',
+                        'to_team_id',
+                        'reply_to_id',
+                        'problem_id',
+                        'text',
+                        'time',
+                        'contest_time',
                     ],
                 ),
                 new AccessEndpoint(

--- a/webapp/src/Controller/API/AccessController.php
+++ b/webapp/src/Controller/API/AccessController.php
@@ -59,6 +59,9 @@ class AccessController extends AbstractApiController
             $organizationProperties[] = 'country';
             $organizationProperties[] = 'country_flag';
         }
+        if ($this->config->get('show_affiliation_logos')) {
+            $organizationProperties[] = 'logo';
+        }
 
         $submissionsProperties = [
             'id',

--- a/webapp/src/Controller/API/AccessController.php
+++ b/webapp/src/Controller/API/AccessController.php
@@ -49,6 +49,9 @@ class AccessController extends AbstractApiController
             'icpc_id',
             'name',
             'formal_name',
+            // DOMjudge specific properties:
+            'affilid',
+            'shortname',
         ];
 
         // Add country data to organizations if supported
@@ -65,6 +68,9 @@ class AccessController extends AbstractApiController
             'time',
             'contest_time',
             'entry_point',
+            // DOMjudge specific properties:
+            'submitid',
+            'import_error',
         ];
 
         // Add files to submissions if allowed
@@ -107,6 +113,14 @@ class AccessController extends AbstractApiController
                         'scoreboard_type',
                         'penalty_time',
                         'banner',
+                        // DOMjudge specific properties:
+                        'cid',
+                        'short_name',
+                        'end_time',
+                        'allow_submit',
+                        'runtime_as_score_tiebreaker',
+                        'warning_message',
+                        'problemset',
                     ],
                 ),
                 new AccessEndpoint(
@@ -128,6 +142,10 @@ class AccessController extends AbstractApiController
                         'extensions',
                         'compiler',
                         'runner',
+                        // DOMjudge specific properties:
+                        'allow_judge',
+                        'time_factor',
+                        'filter_compiler_files',
                     ],
                 ),
                 new AccessEndpoint(
@@ -142,6 +160,8 @@ class AccessController extends AbstractApiController
                         'time_limit',
                         'test_data_count',
                         'statement',
+                        // DOMjudge specific properties:
+                        'probid',
                     ],
                 ),
                 new AccessEndpoint(
@@ -151,6 +171,11 @@ class AccessController extends AbstractApiController
                         'icpc_id',
                         'name',
                         'hidden',
+                        // DOMjudge specific properties:
+                        'categoryid',
+                        'sortorder',
+                        'color',
+                        'allow_self_registration',
                     ],
                 ),
                 new AccessEndpoint(
@@ -170,6 +195,11 @@ class AccessController extends AbstractApiController
                         'hidden',
                         'location',
                         'photo',
+                        // DOMjudge specific properties:
+                        'teamid',
+                        'affiliation',
+                        'nationality',
+                        'public_description',
                     ]
                 ),
                 new AccessEndpoint(
@@ -181,6 +211,16 @@ class AccessController extends AbstractApiController
                         'type',
                         'ip',
                         'team_id',
+                        // DOMjudge specific properties:
+                        'first_login_time',
+                        'last_login_time',
+                        'last_api_login_time',
+                        'team',
+                        'roles',
+                        'userid',
+                        'email',
+                        'last_ip',
+                        'enabled',
                     ]
                 ),
                 new AccessEndpoint(
@@ -209,6 +249,8 @@ class AccessController extends AbstractApiController
                         'end_time',
                         'end_contest_time',
                         'max_run_time',
+                        // DOMjudge specific properties:
+                        'valid',
                     ],
                 ),
                 new AccessEndpoint(
@@ -234,6 +276,9 @@ class AccessController extends AbstractApiController
                         'text',
                         'time',
                         'contest_time',
+                        // DOMjudge specific properties:
+                        'clarid',
+                        'answered',
                     ],
                 ),
                 new AccessEndpoint(

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -111,6 +111,7 @@ class Problem extends BaseApiEntity implements
     /**
      * @var array<int, string>
      */
+    #[Serializer\Exclude]
     private array $typesToString = [
         self::TYPE_PASS_FAIL => 'pass-fail',
         self::TYPE_SCORING => 'scoring',

--- a/webapp/tests/Unit/Controller/API/AccessControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AccessControllerTest.php
@@ -36,10 +36,12 @@ class AccessControllerTest extends BaseTestCase
             'groups' => ['id', 'icpc_id', 'name', 'hidden'],
             'organizations' => ['id', 'icpc_id', 'name', 'formal_name', 'country', 'country_flag'],
             'teams' => ['id', 'icpc_id', 'name', 'display_name', 'organization_id', 'group_ids'],
+            'accounts' => ['id', 'username', 'name', 'type'],
             'state' => ['started', 'frozen', 'ended', 'thawed', 'finalized', 'end_of_updates'],
             'submissions' => ['id', 'language_id', 'problem_id', 'team_id', 'time', 'contest_time', 'entry_point', 'files'],
             'judgements' => ['id', 'submission_id', 'judgement_type_id', 'start_time', 'start_contest_time', 'end_time', 'end_contest_time', 'max_run_time'],
             'runs' => ['id', 'judgement_id', 'ordinal', 'judgement_type_id', 'time', 'contest_time', 'run_time'],
+            'clarifications' => ['id', 'from_team_id', 'problem_id', 'text', 'time', 'contest_time'],
             'awards' => ['id', 'citation', 'team_ids'],
         ];
 
@@ -54,7 +56,9 @@ class AccessControllerTest extends BaseTestCase
                     break;
                 }
             }
-            self::assertSame($expectedProperties, $actualProperties);
+            foreach ($expectedProperties as $property) {
+                self::assertContains($property, $actualProperties);
+            }
         }
     }
 }


### PR DESCRIPTION
List all properties (also DOMjudge specific ones) in the [access](https://ccs-specs.icpc.io/draft/contest_api#access) API endpoint, and add endpoints `accounts` and `clarifications` there.

Also remove exposing `problems.types_to_string` and add `judgements.current` (as alias of `valid`).