### PR TITLE
Avoid toggle re-initialization over and over again when adding problems.

### DIFF
--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -208,10 +208,14 @@
 <script>
     function afterProblemAdd() {
         bindColor();
-        $('[data-toggle="toggle"]').not('.toggle-initialized').bootstrapToggle().addClass('toggle-initialized');
+        // Only initialize toggles in the newly added row (last row in the collection)
+        $('[data-collection-holder] tr:last [data-toggle="toggle"]').bootstrapToggle();
     }
 
     $(function () {
+        // Mark all existing toggles as initialized to prevent accidental re-initialization
+        $('[data-toggle="toggle"]').addClass('toggle-initialized');
+
         function showHideTeams() {
             if ($('#contest_openToAllTeams').is(':checked')) {
                 $('[data-teams-field]').hide();


### PR DESCRIPTION
Without this fix it would result in funny recursive toggles like:


<img width="1170" height="1271" alt="inception" src="https://github.com/user-attachments/assets/b2792100-3f60-4b2f-b889-6844432917c4" />
