### PR TITLE
Return 'other' if no standard account type is found in API

### DIFF
--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -434,24 +434,24 @@ class User extends BaseApiEntity implements
     #[Serializer\VirtualProperty]
     #[Serializer\SerializedName('type')]
     #[Serializer\Type('string')]
-    public function getType(): ?string
+    public function getType(): string
     {
-        // Types allowed by the CCS Specs Contest API in order of most permissions to least.
+        // Types suggested by the CCS Specs Contest API in order of most permissions to least.
         // Either key=>value where key is the DOMjudge role and value is the API account type or
         // only value, where both the DOMjudge role and API type are the same.
-        $allowedTypes = ['admin', 'api_writer' => 'admin', 'api_reader' => 'admin',
-                         'jury' => 'judge', 'api_source_reader' => 'judge',
-                         'team'];
-        foreach ($allowedTypes as $role => $allowedType) {
+        $mappedTypes = ['admin', 'api_writer' => 'admin', 'api_reader' => 'admin',
+                        'jury' => 'judge', 'api_source_reader' => 'judge',
+                        'team'];
+        foreach ($mappedTypes as $role => $mappedType) {
             if (is_numeric($role)) {
-                $role = $allowedType;
+                $role = $mappedType;
             }
             if (in_array($role, $this->getRoleList())) {
-                return $allowedType;
+                return $mappedType;
             }
         }
 
-        return null;
+        return 'other';
     }
 
     /**

--- a/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
+++ b/webapp/tests/Unit/Controller/API/AccountBaseTestCase.php
@@ -26,8 +26,8 @@ abstract class AccountBaseTestCase extends BaseTestCase
         [['type' => 'api_writer'], ['type' => 'admin', 'roles' => ['api_writer']]],
         [['type' => 'api_reader'], ['type' => 'admin', 'roles' => ['api_reader']]],
         [['type' => 'api_source_reader'], ['type' => 'judge', 'roles' => ['api_source_reader']]],
-        [['type' => 'balloon'], ['roles' => ['balloon'], 'type' => null]],
-        [['type' => 'clarification_rw'], ['roles' => ['clarification_rw'], 'type' => null]],
+        [['type' => 'balloon'], ['roles' => ['balloon'], 'type' => 'other']],
+        [['type' => 'clarification_rw'], ['roles' => ['clarification_rw'], 'type' => 'other']],
         [['type' => 'cds'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
         [['username' => 'cds', 'type' => 'admin'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
         [['username' => 'cds', 'type' => 'jury'], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
@@ -35,7 +35,7 @@ abstract class AccountBaseTestCase extends BaseTestCase
 
     protected static array $accountAddCombinationsWithoutFile = [
         [['username' => 'cds', 'roles' => ['admin']], ['roles' => ['api_source_reader', 'api_reader', 'api_writer'], 'type' => 'admin']],
-        [['username' => 'another_judgehost', 'roles' => ['judgehost']], ['type' => null]],
+        [['username' => 'another_judgehost', 'roles' => ['judgehost']], ['type' => 'other']],
     ];
 
     protected static array $optionalAddKeys = ['id', 'name', 'password'];

--- a/webapp/tests/Unit/Controller/API/AccountControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/AccountControllerTest.php
@@ -22,7 +22,7 @@ class AccountControllerTest extends AccountBaseTestCase
             "id"       => "judgehost",
             "username" => "judgehost",
             "team_id"  => null,
-            "type"     => null,
+            "type"     => "other",
             "ip"       => null,
         ],
         'demo' => [


### PR DESCRIPTION
Also rename variables and comment to clarify that the listed types are not the only ones allowed, just the ones suggested/ mentioned in the CLICS specification (as examples).

Closes: #3163