### PR TITLE
Add paths specs to CI runs.

### DIFF
--- a/.github/workflows/autoconf-check-different-distro.yml
+++ b/.github/workflows/autoconf-check-different-distro.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'configure.ac'
+      - 'm4/**'
+      - 'Makefile*'
+      - '**/Makefile'
+      - 'paths.mk.in'
+      - 'bootstrap'
+      - '.github/workflows/autoconf-check*.yml'
+      - '.github/jobs/configure-checks/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'configure.ac'
+      - 'm4/**'
+      - 'Makefile*'
+      - '**/Makefile'
+      - 'paths.mk.in'
+      - 'bootstrap'
+      - '.github/workflows/autoconf-check*.yml'
+      - '.github/jobs/configure-checks/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/chroot-checks.yml
+++ b/.github/workflows/chroot-checks.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'judge/**'
+      - 'misc-tools/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/chroot-checks.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - '**.php'
+      - '**.php.in'
+      - '**.py'
+      - '**.sh'
+      - 'doc/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/codestyle.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/compare-tests.yml
+++ b/.github/workflows/compare-tests.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'judge/**'
+      - 'misc-tests/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/compare-tests.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/database-upgrade.yml
+++ b/.github/workflows/database-upgrade.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'webapp/**'
+      - 'sql/**'
+      - 'etc/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/database-upgrade.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/judge-unit-tests.yml
+++ b/.github/workflows/judge-unit-tests.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'judge/**'
+      - 'webapp/composer.*'
+      - '.github/workflows/judge-unit-tests.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - '**.php'
+      - '**.php.in'
+      - '.github/workflows/phpcodesniffer.yml'
+      - '.github/jobs/data/phpruleset.xml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'webapp/**'
+      - 'phpstan.dist.neon'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/phpstan.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'judge/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/runpipe.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - '**.py'
+      - '**.sh'
+      - '**.bash'
+      - '.github/workflows/shiftleft.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'webapp/**'
+      - 'sql/**'
+      - 'etc/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - 'm4/**'
+      - '.github/workflows/unit-tests.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/webstandard.yml
+++ b/.github/workflows/webstandard.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'webapp/**'
+      - 'Makefile*'
+      - 'configure.ac'
+      - '.github/workflows/webstandard.yml'
+      - '.github/jobs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
There are still certain checks that we run all the time (e.g. integration) and all checks run on the merge queue.