### PR TITLE
Fix rejudging creation.

### DIFF
--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -756,7 +756,7 @@ class RejudgingController extends BaseController
                 ->leftJoin('s.user', 'u')
                 ->leftJoin('j.runs', 'jr')
                 ->leftJoin('jr.judgetask', 'jt')
-                ->select('j', 's', 'r', 'c', 'l', 'p', 't', 'u', 'jr', 'jt')
+                ->select('j', 's', 'r', 'c', 'l', 'p', 't', 'u')
                 ->distinct()
                 ->andWhere('j.contest IN (:contests)')
                 ->andWhere('j.valid = 1')


### PR DESCRIPTION
Commit cf86a18493 added a select on judging runs and judge tasks, causing doctrine to hydrate all of these elements, quickly running out of PHP execution time or memory limitations.

The additional fields were likely added to be able to filter on it.

This was observed when attempting a full rejudge of a regular contest with ~2k submissions, but ~400k judging_runs and judge tasks.