### PR TITLE
Use correct heading

### DIFF
--- a/webapp/templates/jury/clarifications.html.twig
+++ b/webapp/templates/jury/clarifications.html.twig
@@ -57,7 +57,7 @@
         {% endif %}
 
         {% if currentFilter is null or currentFilter == 'new' %}
-            <h3 id="newrequests">New requests</h3>
+            <h2 id="newrequests">New requests</h2>
             {%- if newClarifications | length == 0 %}
                 <p class="nodata">No new clarification requests.</p>
             {%- else %}
@@ -66,7 +66,7 @@
         {% endif %}
 
         {% if currentFilter is null or currentFilter == 'handled' %}
-            <h3 id="oldrequests" class="mt-4">Handled requests</h3>
+            <h2 id="oldrequests" class="mt-4">Handled requests</h2>
             {%- if oldClarifications | length == 0 %}
                 <p class="nodata">No old clarification requests.</p>
             {%- else %}
@@ -75,7 +75,7 @@
         {% endif %}
 
         {% if currentFilter is null or currentFilter == 'general' %}
-            <h3 id="clarifications" class="mt-4">General clarifications</h3>
+            <h2 id="clarifications" class="mt-4">General clarifications</h2>
             {%- if generalClarifications | length == 0 %}
                 <p class="nodata">No general clarifications.</p>
             {%- else %}

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -131,12 +131,12 @@
                         <td>
                             {% if contest.medalsEnabled %}
                                 <div class="card">
-                                    <h6 class="card-header" id="categories">
+                                    <div class="card-header" id="categories">
                                         <a class="collapsed d-block text-dark pt-0 pb-0" data-bs-toggle="collapse" href="#collapsecategories" aria-expanded="true" aria-controls="collapsecategories" id="collapseheader">
                                             {{ (contest.goldMedals > 0) + (contest.silverMedals > 0) + (contest.bronzeMedals > 0) }} different types of medals (Show/Hide details)
                                             <i class="fa fa-chevron-down float-end"></i>
                                         </a>
-                                    </h6>
+                                    </div>
                                     <div id="collapsecategories" class="collapse collapsed">
                                         <div class="card-body pb-1">
                                             <a>{{ contest.goldMedals }} Gold Medal(s)</a>

--- a/webapp/templates/jury/contests.html.twig
+++ b/webapp/templates/jury/contests.html.twig
@@ -10,9 +10,7 @@
 {% endblock %}
 
 {% block content %}
-    <h1>Contests</h1>
-
-    <h3>Current contests</h3>
+    <h1>Current contests</h1>
 
     {% for contest in current_contests %}
         <div class="row mb-4">
@@ -78,7 +76,7 @@
         {% endif %}
     {% endfor %}
 
-    <h3>All available contests</h3>
+    <h1>All available contests</h1>
 
     {{ macros.table(contests_table, table_fields) }}
 

--- a/webapp/templates/jury/partials/rejudge_form.html.twig
+++ b/webapp/templates/jury/partials/rejudge_form.html.twig
@@ -49,7 +49,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">{{ buttonText }}</h5>
+                <h2 class="modal-title">{{ buttonText }}</h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <form action="{{ path('jury_create_rejudge') }}" method="post">

--- a/webapp/templates/jury/partials/rejudging_buttons.html.twig
+++ b/webapp/templates/jury/partials/rejudging_buttons.html.twig
@@ -16,7 +16,7 @@
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Repeat rejudging</h5>
+                    <h2 class="modal-title">Repeat rejudging</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <form action="{{ path('jury_create_rejudge') }}" method="post">

