### PR TITLE
Don't use multipart forms when not needed in the API

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Version 10.0.0DEV
  - Make shadow mode a per contest setting.
  - Allow to specify whether to use internal or external judgings and runs in
    shadow mode.
+ - Use application/x-www-form-urlencoded instead of multipart/form-data for
+   API requests without file uploads to make them work with PUT/PATCH requests.
 
 Version 9.0.0 - 5 October 2025
 ------------------------------

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -95,7 +95,11 @@ class ClarificationController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
+                schema: new OA\Schema(ref: new Model(type: ClarificationPost::class))
+            ),
+            new OA\MediaType(
+                mediaType: 'application/json',
                 schema: new OA\Schema(ref: new Model(type: ClarificationPost::class))
             )
         ]

--- a/webapp/src/Controller/API/GroupController.php
+++ b/webapp/src/Controller/API/GroupController.php
@@ -81,7 +81,7 @@ class GroupController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: TeamCategoryPost::class))
             ),
         ]
@@ -127,7 +127,7 @@ class GroupController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: TeamCategoryPut::class))
             ),
         ]

--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1344,7 +1344,7 @@ class JudgehostController extends AbstractFOSRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(
                     required: ['hostname', 'compiler', 'runner'],
                     properties: [

--- a/webapp/src/Controller/API/OrganizationController.php
+++ b/webapp/src/Controller/API/OrganizationController.php
@@ -236,7 +236,7 @@ class OrganizationController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: AddOrganization::class))
             ),
         ]

--- a/webapp/src/Controller/API/TeamController.php
+++ b/webapp/src/Controller/API/TeamController.php
@@ -259,7 +259,7 @@ class TeamController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: AddTeam::class))),
         ]
     )]

--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -296,7 +296,7 @@ class UserController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: AddUser::class))
             ),
         ]
@@ -323,7 +323,7 @@ class UserController extends AbstractRestController
         required: true,
         content: [
             new OA\MediaType(
-                mediaType: 'multipart/form-data',
+                mediaType: 'application/x-www-form-urlencoded',
                 schema: new OA\Schema(ref: new Model(type: UpdateUser::class))
             ),
         ]


### PR DESCRIPTION
Also allow JSON for clarifications

Fixes #3168

For PUT, Symfony doesn't populate the body for multipart forms. Since we only need multipart for requests with actual binary files, I changed all that don't use them to normal forms. I also added JSON for the clarification requests, since that should also be allowed. We might want to add it to other endpoints as well, but I think we can do that in a different PR.