### PR TITLE
Properly check for errors in forge-passwords script.

### DIFF
--- a/misc-tools/force-passwords.in
+++ b/misc-tools/force-passwords.in
@@ -1,24 +1,53 @@
 #!/usr/bin/python3
 
 import subprocess
+import sys
 
 bindir = '@domserver_bindir@'
 etcdir = '@domserver_etcdir@'
 
-subprocess.run([bindir + '/dj_setup_database', 'update-password'])
+result = subprocess.run([bindir + '/dj_setup_database', 'update-password'])
+if result.returncode != 0:
+    print('Error: dj_setup_database failed', file=sys.stderr)
+    sys.exit(1)
 
-with open(f'{etcdir}/restapi.secret', 'r') as f:
-    while True:
-        line = f.readline()
-        if line.startswith('#'):
-            continue
-        tokens = line.split()
-        if len(tokens) == 4 and tokens[0] == 'default':
-            user = tokens[2]
-            password = tokens[3]
-            subprocess.run([bindir + '/dj_console', 'domjudge:reset-user-password', user, password])
-        break
+api_user = None
+api_password = None
+try:
+    with open(f'{etcdir}/restapi.secret', 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            tokens = line.split()
+            if len(tokens) >= 4 and tokens[0] == 'default':
+                api_user = tokens[2]
+                api_password = tokens[3]
+                break
+except FileNotFoundError:
+    print(f'Error: {etcdir}/restapi.secret not found', file=sys.stderr)
+    sys.exit(1)
 
-with open(f'{etcdir}/initial_admin_password.secret', 'r') as f:
-    password = f.readline().strip()
-    subprocess.run([bindir + '/dj_console', 'domjudge:reset-user-password', 'admin', password])
+if api_user and api_password:
+    result = subprocess.run([bindir + '/dj_console', 'domjudge:reset-user-password', api_user, api_password])
+    if result.returncode != 0:
+        print(f'Error: failed to reset password for API user {api_user}', file=sys.stderr)
+        sys.exit(1)
+else:
+    print('Warning: no default API credentials found in restapi.secret', file=sys.stderr)
+
+try:
+    with open(f'{etcdir}/initial_admin_password.secret', 'r') as f:
+        admin_password = f.readline().strip()
+except FileNotFoundError:
+    print(f'Error: {etcdir}/initial_admin_password.secret not found', file=sys.stderr)
+    sys.exit(1)
+
+if not admin_password:
+    print('Error: initial_admin_password.secret is empty', file=sys.stderr)
+    sys.exit(1)
+
+result = subprocess.run([bindir + '/dj_console', 'domjudge:reset-user-password', 'admin', admin_password])
+if result.returncode != 0:
+    print('Error: failed to reset admin password', file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
Also use more descriptive variable names.