### PR TITLE
Use the default packaged chroot

### DIFF
--- a/.github/jobs/baseinstall.sh
+++ b/.github/jobs/baseinstall.sh
@@ -45,7 +45,7 @@ if [ "$version" = "all" ]; then
     ./configure \
       --with-baseurl='http://localhost/domjudge/' \
       --with-domjudge-user=domjudge \
-      --with-judgehost-chrootdir=/chroot/domjudge | tee "$ARTIFACTS"/configure.txt
+      --with-judgehost-chrootdir=/home/runner/work/domjudge-packaging/domjudge-packaging/docker-gitlabci/domjudge-main/chroot | tee "$ARTIFACTS"/configure.txt
     make build-scripts domserver judgehost docs
     make install-domserver install-judgehost install-docs
 else

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,8 +53,6 @@ jobs:
         run: pstree -p
       - name: Install DOMjudge
         run: .github/jobs/baseinstall.sh all
-      - name: Set up chroot
-        run: sudo misc-tools/dj_make_chroot -a amd64
       - name: Check nginx
         run: curl -v https://localhost/domjudge/
       - name: Configure print command


### PR DESCRIPTION
This should speedup the integration test by quite a lot. We don´t change the `dj_make_chroot` that often and already have tests to build the chroot so we still do it, just not in this test anymore.

This was discussed at NWERC25.