### PR TITLE
Eagerly load submission data for unfinished judgings.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -165,11 +165,12 @@ class JudgehostController extends AbstractFOSRestController
         /** @var Judging[] $judgings */
         $judgings = $this->em->createQueryBuilder()
             ->from(Judging::class, 'j')
+            ->innerJoin('j.submission', 's')
             ->leftJoin('j.rejudging', 'r')
             ->innerJoin('j.runs', 'jr')
             ->innerJoin('jr.judgetask', 'jt')
             ->innerJoin('jt.judgehost', 'jh')
-            ->select('j')
+            ->select('j', 's')
             ->distinct()
             ->andWhere('jh.hostname = :hostname')
             ->andWhere('j.judgingid = jt.jobid')


### PR DESCRIPTION
A few lines down we are calling `->getSubmission()` on each judging, causing a query to be issued for each of the unfinished judgings.

There should not be many, unless we are aborting a large rejudging, but it is better to do the eager load here.