### PR TITLE
Include contest ID in URLs where relevant.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,7 +154,7 @@ jobs:
           curl $CURLOPTS "http://localhost/domjudge/jury/change-contest/${{ matrix.contest }}" -o /dev/null
           # Send a general clarification to later test if we see the event.
           curl $CURLOPTS -F "sendto=" -F "problem=1-" -F "bodytext=Testing" -F "submit=Send" \
-               "http://localhost/domjudge/jury/clarifications/send" -o /dev/null
+               "http://localhost/domjudge/jury/contests/${{ matrix.contest }}/clarifications/send" -o /dev/null
           curl $CURLOPTS "http://localhost/domjudge/jury/judging-verifier?verify_multiple=1" -o /dev/null
           NUMNOTVERIFIED=$(curl $CURLOPTS "http://localhost/domjudge/jury/judging-verifier" | grep "submissions checked"     | sed -r 's/^.* ([0-9]+) submissions checked.*$/\1/')
           NUMVERIFIED=$(   curl $CURLOPTS "http://localhost/domjudge/jury/judging-verifier" | grep "submissions not checked" | sed -r 's/^.* ([0-9]+) submissions not checked.*$/\1/')

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1398,7 +1398,7 @@ class JudgeDaemon
         }
 
         // Get the source code from the DB and store in local file(s).
-        $url = sprintf('judgehosts/get_files/source/%s', $judgeTask['submitid']);
+        $url = sprintf('judgehosts/get_files/source/%s/%s', $judgeTask['contestid'], $judgeTask['submitid']);
         $sources = $this->request($url, 'GET');
         $sources = dj_json_decode($sources);
         $files = [];

--- a/webapp/src/Controller/Jury/AuditLogController.php
+++ b/webapp/src/Controller/Jury/AuditLogController.php
@@ -113,7 +113,7 @@ class AuditLogController extends AbstractController
             case 'balloon':
                 return $this->generateUrl('jury_balloons');
             case 'clarification':
-                return $this->generateUrl('jury_clarification', ['id' => $id]);
+                return $this->generateUrl('jury_clarification_legacy', ['id' => $id]);
             case 'configuration':
                 return $this->generateUrl('jury_config');
             case 'contest':
@@ -138,7 +138,7 @@ class AuditLogController extends AbstractController
             case 'problem':
                 return $this->generateUrl('jury_problem', ['probId' => $id]);
             case 'submission':
-                return $this->generateUrl('jury_submission', ['submitId' => $id]);
+                return $this->generateUrl('jury_submission_legacy', ['submitId' => $id]);
             case 'team':
                 return $this->generateUrl('jury_team', ['teamId' => $id]);
             case 'team_affiliation':

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -302,6 +302,7 @@ class JuryMiscController extends BaseController
                 'actualScore' => $actualScore,
                 'expectedScore' => $expectedScore,
                 'contestProblem' => $submission->getContestProblem(),
+                'contest' => $submission->getContest(),
             ];
 
             $hasExpectation = !empty($expectedResults) || $expectedScore !== null;
@@ -375,8 +376,12 @@ class JuryMiscController extends BaseController
     #[Route(path: '/change-contest/{contestId}', name: 'jury_change_contest')]
     public function changeContestAction(Request $request, RouterInterface $router, string $contestId): Response
     {
-        if ($this->isLocalReferer($router, $request)) {
-            $response = new RedirectResponse($request->headers->get('referer'));
+        $referer = $request->headers->get('referer');
+        // When changing to "no contest" (-1), don't redirect to contest-scoped URLs
+        // because the ContestCookieListener would override the cookie to that contest's ID.
+        if ($this->isLocalReferer($router, $request) &&
+            !($contestId === '-1' && str_contains($referer, '/jury/contests/'))) {
+            $response = new RedirectResponse($referer);
         } else {
             $response = $this->redirectToRoute('jury_index');
         }

--- a/webapp/src/Controller/Jury/TeamController.php
+++ b/webapp/src/Controller/Jury/TeamController.php
@@ -60,6 +60,7 @@ class TeamController extends BaseController
             ->getQuery()->getResult();
 
         $contests                       = $this->dj->getCurrentContests();
+        $currentContest                 = $this->dj->getCurrentContest();
         $num_open_to_all_teams_contests = $this->em->createQueryBuilder()
             ->select('count(c.cid) as num_contests')
             ->from(Contest::class, 'c')
@@ -170,13 +171,16 @@ class TeamController extends BaseController
                     'ajaxModal' => true,
                 ];
             }
-            $teamactions[] = [
-                'icon' => 'envelope',
-                'title' => 'send clarification to this team',
-                'link' => $this->generateUrl('jury_clarification_new', [
-                    'teamto' => $t->getExternalid(),
-                ])
-            ];
+            if ($currentContest) {
+                $teamactions[] = [
+                    'icon' => 'envelope',
+                    'title' => 'send clarification to this team',
+                    'link' => $this->generateUrl('jury_clarification_new', [
+                        'contestId' => $currentContest->getExternalid(),
+                        'teamto' => $t->getExternalid(),
+                    ])
+                ];
+            }
 
             // Add the rest of our row data for the table.
 
