### PR TITLE
Use static link for compare scripts

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -463,10 +463,10 @@ function fetch_executable_internal(
                 }
                 switch ($execlang) {
                     case 'c':
-                        $buildscript .= "gcc -Wall -O2 -std=gnu11 $source -o run -lm\n";
+                        $buildscript .= "gcc -Wall -O2 -static -std=gnu11 $source -o run -lm\n";
                         break;
                     case 'cpp':
-                        $buildscript .= "g++ -Wall -O2 -std=gnu++20 $source -o run\n";
+                        $buildscript .= "g++ -Wall -O2 -static -std=gnu++20 $source -o run\n";
                         break;
                     case 'java':
                         $buildscript .= "javac -cp . -d . $source\n";

--- a/sql/files/defaultdata/compare/build
+++ b/sql/files/defaultdata/compare/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-g++ -std=c++11 -pedantic -g -O1 -Wall -fstack-protector -D_FORTIFY_SOURCE=2 -fPIE -Wformat -Wformat-security -fPIE -Wl,-z,relro -Wl,-z,now  compare.cc -o run
+g++ -std=c++11 -pedantic -g -O1 -static -Wall -fstack-protector -D_FORTIFY_SOURCE=2 -fPIE -Wformat -Wformat-security -fPIE -Wl,-z,relro -Wl,-z,now  compare.cc -o run


### PR DESCRIPTION
In case you have different GLIBC versions inside and outside of the chroot we would get errors. As dynamic linking saves a bit of space we shouldn't always do this but as we only do this for compare scripts and not the submissions this is quite a small diskoverhead.

We already have an issue to fix this in a proper way but as I encountered this both for alpine and in my laptop install (which is quite outdated with 22.04) I do think this is a good temporary fix.