### PR TITLE
Install DS to get set functionality for PHP

### DIFF
--- a/doc/manual/install-domserver.rst
+++ b/doc/manual/install-domserver.rst
@@ -24,7 +24,7 @@ System requirements
 
 Software requirements
 `````````````````````
-* A web server with support for PHP >= 8.2.0 and the ``curl``, ``gd``, ``intl``,
+* A web server with support for PHP >= 8.2.0 and the ``curl``, ``ds``, ``gd``, ``intl``,
   ``json``, ``mbstring``, ``mysqli``, ``xml`` and ``zip`` extensions for PHP.
 * MySQL or MariaDB database. This can be on the same machine, but for
   advanced setups can also run on a dedicated machine.
@@ -36,11 +36,11 @@ software on the DOMjudge server as mentioned above when using Debian
 GNU/Linux, or one of its derivative distributions like Ubuntu::
 
   sudo apt install libcgroup-dev make acl zip unzip pv mariadb-server nginx \
-        php php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
+        php php-ds php-fpm php-gd php-cli php-intl php-mbstring php-mysql \
         php-curl php-json php-xml php-zip composer ntp python3-yaml php-bcmath
 
 The following command can be used on Fedora, and related distributions like
-Red Hat Enterprise Linux and Rocky Linux (before V9)::
+Red Hat Enterprise Linux and Rocky Linux (before V9)[#ds]_::
 
   sudo dnf install libcgroup-devel make acl zip unzip pv mariadb-server httpd \
         php-gd php-cli php-intl php-mbstring php-mysqlnd php-fpm \
@@ -51,6 +51,8 @@ Red Hat Enterprise Linux and Rocky Linux (before V9)::
 The packages `libcgroup-dev` (`libcgroup-devel` on Fedora) and `make` are
 :ref:`judgehost software requirements <judgehost_software>`, but also
 needed here due to `issue 862 <https://github.com/DOMjudge/domjudge/issues/862>`.
+
+.. [#ds] For `php-ds` follow the instructions at: https://www.php.net/manual/en/ds.installation.php
 
 Installation
 ------------

--- a/webapp/composer.json
+++ b/webapp/composer.json
@@ -66,6 +66,7 @@
 		"league/commonmark": "^2.3",
 		"nelmio/api-doc-bundle": "^5.0",
 		"nelmio/cors-bundle": "^2.4",
+		"php-ds/php-ds": "^1.7",
 		"phpdocumentor/reflection-docblock": "^5.3",
 		"phpstan/phpdoc-parser": "^2.0",
 		"promphp/prometheus_client_php": "^2.6",

--- a/webapp/composer.lock
+++ b/webapp/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "994f1c88ded5fa9863d0857e43e37fa3",
+    "content-hash": "ad538cec9e4aa2e3a1bad77398a22729",
     "packages": [
         {
             "name": "brick/math",
@@ -3155,6 +3155,62 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
             "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "php-ds/php-ds",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-ds/polyfill.git",
+                "reference": "017fb5cdfa52a1f13126c94987b04b884c44f9cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-ds/polyfill/zipball/017fb5cdfa52a1f13126c94987b04b884c44f9cd",
+                "reference": "017fb5cdfa52a1f13126c94987b04b884c44f9cd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.4"
+            },
+            "provide": {
+                "ext-ds": "1.5.0"
+            },
+            "require-dev": {
+                "php-ds/tests": "^1.5"
+            },
+            "suggest": {
+                "ext-ds": "to improve performance and reduce memory usage"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rudi Theunissen",
+                    "email": "rudolf.theunissen@gmail.com"
+                }
+            ],
+            "description": "Specialized data structures as alternatives to the PHP array",
+            "keywords": [
+                "data structures",
+                "ds",
+                "php",
+                "polyfill"
+            ],
+            "support": {
+                "issues": "https://github.com/php-ds/polyfill/issues",
+                "source": "https://github.com/php-ds/polyfill/tree/v1.7.0"
+            },
+            "time": "2025-05-18T04:50:53+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -12795,5 +12851,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -131,7 +131,7 @@ readonly class CheckConfigService
     public function checkPhpExtensions(): ConfigCheckItem
     {
         $this->stopwatch->start(__FUNCTION__);
-        $required = ['gd', 'intl', 'json', 'mbstring', 'mysqli', 'zip'];
+        $required = ['ds', 'gd', 'intl', 'json', 'mbstring', 'mysqli', 'zip'];
         $state = 'O';
         $remark = '';
         $missing = [];


### PR DESCRIPTION
I needed sets for another PR and I know we discussed this in the past so looked into how hard it is to support this.

The annoying thing is the installation for fedora, adding this syntactic sugar (and maybe a performance boost) does make installation harder on other distributions.