### PR TITLE
Defend against '\n' at the end of score.txt.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -995,7 +995,7 @@ class JudgehostController extends AbstractFOSRestController
             }
 
             if ($score) {
-                $judgingRun->setScore(base64_decode($score));
+                $judgingRun->setScore(trim(base64_decode($score)));
             }
 
             $judging = $judgingRun->getJudging();


### PR DESCRIPTION
This is to avoid problems with `bcadd` later on.