### PR TITLE
Support both localhost and % host part for mysql users

### DIFF
--- a/sql/dj_setup_database.in
+++ b/sql/dj_setup_database.in
@@ -241,6 +241,8 @@ create_db_users()
 
 	echo "CREATE USER IF NOT EXISTS '$domjudge_DBUSER'@'%' IDENTIFIED BY '$domjudge_PASSWD';"
 	echo "GRANT SELECT, INSERT, UPDATE, DELETE ON \`$DBNAME\`.* TO '$domjudge_DBUSER'@'%';"
+	echo "CREATE USER IF NOT EXISTS '$domjudge_DBUSER'@'localhost' IDENTIFIED BY '$domjudge_PASSWD';"
+	echo "GRANT SELECT, INSERT, UPDATE, DELETE ON \`$DBNAME\`.* TO '$domjudge_DBUSER'@'localhost';"
 
 	echo "FLUSH PRIVILEGES;"
 	) | mysql
@@ -252,6 +254,7 @@ remove_db_users()
 	(
 	echo "DROP DATABASE IF EXISTS \`$DBNAME\`;"
 	echo "DROP USER IF EXISTS '$domjudge_DBUSER'@'%';"
+	echo "DROP USER IF EXISTS '$domjudge_DBUSER'@'localhost';"
 	echo "FLUSH PRIVILEGES;"
 	) | mysql -f
 	verbose "DOMjudge database and user(s) removed."
@@ -260,10 +263,10 @@ remove_db_users()
 update_password()
 {
 	(
-    echo "ALTER USER '$domjudge_DBUSER'@'%' IDENTIFIED BY '$domjudge_PASSWD';"
+	echo "ALTER USER '$domjudge_DBUSER'@'%' IDENTIFIED BY '$domjudge_PASSWD';"
+	echo "ALTER USER '$domjudge_DBUSER'@'localhost' IDENTIFIED BY '$domjudge_PASSWD';"
 	echo "FLUSH PRIVILEGES;"
 	) | mysql
-    verbose "ALTER USER '$domjudge_DBUSER'@'%' IDENTIFIED BY '$domjudge_PASSWD';"
 	verbose "Database user password updated from credentials file."
 }
 


### PR DESCRIPTION
This reverts d6a82b235e59699059ae3aa9629d7 to use localhost again, but also keeps the user with `%` host. MySQL seems to treat these as fully separate users and when connecting with a mysql client locally, the `%` host results in the error:
```
ERROR 1045 (28000): Access denied for user 'domjudge'@'localhost' (using password: YES)
```

Also remove a verbose print statement left over from debugging.