### PR TITLE
Fix incorrect link generation for testcase audit logs

### DIFF
--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -155,11 +155,8 @@ class AuditLogController extends AbstractController
                 }
                 return $this->generateUrl('jury_user', ['userId' => $id]);
             case 'testcase':
-                $testcase = $this->em->getRepository(Testcase::class)->find($id);
-                if ($testcase && $testcase->getProblem()) {
-                    return $this->generateUrl('jury_problem_testcases', ['probId' => $testcase->getProblem()->getProbid()]);
-                }
-                break;
+                // For testcase audit logs, the ID is actually the problem ID
+                return $this->generateUrl('jury_problem_testcases', ['probId' => $id]);
         }
         return null;
     }


### PR DESCRIPTION
The stored ID in the audit log is the problem ID, not a testcase ID

So searching for a testcase by a problem ID results in an incorrect link to a completely different problem.

Storing the problematic audit log happens here https://github.com/DOMjudge/domjudge/blob/af926294f1a5c054dd170a373fe538d47012b0e8/webapp/src/Controller/Jury/ProblemController.php#L634

I also saw a generic audit log mechanism in BaseController
https://github.com/DOMjudge/domjudge/blob/af926294f1a5c054dd170a373fe538d47012b0e8/webapp/src/Controller/BaseController.php#L154

I am wondering if this is a correct-intended behavior. On one side, I see performance/logical reasons why to store only the problem ID, but keeping consistency in mind, it would also seem logical to store the testcase ID and look up the problem ID as it was originally coded.

Should we change the 

```php
$this->dj->auditlog('testcase', $probId
```

in all **3 locations** to pass a testcase ID instead? Or use the change in the link generation I provided in this MR?

- https://github.com/DOMjudge/domjudge/blob/af926294f1a5c054dd170a373fe538d47012b0e8/webapp/src/Controller/Jury/ProblemController.php#L634
- https://github.com/DOMjudge/domjudge/blob/af926294f1a5c054dd170a373fe538d47012b0e8/webapp/src/Controller/Jury/ProblemController.php#L736
- https://github.com/DOMjudge/domjudge/blob/af926294f1a5c054dd170a373fe538d47012b0e8/webapp/src/Controller/Jury/ProblemController.php#L863