### PR TITLE
Make penalty time a per contest setting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Version 10.0.0DEV
  - Use application/x-www-form-urlencoded instead of multipart/form-data for
    API requests without file uploads to make them work with PUT/PATCH requests.
  - Removed email collection for selfregistered users.
+ - Make penalty time a per contest setting.
 
 Version 9.0.0 - 5 October 2025
 ------------------------------

--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -12,13 +12,6 @@
             default_value: false
             public: true
             description: Should submissions with compiler-error incur penalty time (and be shown on the scoreboard)?
-        -   name: penalty_time
-            type: int
-            default_value: 20
-            public: true
-            description: Penalty time in minutes per wrong submission (if eventually solved).
-            regex: /^\d+$/
-            error_message: A non-negative number is required.
         -   name: results_prio
             type: array_keyval
             default_value:

--- a/webapp/migrations/Version20260123092747.php
+++ b/webapp/migrations/Version20260123092747.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\ScoreboardType;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260123092747 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add penalty time to contest.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE contest ADD penalty_time INT UNSIGNED DEFAULT 20 NOT NULL COMMENT \'Penalty time in minutes per wrong submission (if eventually solved)\' AFTER scoreboard_type');
+
+        $penaltyTimeConfig = $this->connection->fetchAssociative('SELECT * FROM configuration WHERE name = :name', ['name' => 'penalty_time']);
+        $penaltyTime = $penaltyTimeConfig ? (int)json_decode($penaltyTimeConfig['value'], true) : 20;
+
+        $this->addSql('UPDATE contest SET penalty_time = :penalty_time WHERE scoreboard_type = :scoreboard_type', [
+            'penalty_time' => $penaltyTime,
+            'scoreboard_type' => ScoreboardType::PASS_FAIL->value,
+        ]);
+
+        $this->addSql('UPDATE contest SET penalty_time = 0 WHERE scoreboard_type = :scoreboard_type', [
+            'scoreboard_type' => ScoreboardType::SCORE->value,
+        ]);
+
+        $this->addSql('DELETE FROM configuration WHERE name = :name', ['name' => 'penalty_time']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $penaltyTimes = $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT penalty_time FROM contest WHERE scoreboard_type = :scoreboard_type',
+            ['scoreboard_type' => ScoreboardType::PASS_FAIL->value]
+        );
+
+        if (count($penaltyTimes) > 1) {
+            throw new \Exception('Cannot migrate down: contests have different penalty times (' . implode(', ', $penaltyTimes) . ')');
+        }
+
+        $penaltyTime = $penaltyTimes ? (int)$penaltyTimes[0] : 20;
+
+        if ($penaltyTime !== 20) {
+            $this->addSql('INSERT INTO configuration (name, value) VALUES (:name, :value)', [
+                'name' => 'penalty_time',
+                'value' => json_encode($penaltyTime),
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE contest DROP penalty_time');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Command/ScoreboardMergeCommand.php
+++ b/webapp/src/Command/ScoreboardMergeCommand.php
@@ -97,6 +97,8 @@ readonly class ScoreboardMergeCommand
         SymfonyStyle $style,
         #[Option(description: 'Name of the team category to use', shortcut: 'c')]
         string $category = 'Participant',
+        #[Option(description: 'Penalty time in minutes', shortcut: 'p')]
+        int $penaltyTime = 20,
     ): int {
         $teams = [];
         $nextTeamId = 0;
@@ -105,7 +107,6 @@ readonly class ScoreboardMergeCommand
         $scoreCache = [];
         /** @var RankCache[] $rankCache */
         $rankCache = [];
-        $penaltyTime = (int)$this->config->get('penalty_time');
         $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
         $timeOfLastCorrect = [];
         $affiliations = [];
@@ -335,7 +336,6 @@ readonly class ScoreboardMergeCommand
             array_values($rankCache),
             $freezeData,
             false,
-            (int)$this->config->get('penalty_time'),
             false
         );
 

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -12,6 +12,7 @@ use App\Entity\JudgeTask;
 use App\Entity\Language;
 use App\Entity\Problem;
 use App\Entity\RemovedInterval;
+use App\Entity\ScoreboardType;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Entity\TeamCategory;
@@ -84,6 +85,7 @@ class ContestController extends BaseController
             'shortname'       => ['title' => 'shortname', 'sort' => true],
             'name'            => ['title' => 'name', 'sort' => true],
             'scoreboard_type' => ['title' => 'scoreboard type', 'sort' => true],
+            'penalty_time'    => ['title' => 'penalty time'],
             'activatetime'    => ['title' => 'activate', 'sort' => true],
             'starttime'       => ['title' => 'start', 'sort' => true,
                                   'default_sort' => true, 'default_sort_order' => 'desc'],
@@ -267,6 +269,12 @@ class ContestController extends BaseController
                 if ($timeIcon !== null) {
                     $contestdata[$timeField . 'time']['icon']  = $timeIcon;
                 }
+            }
+
+            if ($contest->getScoreboardType() === ScoreboardType::PASS_FAIL) {
+                $contestdata['penalty_time']['value'] .= ' minutes';
+            } else {
+                $contestdata['penalty_time']['value'] = '-';
             }
 
             $styles = [];

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -161,6 +161,12 @@ class Contest extends BaseApiEntity implements
     #[Serializer\Exclude]
     private ScoreboardType $scoreboardType = ScoreboardType::PASS_FAIL;
 
+    #[ORM\Column(
+        options: ['comment' => 'Penalty time in minutes per wrong submission (if eventually solved)', 'unsigned' => true, 'default' => 20]
+    )]
+    #[Serializer\SerializedName('penalty_time')]
+    private int $penaltyTime = 20;
+
     #[Serializer\VirtualProperty]
     #[Serializer\SerializedName('scoreboard_type')]
     #[Serializer\Type('string')]
