### PR TITLE
Replace async reporting back of results with guzzle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build-scripts:
 build:                      SUBDIRS=        lib           misc-tools
 domserver:                  SUBDIRS=etc         sql       misc-tools webapp
 install-domserver:          SUBDIRS=etc     lib sql       misc-tools webapp example_problems
-judgehost:                  SUBDIRS=etc             judge misc-tools
+judgehost:                  SUBDIRS=etc             judge misc-tools webapp
 install-judgehost:          SUBDIRS=etc     lib     judge misc-tools
 docs:                       SUBDIRS=    doc
 install-docs:               SUBDIRS=    doc

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/Makefile.global
 SUBDIRS = config
 
 domserver: composer-dump-autoload
+judgehost: composer-dump-autoload
 
 # Install PHP dependencies
 composer-dependencies:
@@ -66,6 +67,9 @@ install-domserver:
 # Change webapp/public/doc symlink
 	ln -sf $(domjudge_docdir) $(DESTDIR)$(domserver_webappdir)/public/doc
 	$(INSTALL_DATA) -t $(DESTDIR)$(domserver_webappdir) phpunit.xml.dist .env
+
+install-judgehost:
+	$(call install_tree,$(DESTDIR),vendor)
 
 maintainer-conf: .env.local
 


### PR DESCRIPTION
Previously, we were in an ugly way calling the judgedaemon again.

A later step can be to replace all curl calls with guzzle.