### PR TITLE
C++-ify evict.

### DIFF
--- a/judge/Makefile
+++ b/judge/Makefile
@@ -13,8 +13,8 @@ judgehost: $(TARGETS) $(SUBST_FILES)
 $(SUBST_FILES): %: %.in $(TOPDIR)/paths.mk
 	$(substconfigvars)
 
-evict: evict.c $(LIBHEADERS) $(LIBSOURCES)
-	$(CC) $(CFLAGS) -o $@ $< $(LIBSOURCES)
+evict: evict.cc $(LIBHEADERS) $(LIBSOURCES)
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LIBSOURCES)
 
 runguard: runguard.cc $(LIBHEADERS) $(LIBSOURCES) $(TOPDIR)/etc/runguard-config.h
 	$(CXX) $(CXXFLAGS) -o $@ $< $(LIBSOURCES) $(LIBCGROUP)


### PR DESCRIPTION
Only functional change is to exit with exit status 1 on missing directory argument.

After this all users of lib.{misc,error}.c are C++-ified and and we can improve/simplify the code there as well.