### PR TITLE
Bump timeout on GitHub to 30mins while preparing the chroot takes lon…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     container:
       image: domjudge/gitlabci:24.04
       options: --privileged --cgroupns=host --init

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   runpipe:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     container:
       image: domjudge/gitlabci:24.04
       options: --privileged --cgroupns=host --init

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       checks: write
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     container:
       image: domjudge/gitlabci:24.04
     services:


### PR DESCRIPTION
…ger than usual.