### PR TITLE
Add and use new option to stay on one filesystem.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1181,7 +1181,7 @@ class JudgeDaemon
         }
 
         // Evict all contents of the workdir from the kernel fs cache
-        if (!$this->runCommandSafe([LIBJUDGEDIR . '/evict', $workdir])) {
+        if (!$this->runCommandSafe([LIBJUDGEDIR . '/evict', '-x', $workdir])) {
             warning("evict script failed, continuing gracefully");
         }
     }


### PR DESCRIPTION
While theoretically we should not leave filesystems behind, sometimes during testing new judging changes `/proc` was still mounted, causing `evict` to traverse into proc where it gets stuck in a loop causing weird failure modes.