### PR TITLE
Handle timediff's with missing start time.

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -184,7 +184,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         ];
     }
 
-    public function printtimediff(float $start, ?float $end = null): string
+    public function printtimediff(?float $start, ?float $end = null): string
     {
         return Utils::printtimediff($start, $end);
     }

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -546,8 +546,11 @@ class Utils
      *
      * Copied from lib/www/print.php
      */
-    public static function printtimediff(float $start, ?float $end = null): string
+    public static function printtimediff(?float $start, ?float $end = null): string
     {
+        if (is_null($start)) {
+            return '-';
+        }
         if (is_null($end)) {
             $end = microtime(true);
         }


### PR DESCRIPTION
Fixes https://github.com/DOMjudge/domjudge/issues/3147

This could happen in race conditions when picking up judgings, or when upgrading from previous DOMjudge versions.