### PR TITLE
Add interactive judgehost timeline to overview page.

### DIFF
--- a/webapp/public/js/judgehost-timeline.js
+++ b/webapp/public/js/judgehost-timeline.js
@@ -1,0 +1,155 @@
+function initJudgehostTimeline(dataUrl) {
+    const margin = {top: 20, right: 30, bottom: 40, left: 150};
+    const $container = $('#judgehost-timeline');
+    const fullWidth = $container.width();
+    const fullHeight = $container.height();
+    const width = fullWidth - margin.left - margin.right;
+    const height = fullHeight - margin.top - margin.bottom;
+
+    const svg = d3.select("#judgehost-timeline svg")
+        .attr("width", fullWidth)
+        .attr("height", fullHeight);
+
+    // Clear previous content if any (for re-init)
+    svg.selectAll("*").remove();
+
+    const container = svg.append("g")
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+    // Clip path for zooming
+    svg.append("defs").append("clipPath")
+        .attr("id", "clip")
+      .append("rect")
+        .attr("width", width)
+        .attr("height", height);
+
+    const mainContent = container.append("g")
+        .attr("clip-path", "url(#clip)");
+
+    let tooltip = d3.select(".timeline-tooltip");
+    if (tooltip.empty()) {
+        tooltip = d3.select("body").append("div")
+            .attr("class", "timeline-tooltip")
+            .style("opacity", 0);
+    }
+
+    d3.json(dataUrl, function(error, json) {
+        if (error) {
+            console.error("Error loading timeline data:", error);
+            return;
+        }
+
+        const allData = json.data;
+        const now = json.now * 1000;
+        const start = json.twenty_four_hours_ago * 1000;
+
+        allData.forEach(function(d) {
+            d.startTime = +d.startTime * 1000;
+            d.endtime = +d.endtime * 1000;
+        });
+
+        function render() {
+            const showDisabled = $('#toggle-disabled-jh').is(':checked');
+            
+            // Filter judgehosts
+            const activeJudgehosts = [];
+            for (const id in json.judgehosts) {
+                const jh = json.judgehosts[id];
+                if (showDisabled || jh.enabled) {
+                    activeJudgehosts.push({id: id, name: jh.hostname});
+                }
+            }
+            activeJudgehosts.sort(function(a, b) { return d3.ascending(a.name, b.name); });
+
+            // Filter data to only include judgehosts being shown
+            const hostNames = new Set(activeJudgehosts.map(d => d.name));
+            const data = allData.filter(d => hostNames.has(d.hostname));
+
+            container.selectAll(".timeline-axis").remove();
+            mainContent.selectAll(".timeline-rect").remove();
+
+            const minStart = d3.min(data, function(d) { return d.startTime; });
+            let displayStart = start;
+            if (minStart) {
+                displayStart = Math.max(start, minStart - 1 * 60 * 1000);
+            }
+
+            const x = d3.time.scale()
+                .domain([displayStart, now])
+                .range([0, width]);
+
+            const y = d3.scale.ordinal()
+                .domain(activeJudgehosts.map(function(d) { return d.name; }))
+                .rangeRoundBands([0, height], 0.1);
+
+            const xAxis = d3.svg.axis()
+                .scale(x)
+                .orient("bottom")
+                .tickFormat(d3.time.format("%H:%M"));
+
+            const yAxis = d3.svg.axis()
+                .scale(y)
+                .orient("left");
+
+            container.append("g")
+                .attr("class", "timeline-axis timeline-y-axis")
+                .call(yAxis);
+
+            const xAxisGroup = container.append("g")
+                .attr("class", "timeline-axis timeline-x-axis")
+                .attr("transform", "translate(0," + height + ")")
+                .call(xAxis);
+
+            const zoom = d3.behavior.zoom()
+                .x(x)
+                .scaleExtent([1, 1000])
+                .on("zoom", function() {
+                    xAxisGroup.call(xAxis);
+                    mainContent.selectAll(".timeline-rect")
+                        .attr("x", function(d) { return x(d.startTime); })
+                        .attr("width", function(d) { return Math.max(1, x(d.endtime) - x(d.startTime)); });
+                });
+
+            svg.call(zoom);
+
+            const colors = d3.scale.category20();
+
+            mainContent.selectAll(".timeline-rect")
+                .data(data)
+                .enter().append("rect")
+                .attr("class", "timeline-rect")
+                .attr("x", function(d) { return x(d.startTime); })
+                .attr("y", function(d) { return y(d.hostname); })
+                .attr("width", function(d) { return Math.max(1, x(d.endtime) - x(d.startTime)); })
+                .attr("height", y.rangeBand())
+                .attr("fill", function(d) { return colors(d.jobid % 20); })
+                .style("pointer-events", "all")
+                .on("mouseover", function(d) {
+                    tooltip.transition().duration(200).style("opacity", .9);
+                    const duration = ((d.endtime - d.startTime) / 1000).toFixed(3);
+                    tooltip.html(
+                        "<b>Contest:</b> " + d.contest_shortname + "<br/>" +
+                        "<b>Problem:</b> " + d.problem_name + "<br/>" +
+                        "<b>Submission:</b> s" + d.submitid + " (j" + d.jobid + ")<br/>" +
+                        "<b>Result:</b> " + (d.runresult || 'judging') + "<br/>" +
+                        "<b>Duration:</b> " + duration + "s"
+                    )
+                    .style("left", (d3.event.pageX + 10) + "px")
+                    .style("top", (d3.event.pageY - 28) + "px");
+                })
+                .on("mousemove", function() {
+                    tooltip.style("left", (d3.event.pageX + 10) + "px")
+                           .style("top", (d3.event.pageY - 28) + "px");
+                })
+                .on("mouseout", function() {
+                    tooltip.transition().duration(500).style("opacity", 0);
+                })
+                .on("click", function(d) {
+                    window.location.href = domjudge_base_url + "/jury/submissions/" + d.submitid;
+                });
+        }
+
+        render();
+        $('#toggle-disabled-jh').on('change', render);
+    });
+}

