### PR TITLE
Allow languages in problem name

### DIFF
--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -395,7 +395,7 @@ class ImportExportService
     /**
      * @param array{name?: string, short-name?: string, id?: string, label?: string,
      *              letter?: string, time_limit?: int, rgb?: string, color?: string,
-     *              problems?: array{name?: string, short-name?: string, id?: string, label?: string,
+     *              problems?: array{name?: string|array<string, string>, short-name?: string, id?: string, label?: string,
      *                              letter?: string, label?: string, letter?: string}} $problems
      * @param string[]|null $ids
      * @param array<string, string[]> $messages
@@ -412,6 +412,16 @@ class ImportExportService
             // Deal with obsolete attribute names. Also for name fall back to ID if it is not specified.
             $problemName  = $problemData['name'] ?? $problemData['short-name'] ?? $problemData['id'] ?? null;
             $problemLabel = $problemData['label'] ?? $problemData['letter'] ?? null;
+
+            // The 2025-09 problem spec allows a 'language code'->'name' map.
+            if (is_array($problemName)) {
+                if (array_key_exists('en', $problemName)) {
+                    $problemName = $problemName['en'];
+                } else {
+                    $errorMessage = sprintf("Problem '%s' should have an English name", $problemName['id']);
+                    return false;
+                }
+            }
 
             $problem = new Problem();
             $problem


### PR DESCRIPTION
- [ ] Removed scoring objective; this now always is "maximize".
- [ ] Removed scoring keyword from problem.yaml.
- [ ] Python 3 is now used for .py files; for backward compatibility .py2 can still be used for Python 2.
- [ ] Clarify various things: sample files for interactive problems, testdata.yaml inheritance.
- [ ] Updated the CC BY-SA license key to mean version 4.0.
- [ ] Allow either a build or run script to be present.
- [ ] Change specification of time limit multipliers and allow to explicitly specify a problem time limit.
- [ ] Add the problem types multi-pass and submit-answer.
- [ ] Add static validators, validators whose input is submission source code.
- [ ] Support invalid testdata that validators must fail on.
- [ ] Only allow a single output validator, remove validator_flags from problem.yaml, update {input,output}_validator_flags in testdata.yaml.
- [x] Make name required and allow a map from language code to name in that language.
- [ ] Add uuid to problem.yaml.
- [ ] Add languages to problem.yaml.
- [ ] Add support for Markdown problem statements.
- [ ] Change languages: and keywords: in problem.yaml to be lists of strings rather than a string of space separated words.
- [ ] Clarified when code limit is applied in the case of included code
- [ ] Make uuid required in problem.yaml.
- [ ] Add /submissions/rejected directory.
- [ ] Clarify working directories for submissions and validators.
- [ ] Add allow_writing_files to problem.yaml.
- [ ] Rename testdata.yaml to test_group.yaml.