@@ -484,9 +490,6 @@ class Contest extends BaseApiEntity implements
     #[ORM\OneToMany(mappedBy: 'contest', targetEntity: ExternalSourceWarning::class)]
     #[Serializer\Exclude]
     private Collection $externalSourceWarnings;
-
-    #[Serializer\SerializedName('penalty_time')]
-    private ?int $penaltyTimeForApi = null;
 
     // This field gets filled by the contest visitor with a data transfer
     // object that represents the banner
@@ -938,6 +941,17 @@ class Contest extends BaseApiEntity implements
     public function getScoreboardType(): ScoreboardType
     {
         return $this->scoreboardType;
+    }
+
+    public function getPenaltyTime(): int
+    {
+        return $this->penaltyTime;
+    }
+
+    public function setPenaltyTime(int $penaltyTime): Contest
+    {
+        $this->penaltyTime = $penaltyTime;
+        return $this;
     }
 
     public function setOpenToAllTeams(bool $openToAllTeams): Contest
@@ -1817,17 +1831,6 @@ class Contest extends BaseApiEntity implements
     public function getContestProblemsetType(): ?string
     {
         return $this->contestProblemsetType;
-    }
-
-    public function setPenaltyTimeForApi(?int $penaltyTimeForApi): Contest
-    {
-        $this->penaltyTimeForApi = $penaltyTimeForApi;
-        return $this;
-    }
-
-    public function getPenaltyTimeForApi(): ?int
-    {
-        return $this->penaltyTimeForApi;
     }
 
     public function setBannerForApi(?ImageFile $bannerForApi = null): Contest

--- a/webapp/src/Form/Type/ContestType.php
+++ b/webapp/src/Form/Type/ContestType.php
@@ -79,13 +79,16 @@ class ContestType extends AbstractExternalIdEntityType
             'required' => false,
             'help' => 'Time when the contest and scoreboard are hidden again. Usually a few hours/days after the contest ends.',
         ]);
-        $builder->add('scoreboardType', ChoiceType::class, [
+        $builder->add('scoreboardType', EnumType::class, [
             'label' => 'Scoreboard type',
-            'choices' => [
-                'pass-fail' => ScoreboardType::PASS_FAIL,
-                'score' => ScoreboardType::SCORE,
-            ],
+            'class' => ScoreboardType::class,
+            'choice_label' => 'value',
             'help' => 'The type of scoreboard to use for this contest.',
+        ]);
+        $builder->add('penaltyTime', IntegerType::class, [
+            'required' => false,
+            'label' => 'Penalty time',
+            'help' => 'Penalty time in minutes per wrong submission (if eventually solved).',
         ]);
         $builder->add('allowSubmit', CheckboxType::class, [
             'required' => false,
@@ -266,6 +269,16 @@ class ContestType extends AbstractExternalIdEntityType
 
             if ($contest && !$contest->getContestProblemset()) {
                 $form->remove('clearContestProblemset');
+            }
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+
+            // For scoring contests, always set penalty time to 0
+            if (isset($data['scoreboardType']) && $data['scoreboardType'] === ScoreboardType::SCORE->value) {
+                $data['penaltyTime'] = 0;
+                $event->setData($data);
             }
         });
     }

--- a/webapp/src/Serializer/ContestVisitor.php
+++ b/webapp/src/Serializer/ContestVisitor.php
@@ -41,13 +41,6 @@ readonly class ContestVisitor implements EventSubscriberInterface
         /** @var Contest $contest */
         $contest = $event->getObject();
 
-        $property = new StaticPropertyMetadata(
-            Contest::class,
-            'penalty_time',
-            null
-        );
-        $contest->setPenaltyTimeForApi((int)$this->config->get('penalty_time'));
-
         $id = $contest->getExternalid();
 
         // Banner

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -893,15 +893,7 @@ class ExternalContestSourceService
         }
 
         $toCheck['name'] = $data->name;
