### PR TITLE
Switch bucket size for problem analysis

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -1119,9 +1119,7 @@ function resizeMobileTeamNamesAndProblemBadges() {
     });
 }
 
-function createSubmissionGraph(submissionStats, contestStartTime, contestDurationSeconds, submissions) {
-    const minBucketCount = 30;
-    const maxBucketCount = 301;
+function createSubmissionGraph(submissionStats, contestStartTime, contestDurationSeconds, submissions, minBucketCount = 30, maxBucketCount = 301) {
     const units = [
         { 'name': 'seconds', 'convert': 1, 'step': 60 },
         { 'name': 'minutes', 'convert': 60, 'step': 15 },

--- a/webapp/templates/jury/analysis/problem.html.twig
+++ b/webapp/templates/jury/analysis/problem.html.twig
@@ -234,7 +234,7 @@ $(function(){
       }{{ loop.last ? '' : ',' }}
       {% endfor %}
     ];
-    createSubmissionGraph(submission_stats, contest_start_time, contest_duration_seconds, submissions);
+    createSubmissionGraph(submission_stats, contest_start_time, contest_duration_seconds, submissions, minBucketCount = 10, maxBucketCount = 101);
 })
 </script>
 {% include 'jury/analysis/download_graphs.html.twig' %}


### PR DESCRIPTION
The graph has less space on the page, so the buckets got too narrow.

Old graph:
<img width="1039" height="467" alt="image" src="https://github.com/user-attachments/assets/31bdd289-cc81-42ed-88a1-827893a8ee49" />


New graph:
<img width="1038" height="467" alt="image" src="https://github.com/user-attachments/assets/421c736c-83ca-418a-a3af-f350b85421b1" />
