### PR TITLE
Remove collection of emails for self-registered users

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Version 10.0.0DEV
    shadow mode.
  - Use application/x-www-form-urlencoded instead of multipart/form-data for
    API requests without file uploads to make them work with PUT/PATCH requests.
+ - Removed email collection for selfregistered users.
 
 Version 9.0.0 - 5 October 2025
 ------------------------------

--- a/webapp/migrations/Version20190803123217.php
+++ b/webapp/migrations/Version20190803123217.php
@@ -591,7 +591,6 @@ CREATE TABLE `user` (
     `userid` int(4) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique ID',
     `username` varchar(255) NOT NULL COMMENT 'User login name',
     `name` varchar(255) NOT NULL COMMENT 'Name',
-    `email` varchar(255) DEFAULT NULL COMMENT 'Email address',
     `last_login` decimal(32,9) unsigned DEFAULT NULL COMMENT 'Time of last successful login',
     `first_login` decimal(32,9) unsigned DEFAULT NULL COMMENT 'Time of first login',
     `last_ip_address` varchar(255) DEFAULT NULL COMMENT 'Last IP address of successful login',

--- a/webapp/src/Controller/API/AccessController.php
+++ b/webapp/src/Controller/API/AccessController.php
@@ -222,7 +222,6 @@ class AccessController extends AbstractApiController
                         'team',
                         'roles',
                         'userid',
-                        'email',
                         'last_ip',
                         'enabled',
                     ]

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -362,7 +362,6 @@ class UserController extends AbstractRestController
         $user
             ->setUsername($addUser->username)
             ->setName($addUser->name)
-            ->setEmail($addUser->email)
             ->setIpAddress($addUser->ip)
             ->setPlainPassword($addUser->password)
             ->setEnabled($addUser->enabled ?? true);

--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -63,7 +63,6 @@ class UserController extends BaseController
             'username'   => ['title' => 'username', 'sort' => true, 'default_sort' => true],
             'externalid' => ['title' => 'ID', 'sort' => true],
             'name'       => ['title' => 'name', 'sort' => true],
-            'email'      => ['title' => 'email', 'sort' => true],
             'user_roles' => ['title' => 'roles', 'sort' => true],
             'teamid'     => ['title' => '', 'sort' => false, 'render' => 'entity_id_badge'],
             'team'       => ['title' => 'team', 'sort' => true],

--- a/webapp/src/DataFixtures/Test/SelfRegisteredUserFixture.php
+++ b/webapp/src/DataFixtures/Test/SelfRegisteredUserFixture.php
@@ -15,7 +15,6 @@ class SelfRegisteredUserFixture extends AbstractTestDataFixture
         $user
             ->setUsername('selfregister')
             ->setName('selfregistered user for example team')
-            ->setEmail('electronic@mail.tld')
             ->setPlainPassword('demo')
             ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => 'exteam']))
             ->addUserRole($manager->getRepository(Role::class)->findOneBy(['dj_role' => 'team']));

--- a/webapp/src/DataTransferObject/AddUser.php
+++ b/webapp/src/DataTransferObject/AddUser.php
@@ -14,8 +14,6 @@ class AddUser
     public function __construct(
         public readonly string $username,
         public readonly string $name,
-        #[OA\Property(format: 'email', nullable: true)]
-        public readonly ?string $email,
         #[OA\Property(nullable: true)]
         public readonly ?string $ip,
         #[OA\Property(format: 'password', nullable: true)]

--- a/webapp/src/DataTransferObject/UpdateUser.php
+++ b/webapp/src/DataTransferObject/UpdateUser.php
@@ -11,13 +11,12 @@ class UpdateUser extends AddUser
         public readonly string $id,
         string $username,
         string $name,
-        ?string $email,
         ?string $ip,
         ?string $password,
         ?bool $enabled,
         ?string $teamId,
         array $roles
     ) {
-        parent::__construct($username, $name, $email, $ip, $password, $enabled, $teamId, $roles);
+        parent::__construct($username, $name, $ip, $password, $enabled, $teamId, $roles);
     }
 }

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -58,12 +58,6 @@ class User extends BaseApiEntity implements
     #[ORM\Column(options: ['comment' => 'Name'])]
     private string $name = '';
 
-    #[ORM\Column(nullable: true, options: ['comment' => 'Email address'])]
-    #[Assert\Email]
-    #[OA\Property(nullable: true)]
-    #[Serializer\Groups([ARC::GROUP_NONSTRICT])]
-    private ?string $email = null;
-
     #[ORM\Column(
         type: 'decimal',
         precision: 32,