--- a/webapp/templates/jury/partials/rejudging_score_matrix.html.twig
+++ b/webapp/templates/jury/partials/rejudging_score_matrix.html.twig
@@ -15,7 +15,7 @@
     </div>
 
     {# Submissions table #}
-    <h4>Submissions with Score Changes</h4>
+    <h3>Submissions with Score Changes</h3>
     <div class="table-responsive">
         <table class="table table-sm table-striped table-hover" id="score-changes-table">
             <thead>

--- a/webapp/templates/jury/rejudging.html.twig
+++ b/webapp/templates/jury/rejudging.html.twig
@@ -150,7 +150,7 @@
 
     {% if stats %}
         <h2>Statistics over repeated rejudgings</h2>
-        <h4>Runtime spread</h4>
+        <h3>Runtime spread</h3>
             <table class="table table-sm table-striped">
                 <tr><th>submission/testcase</th><th>spread</th><th>#judgings</th><th>result</th></tr>
 		{% for spread in stats.runtime_spread %}
@@ -174,7 +174,7 @@
             {% endif %}
         {% endif %}
         {% if stats.judgehost_stats | length > 1 %}
-            <h4>Judgehost stats</h4>
+            <h3>Judgehost stats</h3>
             <table class="table table-sm table-striped">
                 <tr><th>Judgehost</th><th>#judgings</th><th>avg. runtime</th><th>std.dev.</th><th>avg. duration</th></tr>
                 {% for judgehost in stats.judgehost_stats %}
@@ -189,7 +189,7 @@
             </table>
         {% endif %}
         {% if stats.judgings %}
-            <h4>Judging verdicts</h4>
+            <h3>Judging verdicts</h3>
             <table class="table table-sm table-striped">
                 <tr><th>jID</th><th>rID</th><th>Judgehost</th><th>duration (incl. compile)</th><th>verdict</th></tr>
                 {% for judging in stats.judgings %}

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -909,14 +909,14 @@
                     {% else %}
                         {% if run.firstJudgingRun is not null and run.firstJudgingRun.runresult is not null %}
                             {% if combinedRunCompare %}
-                                <h5>Validator output</h5>
+                                <h4>Validator output</h4>
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no validator output.</p>
                                 {% else %}
                                     <pre class="output_text">{{ runsOutput[runIdx].output_diff | convertUnprintableChars }}</pre>
                                 {% endif %}
                             {% else %}
-                                <h5>Diff output</h5>
+                                <h4>Diff output</h4>
                                 {% if runsOutput[runIdx].output_diff is empty %}
                                     <p class="nodata">There was no diff output.</p>
                                 {% else %}

--- a/webapp/templates/jury/team_affiliation.html.twig
+++ b/webapp/templates/jury/team_affiliation.html.twig
@@ -88,7 +88,7 @@
         {% endif %}
     </div>
 
-    <h3>Teams</h3>
+    <h2>Teams</h2>
     {% if teamAffiliation.teams is empty %}
         <p class="nodata">no teams</p>
     {% else %}

--- a/webapp/templates/jury/team_category.html.twig
+++ b/webapp/templates/jury/team_category.html.twig
@@ -112,7 +112,7 @@
         {% endif %}
     </div>
 
-    <h3>Teams</h3>
+    <h2>Teams</h2>
     {% if teamCategory.teams is empty %}
         <p class="nodata">no teams</p>
     {% else %}

--- a/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
@@ -23,10 +23,10 @@ class ClarificationControllerTest extends BaseTestCase
         $this->client->click($link);
         $crawler = $this->checkStatusAndFollowRedirect();
 
-        $h3s = $crawler->filter('h3')->extract(['_text']);
-        self::assertEquals('New requests', $h3s[0]);
-        self::assertEquals('Handled requests', $h3s[1]);
-        self::assertEquals('General clarifications', $h3s[2]);
+        $h2s = $crawler->filter('h2')->extract(['_text']);
+        self::assertEquals('New requests', $h2s[0]);
+        self::assertEquals('Handled requests', $h2s[1]);
+        self::assertEquals('General clarifications', $h2s[2]);
 
         self::assertSelectorExists('html:contains("Is it necessary to read the problem statement carefully?")');
     }
@@ -41,8 +41,8 @@ class ClarificationControllerTest extends BaseTestCase
         $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications', 200);
         $crawler = $this->getCurrentCrawler();
 
