### PR TITLE
Record submission source in database.

### DIFF
--- a/webapp/migrations/Version20250907161952.php
+++ b/webapp/migrations/Version20250907161952.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250907161952 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add submission source to submission info.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submission ADD source VARCHAR(255) NOT NULL COMMENT \'Where did we receive this submission from?\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submission DROP source');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -102,6 +102,12 @@ class Submission extends BaseApiEntity implements
     #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
     private ?string $importError = null;
 
+    #[ORM\Column(options: [
+        'comment' => 'Where did we receive this submission from?',
+    ])]
+    #[Serializer\Exclude]
+    private SubmissionSource $source = SubmissionSource::UNKNOWN;
+
     #[ORM\ManyToOne(inversedBy: 'submissions')]
     #[ORM\JoinColumn(name: 'cid', referencedColumnName: 'cid', onDelete: 'CASCADE')]
     #[Serializer\Exclude]
@@ -552,5 +558,16 @@ class Submission extends BaseApiEntity implements
     public function getFileForApi(): array
     {
         return array_filter([$this->fileForApi]);
+    }
+
+    public function setSource(SubmissionSource $source): Submission
+    {
+        $this->source = $source;
+        return $this;
+    }
+
+    public function getSource(): SubmissionSource
+    {
+        return $this->source;
     }
 }

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -700,7 +700,8 @@ class SubmissionService
             ->setOriginalSubmission($originalSubmission)
             ->setEntryPoint($entryPoint)
             ->setExternalid($externalId)
-            ->setImportError($importError);
+            ->setImportError($importError)
+            ->setSource($source);
 
         // Add expected results from source. We only do this for jury submissions
         // to prevent accidental auto-verification of team submissions.


### PR DESCRIPTION
The motivation for this is that we can use the data to fix the various errors we have seen across the interface when shadowing one by one. But it can also be useful for other reasons, e.g. being able to count how many submissions were received via the API vs web UI.