### PR TITLE
(Partially) fix retrieving full team output

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -627,7 +627,7 @@ class JudgeDaemon
                         urlencode((string)$judgeTask['judgetaskid'])
                     ),
                     'POST',
-                    ['output_run' => $this->restEncodeFile($testcasedir . '/program.out', false)],
+                    ['output_run' => $this->restEncodeFile($testcasedir . '/1/program.out', false)],
                     false
                 );
                 logmsg(LOG_INFO, "  ⇡ Uploading full output of testcase $judgeTask[testcase_id].");


### PR DESCRIPTION
This breaks for multi-pass, but that requires more information from the domserver during the task. Will make a proper fix in the future.