-
-        // Also compare the penalty time
-        $penaltyTime = $data->penaltyTime;
-        if ($penaltyTime !== null && $this->config->get('penalty_time') != $penaltyTime) {
-            $this->logger->warning(
-                'Penalty time does not match between feed (%d) and local (%d)',
-                [$penaltyTime, $this->config->get('penalty_time')]
-            );
-        }
+        $toCheck['penalty_time'] = $data->penaltyTime ?? 0;
 
         $this->compareOrCreateValues($event, $data->id, $contest, $toCheck);
 

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -103,7 +103,7 @@ readonly class ImportExportService
                 ? $contest->getEndtimeString()
                 : Utils::absTime($contest->getEndtime(), true),
             'duration' => Utils::relTime($contest->getContestTime((float)$contest->getEndtime())),
-            'penalty_time' => $this->config->get('penalty_time'),
+            'penalty_time' => $contest->getPenaltyTime(),
             'activate_time' => Utils::isRelTime($contest->getActivatetimeString())
                 ? $contest->getActivatetimeString()
                 : Utils::absTime($contest->getActivatetime(), true),
@@ -354,6 +354,15 @@ readonly class ImportExportService
             $contest->setScoreboardtype($scoreboardType);
         }
 
+        if ($contest->getScoreboardType() === ScoreboardType::PASS_FAIL) {
+            $penaltyTime = $data['penalty_time'] ?? $data['penalty-time'] ?? $data['penalty'] ?? null;
+            if ($penaltyTime !== null) {
+                $contest->setPenaltytime((int)$penaltyTime);
+            }
+        } else {
+            $contest->setPenaltyTime(0);
+        }
+
         // Get all visible categories. For now, we assume these are the ones getting awards
         $visibleCategories = $this->em->getRepository(TeamCategory::class)->findBy(['visible' => true]);
 
@@ -436,21 +445,6 @@ readonly class ImportExportService
         }
 
         $this->em->flush();
-
-        $penaltyTime = $data['penalty_time'] ?? $data['penalty-time'] ?? $data['penalty'] ?? null;
-        if ($penaltyTime !== null) {
-            $currentPenaltyTime = $this->config->get('penalty_time');
-            if ($penaltyTime != $currentPenaltyTime) {
-                $penaltyTimeConfiguration = $this->em->getRepository(Configuration::class)->findOneBy(['name' => 'penalty_time']);
-                if (!$penaltyTimeConfiguration) {
-                    $penaltyTimeConfiguration = new Configuration();
-                    $penaltyTimeConfiguration->setName('penalty_time');
-                    $this->em->persist($penaltyTimeConfiguration);
-                }
-
-                $penaltyTimeConfiguration->setValue((int)$penaltyTime);
-            }
-        }
 
         if (isset($data['problems'])) {
             $this->importProblemsData($contest, $data['problems']);

--- a/webapp/src/Service/ScoreboardService.php
+++ b/webapp/src/Service/ScoreboardService.php
@@ -78,7 +78,6 @@ class ScoreboardService
         return new Scoreboard(
             $contest, $teams, $categories, $problems,
             $scoreCache, $rankCache, $freezeData, $jury || $forceUnfrozen,
-            (int)$this->config->get('penalty_time'),
             (bool)$this->config->get('score_in_seconds'),
         );
     }
@@ -109,7 +108,6 @@ class ScoreboardService
         return new SingleTeamScoreboard(
             $contest, $team, $teamRank, $problems,
             $rankCache, $scoreCache, $freezeData, $showFtsInFreeze,
-            (int)$this->config->get('penalty_time'),
             (bool)$this->config->get('score_in_seconds')
         );
     }
@@ -520,7 +518,7 @@ class ScoreboardService
             $score[$variant] = "0";
         }
 
