### PR TITLE
Store failing page for Crawler test

### DIFF
--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -227,10 +227,12 @@ class ControllerRolesTraversalTest extends BaseTestCase
             try {
                 self::assertSelectorExists('a#navbarDropdownContests:contains("no contest")', "Failed at: " . $url);
             } catch (\Exception $e) {
-                $gitlabArtifacts = getenv('GITLABARTIFACTS');
-                if ($gitlabArtifacts != '') {
-                    $fileHandler = fopen(sprintf("%s/%s", $gitlabArtifacts, str_replace('/', '_s_', $url)), 'w');
-                    fwrite($fileHandler, $response->getContent());
+                if (getenv('CI')) { // We're running in GHA.
+                    $ciArtifacts = getenv('ARTIFACTS');
+                    if ($ciArtifacts != '') {
+                        $fileHandler = fopen(sprintf("%s/%s", $ciArtifacts, str_replace('/', '_s_', $url)), 'w');
+                        fwrite($fileHandler, $response->getContent());
+                    }
                 }
                 throw $e;
             }


### PR DESCRIPTION
As the E2E/Crawler is very generic it's hard to pinpoint what page is failing and why. We stored the failing page(s) with GitLab CI but this was lost after the migration.