### PR TITLE
Remove double check if the $runfile is executable

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1290,10 +1290,10 @@ class JudgeDaemon
                 }
                 chmod($execrunpath, 0755);
             }
-            if (!is_file($execrunpath) || !is_executable($execrunpath)) {
-                return [null, "Invalid build file, must produce an executable file 'run'.", null];
-            }
             if ($combined_run_compare) {
+                if (!is_file($execrunpath) || !is_executable($execrunpath)) {
+                    return [null, "Invalid build file, must produce an executable file 'run'.", null];
+                }
                 # For combined run and compare (i.e. for interactive problems), we
                 # need to wrap the jury provided 'run' script with 'runpipe' to
                 # handle the bidirectional communication.  First 'run' is renamed to


### PR DESCRIPTION
Only when we use runpipe do we need to check this twice, so only check if the original file is executable in that specific path.

See: https://github.com/DOMjudge/domjudge/blob/main/judge/judgedaemon.main.php#L1293C1-L1314C14

In case ($combined_run_compare === false) the same statement is used 2 times.  I think the 2nd time is done because of:
https://github.com/DOMjudge/domjudge/blob/main/judge/judgedaemon.main.php#L1303 where we rename the binary.

I could rewrite this to check the new binary in the statement if that is better, I preferred this first but could live with the other.