--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -310,3 +310,38 @@ table.table-full-clickable-cell tr .table-button-head-right-right{
 .scoring-testcase-score {
     font-weight: bold;
 }
+
+/* Timeline styles */
+#judgehost-timeline {
+    height: 400px;
+    width: 100%;
+}
+
+#judgehost-timeline svg {
+    font-family: sans-serif;
+    font-size: 10px;
+}
+
+.timeline-axis path,
+.timeline-axis line {
+    fill: none;
+    stroke: #000;
+    shape-rendering: crispEdges;
+}
+
+.timeline-rect:hover {
+    opacity: 0.8;
+    cursor: pointer;
+}
+
+.timeline-tooltip {
+    position: absolute;
+    padding: 8px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    pointer-events: none;
+    font-size: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    z-index: 1000;
+}

--- a/webapp/templates/jury/judgehosts.html.twig
+++ b/webapp/templates/jury/judgehosts.html.twig
@@ -6,6 +6,8 @@
 {% block extrahead %}
     {{ parent() }}
     {{ macros.table_extrahead() }}
+    <script src="{{ asset('js/d3.min.js') }}"></script>
+    <script src="{{ asset('js/judgehost-timeline.js') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -44,7 +46,30 @@
                 {{ button(path('jury_judgehost_edit'), 'Edit all judgehosts', 'secondary', 'edit') }}
             </div>
         </div>
-
     {%- endif %}
 
+    <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            Judgehost Activity (last 24h)
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input" type="checkbox" id="toggle-disabled-jh">
+                <label class="form-check-label" for="toggle-disabled-jh">Show disabled</label>
+            </div>
+        </div>
+        <div class="card-body">
+            <div id="judgehost-timeline">
+                <svg></svg>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block footer %}
+    {{ parent() }}
+    <script>
+        $(function() {
+            initJudgehostTimeline('{{ path('jury_judgehost_timeline_data') }}');
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
Examples:

<img width="2252" height="852" alt="image" src="https://github.com/user-attachments/assets/b074ac98-0f4c-4a86-9932-219c44e5b8e6" />

------

<img width="1938" height="522" alt="image" src="https://github.com/user-attachments/assets/a0196b8f-deaf-49b3-bb29-8640f8708cf6" />

------

The view supports pan+zoom. Colors are assigned round robin per jobid so that one visually recognizes the same submission being judged by multiple judgedaemons. A tooltip shows some more info on hover.