### PR TITLE
Disallow opening .php directly with GET request

### DIFF
--- a/etc/nginx-conf-inner.in
+++ b/etc/nginx-conf-inner.in
@@ -17,6 +17,8 @@ set $domjudgeRoot @domserver_webappdir@/public;
 set $prefix /domjudge;
 
 # Uncomment to run it out of the root of your system
+# # Disallow opening .php files directly
+# location ~ ^/+[^/]+\.php$ { return 404; }
 # location / {
 # 	root $domjudgeRoot;
 # 	try_files $uri @domjudgeFront;
@@ -31,6 +33,8 @@ set $prefix /domjudge;
 
 # Or you can install it with a prefix
 location /domjudge { return 301 /domjudge/; }
+# Disallow opening .php files directly
+location ~ ^/domjudge/+[^/]+\.php$ { return 404; }
 location /domjudge/ {
 	root $domjudgeRoot;
 	rewrite ^/domjudge/(.*)$ /$1 break;


### PR DESCRIPTION
This only worked for files in the public directory which is at the moment only index.php. This shouldn't be a real problem but doing it like this shouldn't hurt in case someone misconfigures.

Closes: https://github.com/DOMjudge/domjudge-packaging/issues/215