### PR TITLE
Add forgotten check if the full_debug script is used

### DIFF
--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -370,7 +370,7 @@ class ExecutableController extends BaseController
             'executable' => $executable,
             'default_compare' => (string)$this->config->get('default_compare'),
             'default_run' => (string)$this->config->get('default_run'),
-            'default full debug' => (string)$this->config->get('default_full_debug'),
+            'default_full_debug' => (string)$this->config->get('default_full_debug'),
         ]));
     }
 

--- a/webapp/templates/jury/executable.html.twig
+++ b/webapp/templates/jury/executable.html.twig
@@ -42,6 +42,9 @@
                         {% elseif executable.type == 'run' and default_run == executable.execid %}
                             <em>default run</em>
                             {% set used = true %}
+                        {% elseif executable.type == 'debug' and default_full_debug == executable.execid %}
+                            <em>default full debug</em>
+                            {% set used = true %}
                         {% endif %}
                         {% if executable.type == 'compare' %}
                             {% for problem in executable.problemsCompare %}


### PR DESCRIPTION
We do the same for the `run`/`compare` scripts.