### PR TITLE
Improve layout of compiler/runner version overview in team interface.

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -806,3 +806,70 @@ blockquote {
     min-height: 100px; /* Prefer a double scrollbar over not displaying code at all */
     width: 100%;
 }
+
+/* Allowed Languages page styles */
+.language-card {
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.lang-name {
+    font-weight: 700;
+    margin: 0;
+}
+
+.extension-badge {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    background-color: #f8f9fa;
+    color: #000;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+}
+
+.section-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6c757d;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+/* Solarized Dark Terminal Theme */
+.terminal-block {
+    background-color: #002b36;
+    color: #839496;
+    border-radius: 6px;
+    padding: 1rem;
+    font-family: var(--bs-font-monospace);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    border: 1px solid #001f27;
+}
+
+.terminal-command {
+    margin-bottom: 0.5rem;
+    display: block;
+    color: #268bd2; /* Solarized Blue */
+    font-weight: bold;
+}
+
+.terminal-command::before {
+    content: "$ ";
+    color: #859900; /* Solarized Green */
+}
+
+.terminal-output {
+    display: block;
+    white-space: pre-wrap;
+    color: #93a1a1;
+}

--- a/webapp/templates/team/languages.html.twig
+++ b/webapp/templates/team/languages.html.twig
@@ -3,35 +3,50 @@
 {% block title %}Allowed Languages{% endblock %}
 
 {% block content %}
-    <h1 class="mt-4 text-center">Allowed Languages</h1>
+    <h1 class="mt-4 mb-5 text-center">Allowed Languages</h1>
 
-        <div class="container">
-            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-2 g-2">
-    {% for lang in languages %}
+    <div class="container mb-5">
+        <div class="row row-cols-1 row-cols-lg-2 g-4">
+            {% for lang in languages %}
                 <div class="col">
-                <div class="card">
-                    <div class="card-body">
-                        <h2 class="card-title">
-                            <code>{{ lang.name }}</code>
-                            <span style="font-size:50%; font-weight: normal;"> with
-                                extension{% if lang.extensions|length > 1 %}s{% endif %}:
-                            {% for ext in lang.extensions %}
-                                <code>.{{ ext }}</code>{% if not loop.last %}, {% endif %}
-                            {% endfor %}
-                        </h2>
-                    </div>
-                    {% if lang.compilerVersion and lang.compilerVersionCommand %}
-                        <pre class="output_text" style="background-color: rgba(0,121,54,.1);">$ {{ lang.compilerVersionCommand }}</pre>
-                        <pre class="output_text">{{ lang.compilerVersion }}</pre>
-                    {% endif %}
-                    {% if lang.runnerVersion and lang.runnerVersionCommand %}
-                        <pre class="output_text" style="background-color: rgba(0,121,54,.1);">$ {{ lang.runnerVersionCommand }}</pre>
-                        <pre class="output_text">{{ lang.runnerVersion }}</pre>
-                    {% endif %}
+                    <div class="card language-card">
+                        <div class="card-body p-4">
+                            <div class="mb-4">
+                                <h2 class="lang-name h4">{{ lang.name }}</h2>
+                                <div class="d-flex gap-2 mt-2">
+                                    {% for ext in lang.extensions %}
+                                        <span class="extension-badge">.{{ ext }}</span>
+                                    {% endfor %}
+                                </div>
+                            </div>
 
+                            {% if lang.compilerVersion and lang.compilerVersionCommand %}
+                                <div class="mb-4">
+                                    <div class="section-label">
+                                        <i class="fas fa-square-binary"></i> Compiler
+                                    </div>
+                                    <div class="terminal-block">
+                                        <div class="terminal-command">{{ lang.compilerVersionCommand }}</div>
+                                        <div class="terminal-output">{{ lang.compilerVersion }}</div>
+                                    </div>
+                                </div>
+                            {% endif %}
+
+                            {% if lang.runnerVersion and lang.runnerVersionCommand %}
+                                <div>
+                                    <div class="section-label">
+                                        <i class="fas fa-person-running"></i> Runner
+                                    </div>
+                                    <div class="terminal-block">
+                                        <div class="terminal-command">{{ lang.runnerVersionCommand }}</div>
+                                        <div class="terminal-output">{{ lang.runnerVersion }}</div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
-                </div>
-    {% endfor %}
-            </div>
+            {% endfor %}
         </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
This is draft because we likely want to merge https://github.com/DOMjudge/domjudge/pull/3178 first (and afterwards will have merge conflicts with this one).


------

Example:

Before:

<img width="1732" height="780" alt="image" src="https://github.com/user-attachments/assets/1c4af5db-550c-4795-953f-5c9cecd98b26" />


After:

<img width="1893" height="1265" alt="image" src="https://github.com/user-attachments/assets/40aea645-a0a5-4c8b-bd0f-57eb00ef06c9" />
