### PR TITLE
Do not always consume the mouse wheel

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -868,6 +868,7 @@ $(function() {
         const editor = monaco.editor.create(element, {
             value: content,
             scrollbar: {
+                alwaysConsumeMouseWheel: false,
                 vertical: 'auto',
                 horizontal: 'auto'
             },
@@ -944,6 +945,7 @@ $(function() {
         const diffEditor = monaco.editor.createDiffEditor(
             document.getElementById("__EDITOR__"), {
             scrollbar: {
+                alwaysConsumeMouseWheel: false,
                 vertical: 'auto',
                 horizontal: 'auto'
             },


### PR DESCRIPTION
As both the page and the editor can have a scrollbar, the editor should not always consume it. This allows for scrolling the page when the editor has reached its limits.

When we opt for a stretching editor without scroll, we will still need this option anyway.

Related to #3058