### PR TITLE
runpipe: Use sprintf with limited size buffer.

### DIFF
--- a/judge/runpipe.cc
+++ b/judge/runpipe.cc
@@ -807,7 +807,7 @@ struct state_t {
         int time_millis = time % 1000;
         char direction = from.index == 0 ? ']' : '[';
         char eofbuf[128];
-        sprintf(eofbuf, "[%3d.%03ds/%ld]%c", time_sec, time_millis, 0L, direction);
+        snprintf(eofbuf, sizeof(eofbuf), "[%3d.%03ds/%ld]%c", time_sec, time_millis, 0L, direction);
         write_all(output_file.output_file, eofbuf, strlen(eofbuf));
 
         warning(0, "EOF from process #{}", from.index);


### PR DESCRIPTION
In practice, we should never write something that's larger than the buffer, but it is better to be defensive here.