@@ -216,17 +210,6 @@ class User extends BaseApiEntity implements
     public function getShortDescription(): string
     {
         return $this->getName() ?: $this->getUsername();
-    }
-
-    public function setEmail(?string $email): User
-    {
-        $this->email = $email;
-        return $this;
-    }
-
-    public function getEmail(): ?string
-    {
-        return $this->email;
     }
 
     public function setLastLogin(string|float|null $lastLogin): User

--- a/webapp/src/Form/Type/UserRegistrationType.php
+++ b/webapp/src/Form/Type/UserRegistrationType.php
@@ -15,7 +15,6 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -27,7 +26,6 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Callback;
-use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContext;
 
@@ -58,15 +56,6 @@ class UserRegistrationType extends AbstractType
                     'placeholder' => 'Full name (optional)',
                     'autocomplete' => 'name',
                 ],
-            ])
-            ->add('email', EmailType::class, [
-                'label' => false,
-                'required' => false,
-                'attr' => [
-                    'placeholder' => 'Email address (optional)',
-                    'autocomplete' => 'email',
-                ],
-                'constraints' => new Email(),
             ])
             ->add('teamName', TextType::class, [
                 'label' => false,

--- a/webapp/src/Form/Type/UserType.php
+++ b/webapp/src/Form/Type/UserType.php
@@ -11,7 +11,6 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -53,12 +52,6 @@ class UserType extends AbstractExternalIdEntityType
             'required' => false,
             'help' => 'Optional full name for the user.',
             'empty_data' => ''
-        ]);
-        $builder->add('email', EmailType::class, [
-            'required' => false,
-            'attr' => [
-                'autocomplete' => 'email',
-            ],
         ]);
         $builder->add('plainPassword', PasswordType::class, [
             'required' => false,

--- a/webapp/templates/jury/partials/user_form.html.twig
+++ b/webapp/templates/jury/partials/user_form.html.twig
@@ -31,7 +31,6 @@
                     {{ _self.form_table_row(form.username) }}
                 {% endif %}
                 {{ _self.form_table_row(form.name) }}
-                {{ _self.form_table_row(form.email) }}
 
                 {{ _self.section_header('key', 'Authentication') }}
                 {{ _self.form_table_row(form.plainPassword) }}

--- a/webapp/templates/jury/user.html.twig
+++ b/webapp/templates/jury/user.html.twig
@@ -36,16 +36,6 @@
                         <th>Full name</th>
                         <td>{{ user.name ?: '-' }}</td>
                     </tr>
-                    <tr>
-                        <th>Email</th>
-                        <td>
-                            {% if user.email %}
-                                <a href="mailto:{{ user.email }}">{{ user.email }}</a>
-                            {% else %}
-                                -
-                            {% endif %}
-                        </td>
-                    </tr>
 
                     {{ _self.section_header('key', 'Authentication') }}
                     <tr>

--- a/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GeneralInfoControllerTest.php
@@ -110,7 +110,7 @@ class GeneralInfoControllerTest extends BaseTestCase
         static::assertTrue($response['enabled']);
         static::assertNull($response['last_login_time']);
         static::assertGreaterThanOrEqual($response['first_login_time'], $response['last_api_login_time']);
-        $keysExpected = ['id', 'ip', 'last_ip', 'email'];
+        $keysExpected = ['id', 'ip', 'last_ip'];
         foreach ($keysExpected as $keyExpected) {
             static::assertArrayHasKey($keyExpected, $response);
         }

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -16,7 +16,6 @@ class UserControllerTest extends AccountBaseTestCase
             "id" => "admin",
             "username" => "admin",
             "name" => "Administrator",
-            "email" => null,
             "ip" => null,
             "enabled" => true
         ],
@@ -28,7 +27,6 @@ class UserControllerTest extends AccountBaseTestCase
             "id" => "judgehost",
             "username" => "judgehost",
             "name" => "User for judgedaemons",
-            "email" => null,
             "ip" => null,
             "enabled" => true
         ],
@@ -40,7 +38,6 @@ class UserControllerTest extends AccountBaseTestCase
             "id" => "demo",
             "username" => "demo",
             "name" => "demo user for example team",
-            "email" => null,
             "ip" => null,
             "enabled" => true
         ],

--- a/webapp/tests/Unit/Controller/Jury/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/UserControllerTest.php
@@ -20,19 +20,16 @@ class UserControllerTest extends JuryControllerTestCase
     protected static string  $className                = User::class;
     protected static array   $DOM_elements             = ['h1' => ['Users']];
     protected static string  $addForm                  = 'user[';
