### PR TITLE
Let dependabot update dependencies for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
     allow:
         - dependency-type: "all"
     target-branch: "8.3"


### PR DESCRIPTION
We already set updates for non-security to 0 (see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-) so this change should only open PRs for security issues. IMO this is fine for released versions as we have CI to check for the possible issues.

This would give issues when we need to pin to an unmaintained dependency where an update would require an update to a root dependency. I think in case we don't want to update in that case we can handle it case by case, but we should be aware of such an issue.