-        $penaltyTime      = (int) $this->config->get('penalty_time');
+        $penaltyTime      = $contest->getPenaltyTime();
         $scoreIsInSeconds = (bool)$this->config->get('score_in_seconds');
 
         // Now fetch the ScoreCache entries.

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -997,9 +997,9 @@ HTML;
     }
 
     #[AsTwigFunction('calculatePenaltyTime')]
-    public function calculatePenaltyTime(bool $solved, int $num_submissions): int
+    public function calculatePenaltyTime(int $penaltyTime, bool $solved, int $num_submissions): int
     {
-        return Utils::calcPenaltyTime($solved, $num_submissions, (int)$this->config->get('penalty_time'),
+        return Utils::calcPenaltyTime($solved, $num_submissions, $penaltyTime,
                                       (bool)$this->config->get('score_in_seconds'));
     }
 

--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -43,7 +43,6 @@ class Scoreboard
         protected readonly array      $rankCache,
         protected readonly FreezeData $freezeData,
         bool                          $jury,
-        protected readonly int        $penaltyTime,
         protected readonly bool       $scoreIsInSeconds
     ) {
         $this->restricted = $jury || $freezeData->showFinal($jury);
@@ -181,7 +180,7 @@ class Scoreboard
             $penalty = Utils::calcPenaltyTime(
                 $isCorrect,
                 $scoreCell->getSubmissions($this->restricted),
-                $this->penaltyTime, $this->scoreIsInSeconds
+                $this->contest->getPenaltyTime(), $this->scoreIsInSeconds
             );
 
             $contestProblem = $scoreCell->getContest()->getContestProblem($scoreCell->getProblem());

--- a/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
+++ b/webapp/src/Utils/Scoreboard/SingleTeamScoreboard.php
@@ -32,12 +32,11 @@ class SingleTeamScoreboard extends Scoreboard
         array $scoreCache,
         FreezeData $freezeData,
         bool $showFtsInFreeze,
-        int $penaltyTime,
         bool $scoreIsInSeconds
     ) {
         $this->showRestrictedFts = $showFtsInFreeze || $freezeData->showFinal();
         parent::__construct($contest, [$team->getTeamid() => $team], [], $problems, $scoreCache, $rankCache, $freezeData, true,
-            $penaltyTime, $scoreIsInSeconds);
+            $scoreIsInSeconds);
     }
 
     protected function calculateScoreboard(): void
@@ -55,7 +54,7 @@ class SingleTeamScoreboard extends Scoreboard
 
             $penalty = Utils::calcPenaltyTime(
                 $scoreRow->getIsCorrect($this->restricted), $scoreRow->getSubmissions($this->restricted),
-                $this->penaltyTime, $this->scoreIsInSeconds
+                $this->contest->getPenaltyTime(), $this->scoreIsInSeconds
             );
 
             $contestProblem = $scoreRow->getContest()->getContestProblem($scoreRow->getProblem());

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -93,6 +93,13 @@
                         <td>{{ contest.scoreboardType.value }}</td>
                         <td></td>
                     </tr>
+                    {% if contest.scoreboardType == constant('App\\Entity\\ScoreboardType::PASS_FAIL') %}
+                        <tr>
+                            <th>Penalty time</th>
+                            <td>{{ contest.penaltyTime }} minutes</td>
+                            <td></td>
+                        </tr>
+                    {% endif %}
                     <tr>
                         <th>Score diff epsilon</th>
                         <td>{{ contest.scoreDiffEpsilon }}</td>

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -41,6 +41,14 @@
                 {{ _self.section_header('sliders', 'Scoring') }}
                 {{ _self.form_table_row(form.scoreboardType) }}
                 {{ _self.form_table_row(form.scoreDiffEpsilon) }}
+                <tr data-penalty-time-field>
+                    <th>{{ form.penaltyTime.vars.label }}</th>
+                    <td>
+                        {{ form_errors(form.penaltyTime) }}
+                        {{ form_widget(form.penaltyTime) }}
+                        {{ form_help(form.penaltyTime) }}
+                    </td>
+                </tr>
                 {{ _self.form_table_row(form.allowSubmit) }}
                 {{ _self.form_table_row(form.processBalloons) }}
                 {{ _self.form_table_row(form.runtimeAsScoreTiebreaker) }}
@@ -281,5 +289,16 @@
                 $('i', $(this)).attr('class', 'fa fa-eye');
             }
         });
