### PR TITLE
Allow for ms precision in contest start time.

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -749,9 +749,10 @@ class ExternalContestSourceService
                     [$feedTimezone->getName(), $ourTimezone->getName()]
                 );
             }
+            // We do use precise time with milliseconds if provided, but strip trailing .000 off to make it look nicer.
             $toCheck = [
                 'start_time_enabled' => true,
-                'start_time_string'  => $startTime->format('Y-m-d H:i:s ') . $timezoneToUse,
+                'start_time_string'  => preg_replace('/\.000$/', '', $startTime->format('Y-m-d H:i:s.v')) . ' ' . $timezoneToUse),
                 'end_time_string'    => preg_replace('/\.000$/', '', $fullDuration),
                 'freeze_time_string' => preg_replace('/\.000$/', '', $fullFreeze),
             ];


### PR DESCRIPTION
Also explain why we are stripping off .000.