### PR TITLE
Add check for systemd preventing write errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,14 @@ endif
 		chcon -R -t httpd_sys_rw_content_t $(CURDIR)/webapp/public/images; \
 		chcon    -t httpd_exec_t $(CURDIR)/lib/alert; \
 	fi
+	@sandbox_err=0; \
+	for service in apache2 nginx php$(PHPVERSION)-fpm php-fpm; do \
+		$(CURDIR)/misc-tools/check-systemd-sandbox $$service $(CURDIR)/webapp/var || sandbox_err=1; \
+	done; \
+	if [ $$sandbox_err -ne 0 ]; then \
+		echo "ERROR: Fix the above systemd sandboxing issue(s) before continuing."; \
+		exit 1; \
+	fi
 
 inplace-postinstall-apache: inplace-postinstall-permissions
 	@if [ ! -d "/etc/apache2/conf-enabled" ]; then echo "Couldn't find directory /etc/apache2/conf-enabled. Is apache installed?"; false; fi

--- a/misc-tools/check-systemd-sandbox
+++ b/misc-tools/check-systemd-sandbox
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Check if a systemd service has sandboxing that would prevent writing
+# to a given directory. This detects ProtectHome, ProtectSystem, etc.
+#
+# Usage: check-systemd-sandbox <service> <writable-path>
+
+set -eu
+
+SERVICE="$1.service"
+WRITABLE_PATH="$2"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    exit 0
+fi
+
+if ! systemctl cat "$SERVICE" >/dev/null 2>&1; then
+    exit 0
+fi
+
+WARNINGS=""
+
+PROTECT_HOME=$(systemctl show -p ProtectHome --value "$SERVICE" 2>/dev/null || true)
+if [ "$PROTECT_HOME" = "yes" ] || [ "$PROTECT_HOME" = "read-only" ] || [ "$PROTECT_HOME" = "tmpfs" ]; then
+    case "$WRITABLE_PATH" in
+        /home/*|/root/*|/run/user/*)
+            WARNINGS="${WARNINGS}  - ProtectHome=${PROTECT_HOME} makes ${WRITABLE_PATH} read-only/inaccessible
+"
+            ;;
+    esac
+fi
+
+PROTECT_SYSTEM=$(systemctl show -p ProtectSystem --value "$SERVICE" 2>/dev/null || true)
+case "$PROTECT_SYSTEM" in
+    full)
+        case "$WRITABLE_PATH" in
+            /usr/*|/boot/*|/efi/*|/etc/*)
+                WARNINGS="${WARNINGS}  - ProtectSystem=${PROTECT_SYSTEM} makes ${WRITABLE_PATH} read-only
+"
+                ;;
+        esac
+        ;;
+    strict)
+        # strict makes the entire filesystem read-only except /dev, /proc, /sys
+        WARNINGS="${WARNINGS}  - ProtectSystem=strict makes the entire filesystem read-only
+"
+        ;;
+esac
+
+if [ -n "$WARNINGS" ]; then
+    READ_WRITE_PATHS=$(systemctl show -p ReadWritePaths --value "$SERVICE" 2>/dev/null || true)
+    # Check if our path is already in ReadWritePaths
+    if echo "$READ_WRITE_PATHS" | grep -qF "$WRITABLE_PATH"; then
+        exit 0
+    fi
+
+    echo ""
+    echo "WARNING: systemd service '$SERVICE' has sandboxing that may prevent"
+    echo "         DOMjudge from writing to $WRITABLE_PATH:"
+    echo ""
+    printf '%s' "$WARNINGS"
+    echo ""
+    echo "Fix this by running:"
+    printf '    printf '"'"'[Service]\nReadWritePaths=%s\n'"'"' | sudo SYSTEMD_EDITOR=tee systemctl edit %s\n' "$WRITABLE_PATH" "$SERVICE"
+    printf '    sudo systemctl restart %s\n' "$SERVICE"
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
This is mostly relevant in maintainer installs, and modern debian/ubuntu versions that introduced `ProtectHome=read-only`.