+
+        function showHidePenaltyTime() {
+            if ($('#contest_scoreboardType').val() === 'pass-fail') {
+                $('[data-penalty-time-field]').show();
+            } else {
+                $('[data-penalty-time-field]').hide();
+            }
+        }
+
+        $('#contest_scoreboardType').on('change', showHidePenaltyTime);
+        showHidePenaltyTime();
     });
 </script>

--- a/webapp/templates/partials/scoreboard/_problem_cell.html.twig
+++ b/webapp/templates/partials/scoreboard/_problem_cell.html.twig
@@ -17,7 +17,7 @@
     {% elseif scoreInSeconds %}
         {% set time = time | scoreTime | printTimeRelative %}
         {% if matrixItem.numSubmissions > 1 %}
-            {% set time = time ~ ' + ' ~ (calculatePenaltyTime(true, matrixItem.numSubmissions) | printTimeRelative) %}
+            {% set time = time ~ ' + ' ~ (calculatePenaltyTime(contest.penaltyTime, true, matrixItem.numSubmissions) | printTimeRelative) %}
         {% endif %}
     {% else %}
         {% set time = time | scoreTime %}

--- a/webapp/tests/Unit/Controller/Jury/ConfigControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ConfigControllerTest.php
@@ -32,25 +32,25 @@ class ConfigControllerTest extends BaseTestCase
 
         self::assertSelectorExists('a.nav-link:contains("Scoring")');
 
-        self::assertSelectorExists('label:contains("Penalty time:")');
-        self::assertSelectorExists('p:contains("Penalty time in minutes per wrong submission (if eventually solved).")');
+        self::assertSelectorExists('label:contains("Memory limit:")');
+        self::assertSelectorExists('p:contains("Maximum memory usage (in kB) by submissions. This includes the shell which starts the compiled solution and also any interpreter like the Java VM, which takes away approx. 300MB! Can be overridden per problem.")');
         $crawler = $this->getCurrentCrawler();
-        $minutes = $crawler->filter('input#config_penalty_time')->extract(['value']);
-        self::assertEquals("20", $minutes[0]);
+        $memoryLimit = $crawler->filter('input#config_memory_limit')->extract(['value']);
+        self::assertEquals("2097152", $memoryLimit[0]);
     }
 
     /**
-     * Test that a different penalty time shows up in this page.
+     * Test that a different memory limit shows up in this page.
      */
-    public function testChangedPenaltyTime(): void
+    public function testChangedMemoryLimit(): void
     {
-        $this->withChangedConfiguration('penalty_time', "30",
+        $this->withChangedConfiguration('memory_limit', "123456",
             function ($errors): void {
                 static::assertEmpty($errors);
                 $this->verifyPageResponse('GET', '/jury/config', 200);
                 $crawler = $this->getCurrentCrawler();
-                $minutes = $crawler->filter('input#config_penalty_time')->extract(['value']);
-                static::assertEquals("30", $minutes[0]);
+                $memoryLimit = $crawler->filter('input#config_memory_limit')->extract(['value']);
+                static::assertEquals("123456", $memoryLimit[0]);
             });
     }
 
@@ -67,18 +67,18 @@ class ConfigControllerTest extends BaseTestCase
     }
 
     /**
-     * Test that an invalid penalty time produces an error
+     * Test that an invalid memory limit produces an error
      */
-    public function testChangedPenaltyTimeInvalid(): void
+    public function testChangedMemoryLimitInvalid(): void
     {
-        $this->withChangedConfiguration('penalty_time', "-1",
+        $this->withChangedConfiguration('memory_limit', "-1",
             function ($errors): void {
-                static::assertEquals(['penalty_time' => 'A non-negative number is required.'], $errors);
+                static::assertEquals(['memory_limit' => 'A positive number is required.'], $errors);
                 $this->verifyPageResponse('GET', '/jury/config', 200);
                 $crawler = $this->getCurrentCrawler();
-                $minutes = $crawler->filter('input#config_penalty_time')->extract(['value']);
+                $memoryLimit = $crawler->filter('input#config_memory_limit')->extract(['value']);
                 // test that it is still 20, i.e. it didn't change
-                static::assertEquals("20", $minutes[0]);
+                static::assertEquals("2097152", $memoryLimit[0]);
             });
     }
 }

