### PR TITLE
Use string|float for database decimals

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -644,8 +644,8 @@ class JudgehostController extends AbstractFOSRestController
         }
 
         $runResult    = $request->request->get('runresult');
-        $startTime    = (float)$request->request->get('start_time');
-        $endTime      = (float)$request->request->get('end_time');
+        $startTime    = $request->request->get('start_time');
+        $endTime      = $request->request->get('end_time');
         $runTime      = $request->request->get('runtime');
         $outputRun    = $request->request->get('output_run');
         $outputDiff   = $request->request->get('output_diff');
@@ -926,8 +926,8 @@ class JudgehostController extends AbstractFOSRestController
         string  $hostname,
         string  $runResult,
         string  $runTime,
-        float   $startTime,
-        float   $endTime,
+        string  $startTime,
+        string  $endTime,
         string  $outputSystem,
         string  $outputError,
         string  $outputDiff,

--- a/webapp/src/Entity/AuditLog.php
+++ b/webapp/src/Entity/AuditLog.php
@@ -29,7 +29,7 @@ class AuditLog
         scale: 9,
         options: ['comment' => 'Timestamp of the logentry', 'unsigned' => true]
     )]
-    private float $logtime;
+    private string|float $logtime;
 
     #[ORM\Column(
         nullable: true,
@@ -70,13 +70,13 @@ class AuditLog
         return $this->logid;
     }
 
-    public function setLogtime(float $logtime): AuditLog
+    public function setLogtime(string|float $logtime): AuditLog
     {
         $this->logtime = $logtime;
         return $this;
     }
 
-    public function getLogtime(): float
+    public function getLogtime(): string|float
     {
         return $this->logtime;
     }

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -61,7 +61,7 @@ class Clarification extends BaseApiEntity implements
         options: ['comment' => 'Time sent', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private float $submittime;
+    private string|float $submittime;
 
     #[ORM\Column(nullable: true, options: ['comment' => 'Name of jury member who answered this'])]
     #[Serializer\Exclude]
@@ -145,13 +145,13 @@ class Clarification extends BaseApiEntity implements
         return $this->externalid;
     }
 
-    public function setSubmittime(float $submittime): Clarification
+    public function setSubmittime(string|float $submittime): Clarification
     {
         $this->submittime = $submittime;
         return $this;
     }
 
-    public function getSubmittime(): float
+    public function getSubmittime(): string|float
     {
         return $this->submittime;
     }

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -83,7 +83,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time contest becomes visible in team/public views', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $activatetime;
+    private string|float|null $activatetime;
 
     #[ORM\Column(
         type: 'decimal',
@@ -92,7 +92,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time contest starts, submissions accepted', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $starttime = null;
+    private string|float|null $starttime = null;
 
     #[ORM\Column(options: [
         'comment' => 'If disabled, starttime is not used, e.g. to delay contest start',
@@ -109,7 +109,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time scoreboard is frozen', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $freezetime = null;
+    private string|float|null $freezetime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -118,7 +118,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time after which no more submissions are accepted', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $endtime;
+    private string|float|null $endtime;
 
     #[ORM\Column(
         type: 'decimal',
@@ -128,7 +128,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Unfreeze a frozen scoreboard at this time', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $unfreezetime = null;
+    private string|float|null $unfreezetime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -138,7 +138,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time when contest was finalized, null if not yet', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $finalizetime = null;
+    private string|float|null $finalizetime = null;
 
     #[ORM\Column(
         type: 'text',
@@ -213,7 +213,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Time contest becomes invisible in team/public views', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $deactivatetime = null;
+    private string|float|null $deactivatetime = null;
 
     #[ORM\Column(
         length: 64,
@@ -513,7 +513,7 @@ class Contest extends BaseApiEntity implements
         return $this->activatetime === null ? null : (float)$this->activatetime;
     }
 
