### PR TITLE
Only display changes for scoring problems in the heatmap / table if w…

### DIFF
--- a/webapp/src/Controller/Jury/ShadowDifferencesController.php
+++ b/webapp/src/Controller/Jury/ShadowDifferencesController.php
@@ -151,7 +151,8 @@ class ShadowDifferencesController extends BaseController
 
             // Collect score change data for scoring problems.
             $problem = $submission->getProblem();
-            if ($problem->isScoringProblem() && $externalJudgement && $localJudging) {
+            if ($problem->isScoringProblem()
+                && $externalJudgement?->getResult() && $localJudging?->getResult()) {
                 $hasScoringProblems = true;
                 $externalScore = (float)$externalJudgement->getScore();
                 $localScore = (float)$localJudging->getScore();


### PR DESCRIPTION
…e have both internal and external results.

Note that the verdict matrix will still indicated unjudged submissions, so we won't miss them.