### PR TITLE
Handle expected 204

### DIFF
--- a/misc-tools/dj_utils.py
+++ b/misc-tools/dj_utils.py
@@ -147,11 +147,12 @@ def upload_file(name: str, apifilename: str, file: str, data: dict = {}):
 
         result = parse_api_response(name, response)
 
-    try:
-        result = json.loads(result)
-    except json.decoder.JSONDecodeError as e:
-        print(result)
-        raise RuntimeError(f'Failed to JSON decode the response for API file upload request {name}')
+    if result is not None:
+        try:
+            result = json.loads(result)
+        except json.decoder.JSONDecodeError as e:
+            print(result)
+            raise RuntimeError(f'Failed to JSON decode the response for API file upload request {name}')
 
     return result
 


### PR DESCRIPTION
In case of uploading the problemset we expect a HTTP204 which is not valid JSON and would throw an error by design.