### PR TITLE
Disable phpcs CI run while it is broken

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -40,31 +40,31 @@ jobs:
           webapp/public
           webapp/config
 
-  phpcs_compatibility:
-    runs-on: ubuntu-latest
-    container:
-      image: pipelinecomponents/php-codesniffer:latest
-    strategy:
-      matrix:
-        PHPVERSION: ["8.1", "8.2", "8.3", "8.4"]
-    steps:
-      - run: apk add git
-      - uses: actions/checkout@v4
-      - name: Various fixes to this image
-        run: .github/jobs/fix_pipelinecomponents_image.sh
-      - name: Detect compatibility with supported PHP version
-        run: >
-          phpcs -s -p --colors
-          --standard=PHPCompatibility
-          --extensions=php
-          --runtime-set testVersion ${{ matrix.PHPVERSION }}
-          lib/lib.*.php
-          etc
-          judge
-          webapp/src
-          webapp/tests
-          webapp/public
-          webapp/config
+  # phpcs_compatibility:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: pipelinecomponents/php-codesniffer:latest
+  #   strategy:
+  #     matrix:
+  #       PHPVERSION: ["8.1", "8.2", "8.3", "8.4"]
+  #   steps:
+  #     - run: apk add git
+  #     - uses: actions/checkout@v4
+  #     - name: Various fixes to this image
+  #       run: .github/jobs/fix_pipelinecomponents_image.sh
+  #     - name: Detect compatibility with supported PHP version
+  #       run: >
+  #         phpcs -s -p --colors
+  #         --standard=PHPCompatibility
+  #         --extensions=php
+  #         --runtime-set testVersion ${{ matrix.PHPVERSION }}
+  #         lib/lib.*.php
+  #         etc
+  #         judge
+  #         webapp/src
+  #         webapp/tests
+  #         webapp/public
+  #         webapp/config
 
   pycodestyle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We probably should not use the latest tag but some fixed version so that it doesn't break under us at random times