### PR TITLE
Exclude disabled teams from api/teams endpoint.

### DIFF
--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -308,7 +308,8 @@ class TeamController extends AbstractRestController
             ->leftJoin('t.category', 'tc')
             ->leftJoin('t.contests', 'c')
             ->leftJoin('tc.contests', 'cc')
-            ->select('t, ta');
+            ->select('t, ta')
+            ->andWhere('t.enabled = 1');
 
         if ($request->query->has('category')) {
             $queryBuilder

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -241,6 +241,10 @@ class TeamController extends BaseController
             throw new NotFoundHttpException(sprintf('Team with ID %s not found', $teamId));
         }
 
+        if (!$team->getEnabled()) {
+            $this->addFlash('danger', 'Team is disabled and currently excluded from the scoreboard');
+        }
+
         $data = [
             'refresh' => [
                 'after' => 15,


### PR DESCRIPTION
Also add a flash message in the jury interface when viewing a disabled team.

Fixes #3205