### PR TITLE
Pass separate CPU/wall time limits through testcase_run.sh

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1421,12 +1421,16 @@ function judge(array $judgeTask): bool
     $hardtimelimit = $run_config['time_limit']
         +  overshoot_time($run_config['time_limit'], $overshoot)
         + $run_config['overshoot'];
+    $timelimit = [
+        'cpu'  => [ $run_config['time_limit'], $hardtimelimit ],
+        'wall' => [ $run_config['time_limit'], $hardtimelimit ],
+    ];
     if ($combined_run_compare) {
         // This accounts for wall time spent in the validator. We may likely
         // want to make this configurable in the future. The current factor is
         // under the assumption that the validator has to do approximately the
         // same amount of work wall-time wise as the submission.
-        $hardtimelimit *= 2;
+        $timelimit['wall'][1] *= 2;
     }
 
     // While we already set those above to likely the same values from the
@@ -1462,11 +1466,12 @@ function judge(array $judgeTask): bool
             }
         }
 
+        $timelimit_str = implode(':', $timelimit['cpu']) . ',' . implode(':', $timelimit['wall']);
         $test_run_cmd = LIBJUDGEDIR . "/testcase_run.sh $cpuset_opt " .
             implode(' ', array_map('dj_escapeshellarg', [
                 $input,
                 $output,
-                "$run_config[time_limit]:$hardtimelimit",
+                $timelimit_str,
                 $passdir,
                 $run_runpath,
                 $compare_runpath,

--- a/judge/testcase_run.sh
+++ b/judge/testcase_run.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# To suppress false positive of FILELIMIT misspelling of TIMELIMIT:
+# shellcheck disable=SC2153
 
 # Script to test (run and compare) submissions with a single testcase
 #
@@ -7,8 +9,8 @@
 #
 # <testdata.in>     File containing test-input with absolute pathname.
 # <testdata.out>    File containing test-output with absolute pathname.
-# <timelimit>       Timelimit in seconds, optionally followed by ':' and
-#                   the hard limit to kill still running submissions.
+# <timelimit>       Timelimit in seconds in the format
+#                   "<cpu_soft>:<cpu_hard>,<wall_soft>:<wall_hard>".
 # <workdir>         Directory where to execute submission in a chroot-ed
 #                   environment. For best security leave it as empty as possible.
 #                   Certainly do not place output-files there!
@@ -200,15 +202,15 @@ if [ $COMBINED_RUN_COMPARE -eq 1 ]; then
 fi
 
 exitcode=0
-# To suppress false positive of FILELIMIT misspelling of TIMELIMIT:
-# shellcheck disable=SC2153
+TIMELIMIT_CPU="${TIMELIMIT%%,*}"
+TIMELIMIT_WALL="${TIMELIMIT#*,}"
 runcheck "$RUN_SCRIPT" $RUNARGS \
 	$GAINROOT "$RUNGUARD" ${DEBUG:+-v -V "DEBUG=$DEBUG"} ${TMPDIR:+ -V "TMPDIR=$TMPDIR"} $CPUSET_OPT \
 	-r "$PWD/../.." \
 	--nproc=$PROCLIMIT \
 	--no-core --streamsize=$FILELIMIT \
 	--user="$RUNUSER" --group="$RUNGROUP" \
-	--walltime=$TIMELIMIT --cputime=$TIMELIMIT \
+	--walltime="$TIMELIMIT_WALL" --cputime="$TIMELIMIT_CPU" \
 	--memsize=$MEMLIMIT --filesize=$FILELIMIT \
 	--stderr=program.err --outmeta=program.meta -- \
 	"$PREFIX/$PROGRAM" 2>runguard.err


### PR DESCRIPTION
The script doesn't do anything with these, so this way, we have more flexibility in setting them separately and we can increase only the wall clock hard time limit for interactive problems.