### PR TITLE
Fix cgroup checks for containers

### DIFF
--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -34,8 +34,8 @@ You can try using cgroup V1 by adding systemd.unified_cgroup_hierarchy=0 to the 
     if ! echo "+cpuset" >> /sys/fs/cgroup/cgroup.subtree_control; then
         cgroup_error_and_usage "Error: Cannot add +cpuset to cgroup.subtree_control; check kernel params."
     fi
-    if ! grep -q "slice" /proc/self/cgroup; then
-        cgroup_error_and_usage "Error: Cgroups not configured properly, missing systemd slice under /proc/self/cgroup. If running under docker, make sure to set cgroupns=host."
+    if grep -q ":/$" /proc/self/cgroup; then
+        cgroup_error_and_usage "Error: Cgroups not configured properly, missing cgroup hierarchy prefix under /proc/self/cgroup. If running in a container, make sure to set cgroupns=host."
     fi
 
 else # Trying cgroup V1:


### PR DESCRIPTION
There does not have to be a `slice` string in containers. For example, when running the container in podman:
```
domjudge@5ad0debee049:/$ cat /proc/self/cgroup
0::/libpod_parent/libpod-5ad0debee049e150d851d81fa3e8184ee20725412e5702c7ffe3aae7e5173207
```

Fixes starting issue introduced in b2720396d7f2c9e696002703c3a160a2fb895995