### PR TITLE
Defend against reading before runguard is done writing

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1328,13 +1328,19 @@ class JudgeDaemon
             return null;
         }
 
-        // Don't quite treat it as YAML, but simply key/value pairs.
-        $contents = explode("\n", dj_file_get_contents($filename));
+        $contents = [];
+        $earlier_contents = [];
         $res = [];
-        foreach ($contents as $line) {
-            if (str_contains($line, ":")) {
-                [$key, $value] = explode(":", $line, 2);
-                $res[$key] = trim($value);
+        while (count($contents) === 0 || $contents !== $earlier_contents) {
+            $earlier_contents = $contents;
+            // Don't quite treat it as YAML, but simply key/value pairs.
+            $contents = explode("\n", dj_file_get_contents($filename));
+            $res = [];
+            foreach ($contents as $line) {
+                if (str_contains($line, ":")) {
+                    [$key, $value] = explode(":", $line, 2);
+                    $res[$key] = trim($value);
+                }
             }
         }
 


### PR DESCRIPTION
I was testing for another PR where I kill the judgedaemon after 30s (`timeout 30s ./bin/judgedaemon -n2`), I suspect the judgedaemon gets a signal here, sends it to runguard which kills the submission but is not done writing yet, the judgedaemon already starts reading the file which is still empty (verified that by outputting it in the judgedaemon) but has values after the judgedaemon exits.

This check should fix that racecondition but as this is such a specific case I'm not sure if we want to slow ourselves down by reading such files twice?