### PR TITLE
Fix scoreboard update after rejudging.

### DIFF
--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -359,6 +359,16 @@ class Submission extends BaseApiEntity implements
         return $this->judgings;
     }
 
+    public function getValidJudging(): ?Judging
+    {
+        foreach ($this->judgings as $j) {
+            if ($j->getValid()) {
+                return $j;
+            }
+        }
+        return null;
+    }
+
     public function setLanguage(?Language $language = null): Submission
     {
         $this->language = $language;
@@ -535,6 +545,16 @@ class Submission extends BaseApiEntity implements
     public function getExternalJudgements(): Collection
     {
         return $this->external_judgements;
+    }
+
+    public function getValidExternalJudgement(): ?ExternalJudgement
+    {
+        foreach ($this->external_judgements as $ej) {
+            if ($ej->getValid()) {
+                return $ej;
+            }
+        }
+        return null;
     }
 
     public function setFileForApi(?FileWithName $fileForApi = null): Submission

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -262,9 +262,9 @@ class ScoreboardService
         foreach ($submissions as $submission) {
             /** @var Judging|ExternalJudgement|null $judging */
             if ($useExternalJudgements) {
-                $judging = $submission->getExternalJudgements()->first() ?: null;
+                $judging = $submission->getValidExternalJudgement();
             } else {
-                $judging = $submission->getJudgings()->first() ?: null;
+                $judging = $submission->getValidJudging();
             }
 
             // three things will happen in the loop in this order:


### PR DESCRIPTION
Previous buggy flow was something like:
- fetch all submissions that for this team/contest/problem combination
- that are valid
- and have a valid judging

The idea of https://github.com/DOMjudge/domjudge/blob/95df1de7bce91f43600cfcb8760ea85762936614/webapp/src/Service/ScoreboardService.php#L240 was that this would filter the OneToMany collection down to only valid judgings. This is also what happens on the database side.

However, on the doctrine side, the entity manager keeps a cache, and if the submission is already in the cache with the full collection of valid and invalid judgings, it will only merged with new data from the database query, no data (i.e. no judgings) will magically disappear.

In order to fix this, we explicitly filter on the PHP side. An alternative would be to add a new `OneToMany` mapping with a `where` on it and use that.

Fixes https://github.com/DOMjudge/domjudge/issues/2883