### PR TITLE
Properly handle `--disable-doc-build` with in place installs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,11 +305,13 @@ inplace-postinstall-permissions:
 	setfacl    -m   u:$(WEBSERVER_GROUP):x    $(CURDIR)/doc
 	setfacl    -m d:u:$(WEBSERVER_GROUP):x    $(CURDIR)/doc/manual
 	setfacl    -m   u:$(WEBSERVER_GROUP):x    $(CURDIR)/doc/manual
+ifneq ($(DOC_BUILD_ENABLED),no)
 	setfacl    -m d:u:$(WEBSERVER_GROUP):x    $(CURDIR)/doc/manual/build
 	setfacl    -m   u:$(WEBSERVER_GROUP):x    $(CURDIR)/doc/manual/build
 	setfacl -R -m d:u:$(WEBSERVER_GROUP):rx   $(CURDIR)/doc/manual/build/html
 	setfacl -R -m   u:$(WEBSERVER_GROUP):rx   $(CURDIR)/doc/manual/build/html
 	setfacl -R -m   u:$(WEBSERVER_GROUP):r    $(CURDIR)/doc/manual/build/domjudge-team-manual.pdf
+endif
 	setfacl -R -m d:u:$(WEBSERVER_GROUP):rwx  $(CURDIR)/webapp/var
 	setfacl -R -m   u:$(WEBSERVER_GROUP):rwx  $(CURDIR)/webapp/var
 	setfacl -R -m d:u:$(WEBSERVER_GROUP):rwx  $(CURDIR)/webapp/public/images/countries


### PR DESCRIPTION
Previously, we would try to fix permissions of non-existent files/folders.