### PR TITLE
Disable diff selection if there is no other

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -1422,7 +1422,7 @@ function initDiffEditor(editorId) {
         });
 
         const selected = select[0].options[select[0].selectedIndex];
-        if (selected && selected.dataset.tag) {
+        if (!select[0].disabled && selected && selected.dataset.tag) {
             setDiffTag(selected.dataset.tag);
         }
 

--- a/webapp/templates/jury/partials/submission_diff.html.twig
+++ b/webapp/templates/jury/partials/submission_diff.html.twig
@@ -26,7 +26,7 @@
             {% endif %}
             <div class="btn-group">
                 <a href="#" role="button" class="btn btn-secondary btn-sm pe-none" aria-disabled="true"><i class="fas fa-code-branch"></i></a>
-                <select class="diff-select btn btn-secondary btn-sm form-select-sm text-start" aria-label="Submission to diff against">
+                <select class="diff-select btn btn-secondary btn-sm form-select-sm text-start" aria-label="Submission to diff against" {%- if otherSubmissions is empty %}disabled="true" aria-disabled="true"{%- endif %}>
                     <option value="" data-tag="no-diff">No diff</option>
                     {%- for other in otherSubmissions %}
                         <option value="{{ other.submitid }}" data-url="{{ path('jury_submission', {submitId: other.submitid}) }}" {%- if other.tag %} data-tag="{{ other.tag }}" {%- endif %}>


### PR DESCRIPTION
Also, do not store the preferred diff tag when there is no other diff. This prevents going back to no-diff after viewing a submission without a diff.