@@ -323,6 +327,7 @@ class TeamController extends BaseController
         $data['submissionCounts']   = $submissionCounts;
         $data['showExternalResult'] = $this->dj->shadowMode();
         $data['showContest']        = count($this->dj->getCurrentContests(honorCookie: true)) > 1;
+        $data['currentContest']     = $currentContest;
 
         if ($request->isXmlHttpRequest()) {
             $data['displayRank'] = true;

--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -84,6 +84,13 @@ class JudgeTask
         return $this->submission?->getExternalid();
     }
 
+    #[Serializer\VirtualProperty]
+    #[Serializer\SerializedName('contestid')]
+    #[Serializer\Type('string')]
+    public function getContestId(): ?string
+    {
+        return $this->submission?->getContest()->getExternalid();
+    }
 
     // Note that we rely on the fact here that files with an ID are immutable,
     // so clients are allowed to cache them on disk.

--- a/webapp/src/EventListener/ContestCookieListener.php
+++ b/webapp/src/EventListener/ContestCookieListener.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Service\DOMJudgeService;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * Syncs the contest cookie with the contest ID from the URL.
+ *
+ * When visiting a contest-scoped URL (e.g., /jury/contests/{contestId}/...),
+ * this listener updates the contest cookie to match, ensuring the dropdown
+ * in the UI shows the same contest as the current page.
+ */
+readonly class ContestCookieListener
+{
+    public function __construct(
+        protected DOMJudgeService $dj
+    ) {}
+
+    #[AsEventListener]
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!str_starts_with($request->getPathInfo(), '/jury/')) {
+            return;
+        }
+
+        // Skip change-contest routes - they handle cookie setting in the controller
+        $route = $request->attributes->get('_route');
+        if ($route === 'jury_change_contest') {
+            return;
+        }
+
+        $contestId = $request->attributes->get('contestId');
+
+        if ($contestId === null) {
+            return;
+        }
+
+        $currentCookie = $request->cookies->get('domjudge_cid');
+
+        if ($currentCookie === $contestId) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $path = $request->getBasePath() ?: '/';
+        $response->headers->setCookie(
+            Cookie::create('domjudge_cid', $contestId, 0, $path, '', false, false, false, null)
+        );
+    }
+}

