### PR TITLE
Ignore license generation in more modern yarn versions.

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -46,7 +46,8 @@ ifeq (, $(shell command -v yarn || command -v yarnpkg 2> /dev/null))
 endif
 	@YARN_CMD=$(shell command -v yarn || command -v yarnpkg); \
 	$$YARN_CMD install; \
-	$$YARN_CMD licenses generate-disclaimer > LICENSES.txt
+	$$YARN_CMD licenses generate-disclaimer > LICENSES.txt 2>/dev/null || \
+		echo "Warning: 'yarn licenses' not available; skipping LICENSES.txt generation."
 
 # Run Symfony in dev mode (for maintainer-mode):
 .env.local:


### PR DESCRIPTION
This is only supported in Yarn 1 natively, more modern versions require a plugin, which in turn doesn't work for Yarn 1.

Follow-up on 41a194e1735448bf373be124e663f9942d9abf26