### PR TITLE
Do expose contests before start in the API

### DIFF
--- a/webapp/src/Controller/API/AbstractApiController.php
+++ b/webapp/src/Controller/API/AbstractApiController.php
@@ -30,6 +30,16 @@ abstract class AbstractApiController extends AbstractFOSRestController
     ) {}
 
     /**
+     * Whether to filter out contests that haven't started yet in calls to getQueryBuilder
+     * without an explicit value set for $filterBeforeContest.
+     * Override in subclasses to change this behavior.
+     */
+    protected function shouldFilterBeforeContest(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get the query builder used for getting contests.
      *
      * @param bool $onlyActive return only contests that are active

--- a/webapp/tests/Unit/Controller/API/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Controller\API;
 
+use App\DataFixtures\Test\DemoPreStartContestFixture;
 use App\Entity\Contest;
 
 class ContestControllerTest extends BaseTestCase
@@ -26,4 +27,48 @@ class ContestControllerTest extends BaseTestCase
     protected array $expectedAbsent = ['4242', 'nonexistent'];
 
     protected ?string $objectClassForExternalId = Contest::class;
+
+    /**
+     * Test that a contest that is activated but not yet started is visible in the list action for a team user.
+     */
+    public function testListShowsActivatedButNotStartedContest(): void
+    {
+        $this->loadFixture(DemoPreStartContestFixture::class);
+
+        $url = $this->helperGetEndpointURL($this->apiEndpoint);
+        // Use 'demo' user which has team role
+        $objects = $this->verifyApiJsonResponse('GET', $url, 200, 'demo');
+
+        self::assertIsArray($objects);
+        self::assertNotEmpty($objects, 'Contest list should not be empty');
+
+        // Find the demo contest in the response
+        $foundContest = null;
+        foreach ($objects as $contest) {
+            if ($contest['shortname'] === 'demo') {
+                $foundContest = $contest;
+                break;
+            }
+        }
+
+        self::assertNotNull($foundContest, 'Demo contest should be visible after activation even before start');
+        self::assertSame('Demo contest', $foundContest['formal_name']);
+    }
+
+    /**
+     * Test that a contest that is activated but not yet started is visible in the single action for a team user.
+     */
+    public function testSingleShowsActivatedButNotStartedContest(): void
+    {
+        $this->loadFixture(DemoPreStartContestFixture::class);
+
+        $contestId = $this->resolveEntityId(Contest::class, '1');
+        $url = $this->helperGetEndpointURL($this->apiEndpoint, $contestId);
+        // Use 'demo' user which has team role
+        $contest = $this->verifyApiJsonResponse('GET', $url, 200, 'demo');
+
+        self::assertIsArray($contest);
+        self::assertSame('Demo contest', $contest['formal_name']);
+        self::assertSame('demo', $contest['shortname']);
+    }
 }


### PR DESCRIPTION
Fixes #3166.

Also return 404 for problemset before contest start instead of 403.