### PR TITLE
Add missing deletion count

### DIFF
--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -419,6 +419,7 @@ class ExecutableController extends BaseController
                 'showModalSubmit' => true,
                 'modalUrl' => $request->getRequestUri(),
                 'redirectUrl' => $this->generateUrl('jury_executable', ['execId' => $execId]),
+                'count' => 1,
             ];
             if ($request->isXmlHttpRequest()) {
                 return $this->render('jury/delete_modal.html.twig', $data);


### PR DESCRIPTION
This location was missed in commit 2222a867f9

Fixes a twig rendering error:
```
Variable "count" does not exist in jury/delete_modal.html.twig at line 4.
```