### PR TITLE
VNU validator is installed in our CI image

### DIFF
--- a/.github/jobs/baseinstall.sh
+++ b/.github/jobs/baseinstall.sh
@@ -88,7 +88,7 @@ mysql_log "SHOW GLOBAL STATUS LIKE 'Connection_errors_%'"
 mysql_log "SHOW VARIABLES LIKE '%_timeout'"
 section_end
 
-if [ "${db}" = "install" ]; then
+if [ "${db}" = "install" ] || [ "${db}" = "bare-install" ]; then
     section_start "Install DOMjudge database"
     /opt/domjudge/domserver/bin/dj_setup_database bare-install
     section_end

--- a/.github/jobs/webstandard.sh
+++ b/.github/jobs/webstandard.sh
@@ -87,7 +87,7 @@ if [ "$ROLE" = "public" ]; then
     EXPECTED_HTTP_CODES="$EXPECTED_HTTP_CODES\|401"
 fi
 
-HTTP_404_IGNORED="robots.txt\|imgBase.replace"
+HTTP_404_IGNORED="robots.txt\|imgBase.replace\|request-remaining"
 
 set +e
 NUM_ERRORS=$(grep -v "HTTP/1.1\" \($EXPECTED_HTTP_CODES\)" /var/log/nginx/domjudge.log | grep -v "${HTTP_404_IGNORED}" -c; if [ "$?" -gt 1 ]; then exit 127; fi)

