### PR TITLE
Handle scores in scientific notation.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -2327,6 +2327,17 @@ class JudgeDaemon
                     $this->disable('compare_script', 'compare_script_id', $judgeTask['compare_script_id'], $description, $judgeTask['judgetaskid']);
                     return false;
                 }
+                // Normalize scientific notation (e.g. "1e-3") to fixed-point
+                // decimal, since bccomp does not accept scientific notation.
+                // See: https://github.com/php/php-src/issues/17876
+                if (preg_match('/^([+-]?\d+\.?\d*)[eE]([+-]?\d+)$/', $scoreValue, $m)) {
+                    $exp = (int)$m[2];
+                    if ($exp >= 0) {
+                        $scoreValue = bcmul($m[1], bcpow('10', (string)$exp), 9);
+                    } else {
+                        $scoreValue = bcdiv($m[1], bcpow('10', (string)abs($exp)), 9);
+                    }
+                }
                 if (bccomp($scoreValue, '0', 9) < 0) {
                     $description = sprintf(
                         "compare script %s produced negative score: '%s'",


### PR DESCRIPTION
It's not great that we have duplicated code for this, but there is currently no way to share code between judgedaemon and the webapp.