### PR TITLE
Fix output limit warning.

### DIFF
--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -727,7 +727,7 @@
                             show complete metadata
                         </button>
                         {% if runsOutput[runIdx].metadata is not null %}
-                            {% if runsOutput[runIdx].output_limit is defined %}
+                            {% if runsOutput[runIdx].output_limit is defined and runsOutput[runIdx].output_limit %}
                                 <div class="alert alert-warning">
                                     The submission output (<code>{{ runsOutput[runIdx].output_limit }}</code>) was
                                     truncated because of the configured output limit.


### PR DESCRIPTION
This broke after trying to fix another bug in
43b9c88d8d1bda82c3391e494774a57fdb093fbb.

(cherry picked from commit b3811b5d04df5c0d3015290e058b832d0a8e6bfe)