### PR TITLE
Validate score from validator.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -996,7 +996,16 @@ class JudgehostController extends AbstractFOSRestController
             }
 
             if ($score) {
-                $judgingRun->setScore(trim(base64_decode($score)));
+                $decodedScore = trim(base64_decode($score));
+                if (!is_numeric($decodedScore)) {
+                    throw new BadRequestHttpException(
+                        sprintf("Invalid score '%s' for judgetask %d: not a numeric value.", $decodedScore, $judgeTaskId));
+                }
+                if (bccomp($decodedScore, '0', ScoreboardService::SCALE) < 0) {
+                    throw new BadRequestHttpException(
+                        sprintf("Invalid score '%s' for judgetask %d: must not be negative.", $decodedScore, $judgeTaskId));
+                }
+                $judgingRun->setScore($decodedScore);
             }
 
             $judging = $judgingRun->getJudging();


### PR DESCRIPTION
We do this both on the server side so that a bogus judgedaemon cannot topple the server over and the judgedaemon side to have better error messages and the right action (disable validator).