### PR TITLE
Pin to jquery 3.7.1.

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,6 +10,7 @@
     "datatables.net-bs5": "^2.3.4",
     "file-saver": "^2.0.5",
     "flag-icons": "^7.5.0",
+    "jquery": "^3.7.1",
     "jquery-debounce-throttle": "^1.0.6-rc.0",
     "mathjax": "^4.0.0",
     "monaco-editor": "^0.54.0",


### PR DESCRIPTION
4699203a7 upgraded dependencies and transitively upgraded jquery (unintentionally).

jquery 4.0 is not backwards compatible, leading to errors like:
```
jquery.min.js?v=10.0.0DEV/9eb88215c:2 jQuery.Deferred exception TypeError: c.isArray is not a function
    at n._resolveLanguage (select2.min.js?v=10.…V/9eb88215c:2:56247)
    at n.applyFromElement (select2.min.js?v=10.…V/9eb88215c:2:56074)
    at new e (select2.min.js?v=10.…V/9eb88215c:2:57131)
    at new d (select2.min.js?v=10.…V/9eb88215c:2:59359)
    at HTMLSelectElement.<anonymous> (select2.min.js?v=10.…V/9eb88215c:2:68892)
    at T.each (jquery.min.js?v=10.0…EV/9eb88215c:2:2869)
    at T.fn.init.each (jquery.min.js?v=10.0…EV/9eb88215c:2:1379)
    at i.fn.select2 (select2.min.js?v=10.…V/9eb88215c:2:68852)
    at HTMLDocument.<anonymous> (2:914:27)
    at l (jquery.min.js?v=10.0…V/9eb88215c:2:24813)
 undefined
jquery.min.js?v=10.0.0DEV/9eb88215c:2 Uncaught TypeError: c.camelCase is not a function
    at n.set (select2.min.js?v=10.…V/9eb88215c:2:56876)
    at HTMLDocument.<anonymous> (2:59:35)
    at l (jquery.min.js?v=10.0…V/9eb88215c:2:24813)
    at c (jquery.min.js?v=10.0…V/9eb88215c:2:25132)
jquery.min.js?v=10.0.0DEV/9eb88215c:2 Uncaught TypeError: c.isArray is not a function
    at n._resolveLanguage (select2.min.js?v=10.…V/9eb88215c:2:56247)
    at n.applyFromElement (select2.min.js?v=10.…V/9eb88215c:2:56074)
    at new e (select2.min.js?v=10.…V/9eb88215c:2:57131)
    at new d (select2.min.js?v=10.…V/9eb88215c:2:59359)
    at HTMLSelectElement.<anonymous> (select2.min.js?v=10.…V/9eb88215c:2:68892)
    at T.each (jquery.min.js?v=10.0…EV/9eb88215c:2:2869)
    at T.fn.init.each (jquery.min.js?v=10.0…EV/9eb88215c:2:1379)
    at i.fn.select2 (select2.min.js?v=10.…V/9eb88215c:2:68852)
    at HTMLDocument.<anonymous> (2:914:27)
    at l (jquery.min.js?v=10.0…V/9eb88215c:2:24813)
domjudge.js?v=10.0.0DEV/9eb88215c:599 Uncaught TypeError: window[$refreshTarget.data(...)] is not a function
    at processAjaxResponse (domjudge.js?v=10.0.0DEV/9eb88215c:599:62)
    at Object.<anonymous> (domjudge.js?v=10.0.0DEV/9eb88215c:617:17)
    at c (jquery.min.js?v=10.0…V/9eb88215c:2:23055)
    at Object.fireWith [as resolveWith] (jquery.min.js?v=10.0…V/9eb88215c:2:23817)
    at E (jquery.min.js?v=10.0…V/9eb88215c:2:69766)
    at XMLHttpRequest.<anonymous> (jquery.min.js?v=10.0…V/9eb88215c:2:72269)
```

We are using Select2 bug, see https://github.com/select2/select2/issues/6298 It has an outstanding PR which hopefully gets merged soon.

In the meantime downgrade jquery to a compatible version.