### PR TITLE
Add MathML sanitizer

### DIFF
--- a/webapp/config/packages/html_sanitizer.yaml
+++ b/webapp/config/packages/html_sanitizer.yaml
@@ -4,3 +4,43 @@ framework:
             app.clarification_sanitizer:
                 allow_safe_elements: true
                 allow_relative_medias: true
+                allow_elements:
+                    msup: []
+                    mrow: []
+                    mfrac: []
+                    msqrt: []
+                    mfenced:
+                        - open
+                        - close
+                    mtable: []
+                    mtd: []
+                    mtr: []
+                    msubsup: []
+                    semantics: []
+                    mroot: []
+                    menclose:
+                        - notation
+                    mlabeledtr: []
+                    mstyle:
+                        - mathcolor
+                        - fontfamily
+                        - displaystyle
+                    math:
+                        - display
+                        - class
+                    mi:
+                        - class
+                    mn:
+                        - class
+                    mo:
+                        - class
+                    annotation-xml:
+                        - encoding
+                    apply: []
+                    bvar: []
+                    int: []
+                    ci: []
+                    cn: []
+                    lowlimit: []
+                    uplimit: []
+                    divide: []


### PR DESCRIPTION
As alternative for MathJax, this PR fixes removing MathML tags.

I verified with: https://support.freedomscientific.com/SurfsUp/MathML-Samples.html
More elements can be found at: https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element

All seem to be reasonable safe, e.q. no XSS unless we allow for onload,href etc. we still remove the <body> tag etc.

For now we only allow for the tags and most of the time no attributes as those are probably too advanced for a contest setting. The only reason some are added is for demonstration and to make the examples work.

<img width="597" height="1353" alt="mathml" src="https://github.com/user-attachments/assets/67cfbff4-d7c1-4f9c-8994-9c3758e217ce" />