--- a/webapp/templates/jury/analysis/contest_overview.html.twig
+++ b/webapp/templates/jury/analysis/contest_overview.html.twig
@@ -188,7 +188,7 @@ $(function() {
                           {% for j in delayed_judgings.data %}
                               {% set id=j.submitexternalid %}
                               <tr>
-                                  {% set link = path('jury_submission', {'submitId': id}) %}
+                                  {% set link = path('jury_submission', {'contestId': contest.externalid, 'submitId': id}) %}
                                   <td scope="row"><a href="{{ link }}">{{ id }}</a></td>
                                   <td><a href="{{ link }}">{{ j.judgingid }}</a></td>
                                   <td><a href="{{ link }}">{{ j.submittime | printtime }}</a></td>

--- a/webapp/templates/jury/balloons.html.twig
+++ b/webapp/templates/jury/balloons.html.twig
@@ -11,11 +11,6 @@
 
 {% block content %}
 
-    {% if current_contest is null %}
-        <h1>Balloons</h1>
-        <p class="nodata">No active contest</p>
-    {% else %}
-
     <h1>Balloons - {{ current_contest.name }}</h1>
 
     {% if isfrozen %}
@@ -76,12 +71,10 @@
     <div data-ajax-refresh-target data-ajax-refresh-after="process_balloons_filter">
         {%- include 'jury/partials/balloon_list.html.twig' %}
     </div>
-    {% endif %}
 
 {% endblock %}
 
 {% block extrafooter %}
-    {% if current_contest is not null %}
         <script>
             const selectedBalloons = new Set();
             function updateMarkMultipleDone() {
@@ -203,5 +196,4 @@
                 window.process_balloons_filter();
             });
         </script>
-    {% endif %}
 {% endblock %}

--- a/webapp/templates/jury/check_judgings.html.twig
+++ b/webapp/templates/jury/check_judgings.html.twig
@@ -40,7 +40,7 @@
                     <th>expected score</th>
                 </tr>
                 {% for submitId,result in results %}
-                    {% set link = path('jury_submission', {'submitId': submitId}) %}
+                    {% set link = path('jury_submission', {'contestId': result.contest.externalid, 'submitId': submitId}) %}
                     <tr>
                         <td><a href="{{ link }}">{{ submitId }}</a></td>
                         <td>

--- a/webapp/templates/jury/clarification.html.twig
+++ b/webapp/templates/jury/clarification.html.twig
@@ -58,7 +58,7 @@
                                     </button>
                                 </span>
                                 <span class="clarification-subject-form" data-current-selected-subject="{{ clar.categoryid }}" data-clarification-id="{{ clar.externalid }}">
-                                    <form action="{{ path('jury_clarification_change_subject', {'clarId': clar.externalid }) }}" method="post" class="d-flex">
+                                    <form action="{{ path('jury_clarification_change_subject', {'contestId': contestId, 'clarId': clar.externalid }) }}" method="post" class="d-flex">
                                         <select name="subject" class="subject form-select form-select-sm w-auto" id="subselect">
                                             {% for contest,subject in subjects %}
                                                 <optgroup label="{{ contest }}">
@@ -92,7 +92,7 @@
                                     <button class="btn btn-sm btn-link clarification-queue-change-button"><i class="far fa-edit" title="Change queue"></i></button>
                                 </span>
                                 <span class="clarification-queue-form" data-current-selected-queue="{{ clar.queueid }}" data-clarification-id="{{ clar.externalid }}">
-                                    <form action="{{ path('jury_clarification_change_queue', {'clarId': clar.externalid }) }}" class="d-flex" method="post">
+                                    <form action="{{ path('jury_clarification_change_queue', {'contestId': contestId, 'clarId': clar.externalid }) }}" class="d-flex" method="post">
                                         <select name="queue" class="queue form-select w-auto form-select-sm" id="qselect">
                                             <option value="unassigned">Unassigned issues</option>
                                             {% for qid,queue in queues %}
@@ -125,7 +125,7 @@
                 </div>
 
                 <div class="col-sm text-center">
-                    <form action="{{ path('jury_clarification_claim', {'clarId': origclar.externalid}) }}" method="post">
+                    <form action="{{ path('jury_clarification_claim', {'contestId': contestId, 'clarId': origclar.externalid}) }}" method="post">
                         {% if claimed %}
                             {% if origclar.jurymember_is_me %}
                                 <button class="btn btn-sm btn-outline-success" name="claimed" value="0" type="submit"><i class="fas fa-lock-open"></i> unclaim</button>
@@ -141,7 +141,7 @@
                 </div>
 
                 <div class="col-sm text-end">
-                    <form action="{{ path('jury_clarification_set_answered', {'clarId': origclar.externalid}) }}" method="post">
+                    <form action="{{ path('jury_clarification_set_answered', {'contestId': contestId, 'clarId': origclar.externalid}) }}" method="post">
                         {% if origclar.answered %}
                             <button class="btn btn-sm btn-outline-warning" name="answered" value="0" type="submit">
                                 <i class="fas fa-times"></i> set unanswered

--- a/webapp/templates/jury/clarifications.html.twig
+++ b/webapp/templates/jury/clarifications.html.twig
@@ -19,16 +19,11 @@
 
     <h1>Clarifications</h1>
 
-    {%- if current_contests is empty %}
-
-        <div class="alert alert-danger">No active contests</div>
-    {%- else %}
-
         <div class="float-end">
             <a href="{{ path('jury_html_export_clarifications') }}" target="_blank" class="btn btn-secondary btn-sm">
                 <i class="fas fa-print"></i> Print clarifications
             </a>
-            <a href="{{ path('jury_clarification_new') }}" class="btn btn-primary btn-sm">
+            <a href="{{ path('jury_clarification_new', {'contestId': contestId}) }}" class="btn btn-primary btn-sm">
                 <i class="fas fa-envelope"></i> Send clarification
             </a>
         </div>
@@ -87,12 +82,11 @@
                 {%- include 'jury/partials/clarification_list.html.twig' with {clarifications: generalClarifications, direction: 'to'} %}
             {%- endif %}
         {% endif %}
-    {%- endif %}
 
     <script>
         function doSwitch() {
             // Fallback the queue to all, since it might not be defined.
-            window.location = '{{ path('jury_clarifications', {'queue': 'REPLACE_QUEUE', 'filter': 'REPLACE_FILTER'}) }}'
+            window.location = '{{ path('jury_clarifications', {'contestId': contestId, 'queue': 'REPLACE_QUEUE', 'filter': 'REPLACE_FILTER'}) }}'
                 .replace('REPLACE_QUEUE', $('input[name=queue]:checked').val() || 'all')
                 .replace('REPLACE_FILTER', $('input[name=filter]:checked').val())
                 .replace('&amp;', '&');
@@ -104,7 +98,7 @@
                 var parenttd = $(this).closest('td');
                 var parenttr = $(this).closest('tr');
                 var newname = $(this).closest('label').text().trim();
-                $.post("{{ path('jury_clarification_change_queue', {'clarId': 12345}) }}".replace('12345', $(this).attr('data-clarid')),
+                $.post("{{ path('jury_clarification_change_queue', {'contestId': contestId, 'clarId': 12345}) }}".replace('12345', $(this).attr('data-clarid')),
                     {'queue': $(this).val()})
                     .done(function( data ) {
                         if ( data ) {

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -46,10 +46,10 @@
             <div class="card-body">
                 <ul>
                     {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_BALLOON') %}
-                        <li><a href="{{ path('jury_balloons') }}">Balloon Status</a></li>
+                        <li><a href="{{ path('jury_balloons_legacy') }}">Balloon Status</a></li>
                     {% endif %}
                     {% if is_granted('ROLE_CLARIFICATION_RW') %}
-                        <li><a href="{{ path('jury_clarifications') }}">Clarifications</a></li>
+                        <li><a href="{{ path('jury_clarifications_legacy') }}">Clarifications</a></li>
                     {% endif %}
                     {% if is_granted('ROLE_JURY') %}
                         <li><a href="{{ path('jury_internal_errors') }}">Internal Errors</a></li>
@@ -61,7 +61,7 @@
                         <li><a href="{{ path('jury_rejudgings') }}">Rejudgings</a></li>
                         <li><a href="{{ path('jury_scoreboard') }}">Scoreboard</a></li>
                         <li><a href="{{ path('analysis_index') }}">Statistics/Analysis</a></li>
-                        <li><a href="{{ path('jury_submissions') }}">Submissions</a></li>
+                        <li><a href="{{ path('jury_submissions_legacy') }}">Submissions</a></li>
                         {% if is_granted('ROLE_ADMIN') %}
                             <li><a href="{{ path('jury_queue_tasks') }}">Queue tasks</a></li>
                         {% endif %}

--- a/webapp/templates/jury/judge_tasks.html.twig
+++ b/webapp/templates/jury/judge_tasks.html.twig
@@ -19,8 +19,8 @@
                     <tr>
                         <th>Submission</th>
                         <td>
-                            <a href="{{ path('jury_submission', {'submitId': firstJudgeTask.firstJudgingRun.judging.submission.submitid }) }}">
-                                {{ firstJudgeTask.firstJudgingRun.judging.submission.submitid }}
+                            <a href="{{ path('jury_submission', {'contestId': firstJudgeTask.firstJudgingRun.judging.submission.contest.externalid, 'submitId': firstJudgeTask.firstJudgingRun.judging.submission.externalid }) }}">
+                                {{ firstJudgeTask.firstJudgingRun.judging.submission.externalid }}
                             </a>
                         </td>
                     </tr>

--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -12,7 +12,7 @@
 
             {% if is_granted('ROLE_BALLOON') %}
                 <li class="nav-item">
-                    <a class="nav-link{% if current_route == 'jury_balloons' %} active{% endif %}" href="{{ path('jury_balloons') }}">
+                    <a class="nav-link{% if current_route starts with 'jury_balloon' %} active{% endif %}" href="{{ path('jury_balloons_legacy') }}">
                         <i class="fas fa-map-marker-alt"></i> balloons
                         <span class="badge text-bg-info" id="num-alerts-balloons"></span>
                     </a>
@@ -39,13 +39,13 @@
 
             {% if is_granted('ROLE_CLARIFICATION_RW') %}
                 <li class="nav-item">
-                    <a class="nav-link{% if current_route starts with 'jury_clarification' %} active{% endif %}" href="{{ path('jury_clarifications') }}" id="menu_clarifications"><i class="fas fa-comments"></i> clarifications <span class="badge text-bg-info" id="num-alerts-clarifications"></span></a>
+                    <a class="nav-link{% if current_route starts with 'jury_clarification' %} active{% endif %}" href="{{ path('jury_clarifications_legacy') }}" id="menu_clarifications"><i class="fas fa-comments"></i> clarifications <span class="badge text-bg-info" id="num-alerts-clarifications"></span></a>
                 </li>
             {% endif %}
 
             {% if is_granted('ROLE_JURY') %}
                 <li class="nav-item">
-                    <a class="nav-link{% if current_route starts with 'jury_submission' %} active{% endif %}" href="{{ path('jury_submissions') }}"><i class="fas fa-file-code"></i> submissions</a>
+                    <a class="nav-link{% if current_route starts with 'jury_submission' %} active{% endif %}" href="{{ path('jury_submissions_legacy') }}"><i class="fas fa-file-code"></i> submissions</a>
                 </li>
 
                 {% if show_shadow_differences %}

--- a/webapp/templates/jury/partials/balloon_list.html.twig
+++ b/webapp/templates/jury/partials/balloon_list.html.twig
@@ -4,7 +4,7 @@
 {% if balloons is empty %}
     <div class="alert alert-warning">No balloons</div>
 {% else %}
-    <form action="{{ path('jury_balloons_setdone_multiple') }}" method="post">
+    <form action="{{ path('jury_balloons_setdone_multiple', {contestId: contestId}) }}" method="post">
         <input type="submit" class="btn btn-primary mark-multiple-done-button" value="Mark selected as done" />
 
         <table class="data-table table table-hover table-striped table-sm balloons-table" style="width:auto">
@@ -52,7 +52,7 @@
                     </td>
                     <td>
                         {%- if not balloon.data.done -%}
-                        {%- set link = path('jury_balloons_setdone', {balloonId: balloon.data.balloonid}) %}
+                        {%- set link = path('jury_balloons_setdone', {contestId: contestId, balloonId: balloon.data.balloonid}) %}
                         <a href="{{ link }}" title="mark balloon as done">
                         <i class="fas fa-running"></i>
                         </a>

--- a/webapp/templates/jury/partials/clarification_list.html.twig
+++ b/webapp/templates/jury/partials/clarification_list.html.twig
@@ -6,10 +6,6 @@
         {% if shadowMode() %}
             <th scope="col">external ID</th>
         {% endif %}
-        {%- if current_contest is null and current_contests | length > 1 %}
-            <th scope="col">contest</th>
-        {%- endif %}
-
         <th scope="col">time</th>
         <th scope="col" colspan="2">{{ direction }}</th>
         <th scope="col">subject</th>
@@ -24,14 +20,10 @@
     </thead>
     <tbody>
     {%- for clarification in clarifications %}
-        {%- set link = path('jury_clarification', {id: clarification.externalid}) %}
+        {%- set link = path('jury_clarification', {contestId: clarification.contest.externalid, id: clarification.externalid}) %}
 
         <tr>
             <td><a href="{{ link }}">{{ clarification.externalid }}</a></td>
-            {%- if current_contest is null and current_contests | length > 1 %}
-                <td><a href="{{ link }}">{{ clarification.contest.shortname }}</a></td>
-            {%- endif %}
-
             <td data-order="{{ clarification.submittime }}"><a href="{{ link }}">{{ clarification.submittime | printtime(null, clarification.contest) }}</a></td>
             {%- if clarification.sender is null %}
                 {%- set recipientBadge = '' %}
@@ -90,7 +82,7 @@
             {%- endif %}
 
             <td><a href="{{ link }}">{{ answered | raw }}</a></td>
-            <td><form action="{{ path('jury_clarification_claim', {clarId: clarification.externalid}) }}" method="post">
+            <td><form action="{{ path('jury_clarification_claim', {contestId: clarification.contest.externalid, clarId: clarification.externalid}) }}" method="post">
                 {%- if claim and clarification.sender -%}
                     <button name="claimed" value="1"
                        class="btn btn-outline-success btn-sm">Claim</button>

--- a/webapp/templates/jury/partials/submission_diff.html.twig
+++ b/webapp/templates/jury/partials/submission_diff.html.twig
@@ -16,11 +16,11 @@
         {%- endfor %}
 
         <li class="nav-item flex-grow-1 text-end mb-1">
-            <a class="download btn btn-secondary btn-sm" href="{{ path('jury_submission_source', {submission: submission.externalid, fetch: 0}) }}">
+            <a class="download btn btn-secondary btn-sm" href="{{ path('jury_submission_source', {contestId: submission.contest.externalid, submission: submission.externalid, fetch: 0}) }}">
                 <i class="fas fa-download"></i> Download
             </a>
             {% if allowEdit %}
-                <a class="edit btn btn-secondary btn-sm" href="{{ path('jury_submission_edit_source', {submission: submission.externalid, rank: 0}) }}">
+                <a class="edit btn btn-secondary btn-sm" href="{{ path('jury_submission_edit_source', {contestId: submission.contest.externalid, submission: submission.externalid, rank: 0}) }}">
                     <i class="fas fa-pencil-alt"></i> Edit
                 </a>
             {% endif %}
@@ -29,7 +29,7 @@
                 <select class="diff-select btn btn-secondary btn-sm form-select-sm text-start" aria-label="Submission to diff against" {%- if otherSubmissions is empty %}disabled="disabled" aria-disabled="true"{%- endif %}>
                     <option value="" data-tag="no-diff">No diff</option>
                     {%- for other in otherSubmissions %}
-                        <option value="{{ other.submitid }}" data-url="{{ path('jury_submission', {submitId: other.submitid}) }}" {%- if other.tag %} data-tag="{{ other.tag }}" {%- endif %}>
+                        <option value="{{ other.submitid }}" data-url="{{ path('jury_submission', {contestId: submission.contest.externalid, submitId: other.submitid}) }}" {%- if other.tag %} data-tag="{{ other.tag }}" {%- endif %}>
                             {{ other.submitid }} {%- if other.tag %} ({{ other.tag }}) {%- endif %}
                         </option>
                     {%- endfor %}

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -99,9 +99,9 @@
         <tbody>
         {%- for submission in submissions %}
             {%- if rejudging is defined %}
-                {%- set link = path('jury_submission', {submitId: submission.externalid, rejudgingid: rejudging.rejudgingid}) %}
+                {%- set link = path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid, rejudgingid: rejudging.rejudgingid}) %}
             {%- else %}
-                {%- set link = path('jury_submission', {submitId: submission.externalid}) %}
+                {%- set link = path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid}) %}
             {%- endif %}
 
             {% if submission.team.affiliation %}
@@ -156,7 +156,7 @@
                     </td>
                 {% endif %}
                 {%- if rejudging is defined %}
-                    <td class="{{ tdExtraClass }}"><a href="{{ path('jury_submission', {submitId: submission.externalid}) }}">
+                    <td class="{{ tdExtraClass }}"><a href="{{ path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid}) }}">
                             {{ submission.oldResult | printValidJuryResult }}
                         </a></td>
                 {%- endif %}
@@ -231,9 +231,9 @@
                     {% if not showExternalResult or not showExternalTestcases %}
                         <td class="{{ tdExtraClass }}">
                             {%- if rejudging is defined %}
-                                {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.externalid, rejudgingid: rejudging.rejudgingid})) %}
+                                {%- set claimLink = path('jury_submission', claimArg | merge({contestId: submission.contest.externalid, submitId: submission.externalid, rejudgingid: rejudging.rejudgingid})) %}
                             {%- else %}
