### PR TITLE
Apply compiler/runner version output styling to jury interface.

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -873,3 +873,8 @@ blockquote {
     white-space: pre-wrap;
     color: #93a1a1;
 }
+
+.terminal-warning {
+    color: #cb4b16; /* Solarized Orange */
+    font-weight: bold;
+}

--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -83,14 +83,16 @@
                         <th>Compiler version</th>
                         <td>
                             {% if language.compilerVersionCommand %}
-                                <pre class="output_text">$ {{ language.compilerVersionCommand }}</pre>
+                                <div class="terminal-block">
+                                    <div class="terminal-command">{{ language.compilerVersionCommand }}</div>
+                                    {% if language.compilerVersion %}
+                                        <div class="terminal-output">{{ language.compilerVersion }}</div>
+                                    {% else %}
+                                        <div class="terminal-output terminal-warning">No canonical version recorded.</div>
+                                    {% endif %}
+                                </div>
                             {% else %}
                                 <p class="nodata">No command specified.</p>
-                            {% endif %}
-                            {% if language.compilerVersion %}
-                                <pre class="output_text">{{ language.compilerVersion }}</pre>
-                            {% else %}
-                                <p class="nodata">No canonical version recorded.</p>
                             {% endif %}
                         </td>
                     </tr>
@@ -98,14 +100,16 @@
                         <th>Runner version</th>
                         <td>
                             {% if language.runnerVersionCommand %}
-                                <pre class="output_text">$ {{ language.runnerVersionCommand }}</pre>
+                                <div class="terminal-block">
+                                    <div class="terminal-command">{{ language.runnerVersionCommand }}</div>
+                                    {% if language.runnerVersion %}
+                                        <div class="terminal-output">{{ language.runnerVersion }}</div>
+                                    {% else %}
+                                        <div class="terminal-output terminal-warning">No canonical version recorded.</div>
+                                    {% endif %}
+                                </div>
                             {% else %}
                                 <p class="nodata">No command specified.</p>
-                            {% endif %}
-                            {% if language.runnerVersion %}
-                                <pre class="output_text">{{ language.runnerVersion }}</pre>
-                            {% else %}
-                                <p class="nodata">No canonical version recorded.</p>
                             {% endif %}
                         </td>
                     </tr>

--- a/webapp/templates/jury/versions.html.twig
+++ b/webapp/templates/jury/versions.html.twig
@@ -41,8 +41,10 @@
                                     </div>
                                     <ul class="list-group list-group-flush">
                                         <li class="list-group-item">
-                                            <pre class="output_text" style="background-color: rgba(0,121,54,.1);">$ {{ output.command }}</pre>
-                                            <pre class="output_text">{{ output.version }}</pre>
+                                            <div class="terminal-block">
+                                                <div class="terminal-command">{{ output.command }}</div>
+                                                <div class="terminal-output">{{ output.version }}</div>
+                                            </div>
                                         </li>
                                         <li class="list-group-item">
                                             First reported by
@@ -75,8 +77,10 @@
                                         </div>
                                         <ul class="list-group list-group-flush">
                                             <li class="list-group-item">
-                                                <pre class="output_text" style="background-color: rgba(0,121,54,.1);">$ {{ output.command }}</pre>
-                                                <pre class="output_text">{{ output.version }}</pre>
+                                                <div class="terminal-block">
+                                                    <div class="terminal-command">{{ output.command }}</div>
+                                                    <div class="terminal-output">{{ output.version }}</div>
+                                                </div>
                                             </li>
                                             <li class="list-group-item">
                                                 First reported by


### PR DESCRIPTION
This is a follow-up on 6227d319aaa9f746d7b819faef75ca7781844604.