--- a/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/QueuetaskIntegrationTest.php
@@ -55,7 +55,6 @@ class QueuetaskIntegrationTest extends KernelTestCase
         $this->configValues = [
             'verification_required' => false,
             'compile_penalty' => false,
-            'penalty_time' => 20,
             'score_in_seconds' => false,
             'sourcefiles_limit' => 1,
             'sourcesize_limit' => 1024*256,

--- a/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/ScoreboardIntegrationTest.php
@@ -66,7 +66,6 @@ class ScoreboardIntegrationTest extends KernelTestCase
         $this->configValues = [
             'verification_required'    => false,
             'compile_penalty'          => false,
-            'penalty_time'             => 20,
             'score_in_seconds'         => false,
             'show_teams_on_scoreboard' => 0,
             'submission_rate_limit'    => [],

--- a/webapp/tests/Unit/Integration/ScoringScoreboardIntegrationTest.php
+++ b/webapp/tests/Unit/Integration/ScoringScoreboardIntegrationTest.php
@@ -81,7 +81,6 @@ class ScoringScoreboardIntegrationTest extends KernelTestCase
         $this->configValues = [
             'verification_required'    => false,
             'compile_penalty'          => false,
-            'penalty_time'             => 20,
             'score_in_seconds'         => false,
             'shadow_mode'              => 0,
             'show_teams_on_scoreboard' => 0,

--- a/webapp/tests/Unit/Service/AwardServiceTest.php
+++ b/webapp/tests/Unit/Service/AwardServiceTest.php
@@ -190,7 +190,6 @@ class AwardServiceTest extends KernelTestCase
             $rankCache,
             $this->contest->getFreezeData(),
             true,
-            20,
             false
         );
     }

--- a/webapp/tests/Unit/Service/ImportExportServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportExportServiceTest.php
@@ -116,7 +116,8 @@ class ImportExportServiceTest extends BaseTestCase
         string $expectedShortName,
         string $expectedActivateTimeString,
         ?string $expectedDeactivateTimeString,
-        array $expectedProblems = []
+        array $expectedProblems = [],
+        int $expectedPenaltyTime = 20,
     ): void {
         /** @var ImportExportService $importExportService */
         $importExportService = static::getContainer()->get(ImportExportService::class);
@@ -131,6 +132,7 @@ class ImportExportServiceTest extends BaseTestCase
         self::assertEquals($expectedShortName, $contest->getShortname());
         self::assertEquals($expectedActivateTimeString, $contest->getActivatetimeString());
         self::assertEquals($expectedDeactivateTimeString, $contest->getDeactivatetimeString());
+        self::assertEquals($expectedPenaltyTime, $contest->getPenaltyTime());
 
         if (isset($data['scoreboard_type']) || isset($data['scoreboard-type'])) {
             self::assertEquals($data['scoreboard_type'] ?? $data['scoreboard-type'], $contest->getScoreboardType()->value);
@@ -279,6 +281,23 @@ class ImportExportServiceTest extends BaseTestCase
             'score-test',
             '2020-01-01 10:34:56 UTC',
             null,
+            [],
+            0,
+        ];
+        // Testing different penalty time
+        yield [
+            [
+                'name'            => 'Penalty Type Test',
+                'short-name'      => 'penalty-time-test',
+                'duration'        => '5:00:00',
+                'start-time'      => '2020-01-01T12:34:56+02:00',
+                'penalty-time'    => '123456',
+            ],
+            'penalty-time-test',
+            '2020-01-01 10:34:56 UTC',
+            null,
+            [],
+            123456,
         ];
         // Scoring contest with problems: verify problems get scoring type.
         yield [
@@ -305,6 +324,7 @@ class ImportExportServiceTest extends BaseTestCase
             '2020-01-01 10:34:56 UTC',
             null,
             ['A' => 'scoreprobA', 'B' => 'scoreprobB'],
+            0,
         ];
     }
 

--- a/webapp/tests/Unit/Utils/Scoreboard/ScoreboardTest.php
+++ b/webapp/tests/Unit/Utils/Scoreboard/ScoreboardTest.php
@@ -29,7 +29,7 @@ class ScoreboardTest extends BaseBaseTestCase
         $em = self::getContainer()->get('doctrine')->getManager();
         $contest = $em->getRepository(Contest::class)->findOneBy(['name' => $reference]);
         $freezeData = new FreezeData($contest);
-        $scoreBoard = new Scoreboard($contest, [], [], [], [], [], $freezeData, false, 0, true);
+        $scoreBoard = new Scoreboard($contest, [], [], [], [], [], $freezeData, false, true);
         self::assertEquals($scoreBoard->getProgress(), $progress);
     }
 


### PR DESCRIPTION
For score contests we use `0`, since the spec says "Only relevant if scoreboard_type is pass-fail.".