### PR TITLE
List external libraries under yarn control

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,6 @@ are covered by other copyrights. This will be noted in the files
 themselves and these copyrights/attributions can also be found in the
 DOMjudge manual.
 
-The following JavaScript libraries/snippets are included:
-- coloris: Momo Bassit, licensed under the MIT license, see COPYING.MIT.
-- Monaco editor: licensed under the MIT license, see COPYING.MIT.
-
 The default validator from the Kattis problemtools package is
 included, licensed under the MIT licence, see COPYING.MIT.
 
@@ -81,8 +77,11 @@ The M4 autoconf macros are licensed under all-permissive and GPL3+
 licences; see the respective files under m4/ for details.
 
 The DOMjudge tarball ships external library dependencies in the
-webapp/vendor directory. These are covered by their individual licenses
-as specified in the file composer.lock.
+webapp/vendor and webapp/node_modules directories. The libraries
+shipped under webapp/vendor are covered by their individual licenses
+as specified in the file composer.lock. The libraries shipped under
+webapp/node_modules are covered by the licenses documented in
+webapp/LICENSES.txt.
 
 Contact
 -------

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -45,7 +45,8 @@ ifeq (, $(shell command -v yarn || command -v yarnpkg 2> /dev/null))
 	$(error "neither 'yarnpkg' nor 'yarn' command found in $(PATH), install it via your package manager or https://yarnpkg.com/cli/node")
 endif
 	@YARN_CMD=$(shell command -v yarn || command -v yarnpkg); \
-  $$YARN_CMD install
+	$$YARN_CMD install; \
+	$$YARN_CMD licenses generate-disclaimer > LICENSES.txt
 
 # Run Symfony in dev mode (for maintainer-mode):
 .env.local:


### PR DESCRIPTION
Also remove explicit mention of the libraries we moved under yarn control but were included manually before.

This does make the issue from https://github.com/yarnpkg/yarn/issues/3212 even worse, as before we listed 2 of our dependencies with the license now we're down to 0.

I think a next step would be writing the output of `yarn licenses generate-disclaimer` to another file and linking that in the `make dist` step. as this data is available for `yarn`:
```
yarn licenses list
yarn licenses v1.22.22
warning package.json: No license field
warning No license field
├─ (CC-BY-4.0 AND OFL-1.1 AND MIT)
│  └─ @fortawesome/fontawesome-free@7.1.0
│     ├─ URL: https://github.com/FortAwesome/Font-Awesome
│     ├─ VendorName: The Font Awesome Team
│     └─ VendorUrl: https://fontawesome.com/
├─ (MPL-2.0 OR Apache-2.0)
│  └─ dompurify@3.1.7
│     ├─ URL: git://github.com/cure53/DOMPurify.git
│     ├─ VendorName: Dr.-Ing. Mario Heiderich, Cure53
│     └─ VendorUrl: https://github.com/cure53/DOMPurify
├─ Apache-2.0
│  ├─ @mathjax/mathjax-newcm-font@4.0.0
│  │  └─ URL: git+https://github.com/mathjax/MathJax-fonts.git
│  ├─ mathjax@4.0.0
│  │  └─ URL: https://github.com/mathjax/MathJax
│  └─ nvd3@1.8.6
│     └─ URL: https://github.com/novus/nvd3
├─ BSD-3-Clause
│  └─ d3@3.5.17
│     ├─ URL: https://github.com/mbostock/d3.git
│     ├─ VendorName: Mike Bostock
│     └─ VendorUrl: http://d3js.org/
└─ MIT
   ├─ @melloware/coloris@0.25.0
   │  ├─ URL: https://github.com/melloware/coloris-npm.git
   │  ├─ VendorName: Momo Bassit
   │  └─ VendorUrl: https://coloris.js.org/
   ├─ @popperjs/core@2.11.8
   │  ├─ URL: https://github.com/popperjs/popper-core.git
   │  └─ VendorName: Federico Zivolo
   ├─ bootstrap-toggle@2.2.2
   │  ├─ URL: https://github.com/minhur/bootstrap-toggle.git
   │  ├─ VendorName: Min Hur
   │  └─ VendorUrl: http://www.bootstraptoggle.com/
   ├─ bootstrap@5.3.8
   │  ├─ URL: git+https://github.com/twbs/bootstrap.git
   │  ├─ VendorName: The Bootstrap Authors
   │  └─ VendorUrl: https://getbootstrap.com/
   ├─ datatables.net-bs5@2.3.5
   │  ├─ URL: https://github.com/DataTables/Dist-DataTables-Bootstrap5.git
   │  ├─ VendorName: SpryMedia Ltd
   │  └─ VendorUrl: https://datatables.net/
   ├─ datatables.net@2.3.5
   │  ├─ URL: https://github.com/DataTables/Dist-DataTables.git
   │  ├─ VendorName: SpryMedia Ltd
   │  └─ VendorUrl: https://datatables.net/
   ├─ file-saver@2.0.5
   │  ├─ URL: https://github.com/eligrey/FileSaver.js
   │  ├─ VendorName: Eli Grey
   │  └─ VendorUrl: https://github.com/eligrey/FileSaver.js#readme
   ├─ flag-icons@7.5.0
   │  ├─ URL: https://github.com/lipis/flag-icons
   │  └─ VendorName: Panayiotis Lipiridis
   ├─ jquery-debounce-throttle@1.0.6-rc.0
   │  ├─ URL: https://github.com/dfilatov/jquery-plugins.git
   │  ├─ VendorName: Filatov Dmitry
   │  └─ VendorUrl: https://github.com/dfilatov/jquery-plugins#readme
   ├─ jquery@3.7.1
   │  ├─ URL: https://github.com/jquery/jquery.git
   │  ├─ VendorName: OpenJS Foundation and other contributors
   │  └─ VendorUrl: https://jquery.com/
   ├─ marked@14.0.0
   │  ├─ URL: git://github.com/markedjs/marked.git
   │  ├─ VendorName: Christopher Jeffrey
   │  └─ VendorUrl: https://marked.js.org/
   ├─ monaco-editor@0.54.0
   │  ├─ URL: https://github.com/microsoft/monaco-editor
   │  ├─ VendorName: Microsoft Corporation
   │  └─ VendorUrl: https://github.com/microsoft/monaco-editor
   ├─ select2-bootstrap-5-theme@1.3.0
   │  ├─ URL: git+https://github.com/apalfrey/select2-bootstrap-5-theme.git
   │  └─ VendorName: Andrew Palfrey
   └─ select2@4.0.13
      ├─ URL: git://github.com/select2/select2.git
      ├─ VendorName: Kevin Brown
      └─ VendorUrl: https://select2.org/
Done in 0.18s.
```