### PR TITLE
Only allow modifying test data for admin accounts.

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -614,6 +614,7 @@ class ProblemController extends BaseController
         }
 
         if ($request->isMethod('POST')) {
+            $this->denyAccessUnlessGranted('ROLE_ADMIN');
             if (!empty($lockedContests)) {
                 $this->addFlash('danger', 'Cannot edit problem / testcases, it belongs to locked contest(s) '
                     . join(', ', $lockedContests));
@@ -1254,6 +1255,7 @@ class ProblemController extends BaseController
         return $this->redirectToRoute('jury_problem', ['probId' => $probId]);
     }
 
+    #[IsGranted('ROLE_ADMIN')]
     #[Route(path: '/{contestId}/{probId}/toggle/{type<judge|submit>}', name: 'jury_problem_toggle')]
     public function toggleSubmitAction(
         RouterInterface $router,


### PR DESCRIPTION
This is in line with web UI and other pages, that jury can have read-only but no write access to the data.