### PR TITLE
Hide team submissions on mobile scoreboard when configured to do so

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -340,6 +340,10 @@ class PublicController extends BaseController
             throw $this->createNotFoundException('No submission data found');
         }
 
+        if (!$this->config->get('show_teams_submissions')) {
+            throw $this->createNotFoundException('Submissions are not visible');
+        }
+
         $teamIds = array_map(fn(Team $team) => $team->getTeamid(), $scoreboard->getTeamsInDescendingOrder());
 
         /** @var Submission[] $submissions */

--- a/webapp/templates/partials/scoreboard_table.html.twig
+++ b/webapp/templates/partials/scoreboard_table.html.twig
@@ -588,10 +588,12 @@
                 {% set problemSpan = problemSpan + 1 %}
             {% endif %}
             <td colspan="{{ problemSpan }}">
-                {% for problem in problems %}
-                    {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
-                    {{ problem | problemBadgeMaybe(matrixItem, score, static) }}
-                {% endfor %}
+                {% if showTeamSubmissions or jury %}
+                    {% for problem in problems %}
+                        {% set matrixItem = scoreboard.matrix[score.team.teamid][problem.probid] %}
+                        {{ problem | problemBadgeMaybe(matrixItem, score, static) }}
+                    {% endfor %}
+                {% endif %}
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
Also don't expose them in the JSON in that case.

Fixes #3278.