### PR TITLE
Turn off innodb-snapshot-isolation.

### DIFF
--- a/.github/jobs/baseinstall.sh
+++ b/.github/jobs/baseinstall.sh
@@ -67,6 +67,9 @@ password=${MYSQL_ROOT_PASSWORD}
 EOF
 cat ~/.my.cnf
 
+# TODO: Remove after fixing https://github.com/DOMjudge/domjudge/issues/2848
+mysql_root "SET GLOBAL innodb_snapshot_isolation = OFF;"
+
 mysql_root "CREATE DATABASE IF NOT EXISTS \`$DATABASE_NAME\` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 mysql_root "CREATE USER IF NOT EXISTS \`domjudge\`@'%' IDENTIFIED BY 'domjudge';"
 mysql_root "GRANT SELECT, INSERT, UPDATE, DELETE ON \`$DATABASE_NAME\`.* TO 'domjudge'@'%';"
@@ -79,6 +82,7 @@ mysql_root "SELECT USER();"
 mysql_root "SELECT user,host FROM mysql.user"
 mysql_root "SET GLOBAL max_allowed_packet=1073741824"
 mysql_root "SHOW GLOBAL STATUS LIKE 'Connection_errors_%'"
+mysql_root "SHOW VARIABLES LIKE 'innodb_snapshot_isolation'"
 mysql_root "SHOW VARIABLES LIKE '%_timeout'"
 echo "unused:sqlserver:$DATABASE_NAME:domjudge:domjudge:3306" > /opt/domjudge/domserver/etc/dbpasswords.secret
 mysql_user "SELECT CURRENT_USER();"


### PR DESCRIPTION
This is causing some trouble on CI in our integration tests, e.g. https://github.com/DOMjudge/domjudge/actions/runs/18819431955/job/53692609380:
```
2025-10-26T15:17:47.393646+00:00] request.ERROR: Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\BadRequestHttpException: "["An exception occurred while     executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction"]" at ImportProblemService.php line 8    96 {"exception":"[object] (Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException(code: 0): [\"An exception occurred while executing a query: SQLSTATE[40001    ]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction\"] at /opt/domjudge/domserver/webapp/src/Service/ImportProblemService.    php:896)"} []
```

Related: https://github.com/DOMjudge/domjudge/issues/2848