### PR TITLE
Document array vars in JudgeDaemon code

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -9,6 +9,8 @@
 
 namespace DOMjudge;
 
+use CurlHandle;
+
 if (isset($_SERVER['REMOTE_ADDR'])) {
     die("Commandline use only");
 }
@@ -145,11 +147,19 @@ class JudgeDaemon
 
     private static ?JudgeDaemon $instance = null;
 
+    /**
+     * @var array{id: string, user: string, pass: string, url: string,
+     *        errorred: bool, waiting: bool, retrying: bool, last_attempt: int,
+     *        ch?: CurlHandle|false
+     *      }|null
+     */
     private ?array $endpoint = null;
+    /** @var array<string, mixed> */
     private array $domjudge_config = [];
     private string $myhost;
     private int $verbose = LOG_INFO;
     private ?string $daemonid = null;
+    /** @var array<string, bool|string> */
     private array $options = [];
 
     private bool $exitsignalled = false;
@@ -158,9 +168,11 @@ class JudgeDaemon
     private ?string $lastrequest = '';
     private float $waittime = self::INITIAL_WAITTIME_SEC;
 
+    /** @var array<string, string[]> */
     private array $langexts = [];
 
     private $lockfile;
+    /** @var array<int, string> */
     private array $EXITCODES;
     private string $runuser;
     private string $rungroup;
@@ -797,7 +809,7 @@ class JudgeDaemon
         }
     }
 
-    private function setupCurlHandle(string $restuser, string $restpass): \CurlHandle|false
+    private function setupCurlHandle(string $restuser, string $restpass): CurlHandle|false
     {
         $curl_handle = curl_init();
         curl_setopt($curl_handle, CURLOPT_USERAGENT, "DOMjudge/" . DOMJUDGE_VERSION);


### PR DESCRIPTION
Will squash this when approved,

I added the `use` as we now use it twice so I prefer the (opinionated) cleaner syntax.
Documenting the config options from L157 would be a pain to keep in sync but I wonder if we want to specify this implicit contract between the judgehost & domserver? I don't really like having to use mixed but specifying the other options is not more clear in this case.

Please review the last commit as it's the only "interesting" array.