### PR TITLE
Hint during 2nd import of contests with the existing contest id(s)

### DIFF
--- a/misc-tools/import-contest.in
+++ b/misc-tools/import-contest.in
@@ -188,6 +188,11 @@ if os.path.exists('problems.yaml') or os.path.exists('problems.json') or os.path
         print('Importing problems.')
 
         if cid is None:
+            existing_contests = dj_utils.do_api_request('contests')
+            if existing_contests:
+                print("The DOMjudge server already has these contests:")
+            for c in existing_contests:
+                print(f"'{c['name']}' with cid: {c['id']}")
             cid = answer = input('Please specify the contest id: ')
 
         if not problems_imported:


### PR DESCRIPTION
Closes: https://github.com/DOMjudge/domjudge/issues/3048

Originally I wanted to just pick the one contest in case there is only one as you typically enter this situation by fixing a failed import. But as I'm not sure if we should choose for the user even if it works in 99% of the cases the 2nd is maybe better.