### PR TITLE
Render clarification preview summary with markdown

### DIFF
--- a/webapp/templates/team/partials/clarification_list.html.twig
+++ b/webapp/templates/team/partials/clarification_list.html.twig
@@ -55,7 +55,7 @@
 
                 <td>
                     <a data-ajax-modal data-ajax-modal-after="markSeen" href="{{ link }}">
-                        {{ clarification.summary }}
+                        {{ clarification.summary | markdown_to_html | sanitize_html('app.clarification_sanitizer') }}
                     </a>
                 </td>
             </tr>


### PR DESCRIPTION
The clarification summary on the team overview page didn't render markdown correctly.

New:
<img width="1647" height="1104" alt="image" src="https://github.com/user-attachments/assets/e2287610-9bd2-492f-84c7-fe261e16c4b6" />

Found when playing around with MathJax but probably better on it's own.
