### PR TITLE
Fix problem URL in "Submissions with Score Changes"

### DIFF
--- a/webapp/src/Controller/Jury/RejudgingController.php
+++ b/webapp/src/Controller/Jury/RejudgingController.php
@@ -352,7 +352,7 @@ class RejudgingController extends BaseController
                     'teamName' => $submission->getTeam()->getEffectiveName(),
                     'teamId' => $submission->getTeam()->getTeamid(),
                     'problemName' => $problem->getName(),
-                    'problemId' => $problem->getProbid(),
+                    'problemId' => $problem->getExternalid(),
                     'oldScore' => $oldScore,
                     'newScore' => $newScore,
                     'delta' => $delta,


### PR DESCRIPTION
The URL always expects external ID, ever since the support for Internal Datasource is dropped.