### PR TITLE
Fix resubmission links in submission source view

### DIFF
--- a/webapp/templates/jury/submission_source.html.twig
+++ b/webapp/templates/jury/submission_source.html.twig
@@ -23,7 +23,7 @@
             {% if submission.resubmissions is not empty %}
                 (resubmitted as
                 {%- for resubmission in submission.resubmissions %}
-                    <a href="{{ path('jury_submission', {submitId: resubmission.originalSubmission.submitid}) }}">s{{ resubmission.submitid }}</a>
+                    <a href="{{ path('jury_submission', {submitId: resubmission.submitid}) }}">s{{ resubmission.submitid }}</a>
                     {%- if not loop.last -%},{%- endif -%}
                 {%- endfor -%}
                 )


### PR DESCRIPTION
In the submission source view, both the original submission id and the resubmission id link to the original submission. In the normal submission view, the links are as expected: https://github.com/DOMjudge/domjudge/blob/ac920acd5b926f62e96f3c56c9c32a5cf016f677/webapp/templates/jury/submission.html.twig#L102-L103

I just saw this on an instance we have set up for a lecture and did this edit in the Github edit view. I have not tested this since I don't a development instance set up, but I performed the change based on what I found in the linked file. Please let me know if there is anything else I should change.