--- a/.github/jobs/webstandard.sh
+++ b/.github/jobs/webstandard.sh
@@ -114,7 +114,7 @@ w3c_analyse () {
     do
         section_start "Analyse with $typ"
         # shellcheck disable=SC2086
-        "$DIR"/vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-$typ --format json $FLTR "$URL" 2> result.json
+        /vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-$typ --format json $FLTR "$URL" 2> result.json
 
         # Count errors from JSON and produce gnu-format log
         NEWFOUNDERRORS=$(python3 -c "import json; print(len(json.load(open('result.json'))['messages']))")
@@ -146,13 +146,13 @@ if [ "$TEST" = "w3cval" ]; then
     section_end
 
     section_start "Install testsuite"
-    cd "$DIR"
-    wget https://github.com/validator/validator/releases/download/20.6.30/vnu.linux.zip
+    cd /
     unzip -q vnu.linux.zip
     # Remove a warning by creating an empty config.
     touch vnu.properties
     section_end
 
+    cd "$DIR"
     FLTR1='--filterpattern .*descendant.*|.*Stray.*'
     w3c_analyse "$FLTR1" "Stray" "public" "html"
     FLTR2='--filterpattern .*descendant.*'

--- a/.github/jobs/webstandard.sh
+++ b/.github/jobs/webstandard.sh
@@ -153,10 +153,9 @@ if [ "$TEST" = "w3cval" ]; then
     section_end
 
     cd "$DIR"
-    FLTR1='--filterpattern .*descendant.*|.*Stray.*'
-    w3c_analyse "$FLTR1" "Stray" "public" "html"
-    FLTR2='--filterpattern .*descendant.*'
-    w3c_analyse "$FLTR2" "descendant" "public" "html"
+    # To filter out certain violations use:
+    # FLTR='--filterpattern .*descendant.*'
+    # w3c_analyse "$FLTR" "jobname"" "public" "html"
     w3c_analyse "" "full" "public" "html css svg"
 else
     section_start "Remove files from upstream with problems"

--- a/.github/workflows/webstandard.yml
+++ b/.github/workflows/webstandard.yml
@@ -52,9 +52,7 @@ jobs:
         id: filter
         run: |
           filter_out() {
-            if [ "${{ matrix.db }}" = "bare-install" ]; then
-                echo "should_run=false" >> $GITHUB_OUTPUT
-            elif [ "${{ matrix.role }}" = "public" ]; then
+            if [ "${{ matrix.role }}" = "public" ]; then
               if [ "${{ matrix.test }}" = "WCAG2A" ]; then
                 echo "should_run=false" >> $GITHUB_OUTPUT
               else

--- a/webapp/templates/base.html.twig
+++ b/webapp/templates/base.html.twig
@@ -26,6 +26,9 @@
     {% for file in customAssetFiles('css') %}
         <link rel="stylesheet" href="{{ asset('css/custom/' ~ file) }}">
     {% endfor %}
+    <style>
+        {% block extra_style %}{% endblock %}
+    </style>
 </head>
 <body class="{% if fill_height is defined and fill_height %} fill-height{% endif %}{% if static is defined and static %} static{% endif %}">
 {% block menu %}{% endblock %}

--- a/webapp/templates/jury/config_check.html.twig
+++ b/webapp/templates/jury/config_check.html.twig
@@ -1,12 +1,21 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
+{% block extra_style %}
+.size_h5 {
+  font-size: 1.25rem
+}
+.size_h6 {
+  font-size: 1rem
+}
+{% endblock %}
+
 {% block title %}Configuration check - {{ parent() }}{% endblock %}
 
 {% block content %}
 <div class="card w-40 float-end m-5">
   <div class="card-body">
-  <h5 class="card-title">System information</h5>
+  <h2 class="card-title size_h5">System information</h2>
   <table class="w-100">
   <tr><td>DOMjudge:</td><td id="dj_version">{{ DOMJUDGE_VERSION }}</td></tr>
   <tr><td>Environment:</td><td>{{ app.environment }}</td></tr>
@@ -23,7 +32,7 @@
 
 <div class="card m-3 bg-light">
   <div class="card-body">
-  <h5 class="card-title">Installation locations</h5>
+  <h2 class="card-title size_h5">Installation locations</h2>
   <table class="w-100">
   <tr><td>Base url (use in submit client):</td><td><kbd>{{ url('root') }}</kbd></td></tr>
   <tr><td>API url (use in <kbd>restapi.secret</kbd>):</td><td><kbd>{{ url('current_api_root') | trim('/', 'right') }}</kbd></td></tr>
@@ -38,7 +47,7 @@
   </table>
 
       {% if logFilesWithSize is not empty %}
-          <h5 class="card-title mt-3">Log files</h5>
+          <h2 class="card-title mt-3 size_h5">Log files</h2>
           <table class="w-100">
               <thead>
               <tr>
@@ -79,7 +88,7 @@
 
 {% for test,testresult in groupresults %}
   <div class="card">
-    <h6 class="card-header result {{ testresult.result }}" role="tab" id="heading{{ test }}">
+    <h3 class="card-header size_h6 result {{ testresult.result }}" role="tab" id="heading{{ test }}">
       <a class="collapsed d-block text-dark pt-0 pb-0" data-bs-toggle="collapse" href="#collapse{{ test }}" aria-expanded="true" aria-controls="collapse{{ test }}" data-parent="#{{ resultgroup | replace({' ':''}) }}">
         {% if testresult.result == 'O' %}
         <i class="fas fa-check text-success"></i>
@@ -91,7 +100,7 @@
         <i class="fa fa-chevron-down float-end"></i>
         {{ testresult.caption }}
       </a>
-    </h6>
+    </h3>
 
     <div id="collapse{{ test }}" class="collapse {{ ( testresult.result == 'E' ) ? 'show' : '' }}" role="tabpanel" aria-labelledby="heading{{ test }}">
       <div class="card-body">

--- a/webapp/templates/jury/config_check.html.twig
+++ b/webapp/templates/jury/config_check.html.twig
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="card w-40 float-end m-5">
   <div class="card-body">
-  <h5 class="card-title">System information</h5>
+  <h2 class="card-title h5">System information</h2>
   <table class="w-100">
   <tr><td>DOMjudge:</td><td id="dj_version">{{ DOMJUDGE_VERSION }}</td></tr>
   <tr><td>Environment:</td><td>{{ app.environment }}</td></tr>
@@ -23,7 +23,7 @@
 
 <div class="card m-3 bg-light">
   <div class="card-body">
-  <h5 class="card-title">Installation locations</h5>
+  <h2 class="card-title h5">Installation locations</h2>
   <table class="w-100">
   <tr><td>Base url (use in submit client):</td><td><kbd>{{ url('root') }}</kbd></td></tr>
   <tr><td>API url (use in <kbd>restapi.secret</kbd>):</td><td><kbd>{{ url('current_api_root') | trim('/', 'right') }}</kbd></td></tr>
@@ -38,7 +38,7 @@
   </table>
 
       {% if logFilesWithSize is not empty %}
-          <h5 class="card-title mt-3">Log files</h5>
+          <h2 class="card-title mt-3 h5">Log files</h2>
           <table class="w-100">
               <thead>
               <tr>
@@ -79,7 +79,7 @@
 
 {% for test,testresult in groupresults %}
   <div class="card">
-    <h6 class="card-header result {{ testresult.result }}" role="tab" id="heading{{ test }}">
+    <h3 class="card-header h6 result {{ testresult.result }}" role="tab" id="heading{{ test }}">
       <a class="collapsed d-block text-dark pt-0 pb-0" data-bs-toggle="collapse" href="#collapse{{ test }}" aria-expanded="true" aria-controls="collapse{{ test }}" data-parent="#{{ resultgroup | replace({' ':''}) }}">
         {% if testresult.result == 'O' %}
         <i class="fas fa-check text-success"></i>
@@ -91,7 +91,7 @@
         <i class="fa fa-chevron-down float-end"></i>
         {{ testresult.caption }}
       </a>
-    </h6>
+    </h3>
 
     <div id="collapse{{ test }}" class="collapse {{ ( testresult.result == 'E' ) ? 'show' : '' }}" role="tabpanel" aria-labelledby="heading{{ test }}">
       <div class="card-body">

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -15,6 +15,12 @@
 {{ parent() }}
 {% endblock %}
 
+{% block extra_style %}
+    .size_h5 {
+        font-size: 1.25rem
+    }
+{% endblock %}
+
 {% block content %}
 <a href="https://www.domjudge.org/">
     <img src="{{ asset('images/DOMjudgelogo.svg') }}" id="djlogo" alt="DOMjudge logo" class="float-end d-none d-md-block" title="The DOMjudge logo: free as in beer!">
@@ -23,7 +29,7 @@
 <h1>DOMjudge Jury interface</h1>
 
 {% if is_granted('ROLE_JURY') %}
-<h5 class="mt-4 mb-3">Before contest</h5>
+<h2 class="mt-4 mb-3 size_h5">Before contest</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(path('jury_contests'), 'trophy', 'Contests') }}
     {{ _self.tile(path('jury_executables'), 'file-code', 'Executables') }}
