### PR TITLE
Don't allow clarifications before contest start via API.

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -198,6 +198,11 @@ class ClarificationController extends AbstractRestController
         }
 
         $time = Utils::now();
+        if ($contest->getStartTime() > $time) {
+            throw new BadRequestHttpException(
+                "Sending clarifications via API before the contest is not allowed."
+            );
+        }
         if ($timeString = $clarificationPost->time) {
             if ($this->isGranted('ROLE_API_WRITER')) {
                 try {


### PR DESCRIPTION
This leaves it nicely vague by design if it is allowed via the UI.

I'm not sure if this would fully respect the `proxy` functionality in CLICS but this seems to be the conclusion after the discussions.