### PR TITLE
Display all languages in the contest in teaminterface

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -949,6 +949,10 @@ blockquote {
     margin: 0;
 }
 
+.extensions-team-interface {
+    flex-wrap: wrap;
+}
+
 .extension-badge {
     font-family: var(--bs-font-monospace);
     font-size: 0.8rem;
@@ -957,6 +961,7 @@ blockquote {
     color: #000;
     border: 1px solid #dee2e6;
     border-radius: 4px;
+    white-space: nowrap;
 }
 
 .section-label {

--- a/webapp/src/Controller/Team/LanguageController.php
+++ b/webapp/src/Controller/Team/LanguageController.php
@@ -40,7 +40,7 @@ class LanguageController extends BaseController
      * @param array<string, array{'problems': ContestProblem[], 'language': Language}> $languages
      * @return array<string, array{'problems': ContestProblem[], 'language': Language}>
      */
-    private function addLanguage(array $languages, Language $language, ContestProblem $problem): array
+    private function addLanguage(array $languages, Language $language, ?ContestProblem $problem = null): array
     {
         $langId = $language->getLangid();
         if (!isset($languages[$langId])) {
@@ -65,23 +65,30 @@ class LanguageController extends BaseController
         foreach ($this->dj->getAllowedLanguagesForContest($currentContest) as $language) {
             $allLanguages->add($language);
         }
-        // Add the problem specific languages
-        foreach ($this->dj->getCurrentContest()->getProblems() as $problem) {
-            $problemLanguages = new Set($problem->getProblem()->getLanguages());
-            if ($problemLanguages->isEmpty()) {
-                continue;
-            }
-            if (!Utils::equalSets($allLanguages, $problemLanguages)) {
-                if (!$allLanguages->isEmpty()) {
-                    $limited = true;
+        if ($currentContest) {
+            // Add the problem specific languages
+            $currentContestProblems = $currentContest?->getProblems() ?? [];
+            foreach ($currentContestProblems as $problem) {
+                $problemLanguages = new Set($problem->getProblem()->getLanguages());
+                if ($problemLanguages->isEmpty()) {
+                    continue;
                 }
-                $allLanguages->merge($problem->getProblem()->getLanguages());
+                if (!Utils::equalSets($allLanguages, $problemLanguages)) {
+                    if (!$allLanguages->isEmpty()) {
+                        $limited = true;
+                    }
+                    $allLanguages->merge($problem->getProblem()->getLanguages());
+                }
             }
-        }
-        foreach ($this->dj->getCurrentContest()->getProblems() as $problem) {
-            $problemLanguages = count($problem->getProblem()->getLanguages()) ? new Set($problem->getProblem()->getLanguages()) : $allLanguages;
-            foreach ($problemLanguages as $language) {
-                $languages = $this->addLanguage($languages, $language, $problem);
+            foreach ($currentContestProblems as $problem) {
+                $problemLanguages = count($problem->getProblem()->getLanguages()) ? new Set($problem->getProblem()->getLanguages()) : $allLanguages;
+                foreach ($problemLanguages as $language) {
+                    $languages = $this->addLanguage($languages, $language, $problem);
+                }
+            }
+        } else {
+            foreach ($allLanguages as $language) {
+                $languages = $this->addLanguage($languages, $language);
             }
         }
         return $this->render('team/languages.html.twig', ['languages' => $languages, 'limited' => $limited]);

--- a/webapp/src/Controller/Team/LanguageController.php
+++ b/webapp/src/Controller/Team/LanguageController.php
@@ -67,7 +67,7 @@ class LanguageController extends BaseController
         }
         if ($currentContest) {
             // Add the problem specific languages
-            $currentContestProblems = $currentContest?->getProblems() ?? [];
+            $currentContestProblems = $currentContest->getProblems();
             foreach ($currentContestProblems as $problem) {
                 $problemLanguages = new Set($problem->getProblem()->getLanguages());
                 if ($problemLanguages->isEmpty()) {

--- a/webapp/src/Controller/Team/LanguageController.php
+++ b/webapp/src/Controller/Team/LanguageController.php
@@ -3,10 +3,14 @@
 namespace App\Controller\Team;
 
 use App\Controller\BaseController;
+use App\Entity\ContestProblem;
+use App\Entity\Language;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
+use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
+use Ds\Set;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -32,6 +36,20 @@ class LanguageController extends BaseController
         parent::__construct($em, $eventLogService, $dj, $kernel);
     }
 
+    /**
+     * @param array<string, array{'problems': ContestProblem[], 'language': Language}> $languages
+     * @return array<string, array{'problems': ContestProblem[], 'language': Language}>
+     */
+    private function addLanguage(array $languages, Language $language, ContestProblem $problem): array
+    {
+        $langId = $language->getLangid();
+        if (!isset($languages[$langId])) {
+            $languages[$langId] = ['problems' => [], 'language' => $language];
+        }
+        $languages[$langId]['problems'][] = $problem;
+        return $languages;
+    }
+
     #[Route(path: '', name: 'team_languages')]
     public function languagesAction(): Response
     {
@@ -40,7 +58,32 @@ class LanguageController extends BaseController
             throw new BadRequestHttpException("You are not allowed to view this page.");
         }
         $currentContest = $this->dj->getCurrentContest();
-        $languages = $this->dj->getAllowedLanguagesForContest($currentContest);
-        return $this->render('team/languages.html.twig', ['languages' => $languages]);
+        $languages = [];
+        $limited = false;
+        $allLanguages = new Set();
+        // Get all languages specific to the contest, if those are empty all globally enabled languages
+        foreach ($this->dj->getAllowedLanguagesForContest($currentContest) as $language) {
+            $allLanguages->add($language);
+        }
+        // Add the problem specific languages
+        foreach ($this->dj->getCurrentContest()->getProblems() as $problem) {
+            $problemLanguages = new Set($problem->getProblem()->getLanguages());
+            if ($problemLanguages->isEmpty()) {
+                continue;
+            }
+            if (!Utils::equalSets($allLanguages, $problemLanguages)) {
+                if (!$allLanguages->isEmpty()) {
+                    $limited = true;
+                }
+                $allLanguages->merge($problem->getProblem()->getLanguages());
+            }
+        }
+        foreach ($this->dj->getCurrentContest()->getProblems() as $problem) {
+            $problemLanguages = count($problem->getProblem()->getLanguages()) ? new Set($problem->getProblem()->getLanguages()) : $allLanguages;
+            foreach ($problemLanguages as $language) {
+                $languages = $this->addLanguage($languages, $language, $problem);
+            }
+        }
+        return $this->render('team/languages.html.twig', ['languages' => $languages, 'limited' => $limited]);
     }
 }

--- a/webapp/src/Form/Type/SubmitProblemType.php
+++ b/webapp/src/Form/Type/SubmitProblemType.php
@@ -9,6 +9,7 @@ use App\Service\DOMJudgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
+use Ds\Set;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -48,14 +49,18 @@ class SubmitProblemType extends AbstractType
             ]);
         }
 
+        $qb = $this->em->getRepository(Problem::class)->createQueryBuilder('p')
+            ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
+            ->select('p', 'cp')
+            ->andWhere('cp.allowSubmit = 1')
+            ->setParameter('contest', $contest)
+            ->addOrderBy('cp.shortname');
+
+        $problems = $qb->getQuery()->getResult();
+
         $problemConfig = [
             'class' => Problem::class,
-            'query_builder' => fn(EntityRepository $er) => $er->createQueryBuilder('p')
-                ->join('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
-                ->select('p', 'cp')
-                ->andWhere('cp.allowSubmit = 1')
-                ->setParameter('contest', $contest)
-                ->addOrderBy('cp.shortname'),
+            'query_builder' => $qb,
             'choice_label' => fn(Problem $problem) => sprintf(
                 '%s - %s', $problem->getContestProblems()->first()->getShortName(), $problem->getName()
             ),
@@ -64,7 +69,25 @@ class SubmitProblemType extends AbstractType
         ];
         $builder->add('problem', EntityType::class, $problemConfig);
 
-        $languages = empty($options['data']['languages']) ? $this->dj->getAllowedLanguagesForContest($contest) : $options['data']['languages'];
+        if (empty($options['data']['languages'])) {
+            $languages = new Set();
+            $allProblemsSpecificLanguages = true;
+            foreach ($problems as $problem) {
+                $problemLanguages = new Set($problem->getLanguages());
+                if ($problemLanguages->isEmpty()) {
+                    $allProblemsSpecificLanguages = false;
+                } else {
+                    $languages = $languages->merge($problemLanguages);
+                }
+            }
+            if (!$allProblemsSpecificLanguages) {
+                $languages = $languages->merge($this->dj->getAllowedLanguagesForContest($contest));
+            }
+            $languages->sort();
+        } else {
+            $languages = $options['data']['languages'];
+        }
+            
         $builder->add('language', EntityType::class, [
             'class' => Language::class,
             'choices' => $languages,

--- a/webapp/src/Form/Type/SubmitProblemType.php
+++ b/webapp/src/Form/Type/SubmitProblemType.php
@@ -69,25 +69,8 @@ class SubmitProblemType extends AbstractType
         ];
         $builder->add('problem', EntityType::class, $problemConfig);
 
-        if (empty($options['data']['languages'])) {
-            $languages = new Set();
-            $allProblemsSpecificLanguages = true;
-            foreach ($problems as $problem) {
-                $problemLanguages = new Set($problem->getLanguages());
-                if ($problemLanguages->isEmpty()) {
-                    $allProblemsSpecificLanguages = false;
-                } else {
-                    $languages = $languages->merge($problemLanguages);
-                }
-            }
-            if (!$allProblemsSpecificLanguages) {
-                $languages = $languages->merge($this->dj->getAllowedLanguagesForContest($contest));
-            }
-            $languages->sort();
-        } else {
-            $languages = $options['data']['languages'];
-        }
-            
+        $languages = empty($options['data']['languages']) ? $this->dj->getAllowedLanguagesForContest($contest, true) : $options['data']['languages'];
+
         $builder->add('language', EntityType::class, [
             'class' => Language::class,
             'choices' => $languages,

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1177,6 +1177,20 @@ class DOMJudgeService
                 ->getQuery()
                 ->getResult();
 
+            $limited = false;
+            foreach ($problems as $problem) {
+                if (count($problem->getProblem()->getLanguages())) {
+                    $limited = true;
+                }
+            }
+            foreach ($problems as $problem) {
+                if (!count($problem->getProblem()->getLanguages()) && $limited) {
+                    foreach ($this->getAllowedLanguagesForContest($contest) as $language) {
+                        $problem->getProblem()->addLanguage($language);
+                    }
+                }
+            }
+
             $samplesData = $this->em->createQueryBuilder()
                 ->from(ContestProblem::class, 'cp')
                 ->join('cp.problem', 'p')

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -39,6 +39,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Ds\Set;
 use Exception;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -1861,9 +1862,25 @@ class DOMJudgeService
     }
 
     /** @return Language[] */
-    public function getAllowedLanguagesForContest(?Contest $contest) : array {
+    public function getAllowedLanguagesForContest(?Contest $contest, bool $alsoProblemSpecific = false) : array {
         if ($contest) {
             $languages = $contest->getLanguages();
+            if ($alsoProblemSpecific) {
+                $limited = true;
+                $allLanguages = new Set();
+                // Add the problem specific languages
+                foreach ($contest->getProblems() as $problem) {
+                    $problemLanguages = new Set($problem->getProblem()->getLanguages());
+                    if ($problemLanguages->isEmpty()) {
+                        $limited = false;
+                    } else {
+                        $allLanguages = $allLanguages->merge($problemLanguages);
+                    }
+                }
+                if ($limited) {
+                    $allLanguages = $allLanguages->merge($languages);
+                }
+            }
             if (!$languages->isEmpty()) {
                 return $languages->toArray();
             }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -3,6 +3,7 @@ namespace App\Utils;
 
 use DateTime;
 use Doctrine\Inflector\InflectorFactory;
+use Ds\Set;
 use enshrined\svgSanitize\Sanitizer as SvgSanitizer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -1146,5 +1147,14 @@ class Utils
     {
         $value = (string)$value;
         return bcadd($value, '0', $scale);
+    }
+
+    /**
+     * @template V
+     * @param Set<V> $a
+     * @param Set<V> $b
+     */
+    public static function equalSets(Set $a, Set $b): bool {
+        return $a->diff($b)->isEmpty() && $b->diff($a)->isEmpty();
     }
 }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -1155,6 +1155,6 @@ class Utils
      * @param Set<V> $b
      */
     public static function equalSets(Set $a, Set $b): bool {
-        return $a->diff($b)->isEmpty() && $b->diff($a)->isEmpty();
+        return $a->xor($b)->isEmpty();
     }
 }

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -19,8 +19,33 @@
                                     {% for ext in lang.extensions %}
                                         <span class="extension-badge">.{{ ext }}</span>
                                     {% endfor %}
+                                    {% if limited %}
+                                        <div style="margin-left: auto; float: right; text-align: right;">
+                                            {% for problem in problems %}
+                                                {{ problem | problemBadge }}
+                                            {% endfor %}
+                                        </div>
+                                    {% endif %}
                                 </div>
                             </div>
+
+                            {% if limited %}
+                                <div class="mb-4">
+                                    <div class="section-label">
+                                        <i class="fas fa-book-open"></i> Problems
+                                    </div>
+                                    <div>
+                                        {% for problem in problems %}
+                                            {{ problem | problemBadge }}
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="output_test" style="scrollbar-width: thin; scrollbar-gutter: stable both-edges; text-wrap: nowrap; overflow: scroll; max-height: 4em;">
+                                    {% for problem in problems %}
+                                        {{ problem | problemBadge }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
 
                             {% if lang.compilerVersion and lang.compilerVersionCommand %}
                                 <div class="mb-4">

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -19,13 +19,6 @@
                                     {% for ext in lang.extensions %}
                                         <span class="extension-badge">.{{ ext }}</span>
                                     {% endfor %}
-                                    {% if limited %}
-                                        <div style="margin-left: auto; float: right; text-align: right;">
-                                            {% for problem in problems %}
-                                                {{ problem | problemBadge }}
-                                            {% endfor %}
-                                        </div>
-                                    {% endif %}
                                 </div>
                             </div>
 
@@ -39,11 +32,6 @@
                                             {{ problem | problemBadge }}
                                         {% endfor %}
                                     </div>
-                                </div>
-                                <div class="output_test" style="scrollbar-width: thin; scrollbar-gutter: stable both-edges; text-wrap: nowrap; overflow: scroll; max-height: 4em;">
-                                    {% for problem in problems %}
-                                        {{ problem | problemBadge }}
-                                    {% endfor %}
                                 </div>
                             {% endif %}
 

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -13,7 +13,7 @@
                         <div class="card-body p-4">
                             <div class="mb-4">
                                 <h2 class="lang-name h4">{{ lang.name }}</h2>
-                                <div class="d-flex gap-2 mt-2">
+                                <div class="d-flex gap-2 mt-2 extensions-team-interface">
                                     {% for ext in lang.extensions %}
                                         <span class="extension-badge">.{{ ext }}</span>
                                     {% endfor %}

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -19,6 +19,13 @@
                                     {% for ext in lang.extensions %}
                                         <span class="extension-badge">.{{ ext }}</span>
                                     {% endfor %}
+                                    {% if limited %}
+                                        <div style="margin-left: auto; float: right; text-align: right;">
+                                            {% for problem in problems %}
+                                                {{ problem | problemBadge }}
+                                            {% endfor %}
+                                        </div>
+                                    {% endif %}
                                 </div>
                             </div>
 
@@ -32,6 +39,11 @@
                                             {{ problem | problemBadge }}
                                         {% endfor %}
                                     </div>
+                                </div>
+                                <div class="output_test" style="scrollbar-width: thin; scrollbar-gutter: stable both-edges; text-wrap: nowrap; overflow: scroll; max-height: 4em;">
+                                    {% for problem in problems %}
+                                        {{ problem | problemBadge }}
+                                    {% endfor %}
                                 </div>
                             {% endif %}
 

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -7,7 +7,9 @@
 
     <div class="container mb-5">
         <div class="row row-cols-1 row-cols-lg-2 g-4">
-            {% for lang in languages %}
+            {% for langarray in languages %}
+                {% set lang = langarray['language'] %}
+                {% set problems = langarray['problems'] %}
                 <div class="col">
                     <div class="card language-card">
                         <div class="card-body p-4">


### PR DESCRIPTION
Also limit the languages in case the problem has different languages.

<img width="2787" height="1152" alt="image" src="https://github.com/user-attachments/assets/2ddca29d-dfa7-4d2c-aab4-a709b1c30fc3" />

I don't really like the `[All]` as it is not really true but `rest` is also not that good. Found this when playing around with something and needed the info so added it.

@nickygerritsen suggested this as alternative:
<img width="2181" height="1665" alt="image" src="https://github.com/user-attachments/assets/28aad487-9875-4f0c-91e2-87e6ce83c270" />
Or this:
<img width="2263" height="834" alt="image" src="https://github.com/user-attachments/assets/9f7b0080-afde-4944-a105-dd594b4d6dfc" />
