### PR TITLE
Allow any daemon with read access access for ranking

### DIFF
--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -84,7 +84,7 @@ class TeamController extends AbstractRestController
     )]
     public function listAction(Request $request): Response
     {
-        if (!$this->config->get('enable_ranking') && !$this->dj->checkrole('jury')) {
+        if (!$this->config->get('enable_ranking') && !$this->dj->checkrole('api_reader')) {
             throw new BadRequestHttpException("teams list not available.");
         }
         return parent::performListAction($request);


### PR DESCRIPTION
Otherwise DOMlogo can't get the data with local judgehosts against an online (non)ranked contest. The alternative of default allowing the judgedaemon is worse as it normally doesn't need those credentials so for this case you need to extend that user with API_READER, giving it JURY would give it much more access than we want.