### PR TITLE
Restrict clarifications to teams in the contest

### DIFF
--- a/webapp/src/Form/Type/JuryClarificationType.php
+++ b/webapp/src/Form/Type/JuryClarificationType.php
@@ -44,7 +44,7 @@ class JuryClarificationType extends AbstractType
             $recipientOptions[$this->getTeamLabel($limitToTeam)] = $limitToTeam->getTeamid();
         } else {
             /** @var Team|null $limitToTeam */
-            $teams = $this->em->getRepository(Team::class)->findAll();
+            $teams = $this->dj->getTeamsForContest($this->dj->getCurrentContest());
             foreach ($teams as $team) {
                 $recipientOptions[$this->getTeamLabel($team)] = $team->getTeamid();
             }

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1699,4 +1699,20 @@ class DOMJudgeService
             ->getQuery()
             ->getResult();
     }
+
+    /** @return Team[] */
+    public function getTeamsForContest(?Contest $contest) : array {
+        if ($contest && !$contest->isOpenToAllTeams()) {
+            $contestTeams = $contest->getTeams()->toArray();
+            foreach ($contest->getTeamCategories() as $category) {
+                $contestTeams = array_merge($contestTeams, $category->getTeams()->toArray());
+            }
+            return $contestTeams;
+        }
+        return $this->em->createQueryBuilder()
+            ->select('l')
+            ->from(Team::class, 'l')
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
This is helpful for when:
You have a shared DOMjudge instance with 2 different contests
The contests are not open to all teams but limited by categories (or directly assigned).
When you're a jury member in one of the contests you would still see all teams (union of both contests) in the `send clarification` page.

I do wonder if this is duplicated somewhere, and if we shouldn't let a dedicated Service handle the teams. The other reasonable place is the Contest itself but as that's an Entity it doesn't have an easy way of exposing which teams are in the contest when the contest is open to all teams (as you would need to query the database).
If there would be a TeamService we can change all queries to there and make sure we always get the consistent set without having to do this logic everywhere. For example I first tried this with the `Contest->getTeams()` which would return nothing in normal cases (but I would say is reasonable without this background knowledge).