-    protected static array   $addEntitiesShown         = ['name', 'username', 'email'];
+    protected static array   $addEntitiesShown         = ['name', 'username'];
     protected static array   $overviewSingleNotShown   = ['plainPassword'];
     protected static array   $addEntities              = [['username'      => 'un',
                                                            'name'          => 'Alice',
-                                                           'email'         => 'alice@example.org',
                                                            'plainPassword' => 'plainpassword',
                                                            'ipAddress'     => '10.0.0.0',
                                                            'enabled'       => true,
                                                            'team'          => '',
                                                            'user_roles'    => ['0' => true, '1' => true]],
                                                           ['username' => 'ABCabc123_-@', 'name' => 'Allowed username'],
-                                                          ['username' => 'nem', 'name' => 'No Email',
-                                                           'email' => ''],
                                                           ['username' => 'npw', 'name' => 'No password',
                                                            'plainPassword' => ''],
                                                           ['username' => 'specialchar', 'name' => 'Special char in password',

--- a/webapp/tests/Unit/Controller/PublicControllerTest.php
+++ b/webapp/tests/Unit/Controller/PublicControllerTest.php
@@ -21,7 +21,7 @@ class PublicControllerTest extends BaseTestCase
     protected static string $urlTeams        = '/jury/teams';
     protected static string $urlAffil        = '/jury/affiliations';
     protected static array  $requiredFields  = ['teamName','affiliationName','affiliationShortName','existingAffiliation'];
-    protected static array  $formFields      = ['username','name','email','teamName','affiliation','affiliationName',
+    protected static array  $formFields      = ['username','name','teamName','affiliation','affiliationName',
                                                 'affiliationShortName','affiliationCountry','existingAffiliation'];
     protected static array  $duplicateFields = ['username'=>['input'=>'selfregister','error'=>'The username \'"selfregistered"\' is already in use.'],
                                                 'teamName'=>['input'=>'Example teamname','error'=>'This team name is already in use.'],
@@ -198,7 +198,7 @@ class PublicControllerTest extends BaseTestCase
         self::assertSelectorExists($selector);
     }
 
-    // username, name, email, teamName, affiliation, affiliationName
+    // username, name, teamName, affiliation, affiliationName
     // affiliationShortName, affiliationCountry, existingAffiliation
     // plainPassword
     public function selfRegisterProvider(): Generator
@@ -210,7 +210,7 @@ class PublicControllerTest extends BaseTestCase
                 }
                 yield[['username'=>'minimaluser', 'teamName'=>'NewTeam','affiliation'=>'none'],'shirt-recognize-bar-together', $fixtures, $category];
                 yield[['username'=>'bruteforce', 'teamName'=>'Fib(9)','affiliation'=>'none'],'01123581321', $fixtures, $category];
-                yield[['username'=>'fullUser', 'name'=>'Full User', 'email'=>'email@domain.com','teamName'=>'Trial','affiliation'=>'none'],'..........', $fixtures, $category];
+                yield[['username'=>'fullUser', 'name'=>'Full User', 'teamName'=>'Trial','affiliation'=>'none'],'..........', $fixtures, $category];
                 yield[['username'=>'student@', 'teamName'=>'Student@Uni',
                        'affiliation'=>'new','affiliationName'=>'NewUni','affiliationShortName'=>'nu'],'p@ssword_Is_long', $fixtures, $category];
                 yield[['username'=>'winner@', 'teamName'=>'FunnyTeamname',
@@ -219,7 +219,7 @@ class PublicControllerTest extends BaseTestCase
                 yield[['username'=>'newinstsamecountry', 'name'=>'CompetingDutchTeam', 'teamName'=>'SupperT3@m','affiliation'=>'new','affiliationName'=>'Vrije Universiteit',
                        'affiliationShortName'=>'vu','affiliationCountry'=>'NLD'],'demodemodemo', $fixtures, $category];
                 if (count($fixtures)===1) {
-                    yield[['username'=>'reusevaluesofexistinguser', 'name'=>'selfregistered user for example team','email'=>'electronic@mail.tld','teamName'=>'EasyEnough','affiliation'=>'none'],'demodemodemo', [...$fixtures, SelfRegisteredUserFixture::class],''];
+                    yield[['username'=>'reusevaluesofexistinguser', 'name'=>'selfregistered user for example team','teamName'=>'EasyEnough','affiliation'=>'none'],'demodemodemo', [...$fixtures, SelfRegisteredUserFixture::class],''];
                 }
             }
         }


### PR DESCRIPTION
In all years that I've worked with DOMjudge I've never seen a good reason to collect the email separately. So I propose to remove the collection in the next major release.

We keep storing the emails in development dumps and although it doesn´t hurt that much it is a bit more privacy sensitive than most other fields IMHO.