### PR TITLE
Allow multiple classes in 1 file

### DIFF
--- a/.github/jobs/data/phpruleset.xml
+++ b/.github/jobs/data/phpruleset.xml
@@ -6,6 +6,10 @@
     <rule ref="PSR2.Methods.FunctionCallSignature.Indent">
         <severity>0</severity>
     </rule>
+    <!-- We have the JudgeDaemon where we do this with intent. -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+      <severity>0</severity>
+    </rule>
     <!-- We have multiple lines of +120 where splitting is not trivial -->
     <rule ref="Generic.Files.LineLength">
         <severity>0</severity>


### PR DESCRIPTION
Not sure if this is also the rule for the enums but I suspect it is. I think this is cleaner than adding the comment in the file for all enums/classes.