### PR TITLE
Remove support for cgroup v1.

### DIFF
--- a/doc/manual/install-judgehost.rst
+++ b/doc/manual/install-judgehost.rst
@@ -169,9 +169,9 @@ no separate measures are necessary, and they allow running
 :ref:`multiple judgedaemons <multiple-judgedaemons>`
 on a multi-core machine by using CPU binding.
 
-The judgedaemon needs to run a recent Linux kernel (at least 3.2.0). The
-following steps configure cgroups on Debian. Instructions for other
-distributions may be different (send us your feedback!).
+The judgedaemon needs to run a recent Linux kernel (at least 5.19 or 6.0 or
+later). The following steps configure cgroups v2 on Debian. Instructions for
+other distributions may be different (send us your feedback!).
 
 Edit grub config to add cgroup memory and swap accounting to the boot
 options. Edit ``/etc/default/grub`` and change the default
@@ -180,12 +180,6 @@ commandline to
 Optionally the timings can be made more stable by not letting the OS schedule
 any other tasks on the same CPU core the judgedaemon is using:
 ``GRUB_CMDLINE_LINUX_DEFAULT="quiet cgroup_enable=memory swapaccount=1 isolcpus=2"``
-
-On modern systems where cgroup v2 is available, DOMjudge will try to
-use that. This requires kernel versions 5.19 or 6.0 or later to
-support reporting peak memory usage. If not found, the system will try
-to fall back to cgroup v1, but this might require you to add
-``systemd.unified_cgroup_hierarchy=0`` to the boot options as well.
 
 You have now configured the system to use cgroups. To create
 the actual cgroups that DOMjudge will use you need to run::

--- a/judge/create_cgroups.in
+++ b/judge/create_cgroups.in
@@ -25,8 +25,7 @@ if [ "$fs_type" = "cgroup2" ]; then
     major=$(echo "$kernel_version" | cut -d '.' -f 1)
     minor=$(echo "$kernel_version" | cut -d '.' -f 2)
     if [ "$major" -lt 5 ] || { [ "$major" -eq 5 ] && [ "$minor" -lt 19 ]; }; then
-        cgroup_error_and_usage "Error: kernel ($kernel_version) is too old to record peak RAM usage with cgroup V2.
-You can try using cgroup V1 by adding systemd.unified_cgroup_hierarchy=0 to the kernel params."
+        cgroup_error_and_usage "Error: kernel ($kernel_version) is too old to record peak RAM usage with cgroup V2."
     fi
     if ! echo "+memory" >> /sys/fs/cgroup/cgroup.subtree_control; then
         cgroup_error_and_usage "Error: Cannot add +memory to cgroup.subtree_control; check kernel params."
@@ -37,26 +36,6 @@ You can try using cgroup V1 by adding systemd.unified_cgroup_hierarchy=0 to the 
     if grep -q ":/$" /proc/self/cgroup; then
         cgroup_error_and_usage "Error: Cgroups not configured properly, missing cgroup hierarchy prefix under /proc/self/cgroup. If running in a container, make sure to set cgroupns=host."
     fi
-
-else # Trying cgroup V1:
-
-    for i in cpuset memory; do
-        mkdir -p $CGROUPBASE/$i
-        if [ ! -d $CGROUPBASE/$i/ ]; then
-            if ! mount -t cgroup -o$i $i $CGROUPBASE/$i/; then
-                cgroup_error_and_usage "Error: Can not mount $i cgroup. Probably cgroup support is missing from running kernel."
-            fi
-        fi
-        mkdir -p $CGROUPBASE/$i/domjudge
-    done
-
-    if [ ! -f $CGROUPBASE/memory/memory.limit_in_bytes ] || [ ! -f $CGROUPBASE/memory/memory.memsw.limit_in_bytes ]; then
-        cgroup_error_and_usage "Error: cgroup support missing memory features in running kernel."
-    fi
-
-    chown -R $JUDGEHOSTUSER $CGROUPBASE/*/domjudge
-
-    cat $CGROUPBASE/cpuset/cpuset.cpus > $CGROUPBASE/cpuset/domjudge/cpuset.cpus
-    cat $CGROUPBASE/cpuset/cpuset.mems > $CGROUPBASE/cpuset/domjudge/cpuset.mems
-
-fi # cgroup V1
+else
+    cgroup_error_and_usage "Error: Cgroups not configured properly, did not find cgroup v2 in /sys/fs/cgroup but '$fs_type'."
+fi


### PR DESCRIPTION
All relevant environments (Debian, Ubuntu, RedHat, ArchLinux, WSL2, Fedora) support and default to cgroup v2 since years, and it helps with simplification of runguard, which is a precursor of merging runpipe and runguard.