### PR TITLE
Remove `->setAccessible(...)` calls from our reflective tests.

### DIFF
--- a/judge/tests/Unit/RunCommandSafeTest.php
+++ b/judge/tests/Unit/RunCommandSafeTest.php
@@ -18,7 +18,6 @@ class RunCommandSafeTest extends TestCase
         $reflection = new ReflectionClass(JudgeDaemon::class);
         $this->daemon = $reflection->newInstanceWithoutConstructor();
         $this->method = $reflection->getMethod('runCommandSafe');
-        $this->method->setAccessible(true);
 
         $this->tempDir = sys_get_temp_dir() . '/domjudge-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);

--- a/judge/tests/Unit/TestcaseRunInternalTest.php
+++ b/judge/tests/Unit/TestcaseRunInternalTest.php
@@ -22,15 +22,12 @@ class TestcaseRunInternalTest extends TestCase
         $reflection = new ReflectionClass(JudgeDaemon::class);
         $this->daemon = $reflection->newInstanceWithoutConstructor();
         $this->method = $reflection->getMethod('testcaseRunInternal');
-        $this->method->setAccessible(true);
 
         // Initialize the runuser and rungroup properties that testcaseRunInternal now uses
         $runuserProperty = $reflection->getProperty('runuser');
-        $runuserProperty->setAccessible(true);
         $runuserProperty->setValue($this->daemon, RUNUSER);
 
         $rungroupProperty = $reflection->getProperty('rungroup');
-        $rungroupProperty->setAccessible(true);
         $rungroupProperty->setValue($this->daemon, RUNGROUP);
 
         $this->tempDir = sys_get_temp_dir() . '/domjudge-test-' . uniqid();

--- a/judge/tests/Unit/VerdictDeterminationTest.php
+++ b/judge/tests/Unit/VerdictDeterminationTest.php
@@ -24,7 +24,6 @@ class VerdictDeterminationTest extends TestCase
     {
         $reflection = new ReflectionClass(JudgeDaemon::class);
         $method = $reflection->getMethod('getVerdictMessage');
-        $method->setAccessible(true);
         return $method->invoke($this->daemon, $verdict, $input->programMeta, $input->compareMeta, $input->combinedRunCompare, $filelimit);
     }
 


### PR DESCRIPTION
They are no-ops since PHP 8.1 and get flagged as deprecated by our unit tests when we enabled testing for PHP 8.5.