-                                {%- set claimLink = path('jury_submission', claimArg | merge({submitId: submission.externalid})) %}
+                                {%- set claimLink = path('jury_submission', claimArg | merge({contestId: submission.contest.externalid, submitId: submission.externalid})) %}
                             {%- endif %}
                             {%- if claim -%}
                                 <a class="btn btn-outline-secondary btn-sm"

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -191,13 +191,13 @@
             <h1 style="display: inline;">
                 Submission {{ submission.externalid }}
                 {% if submission.originalSubmission %}
-                    {% set origSubmissionUrl = path('jury_submission', {submitId: submission.originalSubmission.externalid}) %}
+                    {% set origSubmissionUrl = path('jury_submission', {contestId: submission.originalSubmission.contest.externalid, submitId: submission.originalSubmission.externalid}) %}
                     (resubmit of <a href="{{ origSubmissionUrl }}">{{ submission.originalSubmission.externalid }}</a>)
                 {% endif %}
                 {% if submission.resubmissions is not empty %}
                     (resubmitted as
                     {%- for resubmission in submission.resubmissions -%}
-                        {% set resubmissionUrl = path('jury_submission', {submitId: resubmission.externalid}) %}
+                        {% set resubmissionUrl = path('jury_submission', {contestId: resubmission.contest.externalid, submitId: resubmission.externalid}) %}
                         <a href="{{ resubmissionUrl }}">{{ resubmission.externalid }}</a>
                         {%- if not loop.last -%},{%- endif -%}
                     {%- endfor -%}
@@ -215,7 +215,7 @@
                         {% else %}
                             {% set action = 'unignore' %}
                         {% endif %}
-                        <form action="{{ path('jury_submission_update_status', {'submitId': submission.externalid}) }}" method="post"
+                        <form action="{{ path('jury_submission_update_status', {'contestId': submission.contest.externalid, 'submitId': submission.externalid}) }}" method="post"
                               style="display: inline; ">
                             <input type="hidden" name="valid" value="{% if submission.valid %}0{% else %}1{% endif %}"/>
                             <input type="submit" class="btn btn-outline-secondary btn-sm"
@@ -246,7 +246,7 @@
                     </span>
                 {% endif %}
 
-                {% if current_contest.cid != submission.contest.cid %}
+                {% if current_contest and current_contest.cid != submission.contest.cid %}
                     <span>
                         <i class="fas fa-trophy" title="Contest:"></i>
                         <a href="{{ path('jury_contest', {'contestId': submission.contest.externalid}) }}">
@@ -290,7 +290,7 @@
 
                 <span>
                     <i class="fas fa-code" title="Source code:"></i>
-                    <a href="{{ path('jury_submission_source', {submission: submission.externalid}) }}">
+                    <a href="{{ path('jury_submission_source', {contestId: submission.contest.externalid, submission: submission.externalid}) }}">
                         View {{ submission.files | printFiles }}
                     </a>
                 </span>
@@ -384,7 +384,7 @@
             </thead>
             <tbody>
             {% for judging in judgings %}
-                {% set link = path('jury_submission', {submitId: submission.externalid, jid: judging.judgingid}) %}
+                {% set link = path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid, jid: judging.judgingid}) %}
                 <tr {% if not judging.valid %}class="disabled"{% endif %}>
                     <td>
                         <a href="{{ link }}">
