### PR TITLE
Allow teams to download all samples/attachments

### DIFF
--- a/webapp/templates/partials/problem_list.html.twig
+++ b/webapp/templates/partials/problem_list.html.twig
@@ -4,17 +4,24 @@
 
 <h1 class="mt-4 text-center">
     {{ contest.name | default('Contest') }} problems
-    {% if contest and show_contest_problemset and contest.contestProblemsetType is not empty %}
-        {% if contest_problemset_add_cid %}
-            {% set contest_problemset_url = path(contest_problemset_path, {'cid': contest.cid}) %}
-        {% else %}
-            {% set contest_problemset_url = path(contest_problemset_path) %}
+    {% if contest and show_contest_problemset %}
+        {% if contest.contestProblemsetType is not empty %}
+            {% if contest_problemset_add_cid %}
+                {% set contest_problemset_url = path(contest_problemset_path, {'cid': contest.cid}) %}
+            {% else %}
+                {% set contest_problemset_url = path(contest_problemset_path) %}
+            {% endif %}
+            <a class="btn btn-secondary" role="button"
+               href="{{ contest_problemset_url }}">
+                <i class="fas fa-file-{{ contest.contestProblemsetType }}"></i>
+                problemset
+            </a>
         {% endif %}
-        <a class="btn btn-secondary" role="button"
-           href="{{ contest_problemset_url }}">
-            <i class="fas fa-file-{{ contest.contestProblemsetType }}"></i>
-            problemset
-        </a>
+        {% if showSamples %}
+            <a class="btn btn-secondary" href="{{ path('current_samples_data_zip', {cid: contest.cid}) }}" title="Contains samples, attachments and statement for all problems.">
+                <i class="fas fa-download"></i> samples
+            </a>
+        {% endif %}
     {% endif %}
 </h1>
 


### PR DESCRIPTION
We already allow this over the API so use the same URL.

<img width="911" height="320" alt="image" src="https://github.com/user-attachments/assets/49e1eaeb-b335-4ba4-a732-14b381e14141" />

This doesn't check if there are actually samples as I think it will in 99% of the cases and in case there are none someone would just get a 404.