### PR TITLE
Improve external import progress messages.

### DIFF
--- a/webapp/src/Command/ImportEventFeedCommand.php
+++ b/webapp/src/Command/ImportEventFeedCommand.php
@@ -123,7 +123,12 @@ class ImportEventFeedCommand
             $progressBar->advance();
         };
 
-        if (!$this->sourceService->import($fromStart, $eventsToSkip, $progressReporter)) {
+        $statusReporter = function (string $message) use ($progressBar): void {
+            $progressBar->setMessage($message);
+            $progressBar->display();
+        };
+
+        if (!$this->sourceService->import($fromStart, $eventsToSkip, $progressReporter, $statusReporter)) {
             return Command::FAILURE;
         }
 


### PR DESCRIPTION
This helps against gigantic events which have thousands of small updates in them.

----------------

Example:

![import](https://github.com/user-attachments/assets/488432d3-539e-43e0-ba0a-722011cb6e40)
