### PR TITLE
Don't display output if the key isn't set

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -727,7 +727,7 @@
                             show complete metadata
                         </button>
                         {% if runsOutput[runIdx].metadata is not null %}
-                            {% if runsOutput[runIdx].output_limit %}
+                            {% if runsOutput[runIdx].output_limit is defined %}
                                 <div class="alert alert-warning">
                                     The submission output (<code>{{ runsOutput[runIdx].output_limit }}</code>) was
                                     truncated because of the configured output limit.


### PR DESCRIPTION
Catched while investigating a broken judgedaemon config.

(cherry picked from commit c126845c6e0b282f82846cc73adaea267b6c2e4d)