### PR TITLE
Fix field type in ExternalSourceWarning.

### DIFF
--- a/webapp/src/Entity/ExternalSourceWarning.php
+++ b/webapp/src/Entity/ExternalSourceWarning.php
@@ -40,7 +40,7 @@ class ExternalSourceWarning
         scale: 9,
         options: ['comment' => 'Time this warning happened last', 'unsigned' => true]
     )]
-    private float $lastTime;
+    private string $lastTime;
 
     #[ORM\Column(options: ['comment' => 'Type of the entity for this warning'])]
     private string $entityType;
@@ -81,14 +81,14 @@ class ExternalSourceWarning
         return $this;
     }
 
-    public function getLastTime(): float
+    public function getLastTime(): string
     {
         return $this->lastTime;
     }
 
-    public function setLastTime(float $lastTime): ExternalSourceWarning
+    public function setLastTime(float|string $lastTime): ExternalSourceWarning
     {
-        $this->lastTime = $lastTime;
+        $this->lastTime = (string)$lastTime;
         return $this;
     }
 


### PR DESCRIPTION
Otherwise seeing warnings like this:

<img width="1784" height="1212" alt="image" src="https://github.com/user-attachments/assets/d1f812b9-e4b4-48fd-be04-9495d2122033" />