@@ -41,7 +47,7 @@
 {% endif %}
 
 {% if is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON') or is_granted('ROLE_CLARIFICATION_RW') or have_printing %}
-<h5 class="mt-4 mb-3">During contest</h5>
+<h2 class="mt-4 mb-3 style_h5">During contest</h2>
 <div class="row g-2 mb-3">
     {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_BALLOON') %}
     {{ _self.tile(path('jury_balloons_legacy'), 'map-marker-alt', 'Balloon Status') }}
@@ -72,7 +78,7 @@
 {% endif %}
 
 {% if is_granted('ROLE_ADMIN') %}
-<h5 class="mt-4 mb-3">Administrator</h5>
+<h2 class="mt-4 mb-3 style_h5">Administrator</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(path('jury_config'), 'cog', 'Configuration') }}
     {{ _self.tile(path('jury_config_check'), 'clipboard-check', 'Config checker') }}
@@ -86,7 +92,7 @@
 </div>
 {% endif %}
 
-<h5 class="mt-4 mb-3">Documentation</h5>
+<h2 class="mt-4 mb-3 style_h5">Documentation</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(asset('doc/manual/html/index.html'), 'book', 'DOMjudge manual') }}
     {{ _self.tile(asset('doc/manual/domjudge-team-manual.pdf'), 'file-pdf', 'Team manual') }}

--- a/webapp/templates/jury/index.html.twig
+++ b/webapp/templates/jury/index.html.twig
@@ -23,7 +23,7 @@
 <h1>DOMjudge Jury interface</h1>
 
 {% if is_granted('ROLE_JURY') %}
-<h5 class="mt-4 mb-3">Before contest</h5>
+<h2 class="mt-4 mb-3 h5">Before contest</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(path('jury_contests'), 'trophy', 'Contests') }}
     {{ _self.tile(path('jury_executables'), 'file-code', 'Executables') }}
@@ -41,7 +41,7 @@
 {% endif %}
 
 {% if is_granted('ROLE_JURY') or is_granted('ROLE_BALLOON') or is_granted('ROLE_CLARIFICATION_RW') or have_printing %}
-<h5 class="mt-4 mb-3">During contest</h5>
+<h2 class="mt-4 mb-3 h5">During contest</h2>
 <div class="row g-2 mb-3">
     {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_BALLOON') %}
     {{ _self.tile(path('jury_balloons_legacy'), 'map-marker-alt', 'Balloon Status') }}
@@ -72,7 +72,7 @@
 {% endif %}
 
 {% if is_granted('ROLE_ADMIN') %}
-<h5 class="mt-4 mb-3">Administrator</h5>
+<h2 class="mt-4 mb-3 h5">Administrator</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(path('jury_config'), 'cog', 'Configuration') }}
     {{ _self.tile(path('jury_config_check'), 'clipboard-check', 'Config checker') }}
@@ -86,7 +86,7 @@
 </div>
 {% endif %}
 
