### PR TITLE
Properly restrict clarification thread to team.

### DIFF
--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -101,9 +101,12 @@ class ClarificationController extends BaseController
             throw new HttpException(401, 'Permission denied');
         }
 
-        // Get the "parent" message if we have one.
+        // Get the "parent" message if we have one - if we have access to it
         if ($clarification->getInReplyTo()) {
-            $clarification = $clarification->getInReplyTo();
+            $parent = $clarification->getInReplyTo();
+            if ($team->canViewClarification($parent)) {
+                $clarification = $parent;
+            }
         }
 
         // Mark clarification as read.


### PR DESCRIPTION
Previously, the following could happen:
- team A requests a clarification, potentially including details the jury doesn't want to broadcast
- the jury replies to everyone, removing the part from the question that they don't want to have broadcasted
- team B views the reply from the jury, sees the whole clarification thread

Found while working on https://github.com/DOMjudge/domjudge/pull/3087