### PR TITLE
Fix user add and update api endpoints

### DIFF
--- a/webapp/src/DataTransferObject/AddUser.php
+++ b/webapp/src/DataTransferObject/AddUser.php
@@ -4,27 +4,24 @@ namespace App\DataTransferObject;
 
 use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
 
-#[OA\Schema(required: ['username', 'name', 'roles'])]
 class AddUser
 {
+    #[Assert\NotBlank]
+    public string $username;
+    #[Assert\NotBlank]
+    public string $name;
+    public ?string $id = null;
+    public ?string $email = null;
+    public ?string $ip = null;
+    #[OA\Property(format: 'password')]
+    public ?string $password = null;
+    public ?bool $enabled = null;
+    public ?string $teamId = null;
     /**
-     * @param array<string> $roles
+     * @var array<string>
      */
-    public function __construct(
-        public readonly string $username,
-        public readonly string $name,
-        #[OA\Property(format: 'email', nullable: true)]
-        public readonly ?string $email,
-        #[OA\Property(nullable: true)]
-        public readonly ?string $ip,
-        #[OA\Property(format: 'password', nullable: true)]
-        public readonly ?string $password,
-        #[OA\Property(nullable: true)]
-        public readonly ?bool $enabled,
-        #[OA\Property(nullable: true)]
-        public readonly ?string $teamId,
-        #[Serializer\Type('array<string>')]
-        public readonly array $roles,
-    ) {}
+    #[Serializer\Type('array<string>')]
+    public array $roles = [];
 }

--- a/webapp/src/DataTransferObject/UpdateUser.php
+++ b/webapp/src/DataTransferObject/UpdateUser.php
@@ -2,22 +2,23 @@
 
 namespace App\DataTransferObject;
 
+use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
 
-#[OA\Schema(required: ['id', 'username', 'name', 'roles'])]
-class UpdateUser extends AddUser
+class UpdateUser
 {
-    public function __construct(
-        public readonly string $id,
-        string $username,
-        string $name,
-        ?string $email,
-        ?string $ip,
-        ?string $password,
-        ?bool $enabled,
-        ?string $teamId,
-        array $roles
-    ) {
-        parent::__construct($username, $name, $email, $ip, $password, $enabled, $teamId, $roles);
-    }
+    public ?string $id = null;
+    public ?string $username = null;
+    public ?string $name = null;
+    public ?string $email = null;
+    public ?string $ip = null;
+    #[OA\Property(format: 'password')]
+    public ?string $password = null;
+    public ?bool $enabled = null;
+    public ?string $teamId = null;
+    /**
+     * @var array<string>
+     */
+    #[Serializer\Type('array<string>')]
+    public array $roles = [];
 }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace App\Entity;
 
 use App\Controller\API\AbstractRestController as ARC;
@@ -132,7 +133,7 @@ class User extends BaseApiEntity implements
     #[ORM\JoinTable(name: 'userrole')]
     #[ORM\JoinColumn(name: 'userid', referencedColumnName: 'userid', onDelete: 'CASCADE')]
     #[ORM\InverseJoinColumn(name: 'roleid', referencedColumnName: 'roleid', onDelete: 'CASCADE')]
-    #[Assert\Count(min: 1)]
+    #[Assert\Count(min: 1, minMessage: 'User should have at least {{ limit }} role')]
     #[Serializer\Exclude]
     private Collection $user_roles;
 
@@ -439,9 +440,14 @@ class User extends BaseApiEntity implements
         // Types allowed by the CCS Specs Contest API in order of most permissions to least.
         // Either key=>value where key is the DOMjudge role and value is the API account type or
         // only value, where both the DOMjudge role and API type are the same.
-        $allowedTypes = ['admin', 'api_writer' => 'admin', 'api_reader' => 'admin',
-                         'jury' => 'judge', 'api_source_reader' => 'judge',
-                         'team'];
+        $allowedTypes = [
+            'admin',
+            'api_writer' => 'admin',
+            'api_reader' => 'admin',
+            'jury' => 'judge',
+            'api_source_reader' => 'judge',
+            'team'
+        ];
         foreach ($allowedTypes as $role => $allowedType) {
             if (is_numeric($role)) {
                 $role = $allowedType;

--- a/webapp/src/EventListener/ValidationExceptionListener.php
+++ b/webapp/src/EventListener/ValidationExceptionListener.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+#[AsEventListener(event: 'kernel.exception', priority: 0)]
+class ValidationExceptionListener
+{
+    public function __invoke(ExceptionEvent $event): void
+    {
+        $e = $event->getThrowable();
+
+        if (!$e instanceof ValidationFailedException) {
+            return;
+        }
+
+        $errors = [];
+        foreach ($e->getViolations() as $violation) {
+            $errors[] = [
+                'property' => $violation->getPropertyPath(),
+                'message'  => $violation->getMessage(),
+                'code'     => $violation->getCode(),
+            ];
+        }
+
+        $response = new JsonResponse([
+            'title'  => 'Bad Request',
+            'status' => 400,
+            'errors' => $errors,
+        ], 400);
+
+        $event->setResponse($response);
+    }
+}


### PR DESCRIPTION
Found some bugs while using the API, and since I need the endpoints, fixed them.

Problem I encountered:
Endpoint /api/v4/users/{id} PUT request returned{ 400, Body data exceeded php.ini's 'post_max_size' directive (currently set to 512M)}.
Could not get it to work whatever I tried. When looking at the code I also discovered some other issues in the case of updating the user with App\Controller\API\UserController.php addOrUpdateUser(). 
What I did is changing the content type of the api-doc attribute to application/json, and separated the add and update method in to dedicated methods. I realize this is a breaking change in the api spec and not ideal.

I got the errors on both the DOMjudge instance running on the GEHACK server in Eindhoven, and my own local instance.


This exception is generated in App\EventListener\BodyToBigListener.php. This happens because the amount of parameters on the request is 0. (I get this even when using /api/doc on a running domjudge instance). I first tried fixing the request, but could not get it to work. Because it made more sense to me for a request like this to accept json instead of formdata I decided to change it to that. After I did this the request now worked, but i found some flaws in the update logic for user. 

For example: name, username and id are required to even make an update by the documentation. I would have expected to just need an id and being able to update any field. Then, on line 150 in App\Controller\Api\Usercontroler:
``` 
protected function addOrUpdateUser(AddUser $addUser, Request $request): Response
    {
        if ($addUser instanceof UpdateUser && !$addUser->id) {
            throw new BadRequestHttpException('`id` field is required');
        }

        if ($this->em->getRepository(User::class)->findOneBy(['username' => $addUser->username])) {
            throw new BadRequestHttpException(sprintf("User %s already exists", $addUser->username));
        }
        $user = new User();
              if ($addUser instanceof UpdateUser) {
                  $existingUser = $this->em->getRepository(User::class)->findOneBy(['externalid' => $addUser->id]);
                  if ($existingUser) {
                      $user = $existingUser;
                  }
              }

        $user
            ->setUsername($addUser->username)
            ->setName($addUser->name)
            ->setEmail($addUser->email)
            ->setIpAddress($addUser->ip)
            ->setPlainPassword($addUser->password)
            ->setEnabled($addUser->enabled ?? true);

       // rest of method
}
```
So if the user already exists we get a BadRequestException. This effectively means that for every update we want to do to a user, the username has to be changed.
Then also we cannot do partial update by leaving fields in the request null, since all properties of the UpdateUser dto are assigned to the existing user, even when null. 