### PR TITLE
Allow QUIET=0 as temporary fix in installation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ paths.mk:
 maintainer-conf: inplace-conf-common dependencies-dev
 inplace-conf: inplace-conf-common dependencies
 inplace-conf-common: dist
-	./configure $(subst 1,-q,$(QUIET)) --prefix=$(CURDIR) \
+	./configure $(QUIET_FLAG) --prefix=$(CURDIR) \
 	            --with-domserver_root=$(CURDIR) \
 	            --with-judgehost_root=$(CURDIR) \
 	            --with-domjudge_docdir=$(CURDIR)/doc \

--- a/Makefile.global
+++ b/Makefile.global
@@ -8,9 +8,18 @@ ifndef GLOBALINCLUDED
 GLOBALINCLUDED=1
 
 # Check for QUIET environment variable:
-ifneq ($(QUIET),)
+ifeq ($(QUIET),0)
+QUIET_FLAG =
+QUIET_FLAG_CAPITAL =
+else ifeq ($(QUIET),)
+QUIET_FLAG =
+QUIET_FLAG_CAPITAL =
+else
+# Whenever QUIET is set and is not 0 assume it to be true
 export QUIET=1
 MAKEFLAGS += --no-print-directory --quiet
+QUIET_FLAG = -q
+QUIET_FLAG_CAPITAL = -Q
 endif
 
 # Define the 'default' target here: because of inclusion of this file,

--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -6,7 +6,14 @@ REC_TARGETS = inplace-install inplace-uninstall
 
 include $(TOPDIR)/Makefile.global
 
-ifneq ($(QUIET),)
+ifeq ($(QUIET),0)
+# Ignore option for 0
+QUIET_REDIRECT =
+else ifeq ($(QUIET),)
+# Ignore option for unset
+QUIET_REDIRECT =
+else
+# Set all other QUIET values as true
 export LATEXMKOPTS=-quiet
 QUIET_REDIRECT = >/dev/null 2>&1
 endif
@@ -61,10 +68,10 @@ conf_ref.rst: gen_conf_ref.py
 	./gen_conf_ref.py
 
 html: conf_ref.rst
-	sphinx-build -M $@ . build $(subst 1,-Q,$(QUIET))
+	sphinx-build -M $@ . build $(QUIET_FLAG_CAPITAL)
 
 team:
-	sphinx-build -b latex . build/team $(subst 1,-Q,$(QUIET))
+	sphinx-build -b latex . build/team $(QUIET_FLAG_CAPITAL)
 	$(MAKE) -C build/team domjudge-team-manual.pdf $(QUIET_REDIRECT)
 	cp build/team/domjudge-team-manual.pdf build
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -29,7 +29,7 @@ domserver: apache.conf nginx-conf nginx-conf-inner $(SECRETS)
 judgehost: restapi.secret
 
 $(SECRETS):
-	./gen_all_secrets $(subst 1,-q,$(QUIET))
+	./gen_all_secrets $(QUIET_FLAG)
 
 install-domserver:
 	$(INSTALL_DATA) -t $(DESTDIR)$(domserver_etcdir) \

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -21,12 +21,12 @@ ifeq (, $(shell command -v composer 2> /dev/null))
 endif
 # We use --no-scripts here because at this point the autoload.php file is
 # not generated yet, which is needed to run the post-install scripts.
-	composer $(subst 1,-q,$(QUIET)) install --prefer-dist -o -a --no-scripts --no-plugins
+	composer install $(QUIET_FLAG) --prefer-dist -o -a --no-scripts --no-plugins
 
 dependencies-dev: composer-dependencies-dev node-dependencies
 
 composer-dependencies-dev:
-	composer $(subst 1,-q,$(QUIET)) install --prefer-dist --no-scripts --no-plugins
+	composer $(QUIET_FLAG) install --prefer-dist --no-scripts --no-plugins
 
 # Dump autoload dependencies (including plugins)
 # This is needed since symfony/runtime is a Composer plugin that runs while dumping
@@ -36,10 +36,10 @@ composer-dependencies-dev:
 composer-dump-autoload: vendor/autoload_runtime.php
 
 vendor/autoload_runtime.php:
-	composer $(subst 1,-q,$(QUIET)) dump-autoload -o -a
+	composer $(QUIET_FLAG) dump-autoload -o -a
 
 composer-dump-autoload-dev:
-	composer $(subst 1,-q,$(QUIET)) dump-autoload
+	composer $(QUIET_FLAG) dump-autoload
 
 define detect_yarn
 YARN_CMD=$$(command -v yarn || command -v yarnpkg); \


### PR DESCRIPTION
I encountered this when changing our update_*.sh scripts. We use `QUIET=1` there, I replaced that with `QUIET=0` which would enter `0` in a couple of places where we don't really need that. The same would happen with `QUIET=2` which would be a strange but valid boolean.

Those fixes should make it hopefully easier to read and remove this specific issue. I couldn't find a nice way to do an or to remove the duplication so we end up with some (ugly) replication of the flags.