### PR TITLE
Fix range check in cgroup error check.

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -239,7 +239,9 @@ void die(int errnum, std::format_string<Args...> fmt, Args&&... args)
 			errstr += ": libcgroup";
 			errnum = errno;
 		}
-		if ( errnum>=ECGROUPNOTCOMPILED && errnum<=ECGROUPNOTCOMPILED ) {
+		// The upper bound depends on the libcgroup version, we got the value from
+		// https://github.com/libcgroup/libcgroup/blob/b26f58ec3fce95f81b3c0dac4ea44d1c5793670c/include/libcgroup/error.h#L79
+		if ( errnum>=ECGROUPNOTCOMPILED && errnum<=50031 ) {
 			errstr += ": ";
 			errstr += cgroup_strerror(errnum);
 		} else {


### PR DESCRIPTION
Both sides of the check were checking the same value (so only going into the if statement for the exact value), but we wanted to use `cgroup_strerror` for all error values.

We got the range from `/usr/include/libcgroup/error.h`.