### PR TITLE
Add concurrency groups to our github actions.

### DIFF
--- a/.github/workflows/autoconf-check-different-distro.yml
+++ b/.github/workflows/autoconf-check-different-distro.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   redhat-family:
     strategy:

--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   debian-family:
     strategy:

--- a/.github/workflows/chroot-checks.yml
+++ b/.github/workflows/chroot-checks.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-chroot-arch:
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     container:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
- 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   syntax-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/compare-tests.yml
+++ b/.github/workflows/compare-tests.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compare:
     runs-on: ubuntu-24.04

--- a/.github/workflows/database-upgrade.yml
+++ b/.github/workflows/database-upgrade.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upgrade_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-24.04

--- a/.github/workflows/judge-unit-tests.yml
+++ b/.github/workflows/judge-unit-tests.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   judge-unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpcs:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   runpipe:
     runs-on: ubuntu-24.04

--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-static-codecov:
     runs-on: ubuntu-24.04

--- a/.github/workflows/webstandard.yml
+++ b/.github/workflows/webstandard.yml
@@ -6,6 +6,10 @@ on:
       - main
       - '[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   standards:
     runs-on: ubuntu-latest


### PR DESCRIPTION
These should make sure that for each PR there is at most one action of the same test running, i.e. on repeated pushs for the same PR we cancel all the old runs that are no longer relevant.

This should free up some small amount of capacity.