-    public function setStarttime(float $starttime): Contest
+    public function setStarttime(string|float $starttime): Contest
     {
         $this->starttime = $starttime;
         return $this;
@@ -581,7 +581,7 @@ class Contest extends BaseApiEntity implements
         return $this->finalizetime === null ? null : (float)$this->finalizetime;
     }
 
-    public function setFinalizetime(?float $finalizetimeString): Contest
+    public function setFinalizetime(string|float|null $finalizetimeString): Contest
     {
         $this->finalizetime = $finalizetimeString;
         return $this;
@@ -699,31 +699,31 @@ class Contest extends BaseApiEntity implements
         return $this->deactivatetimeString;
     }
 
-    public function setActivatetime(float $activatetime): Contest
+    public function setActivatetime(string|float|null $activatetime): Contest
     {
         $this->activatetime = $activatetime;
         return $this;
     }
 
-    public function setFreezetime(float $freezetime): Contest
+    public function setFreezetime(string|float $freezetime): Contest
     {
         $this->freezetime = $freezetime;
         return $this;
     }
 
-    public function setEndtime(float $endtime): Contest
+    public function setEndtime(string|float $endtime): Contest
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function setUnfreezetime(float $unfreezetime): Contest
+    public function setUnfreezetime(string|float $unfreezetime): Contest
     {
         $this->unfreezetime = $unfreezetime;
         return $this;
     }
 
-    public function setDeactivatetime(float $deactivatetime): Contest
+    public function setDeactivatetime(string|float $deactivatetime): Contest
     {
         $this->deactivatetime = $deactivatetime;
         return $this;
@@ -1042,7 +1042,7 @@ class Contest extends BaseApiEntity implements
             ($this->deactivatetime == null || $this->deactivatetime > time());
     }
 
-    public function getAbsoluteTime(?string $time_string): float|int|null
+    public function getAbsoluteTime(?string $time_string): string|float|int|null
     {
         if ($time_string === null) {
             return null;
@@ -1073,7 +1073,7 @@ class Contest extends BaseApiEntity implements
             } catch (Exception) {
                 return null;
             }
-            return (float)$date->format('U.v');
+            return $date->format('U.v');
         }
     }
 

--- a/webapp/src/Entity/Event.php
+++ b/webapp/src/Entity/Event.php
@@ -29,7 +29,7 @@ class Event
         scale: 9,
         options: ['comment' => 'When the event occurred', 'unsigned' => true]
     )]
-    private float $eventtime;
+    private string|float $eventtime;
 
     #[ORM\Column(length: 32, options: ['comment' => 'API endpoint associated to this entry'])]
     private string $endpointtype;
@@ -64,13 +64,13 @@ class Event
         return $this->eventid;
     }
 
-    public function setEventtime(float $eventtime): Event
+    public function setEventtime(string|float $eventtime): Event
     {
         $this->eventtime = $eventtime;
         return $this;
     }
 
-    public function getEventtime(): float
+    public function getEventtime(): string|float
     {
         return $this->eventtime;
     }

--- a/webapp/src/Entity/ExternalContestSource.php
+++ b/webapp/src/Entity/ExternalContestSource.php
@@ -47,7 +47,7 @@ class ExternalContestSource
         nullable: true,
         options: ['comment' => 'Time of last poll by event feed reader', 'unsigned' => true]
     )]
-    private ?float $lastPollTime = null;
+    private string|float|null $lastPollTime = null;
 
     #[ORM\Column(
         type: 'smallint',
@@ -139,12 +139,12 @@ class ExternalContestSource
         return $this;
     }
 
-    public function getLastPollTime(): float|null
+    public function getLastPollTime(): string|float|null
     {
         return $this->lastPollTime;
     }
 
-    public function setLastPollTime(?float $lastPollTime): ExternalContestSource
+    public function setLastPollTime(string|float|null $lastPollTime): ExternalContestSource
     {
         $this->lastPollTime = $lastPollTime;
         return $this;

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -68,7 +68,7 @@ class ExternalJudgement
         scale: 9,
         options: ['comment' => 'Time judging started', 'unsigned' => true]
     )]
