### PR TITLE
Dynamically stretch the code editor height

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -1290,3 +1290,11 @@ function initScoreboardSubmissions() {
         });
     });
 }
+
+function resizeEditors() {
+    // This function assumes that there is at most one tabbed editor in the screen.
+    const activeEditor = document.querySelector(".tab-pane.active .editor");
+    const height = $(window).height() - document.body.offsetHeight + activeEditor.clientHeight - 1 + "px";
+    $('.editor').height(height);
+}
+$(window).resize(resizeEditors);

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -754,6 +754,5 @@ blockquote {
 
 .editor {
     width: 100%;
-    height: 80vh;
     border: 1px solid grey;
 }

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -883,6 +883,7 @@ $(function() {
         });
         %s
         %s
+        resizeEditors();
     });
 });
 </script>
@@ -1011,6 +1012,7 @@ $(function() {
             updateMode(e.target.value);
         });
         updateMode(initialDiffMode);
+        resizeEditors();
     });
 });
 </script>


### PR DESCRIPTION
Depends on #3132 + #3197 to clear vertical space for better UX.
Fixes #3058 