### PR TITLE
Use name instead of internal ID in language/compiler version overview.

### DIFF
--- a/webapp/templates/jury/versions.html.twig
+++ b/webapp/templates/jury/versions.html.twig
@@ -14,7 +14,7 @@
     {% for lang in data %}
         <div class="card mb-3">
             <div class="card-header">
-                Language <code>{{ lang.language.langid }}</code>
+                Language <code>{{ lang.language.name }}</code>
                 {% if is_granted('ROLE_ADMIN') %}
                 <span style="float: right">
                     {{ button(path('jury_language_edit', {'langId': lang.language.externalid}), 'Edit version command(s)', 'primary btn-sm', 'edit') }}


### PR DESCRIPTION
Example: 

<img width="684" height="899" alt="image" src="https://github.com/user-attachments/assets/49fe517e-ef4c-4711-9b6e-76796f03b926" />
