### PR TITLE
Fix one more brittle submit test.

### DIFF
--- a/submit/submit_standalone.bats
+++ b/submit/submit_standalone.bats
@@ -18,7 +18,7 @@ setup() {
 @test "baseurl set in environment" {
     run ./submit
     assert_failure 1
-    assert_regex "$SUBMITBASEHOST.*/api(/.*)?/contests.*\[Errno -2\] Name or service not known"
+    assert_regex "$SUBMITBASEHOST"
 }
 
 @test "baseurl via parameter overrides environment" {


### PR DESCRIPTION
Previous example failure:
```
not ok 2 baseurl set in environment
 # (from function `fail' in file assert.bash, line 13,
 #  from function `assert_regex' in file assert.bash, line 44,
 #  in test file submit_standalone.bats, line 21)
 #   `assert_regex "$SUBMITBASEHOST.*/api(/.*)?/contests.*\[Errno -2\] Name or service not known"' failed
 # Expected: 'domjudge.example.org.*/api(/.*)?/contests.*\[Errno -2\] Name or service not known'
 # Output:
 # Using 'https://domjudge.example.org/somejudge' as defined in the 'SUBMITBASEURL' environment variable. Pass '-u <url>' to override.
 # HTTPSConnectionPool(host='domjudge.example.org', port=443): Max retries exceeded with url: /somejudge/api/contests (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f9dd4abf680>: Failed to resolve 'domjudge.example.org' ([Errno -5] No address associated with hostname)"))
 # Could not obtain active contests.
 # ERROR: No (valid) contest specified, pass it as --contest or set as SUBMITCONTEST environment variable.
 # WARNING: No active contests found (and no contest specified)!
 # Type './submit --help' to get help.
```

Not sure why this started being brittle now, but seems to have still worked in 26c780a7b35ad7a03d7ff488a0620657b930ee26, but it is following the same pattern