-        self::assertSelectorTextContains('h3#newrequests ~ div.table-wrapper', 'Is it necessary to');
-        self::assertSelectorTextContains('h3#oldrequests ~ div.table-wrapper', 'What is 2+2?');
+        self::assertSelectorTextContains('h2#newrequests ~ div.table-wrapper', 'Is it necessary to');
+        self::assertSelectorTextContains('h2#oldrequests ~ div.table-wrapper', 'What is 2+2?');
     }
     /**
      * Test that general clarification is under general clarifications header.
@@ -55,9 +55,9 @@ class ClarificationControllerTest extends BaseTestCase
         $crawler = $this->getCurrentCrawler();
 
         // General clarification to all.
-        self::assertSelectorTextContains('h3#clarifications ~ div.table-wrapper', 'Lunch is served');
+        self::assertSelectorTextContains('h2#clarifications ~ div.table-wrapper', 'Lunch is served');
         // Jury initiated message to specific team.
-        self::assertSelectorTextContains('h3#clarifications ~ div.table-wrapper', 'There was a mistake');
+        self::assertSelectorTextContains('h2#clarifications ~ div.table-wrapper', 'There was a mistake');
     }
 
     /**

--- a/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
@@ -19,9 +19,8 @@ class ContestControllerTest extends JuryControllerTestCase
     protected static string  $deleteEntityIdentifier   = 'name';
     protected static string  $getIDFunc                = 'getExternalid';
     protected static string  $className                = Contest::class;
-    protected static array $DOM_elements               = ['h1'                            => ['Contests'],
-                                                          'h3'                            => ['admin' => ['Current contests', 'All available contests'],
-                                                             'jury' => []],
+    protected static array $DOM_elements               = ['h1'                            => ['admin' => ['Current contests', 'All available contests'],
+                                                                                              'jury'  => []],
                                                           'a.btn[title="Import contest"]' => ['admin' => [" Import contest"],'jury'=>[]]];
     protected static ?array $deleteExtra               = ['pageurl'   => '/jury/contests/demo',
                                                           'deleteurl' => '/jury/contests/demo/problems/boolfind/delete',


### PR DESCRIPTION
I'll squash this into 1 commit after approval.

Inspected and the larger heading doesn't make the page worse, we could think about the modal as it is rather large but as this is the title of the modal it kinda fits.

This gets flagged by the latest VNU/Webstandard validator, we ourselves run with an older one so this is to prepare for the upgrade.

Difference in H3 -> H2
<img width="1038" height="840" alt="Screenshot_2026-03-09_19-32-21" src="https://github.com/user-attachments/assets/b91bf793-d73d-4c5d-bef2-de99e79b1e6d" />

Difference in H4 -> H3
<img width="1038" height="840" alt="Screenshot_2026-03-09_17-31-38" src="https://github.com/user-attachments/assets/e064fd1e-dbb2-432f-9d32-8baa83a53c38" />

h6 -> div
<img width="1696" height="910" alt="Screenshot_2026-03-09_19-56-02" src="https://github.com/user-attachments/assets/35368e6e-b832-4419-b457-54b85afccc66" />

Removing the H1, similar to the `executables` page
<img width="768" height="752" alt="Screenshot_2026-03-09_20-15-11" src="https://github.com/user-attachments/assets/23a76979-bbe4-411f-b0bb-7ce9479a0479" />

<img width="898" height="1076" alt="Screenshot_2026-03-09_20-39-15" src="https://github.com/user-attachments/assets/1ec3f802-f41c-48b3-af50-933863c70f7d" />


Modal, h5 -> h2
<img width="1006" height="446" alt="Screenshot_2026-03-09_21-05-34" src="https://github.com/user-attachments/assets/3077bb34-49c3-4759-8978-e73244b05cb7" />

<img width="1098" height="644" alt="Screenshot_2026-03-09_21-41-36" src="https://github.com/user-attachments/assets/5408d44c-61cc-4b0e-a8bd-9fed83087f52" />

<img width="1098" height="644" alt="Screenshot_2026-03-09_22-10-01" src="https://github.com/user-attachments/assets/2eb1bae0-cd6f-45d5-aab0-93c1453caf18" />


For all of the screenshots, this is the difference, not what I committed in the PR as there the item is not copied but replaced.