-    private float $starttime;
+    private string|float $starttime;
 
     #[ORM\Column(
         type: 'decimal',
@@ -77,7 +77,7 @@ class ExternalJudgement
         nullable: true,
         options: ['comment' => 'Time judging ended, null = still busy', 'unsigned' => true]
     )]
-    private ?float $endtime = null;
+    private string|float|null $endtime = null;
 
     #[ORM\Column(
         options: ['comment' => 'Old external judgement is marked as invalid when receiving a new one', 'default' => 1]
@@ -163,24 +163,24 @@ class ExternalJudgement
         return $this->verify_comment;
     }
 
-    public function setStarttime(float $starttime): ExternalJudgement
+    public function setStarttime(string|float $starttime): ExternalJudgement
     {
         $this->starttime = $starttime;
         return $this;
     }
 
-    public function getStarttime(): float
+    public function getStarttime(): string|float
     {
         return $this->starttime;
     }
 
-    public function setEndtime(?float $endtime): ExternalJudgement
+    public function setEndtime(string|float|null $endtime): ExternalJudgement
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function getEndtime(): float|null
+    public function getEndtime(): string|float|null
     {
         return $this->endtime;
     }

--- a/webapp/src/Entity/ExternalRun.php
+++ b/webapp/src/Entity/ExternalRun.php
@@ -45,7 +45,7 @@ class ExternalRun
         scale: 9,
         options: ['comment' => 'Time run ended', 'unsigned' => true]
     )]
-    private float $endtime;
+    private string|float $endtime;
 
     #[ORM\Column(options: ['comment' => 'Running time on this testcase'])]
     private float $runtime;
@@ -89,13 +89,13 @@ class ExternalRun
         return $this->result;
     }
 
-    public function setEndtime(float $endtime): ExternalRun
+    public function setEndtime(string|float $endtime): ExternalRun
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function getEndtime(): float
+    public function getEndtime(): string|float
     {
         return $this->endtime;
     }

--- a/webapp/src/Entity/InternalError.php
+++ b/webapp/src/Entity/InternalError.php
@@ -43,7 +43,7 @@ class InternalError
         scale: 9,
         options: ['comment' => 'Timestamp of the internal error', 'unsigned' => true]
     )]
