### PR TITLE
Cache node/composer dependencies

### DIFF
--- a/.github/workflows/database-upgrade.yml
+++ b/.github/workflows/database-upgrade.yml
@@ -24,6 +24,20 @@ jobs:
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: npm-${{ hashFiles('webapp/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: webapp/vendor
+          key: composer-${{ hashFiles('webapp/composer.lock') }}
+          restore-keys: |
+            composer-
       - name: Import Database
         run: mysql -hsqlserver -uroot -proot < .github/jobs/data/dj733.sql
       - name: Upgrade DOMjudge

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,20 @@ jobs:
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: npm-${{ hashFiles('webapp/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: webapp/vendor
+          key: composer-${{ hashFiles('webapp/composer.lock') }}
+          restore-keys: |
+            composer-
       - name: info
         run: |
           cat /proc/cmdline && echo &&

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,6 +48,20 @@ jobs:
         TEST: [Unit, E2E]
     steps:
       - uses: actions/checkout@v4
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: npm-${{ hashFiles('webapp/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: webapp/vendor
+          key: composer-${{ hashFiles('webapp/composer.lock') }}
+          restore-keys: |
+            composer-
       - name: info
         run: |
           cat /proc/cmdline && echo &&

--- a/.github/workflows/webstandard.yml
+++ b/.github/workflows/webstandard.yml
@@ -50,6 +50,20 @@ jobs:
             db: install
     steps:
       - uses: actions/checkout@v4
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: npm-${{ hashFiles('webapp/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: webapp/vendor
+          key: composer-${{ hashFiles('webapp/composer.lock') }}
+          restore-keys: |
+            composer-
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh ${{ matrix.role }}
       - name: Run webstandard tests (W3C, WCAG)


### PR DESCRIPTION
A bit based on Copilot, can't find the docs if this indeed captures the cache at the end of the job. If not we should use a second GHA to store the job.

Hopefully this will make CI faster in case we have a hackathon.