@@ -482,7 +482,7 @@
                             {%- endif -%}
                         {% endif %}
                         {%- if lastJudging is not null -%}
-                            {% set lastSubmissionLink = path('jury_submission', {submitId: lastSubmission.externalid}) %}{#-
+                            {% set lastSubmissionLink = path('jury_submission', {contestId: lastSubmission.contest.externalid, submitId: lastSubmission.externalid}) %}{#-
                         -#}<span class="lastresult">
                             (<a href="{{ lastSubmissionLink }}">{{ lastSubmission.externalid }}</a>: {{ lastJudging.result | printResult }}){#-
                         -#}</span>
@@ -547,7 +547,7 @@
                     {% endif %}
                 &nbsp;
                 {% if not selectedJudging.verified %}
-                    <form action="{{ path('jury_submission', {submitId: submission.externalid, jid: selectedJudging.judgingid}) }}"
+                    <form action="{{ path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid, jid: selectedJudging.judgingid}) }}"
                           method="post" style="display: inline;">
                         {% if selectedJudging.juryMember is not empty %}
                             (claimed by {{ selectedJudging.juryMember }})
@@ -563,7 +563,7 @@
                 &nbsp;
                 {% if selectedJudging is null or selectedJudging.result is empty %}
                     {%- if not selectedJudging or not selectedJudging.started %}
-                        <a href="{{ path('jury_submission_create_tasks', {'submitId': submission.externalid}) }}">
+                        <a href="{{ path('jury_submission_create_tasks', {'contestId': submission.contest.externalid, 'submitId': submission.externalid}) }}">
                             <button class="btn btn-sm btn-outline-secondary" >
                                 <i class="fas fa-gavel"></i>
                                 Judge submission
@@ -842,7 +842,7 @@
                                 </button>
                             </a>
                             {% if run.firstJudgingRun is not null %}
-                                <a href="{{ path('jury_submission_team_output', {'submission': submission.externalid, 'run': run.firstJudgingRun.runid, 'contest': submission.contest.externalid}) }}">
+                                <a href="{{ path('jury_submission_team_output', {'contestId': submission.contest.externalid, 'submission': submission.externalid, 'run': run.firstJudgingRun.runid}) }}">
                                     <button class="btn btn-sm btn-outline-secondary" >
                                         <i class="fas fa-download"></i>
                                         {% if runsOutput[runIdx].is_output_run_truncated_in_db %}

--- a/webapp/templates/jury/submission_edit_source.html.twig
+++ b/webapp/templates/jury/submission_edit_source.html.twig
@@ -7,7 +7,7 @@
 
     <h1>
         Edit submission
-        <a href="{{ path('jury_submission', {submitId: submission.externalid}) }}">{{ submission.externalid }}</a>
+        <a href="{{ path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid}) }}">{{ submission.externalid }}</a>
         source files
     </h1>
 
@@ -21,7 +21,7 @@
         {%- endfor %}
 
         <li class="nav-item flex-grow-1 text-end mb-1">
-            <a class="btn btn-success btn-sm" data-ajax-modal data-ajax-modal-after="transferSourceToModal" href="{{ path('jury_submission_edit_source', {submission: submission.submitid}) }}">
+            <a class="btn btn-success btn-sm" data-ajax-modal data-ajax-modal-after="transferSourceToModal" href="{{ path('jury_submission_edit_source', {contestId: submission.contest.externalid, submission: submission.externalid}) }}">
                 <i class="fas fa-cloud-upload-alt"></i> Submit
             </a>
         </li>

--- a/webapp/templates/jury/submission_source.html.twig
+++ b/webapp/templates/jury/submission_source.html.twig
@@ -14,16 +14,16 @@
         <span class="d-none d-md-inline">
             code for submission
         </span>
-        <a href="{{ path('jury_submission', {submitId: submission.externalid}) }}">{{ submission.externalid }}</a>
+        <a href="{{ path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid}) }}">{{ submission.externalid }}</a>
         <span class="d-none d-md-inline">
             {%- if submission.originalSubmission %}
                 (resubmit of
-                <a href="{{ path('jury_submission', {submitId: submission.originalSubmission.externalid}) }}">{{ submission.originalSubmission.externalid }}</a>)
+                <a href="{{ path('jury_submission', {contestId: submission.originalSubmission.contest.externalid, submitId: submission.originalSubmission.externalid}) }}">{{ submission.originalSubmission.externalid }}</a>)
             {%- endif %}
             {% if submission.resubmissions is not empty %}
                 (resubmitted as
                 {%- for resubmission in submission.resubmissions %}
-                    <a href="{{ path('jury_submission', {submitId: resubmission.externalid}) }}">{{ resubmission.externalid }}</a>
+                    <a href="{{ path('jury_submission', {contestId: resubmission.contest.externalid, submitId: resubmission.externalid}) }}">{{ resubmission.externalid }}</a>
                     {%- if not loop.last -%},{%- endif -%}
                 {%- endfor -%}
                 )

--- a/webapp/templates/jury/submissions.html.twig
+++ b/webapp/templates/jury/submissions.html.twig
@@ -80,7 +80,7 @@
     <script>
         $(function () {
             $('input[name=viewtype]').on('change', function () {
-                window.location = '{{ path('jury_submissions', {'view': 'REPLACE_ME'}) }}'.replace('REPLACE_ME', $(this).val());
+                window.location = '{{ path('jury_submissions', {'contestId': contestId, 'view': 'REPLACE_ME'}) }}'.replace('REPLACE_ME', $(this).val());
             });
 
             $('#filter-toggle').on('change', function () {

--- a/webapp/templates/jury/team.html.twig
+++ b/webapp/templates/jury/team.html.twig
@@ -188,7 +188,9 @@
             {{ button(path('jury_team_edit', {'teamId': team.externalid}), 'Edit', 'primary', 'edit') }}
             {{ button(path('jury_team_delete', {'teamId': team.externalid}), 'Delete', 'danger', 'trash-alt', true) }}
         {% endif %}
-        {{ button(path('jury_clarification_new', {'teamto': team.externalid}), 'Send message', 'secondary', 'envelope') }}
+        {% if currentContest %}
+            {{ button(path('jury_clarification_new', {'contestId': currentContest.externalid, 'teamto': team.externalid}), 'Send message', 'secondary', 'envelope') }}
+        {% endif %}
         {% include 'jury/partials/rejudge_form.html.twig' with {table: 'team', id: team.externalid, buttonClass: 'btn-secondary'} %}
     </div>
 

--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -103,6 +103,9 @@ class ControllerRolesTraversalTest extends BaseTestCase
                 self::assertTrue(str_contains($response->headers->get('location'), '/jury/external-contest/manage'));
             } elseif (str_contains($url, '/jury/shadow-differences')) {
                 self::assertTrue(str_contains($response->headers->get('location'), '/jury'));
+            } elseif (str_contains($url, '/jury/submissions') || str_contains($url, '/jury/clarifications') || str_contains($url, '/jury/balloons')) {
+                // Legacy routes redirect to contest-scoped routes
+                self::assertTrue(str_contains($response->headers->get('location'), '/jury/contests/'));
             } else {
                 self::assertTrue(str_contains($response->headers->get('location'), '/public'));
             }
@@ -223,7 +226,9 @@ class ControllerRolesTraversalTest extends BaseTestCase
         $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         self::assertNotEquals(500, $response->getStatusCode(), sprintf('Failed at %s', $url));
-        if ($dropdown && !str_contains($url, '/public')) {
+        // Contest-scoped URLs (e.g., /jury/contests/demo/...) have the contest set from the URL,
+        // so we don't expect "no contest" in the dropdown for those.
+        if ($dropdown && !str_contains($url, '/public') && !str_contains($url, '/jury/contests/')) {
             try {
                 self::assertSelectorExists('a#navbarDropdownContests:contains("no contest")', "Failed at: " . $url);
             } catch (\Exception $e) {

--- a/webapp/tests/Unit/Controller/Jury/BalloonControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/BalloonControllerTest.php
@@ -19,7 +19,7 @@ class BalloonControllerTest extends BaseTestCase
         $this->roles = [$role];
         $this->logOut();
         $this->logIn();
-        $this->verifyPageResponse('GET', '/jury/balloons', 403);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/balloons', 403);
     }
 
     /**
@@ -32,7 +32,7 @@ class BalloonControllerTest extends BaseTestCase
         $this->roles = [$role];
         $this->logOut();
         $this->logIn();
-        $this->verifyPageResponse('GET', '/jury/balloons', 200);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/balloons', 200);
         self::assertSelectorExists('h1:contains("Balloons - Demo contest")');
 
         // Test database does not contain balloon info.

--- a/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
@@ -20,7 +20,8 @@ class ClarificationControllerTest extends BaseTestCase
         $this->verifyPageResponse('GET', '/jury', 200);
         $link = $this->verifyLinkToURL('Clarifications',
                                        'http://localhost/jury/clarifications');
-        $crawler = $this->client->click($link);
+        $this->client->click($link);
+        $crawler = $this->checkStatusAndFollowRedirect();
 
         $h3s = $crawler->filter('h3')->extract(['_text']);
         self::assertEquals('New requests', $h3s[0]);
@@ -37,7 +38,7 @@ class ClarificationControllerTest extends BaseTestCase
     {
         $this->loadFixture(ClarificationFixture::class);
 
-        $this->verifyPageResponse('GET', '/jury/clarifications', 200);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications', 200);
         $crawler = $this->getCurrentCrawler();
 
         self::assertSelectorTextContains('h3#newrequests ~ div.table-wrapper', 'Is it necessary to');
@@ -50,7 +51,7 @@ class ClarificationControllerTest extends BaseTestCase
     {
         $this->loadFixture(ClarificationFixture::class);
 
-        $this->verifyPageResponse('GET', '/jury/clarifications', 200);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications', 200);
         $crawler = $this->getCurrentCrawler();
 
         // General clarification to all.
@@ -67,7 +68,7 @@ class ClarificationControllerTest extends BaseTestCase
         $this->loadFixture(ClarificationFixture::class);
         /** @var Clarification $clar */
         $clar = static::getContainer()->get(EntityManagerInterface::class)->getRepository(Clarification::class)->findOneBy(['body' => 'What is 2+2?']);
-        $this->verifyPageResponse('GET', '/jury/clarifications/' . $clar->getClarid(), 200);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications/' . $clar->getExternalid(), 200);
 
         /** @var Clarification[] $clarifications */
         $clarifications = static::getContainer()->get(EntityManagerInterface::class)->getRepository(Clarification::class)->findAll();
@@ -86,9 +87,9 @@ class ClarificationControllerTest extends BaseTestCase
      */
     public function testClarificationRequestComposeForm(): void
     {
-        $this->verifyPageResponse('GET', '/jury/clarifications', 200);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications', 200);
         $link = $this->verifyLinkToURL('Send clarification',
-                                       'http://localhost/jury/clarifications/send');
+                                       'http://localhost/jury/contests/demo/clarifications/send');
 
         $crawler = $this->client->click($link);
 

--- a/webapp/tests/Unit/Controller/Jury/SubmissionControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/SubmissionControllerTest.php
@@ -9,7 +9,7 @@ use Generator;
 class SubmissionControllerTest extends BaseTestCase
 {
     protected array         $roles   = ['jury'];
-    protected static string $baseURL = '/jury/submissions';
+    protected static string $baseURL = '/jury/contests/demo/submissions';
 
     /**
      * Test that the basic building blocks of the index page are there.


### PR DESCRIPTION
This is a follow-up on the external ID rewrite (see cf86a1849308b135c6821c96c437fbd4b91c7059).

Prior to that rewrite IDs were globally unique, now two contests can have the same IDs, e.g. for submissions, since we are using the external ID. This broke some assumptions, that we are trying to fix with this change.

We are introducing for submissions, clarifications and balloons new default URL paths which include the contest ID to make IDs unique by composition, e.g. `/jury/submissions/<submitid>` will become `/jury/contests/<contestid>/submissions/<submitid>` (similar for the other entities with contest associated data).

We have added redirects for the legacy routes if a contest has already been selected.

This continues to align the UI with the API, both in terms of IDs and also URL structure.