-    private float $time;
+    private string|float $time;
 
     /**
      * @var array{kind: string, hostname?: string, execid?: string, probid: string, langid: string}
@@ -118,13 +118,13 @@ class InternalError
         return $this->judgehostlog;
     }
 
-    public function setTime(float $time): InternalError
+    public function setTime(string|float $time): InternalError
     {
         $this->time = $time;
         return $this;
     }
 
-    public function getTime(): float
+    public function getTime(): string|float
     {
         return $this->time;
     }

--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -152,7 +152,7 @@ class JudgeTask
         options: ['comment' => 'Time the judgetask was started', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $starttime = null;
+    private string|float|null $starttime = null;
 
     /**
      * @var Collection<int, JudgingRun>
@@ -341,13 +341,13 @@ class JudgeTask
         return $this->valid;
     }
 
-    public function setStarttime(?float $starttime): JudgeTask
+    public function setStarttime(string|float|null $starttime): JudgeTask
     {
         $this->starttime = $starttime;
         return $this;
     }
 
-    public function getStarttime(): float|null
+    public function getStarttime(): string|float|null
     {
         return $this->starttime;
     }

--- a/webapp/src/Entity/Judgehost.php
+++ b/webapp/src/Entity/Judgehost.php
@@ -42,7 +42,7 @@ class Judgehost
         options: ['comment' => 'Time of last poll by autojudger', 'unsigned' => true]
     )]
     #[OA\Property(nullable: true)]
-    private ?float $polltime = null;
+    private string|float|null $polltime = null;
 
     /**
      * @var Collection<int, JudgeTask>
@@ -91,13 +91,13 @@ class Judgehost
         return $this->enabled;
     }
 
-    public function setPolltime(float $polltime): Judgehost
+    public function setPolltime(string|float $polltime): Judgehost
     {
         $this->polltime = $polltime;
         return $this;
     }
 
-    public function getPolltime(): float|null
+    public function getPolltime(): string|float|null
     {
         return $this->polltime;
     }

--- a/webapp/src/Entity/Judging.php
+++ b/webapp/src/Entity/Judging.php
@@ -43,7 +43,7 @@ class Judging extends BaseApiEntity
         options: ['comment' => 'Time judging started', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $starttime = null;
+    private string|float|null $starttime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -54,7 +54,7 @@ class Judging extends BaseApiEntity
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\Exclude]
-    private ?float $endtime = null;
+    private string|float|null $endtime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -64,7 +64,7 @@ class Judging extends BaseApiEntity
         options: ['comment' => 'The maximum runtime for all runs that resulted in the verdict', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $maxRuntimeForVerdict = null;
+    private string|float|null $maxRuntimeForVerdict = null;
 
     #[ORM\Column(
         length: 32,
@@ -203,13 +203,13 @@ class Judging extends BaseApiEntity
         return $this->judgingid;
     }
 
-    public function setStarttime(float $starttime): Judging
+    public function setStarttime(string|float $starttime): Judging
     {
         $this->starttime = $starttime;
         return $this;
     }
 
-    public function getStarttime(): float|null
+    public function getStarttime(): string|float|null
     {
         return $this->starttime;
     }
@@ -231,13 +231,13 @@ class Judging extends BaseApiEntity
         return Utils::relTime($this->getStarttime() - $this->getContest()->getStarttime());
     }
 
-    public function setEndtime(float $endtime): Judging
+    public function setEndtime(string|float $endtime): Judging
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function getEndtime(): float|null
+    public function getEndtime(): string|float|null
     {
         return $this->endtime;
     }
@@ -260,13 +260,13 @@ class Judging extends BaseApiEntity
         return $this->getEndtime() ? Utils::relTime($this->getEndtime() - $this->getContest()->getStarttime()) : null;
     }
 
-    public function setMaxRuntimeForVerdict(float $maxRuntimeForVerdict): Judging
+    public function setMaxRuntimeForVerdict(string|float $maxRuntimeForVerdict): Judging
     {
         $this->maxRuntimeForVerdict = $maxRuntimeForVerdict;
         return $this;
     }
 
-    public function getMaxRuntimeForVerdict(): float|null
+    public function getMaxRuntimeForVerdict(): string|float|null
     {
         return $this->maxRuntimeForVerdict;
     }

--- a/webapp/src/Entity/JudgingRun.php
+++ b/webapp/src/Entity/JudgingRun.php
@@ -48,7 +48,7 @@ class JudgingRun extends BaseApiEntity
         options: ['comment' => 'Submission running time on this testcase']
     )]
     #[Serializer\Exclude]
-    private ?float $runtime = null;
+    private string|float|null $runtime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -58,7 +58,7 @@ class JudgingRun extends BaseApiEntity
         options: ['comment' => 'Time run judging ended', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $endtime = null;
+    private string|float|null $endtime = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -68,7 +68,7 @@ class JudgingRun extends BaseApiEntity
         options: ['comment' => 'Time run judging started', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $startTime = null;
+    private string|float|null $startTime = null;
 
     #[ORM\ManyToOne(inversedBy: 'runs')]
     #[ORM\JoinColumn(name: 'judgingid', referencedColumnName: 'judgingid', onDelete: 'CASCADE')]
@@ -147,7 +147,7 @@ class JudgingRun extends BaseApiEntity
         return $this->runresult;
     }
 
-    public function setRuntime(float $runtime): JudgingRun
+    public function setRuntime(string|float $runtime): JudgingRun
     {
         $this->runtime = $runtime;
         return $this;
@@ -156,29 +156,29 @@ class JudgingRun extends BaseApiEntity
     #[Serializer\VirtualProperty]
     #[Serializer\SerializedName('run_time')]
     #[Serializer\Type('float')]
-    public function getRuntime(): ?float
+    public function getRuntime(): string|float|null
     {
         return Utils::roundedFloat($this->runtime);
     }
 
-    public function setEndtime(float $endtime): JudgingRun
+    public function setEndtime(string|float $endtime): JudgingRun
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function setStarttime(float $startTime): JudgingRun
+    public function setStarttime(string|float $startTime): JudgingRun
     {
         $this->startTime = $startTime;
         return $this;
     }
 
-    public function getStarttime(): float|null
+    public function getStarttime(): string|float|null
     {
         return $this->startTime;
     }
 
-    public function getEndtime(): float|null
+    public function getEndtime(): string|float|null
     {
         return $this->endtime;
     }

--- a/webapp/src/Entity/QueueTask.php
+++ b/webapp/src/Entity/QueueTask.php
@@ -114,13 +114,13 @@ class QueueTask
         return $this->team;
     }
 
-    public function setStartTime(?float $startTime = null): QueueTask
+    public function setStartTime(string|float|null $startTime = null): QueueTask
     {
         $this->startTime = $startTime;
         return $this;
     }
 
-    public function getStartTime(): float|null
+    public function getStartTime(): string|float|null
     {
         return $this->startTime;
     }

--- a/webapp/src/Entity/Rejudging.php
+++ b/webapp/src/Entity/Rejudging.php
@@ -31,7 +31,7 @@ class Rejudging
         scale: 9,
         options: ['comment' => 'Time rejudging started', 'unsigned' => true]
     )]
-    private float $starttime;
+    private string|float $starttime;
 
     #[ORM\Column(
         type: 'decimal',
@@ -40,7 +40,7 @@ class Rejudging
         nullable: true,
         options: ['comment' => 'Time rejudging ended, null = still busy', 'unsigned' => true]
     )]
-    private ?float $endtime = null;
+    private string|float|null $endtime = null;
 
     #[ORM\Column(options: ['comment' => 'Reason to start this rejudge'])]
     private string $reason;
@@ -107,24 +107,24 @@ class Rejudging
         return $this->rejudgingid;
     }
 
-    public function setStarttime(float $starttime): Rejudging
+    public function setStarttime(string|float $starttime): Rejudging
     {
         $this->starttime = $starttime;
         return $this;
     }
 
-    public function getStarttime(): float
+    public function getStarttime(): string|float
     {
         return $this->starttime;
     }
 
-    public function setEndtime(float $endtime): Rejudging
+    public function setEndtime(string|float $endtime): Rejudging
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function getEndtime(): float|null
+    public function getEndtime(): string|float|null
     {
         return $this->endtime;
     }

--- a/webapp/src/Entity/RemovedInterval.php
+++ b/webapp/src/Entity/RemovedInterval.php
@@ -33,7 +33,7 @@ class RemovedInterval
         scale: 9,
         options: ['comment' => 'Initial time of removed interval', 'unsigned' => true]
     )]
-    private float $starttime;
+    private string|float $starttime;
 
     #[ORM\Column(
         type: 'decimal',
@@ -41,7 +41,7 @@ class RemovedInterval
         scale: 9,
         options: ['comment' => 'Final time of removed interval', 'unsigned' => true]
     )]
-    private float $endtime;
+    private string|float $endtime;
 
     #[ORM\Column(
         length: 64,
@@ -66,24 +66,24 @@ class RemovedInterval
         return $this->intervalid;
     }
 
-    public function setStarttime(float $starttime): RemovedInterval
+    public function setStarttime(string|float $starttime): RemovedInterval
     {
         $this->starttime = $starttime;
         return $this;
     }
 
-    public function getStarttime(): float
+    public function getStarttime(): string|float
     {
         return $this->starttime;
     }
 
-    public function setEndtime(float $endtime): RemovedInterval
+    public function setEndtime(string|float $endtime): RemovedInterval
     {
         $this->endtime = $endtime;
         return $this;
     }
 
-    public function getEndtime(): float
+    public function getEndtime(): string|float
     {
         return $this->endtime;
     }
@@ -95,7 +95,7 @@ class RemovedInterval
     {
         $this->starttimeString = $starttimeString;
         $date                  = new DateTime($starttimeString);
-        $this->starttime       = (float)$date->format('U.v');
+        $this->starttime       = $date->format('U.v');
 
         return $this;
     }
@@ -112,7 +112,7 @@ class RemovedInterval
     {
         $this->endtimeString = $endtimeString;
         $date                = new DateTime($endtimeString);
-        $this->endtime       = (float)$date->format('U.v');
+        $this->endtime       = $date->format('U.v');
 
         return $this;
     }

--- a/webapp/src/Entity/ScoreCache.php
+++ b/webapp/src/Entity/ScoreCache.php
@@ -49,7 +49,7 @@ class ScoreCache
             'default' => '0.000000000',
         ]
     )]
-    private float $solvetime_restricted = 0;
+    private string|float $solvetime_restricted = 0;
 
     #[ORM\Column(options: [
         'comment' => 'Runtime in milliseconds (restricted audience)',
@@ -83,7 +83,7 @@ class ScoreCache
             'default' => '0.000000000',
         ]
     )]
-    private float $solvetime_public = 0;
+    private string|float $solvetime_public = 0;
 
     #[ORM\Column(options: ['comment' => 'Runtime in milliseconds (public)', 'default' => 0])]
     private int $runtime_public = 0;
@@ -142,13 +142,13 @@ class ScoreCache
         return $this->is_correct_restricted;
     }
 
-    public function setSolvetimeRestricted(float $solvetimeRestricted): ScoreCache
+    public function setSolvetimeRestricted(string|float $solvetimeRestricted): ScoreCache
     {
         $this->solvetime_restricted = $solvetimeRestricted;
         return $this;
     }
 
-    public function getSolvetimeRestricted(): float
+    public function getSolvetimeRestricted(): string|float
     {
         return $this->solvetime_restricted;
     }
@@ -197,13 +197,13 @@ class ScoreCache
         return $this->is_correct_public;
     }
 
-    public function setSolvetimePublic(float $solvetimePublic): ScoreCache
+    public function setSolvetimePublic(string|float $solvetimePublic): ScoreCache
     {
         $this->solvetime_public = $solvetimePublic;
         return $this;
     }
 
-    public function getSolvetimePublic(): float
+    public function getSolvetimePublic(): string|float
     {
         return $this->solvetime_public;
     }
@@ -273,7 +273,7 @@ class ScoreCache
         return $restricted ? $this->getPendingRestricted() : $this->getPendingPublic();
     }
 
-    public function getSolveTime(bool $restricted): float
+    public function getSolveTime(bool $restricted): string|float
     {
         return $restricted ? $this->getSolvetimeRestricted() : $this->getSolvetimePublic();
     }

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -66,7 +66,7 @@ class Submission extends BaseApiEntity implements
         options: ['comment' => 'Time submitted', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $submittime = null;
+    private string|float|null $submittime = null;
 
     #[ORM\Column(options: [
         'comment' => 'If false ignore this submission in all scoreboard calculations',
@@ -232,13 +232,13 @@ class Submission extends BaseApiEntity implements
         return $this->getLanguage()->getExternalid();
     }
 
-    public function setSubmittime(float $submittime): Submission
+    public function setSubmittime(string|float $submittime): Submission
     {
         $this->submittime = $submittime;
         return $this;
     }
 
-    public function getSubmittime(): float
+    public function getSubmittime(): string|float
     {
         return $this->submittime;
     }

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -114,7 +114,7 @@ class Team extends BaseApiEntity implements
         options: ['comment' => 'Start time of last judging for prioritization', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $judging_last_started = null;
+    private string|float|null $judging_last_started = null;
 
     #[ORM\Column(options: ['comment' => 'Additional penalty time in minutes', 'default' => 0])]
     #[Serializer\Exclude]
@@ -327,13 +327,13 @@ class Team extends BaseApiEntity implements
         return $this->internalComments;
     }
 
-    public function setJudgingLastStarted(float $judgingLastStarted): Team
+    public function setJudgingLastStarted(string|float $judgingLastStarted): Team
     {
         $this->judging_last_started = $judgingLastStarted;
         return $this;
     }
 
-    public function getJudgingLastStarted(): float
+    public function getJudgingLastStarted(): string|float
     {
         return $this->judging_last_started;
     }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -73,7 +73,7 @@ class User extends BaseApiEntity implements
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\Exclude]
-    private ?float $last_login = null;
+    private string|float|null $last_login = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -84,7 +84,7 @@ class User extends BaseApiEntity implements
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\Exclude]
-    private ?float $last_api_login = null;
+    private string|float|null $last_api_login = null;
 
     #[ORM\Column(
         type: 'decimal',
@@ -95,7 +95,7 @@ class User extends BaseApiEntity implements
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\Exclude]
-    private ?float $first_login = null;
+    private string|float|null $first_login = null;
 
     #[ORM\Column(nullable: true, options: ['comment' => 'Last IP address of successful login'])]
     #[OA\Property(nullable: true)]
@@ -228,13 +228,13 @@ class User extends BaseApiEntity implements
         return $this->email;
     }
 
-    public function setLastLogin(?float $lastLogin): User
+    public function setLastLogin(string|float|null $lastLogin): User
     {
         $this->last_login = $lastLogin;
         return $this;
     }
 
-    public function getLastLogin(): float|null
+    public function getLastLogin(): string|float|null
     {
         return $this->last_login;
     }
@@ -249,13 +249,13 @@ class User extends BaseApiEntity implements
         return $this->getLastLogin() ? new DateTime(Utils::absTime($this->getLastLogin())) : null;
     }
 
-    public function setLastApiLogin(?float $lastApiLogin): User
+    public function setLastApiLogin(string|float|null $lastApiLogin): User
     {
         $this->last_api_login = $lastApiLogin;
         return $this;
     }
 
-    public function getLastApiLogin(): float|null
+    public function getLastApiLogin(): string|float|null
     {
         return $this->last_api_login;
     }
@@ -270,13 +270,13 @@ class User extends BaseApiEntity implements
         return $this->getLastApiLogin() ? new DateTime(Utils::absTime($this->getLastApiLogin())) : null;
     }
 
-    public function setFirstLogin(?float $firstLogin): User
+    public function setFirstLogin(string|float|null $firstLogin): User
     {
         $this->first_login = $firstLogin;
         return $this;
     }
 
-    public function getFirstLogin(): float|null
+    public function getFirstLogin(): string|float|null
     {
         return $this->first_login;
     }

--- a/webapp/src/Entity/Version.php
+++ b/webapp/src/Entity/Version.php
@@ -52,7 +52,7 @@ class Version
         options: ['comment' => 'Time this version command output was last updated', 'unsigned' => true]
     )]
     #[Serializer\Exclude]
-    private ?float $lastChangedTime = null;
+    private string|float|null $lastChangedTime = null;
 
     #[ORM\Column(options: [
         'comment' => 'True if this version is active for this judgehost/language combination.',

--- a/webapp/src/Service/EventLogService.php
+++ b/webapp/src/Service/EventLogService.php
@@ -334,9 +334,9 @@ class EventLogService
             }
         }
 
-        // Explicitly construct the time as string and then cast to float
-        // to prevent float representation issues.
-        $now = (float)sprintf('%.3f', microtime(true));
+        // Explicitly construct the time as string to prevent float
+        // representation issues.
+        $now = sprintf('%.3f', microtime(true));
 
         if ($jsonPassed) {
             $json = Utils::jsonDecode($json);


### PR DESCRIPTION
This reverts part of 761f3238de3dc21c3da6b0af07c9fb1e1742f2a3 since Doctrine stroes decimals as strings to not loose precision.

When we upgrade to PHP 8.4, we can use a differnt type to store them as `BCMath\Number` objects instead, which seems to be the better way to do this.