### PR TITLE
Add expected exit code to `assert_failure` where it was missing.

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -437,7 +437,7 @@ compile_assertions_finished () {
   assert_line " * judgehost...........: /opt/domjudge/judgehost"
   assert_line " * runguard group......: domjudge-run"
   run make domserver
-  assert_failure
+  assert_failure 2
   run make judgehost
   assert_success
 }
@@ -456,5 +456,5 @@ compile_assertions_finished () {
   run make domserver
   assert_success
   run make judgehost
-  assert_failure
+  assert_failure 2
 }


### PR DESCRIPTION
Unclear how this worked in general, but it was failing for one of my PRs.

Definition for `assert_failure` can be found in submit/assert.bash