### PR TITLE
Defence in depth for adding directories to the zip

### DIFF
--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1574,6 +1574,10 @@ class DOMJudgeService
             if ($filepath === false) {
                 throw new Exception("Could not find (possibly symlinked) file: " . $file . ", at: " . $publicPath);
             }
+            if (!in_array(filetype($filepath), ['file', 'link'])) {
+                // Ignore special filetypes
+                continue;
+            }
             if (!(str_starts_with($filepath, $publicPath) ||
                   str_starts_with($filepath, $this->vendorDir) ||
                   str_starts_with($filepath, $this->nodeModulesDir))


### PR DESCRIPTION
Found while debugging the MathJax issue (https://github.com/DOMjudge/domjudge/pull/3276),

MathJax requires the `mathjaxfonts` to be specified in the config. We parse that URL and try to add that directory to the zip which fails.