### PR TITLE
Fix maintainer install nginx option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ inplace-postinstall-nginx: inplace-postinstall-permissions
 	fi
 	@service="php-fpm"; phppool="$(fedpool)"; \
 	if [ -d "$(debpool)" ]; then \
-		phppool="ln -sf $(CURDIR)/etc/domjudge-fpm.conf $(debpool)/domjudge-fpm.conf"; \
+		phppool="$(debpool)"; \
 		service="php$(PHPVERSION)-fpm"; \
 	fi; \
 	service="systemctl restart $$service"; \


### PR DESCRIPTION
The duplication for fedora was not correctly fixed for debian based installs in 540a41ef5ec8e3589591d775e80794ad717449d8.