### PR TITLE
Fix Monaco-editor font rendering

### DIFF
--- a/webapp/src/EventListener/AddContentSecurityPolicyListener.php
+++ b/webapp/src/EventListener/AddContentSecurityPolicyListener.php
@@ -17,7 +17,7 @@ class AddContentSecurityPolicyListener
         // the profiler requires 'unsafe-eval' for script-src 'self'.
         $response = $event->getResponse();
         $cspExtra = $this->profiler ? "'unsafe-eval'" : "";
-        $csp = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' $cspExtra; img-src 'self' data:; worker-src 'self' blob:";
+        $csp = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' $cspExtra; img-src 'self' data:; worker-src 'self' blob:; font-src 'self' data:;";
         $response->headers->set('Content-Security-Policy', $csp);
     }
 }


### PR DESCRIPTION
Fixes a CSP violation as monaco-editor loads a font over data:.

@Kevinjil can you check if you get the same warning without it?