-<h5 class="mt-4 mb-3">Documentation</h5>
+<h2 class="mt-4 mb-3 h5">Documentation</h2>
 <div class="row g-2 mb-3">
     {{ _self.tile(asset('doc/manual/html/index.html'), 'book', 'DOMjudge manual') }}
     {{ _self.tile(asset('doc/manual/domjudge-team-manual.pdf'), 'file-pdf', 'Team manual') }}

--- a/webapp/templates/jury/refresh_cache.html.twig
+++ b/webapp/templates/jury/refresh_cache.html.twig
@@ -3,6 +3,12 @@
 
 {% block title %}Refresh cache - {{ parent() }}{% endblock %}
 
+{% block extra_style %}
+    size_h5 {
+      font-size: 1.25rem;
+    }
+{% endblock %}
+
 {% block extrahead %}
     {{ parent() }}
     {{ macros.table_extrahead() }}
@@ -16,7 +22,7 @@
         {{ macros.progress_bar() }}
     {% else %}
         <div class="alert alert-warning">
-            <h5 class="alert-heading">Significant database impact</h5>
+            <h2 class="alert-heading">Significant database impact</h2>
             <hr>
             <p>
                 Refreshing the scoreboard cache can have a significant impact on the database load,

--- a/webapp/templates/jury/refresh_cache.html.twig
+++ b/webapp/templates/jury/refresh_cache.html.twig
@@ -16,7 +16,7 @@
         {{ macros.progress_bar() }}
     {% else %}
         <div class="alert alert-warning">
-            <h5 class="alert-heading">Significant database impact</h5>
+            <h2 class="alert-heading h5">Significant database impact</h2>
             <hr>
             <p>
                 Refreshing the scoreboard cache can have a significant impact on the database load,

--- a/webapp/templates/jury/versions.html.twig
+++ b/webapp/templates/jury/versions.html.twig
@@ -1,6 +1,17 @@
 {% extends "jury/base.html.twig" %}
 {% import "jury/jury_macros.twig" as macros %}
 
+{% block extra_style %}
+  .size_h5 {
+      font-size: 1.25rem
+  }
+
+  .size_h6 {
+      font-size: 1rem
+  }
+{% endblock %}
+
+
 {% block title %}Compiler and runner versions overview{% endblock %}
 
 {% block extrahead %}
@@ -25,7 +36,7 @@
                 <div class="card-title">
                     <div class="row">
                         <div class="col-sm">
-                            <h6>Compiler version(s)</h6>
+                            <h2 class="size_h6">Compiler version(s)</h2>
                             {% if lang.compiler_outputs | length > 1 %}
                                 <div class="alert alert-danger" role="alert">Versions do not match.</div>
                             {% endif %}
@@ -61,7 +72,7 @@
                             {% endfor %}
                             {% if lang.runner_outputs | length > 0 %}
                                 <br/>
-                                <h6>Runner version(s)</h6>
+                                <h2 class="size_h6">Runner version(s)</h2>
                                 {% if lang.runner_outputs | length > 1 %}
                                     <div class="alert alert-danger" role="alert">Versions do not match.</div>
                                 {% endif %}

--- a/webapp/templates/jury/versions.html.twig
+++ b/webapp/templates/jury/versions.html.twig
@@ -25,7 +25,7 @@
                 <div class="card-title">
                     <div class="row">
                         <div class="col-sm">
-                            <h6>Compiler version(s)</h6>
+                            <h2 class="h6">Compiler version(s)</h2>
                             {% if lang.compiler_outputs | length > 1 %}
                                 <div class="alert alert-danger" role="alert">Versions do not match.</div>
                             {% endif %}
@@ -61,7 +61,7 @@
                             {% endfor %}
                             {% if lang.runner_outputs | length > 0 %}
                                 <br/>
-                                <h6>Runner version(s)</h6>
+                                <h2 class="h6">Runner version(s)</h2>
                                 {% if lang.runner_outputs | length > 1 %}
                                     <div class="alert alert-danger" role="alert">Versions do not match.</div>
                                 {% endif %}


### PR DESCRIPTION
See: https://github.com/DOMjudge/domjudge-packaging/pull/250

The validator/validator team has moved to releasing only latest and no specific version anymore:

```
Important
The release named “latest” is “production-ready” and is the only release
you want to use. This project no longer does “major” version-numbered
releases. Release 20.6.30 (30 June 2020) was the final such release.

For a changelog of the latest changes, see
https://github.com/validator/validator/commits/latest/.
```

See: https://github.com/validator/validator/releases/tag/latest

As new rules require us to update some code most of the time it is better to control this and temporarily sync with the latest version. So we pin a "latest" on domjudge.org.