### PR TITLE
Allow the judgehost role to access submissions past end of contest vi…

### DIFF
--- a/webapp/src/Controller/API/SubmissionController.php
+++ b/webapp/src/Controller/API/SubmissionController.php
@@ -455,7 +455,8 @@ class SubmissionController extends AbstractRestController
 
         // If an ID has not been given directly, only show submissions before contest end.
         // This allows us to use eventlog on too-late submissions while not exposing them in the API directly.
-        if (!$request->attributes->has('id') && !$request->query->has('ids') && !$this->dj->checkrole('admin')) {
+        if (!$request->attributes->has('id') && !$request->query->has('ids') &&
+            !($this->dj->checkrole('admin') || $this->dj->checkrole('judgehost'))) {
             $queryBuilder->andWhere('s.submittime < c.endtime');
         }
 


### PR DESCRIPTION
…a the API.

This is already possible by requesting a specific submissions; this will make it more consistent.