### PR TITLE
Improve runguard error message when command cannot be executed

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -815,6 +815,20 @@ int groupid(char *name)
 	return (int) grp->gr_gid;
 }
 
+char *username()
+{
+	int saved_errno = errno;
+	errno = 0; /* per the linux GETPWNAM(3) man-page */
+
+	struct passwd *pwd;
+	pwd = getpwuid(getuid());
+
+	if ( pwd==nullptr || errno ) error(errno,"failed to get username");
+	errno = saved_errno;
+
+	return pwd->pw_name;
+}
+
 long read_optarg_int(const char *desc, long minval, long maxval)
 {
 	char *ptr;
@@ -1426,9 +1440,7 @@ int main(int argc, char **argv)
 
 		/* And execute child command. */
 		execvp(cmdname,cmdargs);
-		struct rlimit limit;
-		getrlimit(RLIMIT_NPROC, &limit);
-		error(errno,"cannot start `%s', limit: %ld/%ld | ",cmdname, limit.rlim_cur, limit.rlim_max);
+		error(errno,"cannot start `%s' as user `%s'", cmdname, username());
 
 	default: /* become watchdog */
 		verbose("child pid = %d", child_pid);


### PR DESCRIPTION
When the system error is "Permission denied" this typically means that the full path of the command is not traversible for the user. This can happen for example when a validator is executed as `domjudge-run` user and `/home/domjudge` does not have `o+x` set.

(cherry picked from commit aa67a2ba19d2ae2b53df877e74e0b9259656cfbc)