### PR TITLE
Make iteration order of sub-child groups deterministic.

### DIFF
--- a/example_scoring_problems/fibonacci/submissions/partial/fibonacci-recursive.py
+++ b/example_scoring_problems/fibonacci/submissions/partial/fibonacci-recursive.py
@@ -3,7 +3,7 @@
 # @EXPECTED_RESULTS@: TIMELIMIT
 # @EXPECTED_SCORE@: 25
 import sys
-sys.setrecursionlimit(100)
+sys.setrecursionlimit(1000000)
 
 def fibonacci(n):
     if n <= 1:

--- a/example_scoring_problems/fibonacci/submissions/partial/fibonacci-rte.c
+++ b/example_scoring_problems/fibonacci/submissions/partial/fibonacci-rte.c
@@ -1,6 +1,6 @@
 /* Solution that crashes (RTE) on large inputs but works for basic
  * Demonstrates partial scoring with runtime error
- * @EXPECTED_RESULTS@: WRONG-ANSWER
+ * @EXPECTED_RESULTS@: RUN-ERROR
  * @EXPECTED_SCORE@: 25
  */
 #include <stdio.h>

--- a/webapp/src/Entity/TestcaseGroup.php
+++ b/webapp/src/Entity/TestcaseGroup.php
@@ -53,6 +53,7 @@ class TestcaseGroup
      * @var Collection<int, self>
      */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
     private Collection $children;
 
     /**


### PR DESCRIPTION
This makes sure we get the same result even for different ZIP iteration orders (see current failures on CI).