### PR TITLE
Warn for non-UTF-8 encodings.

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -699,6 +699,12 @@ class ProblemController extends BaseController
                             );
                         }
 
+                        if ($type !== 'image') {
+                            foreach (Utils::detectTestcaseEncoding($content, $file->getClientOriginalName()) as $encodingWarning) {
+                                $message .= "\nWarning: " . $encodingWarning;
+                            }
+                        }
+
                         $messages[] = $message;
                     }
                 }
@@ -808,6 +814,17 @@ class ProblemController extends BaseController
                     empty($newTestcaseContent->getOutput())) {
                     $message .= "\nWarning: empty testcase file(s)!\n";
                     $haswarnings = true;
+                }
+
+                foreach (['input', 'output'] as $tcType) {
+                    $tcFile = $request->files->get('add_' . $tcType);
+                    $tcContent = $tcType === 'input'
+                        ? $newTestcaseContent->getInput()
+                        : $newTestcaseContent->getOutput();
+                    foreach (Utils::detectTestcaseEncoding($tcContent, $tcFile->getClientOriginalName()) as $encodingWarning) {
+                        $message .= "\nWarning: " . $encodingWarning;
+                        $haswarnings = true;
+                    }
                 }
 
                 $messages[] = $message;

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -450,6 +450,12 @@ readonly class ImportProblemService
                 if (str_contains($testOutput, "\r")) {
                     $messages['warning'][] = "Testcase file '$baseFileName.ans' contains Windows newlines.";
                 }
+                foreach (Utils::detectTestcaseEncoding($testInput, "$baseFileName.in") as $warning) {
+                    $messages['warning'][] = $warning;
+                }
+                foreach (Utils::detectTestcaseEncoding($testOutput, "$baseFileName.ans") as $warning) {
+                    $messages['warning'][] = $warning;
+                }
 
                 $md5in  = md5($testInput);
                 $md5out = md5($testOutput);


### PR DESCRIPTION
Fixes #3360

---------

Example:

<img width="1550" height="640" alt="image" src="https://github.com/user-attachments/assets/c7d4c059-0cba-45de-964d-30dacb2d3d6f" />
