### PR TITLE
Add option to submit via online code editor/paste.

### DIFF
--- a/etc/db-config.yaml
+++ b/etc/db-config.yaml
@@ -334,6 +334,15 @@
                 2: After first submission
             regex: /^\d+$/
             error_message: A value between 0 and 2 is required.
+        -   name: submit_methods
+            type: array_val
+            default_value:
+                - upload
+            public: true
+            description: Allowed submission methods in the web interface.
+            options:
+                - upload
+                - paste
         -   name: enable_ranking
             type: bool
             default_value: true

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -3,6 +3,7 @@
     --background-color: white;
     --text-color: black;
     --navbar-height: 3.5rem;
+    --body-padding-top: 4.5rem;
 }
 
 /** WCAG fixes start **/
@@ -22,7 +23,7 @@ body {
     background-color: var(--background-color);
     font-family: Roboto, sans-serif;
     padding-bottom: 4em;
-    padding-top: 4.5rem;
+    padding-top: var(--body-padding-top);
 }
 
 /* has no menu */
@@ -864,6 +865,56 @@ blockquote {
     height: 0;
     min-height: 100px; /* Prefer a double scrollbar over not displaying code at all */
     width: 100%;
+}
+
+.paste-submit-page {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 4.5rem);
+}
+
+.paste-submit-page .paste-editor-container {
+    flex: 1;
+    min-height: 200px;
+    overflow: hidden;
+    position: relative;
+}
+
+.paste-submit-page .paste-editor-container .editor {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: auto;
+    min-height: 0;
+}
+
+.paste-toolbar {
+    background: #f8f9fa;
+}
+
+.paste-toolbar-field label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #6c757d;
+    margin-bottom: 0.15rem;
+}
+
+.paste-toolbar-field select,
+.paste-toolbar-field input {
+    min-width: 10rem;
+}
+
+/* Hidden by default; shown via JS when the selected language requires an entry point */
+[data-entry-point-toolbar] {
+    display: none;
+}
+
+/* Ensure the paste tab pane uses flex layout when active */
+#paste-pane-page.active {
+    display: flex !important;
 }
 
 /* Allowed Languages page styles */

--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -3,11 +3,13 @@
 namespace App\Controller\Team;
 
 use App\Controller\BaseController;
+use App\Entity\Contest;
 use App\Entity\Judging;
 use App\Entity\Language;
 use App\Entity\Problem;
 use App\Entity\Submission;
 use App\Entity\SubmissionSource;
+use App\Entity\Team;
 use App\Entity\Testcase;
 use App\Form\Type\SubmitProblemType;
 use App\Service\ConfigurationService;
@@ -19,6 +21,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,57 +65,149 @@ class SubmissionController extends BaseController
             $data['problem'] = $problem;
             $data['languages'] = $problem->getLanguages()->toArray();
         }
-        $form    = $this->formFactory
-            ->createBuilder(SubmitProblemType::class, $data)
-            ->setAction($this->generateUrl('team_submit'))
-            ->getForm();
 
-        $form->handleRequest($request);
+        $submitMethods = $this->config->get('submit_methods');
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            if ($contest === null) {
-                $this->addFlash('danger', 'No active contest');
-            } elseif (!$this->dj->checkrole('jury') && !$contest->getFreezeData()->started()) {
-                $this->addFlash('danger', 'Contest has not yet started');
-            } else {
-                /** @var Problem $problem */
-                $problem = $form->get('problem')->getData();
-                /** @var Language $language */
-                $language = $form->get('language')->getData();
-                /** @var UploadedFile[]|UploadedFile $files */
-                $files      = $form->get('code')->getData();
-                if (!is_array($files)) {
-                    $files = [$files];
-                }
-                $entryPoint = $form->get('entry_point')->getData() ?: null;
-                $submission = $this->submissionService->submitSolution(
-                    $team, $this->dj->getUser(), $problem->getProbid(), $contest, $language, $files, SubmissionSource::TEAM_PAGE, null,
-                    null, $entryPoint, null, null, $message
-                );
+        $uploadForm = null;
+        $pasteForm = null;
 
-                if ($submission) {
-                    $this->addFlash(
-                        'success',
-                        'Submission done! Watch for the verdict in the list below.'
-                    );
-                } else {
-                    $this->addFlash('danger', $message);
-                }
-                return $this->redirectToRoute('team_index');
+        if (in_array('upload', $submitMethods)) {
+            $uploadForm = $this->formFactory
+                ->createNamedBuilder('submit_problem', SubmitProblemType::class, $data, ['submission_mode' => 'upload'])
+                ->setAction($this->generateUrl('team_submit'))
+                ->getForm();
+        }
+
+        // Only create the paste form for the full page (not the modal)
+        if (in_array('paste', $submitMethods) && !$request->isXmlHttpRequest()) {
+            $pasteForm = $this->formFactory
+                ->createNamedBuilder('submit_problem_paste', SubmitProblemType::class, $data, ['submission_mode' => 'paste'])
+                ->setAction($this->generateUrl('team_submit'))
+                ->getForm();
+        }
+
+        // Handle upload form submission
+        if ($uploadForm !== null) {
+            $uploadForm->handleRequest($request);
+            if ($uploadForm->isSubmitted() && $uploadForm->isValid()) {
+                return $this->handleSubmission($uploadForm, $team, $contest, 'upload');
             }
         }
 
-        $data = ['form' => $form->createView(), 'problem' => $problem];
-        $data['validFilenameRegex'] = SubmissionService::FILENAME_REGEX;
+        // Handle paste form submission
+        if ($pasteForm !== null) {
+            $pasteForm->handleRequest($request);
+            if ($pasteForm->isSubmitted() && $pasteForm->isValid()) {
+                return $this->handleSubmission($pasteForm, $team, $contest, 'paste');
+            }
+        }
+
+        $templateData = [
+            'problem' => $problem,
+            'upload_form' => $uploadForm?->createView(),
+            'paste_form' => $pasteForm?->createView(),
+            'submit_methods' => $submitMethods,
+        ];
+        $templateData['validFilenameRegex'] = SubmissionService::FILENAME_REGEX;
         if ($contest && $team) {
-            $data['rateLimitStatus'] = $this->submissionService->getRateLimitStatus($team, $contest);
+            $templateData['rateLimitStatus'] = $this->submissionService->getRateLimitStatus($team, $contest);
         }
 
         if ($request->isXmlHttpRequest()) {
-            return $this->render('team/submit_modal.html.twig', $data);
+            return $this->render('team/submit_modal.html.twig', $templateData);
         } else {
-            return $this->render('team/submit.html.twig', $data);
+            return $this->render('team/submit.html.twig', $templateData);
         }
+    }
+
+    private function handleSubmission(FormInterface $form, Team $team, ?Contest $contest, string $mode): Response
+    {
+        if ($contest === null) {
+            $this->addFlash('danger', 'No active contest');
+            return $this->redirectToRoute('team_index');
+        }
+        if (!$this->dj->checkrole('jury') && !$contest->getFreezeData()->started()) {
+            $this->addFlash('danger', 'Contest has not yet started');
+            return $this->redirectToRoute('team_index');
+        }
+
+        /** @var Problem $problem */
+        $problem = $form->get('problem')->getData();
+        /** @var Language $language */
+        $language = $form->get('language')->getData();
+        $entryPoint = $form->get('entry_point')->getData() ?: null;
+
+        $tmpFile = null;
+        if ($mode === 'paste') {
+            $result = $this->buildPasteFiles($problem, $language, $contest, $form->get('code_content')->getData(), $entryPoint);
+            if ($result === null) {
+                return $this->redirectToRoute('team_index');
+            }
+            [$files, $tmpFile] = $result;
+        } else {
+            /** @var UploadedFile[]|UploadedFile $files */
+            $files = $form->get('code')->getData();
+            if (!is_array($files)) {
+                $files = [$files];
+            }
+        }
+
+        try {
+            $message = '';
+            $submission = $this->submissionService->submitSolution(
+                $team, $this->dj->getUser(), $problem->getProbid(), $contest, $language, $files, SubmissionSource::TEAM_PAGE, null,
+                null, $entryPoint, null, null, $message
+            );
+
+            if ($submission) {
+                $this->addFlash('success', 'Submission done! Watch for the verdict in the list below.');
+            } else {
+                $this->addFlash('danger', $message);
+            }
+        } finally {
+            if ($tmpFile !== null && file_exists($tmpFile)) {
+                unlink($tmpFile);
+            }
+        }
+
+        return $this->redirectToRoute('team_index');
+    }
+
+    /**
+     * Build an UploadedFile from pasted code content.
+     *
+     * @return array{UploadedFile[], string}|null [files, tmpFilePath], or null if the code content is empty
+     */
+    private function buildPasteFiles(Problem $problem, Language $language, Contest $contest, ?string $codeContent, ?string $entryPoint): ?array
+    {
+        if (empty($codeContent)) {
+            $this->addFlash('danger', 'No code provided.');
+            return null;
+        }
+
+        // Determine filename — find the contest problem for the current contest
+        $contestProblem = $problem->getContestProblems()->filter(
+            fn($cp) => $cp->getContest() === $contest
+        )->first();
+        $extensions = $language->getExtensions();
+        $extension = $extensions[0] ?? 'txt';
+
+        if ($language->getRequireEntryPoint() && $entryPoint !== null) {
+            $filename = $entryPoint . '.' . $extension;
+        } elseif ($contestProblem !== false) {
+            $filename = $contestProblem->getShortname() . '.' . $extension;
+        } else {
+            $filename = 'submission.' . $extension;
+        }
+
+        $filename = SubmissionService::sanitizeFilename($filename);
+
+        // Write to temp file and create UploadedFile
+        $tmpFile = tempnam(sys_get_temp_dir(), 'dj_paste_');
+        file_put_contents($tmpFile, $codeContent);
+        $uploadedFile = new UploadedFile($tmpFile, $filename, null, null, true);
+
+        return [[$uploadedFile], $tmpFile];
     }
 
     /**

--- a/webapp/src/Form/Type/SubmitProblemType.php
+++ b/webapp/src/Form/Type/SubmitProblemType.php
@@ -12,11 +12,13 @@ use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -30,14 +32,21 @@ class SubmitProblemType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $allowMultipleFiles = $this->config->get('sourcefiles_limit') > 1;
-        $user               = $this->dj->getUser();
-        $contest            = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
+        $submissionMode = $options['submission_mode'];
+        $user           = $this->dj->getUser();
+        $contest        = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
 
-        $builder->add('code', FileType::class, [
-            'label' => 'Source file' . ($allowMultipleFiles ? 's' : ''),
-            'multiple' => $allowMultipleFiles,
-        ]);
+        if ($submissionMode === 'paste') {
+            $builder->add('code_content', HiddenType::class, [
+                'required' => true,
+            ]);
+        } else {
+            $allowMultipleFiles = $this->config->get('sourcefiles_limit') > 1;
+            $builder->add('code', FileType::class, [
+                'label' => 'Source file' . ($allowMultipleFiles ? 's' : ''),
+                'multiple' => $allowMultipleFiles,
+            ]);
+        }
 
         $problemConfig = [
             'class' => Problem::class,
@@ -93,5 +102,13 @@ class SubmitProblemType extends AbstractType
                 $event->getForm()->add('problem', EntityType::class, $problemConfig);
             }
         });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'submission_mode' => 'upload',
+        ]);
+        $resolver->setAllowedValues('submission_mode', ['upload', 'paste']);
     }
 }

--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -38,6 +38,18 @@ use ZipArchive;
 class SubmissionService
 {
     final public const FILENAME_REGEX = '/^[a-zA-Z0-9_][a-zA-Z0-9+_\.-]*$/';
+
+    /**
+     * Sanitize a filename to match FILENAME_REGEX by replacing invalid characters with underscores.
+     */
+    public static function sanitizeFilename(string $filename): string
+    {
+        if (preg_match(self::FILENAME_REGEX, $filename)) {
+            return $filename;
+        }
+        return preg_replace('/[^a-zA-Z0-9+_.\-]/', '_', $filename);
+    }
+
     final public const PROBLEM_RESULT_MATCHSTRING = ['@EXPECTED_RESULTS@: ', '@EXPECTED_SCORE@: '];
     final public const PROBLEM_RESULT_REMAP = [
         'ACCEPTED' => 'CORRECT',

--- a/webapp/src/Twig/TwigGlobalsExtension.php
+++ b/webapp/src/Twig/TwigGlobalsExtension.php
@@ -77,6 +77,7 @@ class TwigGlobalsExtension extends AbstractExtension implements GlobalsInterface
             'doc_links'                     => $this->dj->getDocLinks(),
             'allow_registration'            => $selfRegistrationCategoriesCount !== 0,
             'enable_ranking'                => $this->config->get('enable_ranking'),
+            'submit_methods'                => $this->config->get('submit_methods'),
             'editor_themes'                 => [
                 'vs'                        => ['name' => 'Visual Studio (light)'],
                 'vs-dark'                   => ['name' => 'Visual Studio (dark)'],

--- a/webapp/templates/team/base.html.twig
+++ b/webapp/templates/team/base.html.twig
@@ -7,6 +7,7 @@
 {% endblock %}
 
 {% block footer %}
+    {% block team_scripts %}{% endblock %}
     {% include 'team/partials/submit_scripts.html.twig' %}
 
     <script>

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -71,11 +71,32 @@
         </div>
         <div class="ml-auto me-3">
             {% if is_granted('ROLE_JURY') or (current_team_contest is not null and current_team_contest.freezeData.started) %}
+                {% if 'upload' in submit_methods and 'paste' in submit_methods %}
+                    {# Both methods enabled: default to modal (upload), but JS will switch to
+                       direct link if the user's last submit tab was paste. #}
+                    <a class="nav-link" id="submit-btn-modal" data-ajax-modal data-ajax-modal-after="initSubmitModal" href="{{ path('team_submit') }}">
+                        <span class="btn btn-success btn-sm">
+                            <i class="fas fa-cloud-upload-alt"></i> Submit
+                        </span>
+                    </a>
+                    <a class="nav-link d-none" id="submit-btn-paste" href="{{ path('team_submit') }}?tab=paste">
+                        <span class="btn btn-success btn-sm">
+                            <i class="fas fa-paste"></i> Submit
+                        </span>
+                    </a>
+                {% elseif 'upload' in submit_methods %}
                 <a class="nav-link" data-ajax-modal data-ajax-modal-after="initSubmitModal" href="{{ path('team_submit') }}">
                     <span class="btn btn-success btn-sm">
                         <i class="fas fa-cloud-upload-alt"></i> Submit
                     </span>
                 </a>
+                {% else %}
+                <a class="nav-link" href="{{ path('team_submit') }}">
+                    <span class="btn btn-success btn-sm">
+                        <i class="fas fa-paste"></i> Submit
+                    </span>
+                </a>
+                {% endif %}
             {% else %}
                 <a class="nav-link">
                     <span class="btn btn-success btn-sm disabled">

--- a/webapp/templates/team/partials/paste_form.html.twig
+++ b/webapp/templates/team/partials/paste_form.html.twig
@@ -1,0 +1,29 @@
+{{ form_start(paste_form, {'attr': {'class': 'd-flex flex-column flex-fill'}}) }}
+<div class="paste-toolbar px-3 py-2 border-bottom d-flex align-items-end gap-3 flex-wrap">
+    <div class="paste-toolbar-field">
+        {{ form_label(paste_form.problem) }}
+        {{ form_widget(paste_form.problem) }}
+    </div>
+    <div class="paste-toolbar-field">
+        {{ form_label(paste_form.language) }}
+        {{ form_widget(paste_form.language) }}
+    </div>
+    <div class="paste-toolbar-field" data-entry-point-toolbar>
+        {{ form_label(paste_form.entry_point) }}
+        {{ form_widget(paste_form.entry_point) }}
+    </div>
+    <div class="paste-toolbar-info align-self-end pb-1">
+        <small class="text-muted">
+            Filename: <code class="paste-derived-filename" data-form-prefix="submit_problem_paste">-</code>
+        </small>
+    </div>
+    <div class="paste-toolbar-submit align-self-end ms-auto">
+        <button type="submit" class="btn btn-success"><i class="fas fa-cloud-upload-alt"></i> Submit</button>
+    </div>
+</div>
+{% include 'team/partials/rate_limit_warning.html.twig' with {'alert_extra_classes': 'mx-3 mt-2 mb-0'} %}
+<div class="paste-editor-container flex-fill">
+    {{ '' | codeEditor('paste_page', null, true, paste_form.code_content.vars.id) }}
+</div>
+{{ form_widget(paste_form.code_content) }}
+{{ form_end(paste_form) }}

--- a/webapp/templates/team/partials/rate_limit_warning.html.twig
+++ b/webapp/templates/team/partials/rate_limit_warning.html.twig
@@ -1,0 +1,11 @@
+{% if rateLimitStatus is defined and rateLimitStatus is not empty %}
+    <div class="alert alert-warning {{ alert_extra_classes | default('') }}">
+        <i class="fas fa-exclamation-triangle"></i>
+        <strong>Submission limit reached - if you submit now, it will likely be rejected:</strong>
+        <ul class="mb-0">
+            {% for limit in rateLimitStatus %}
+                <li>Maximum of {{ limit.limit }} submission(s) per {{ limit.period }} allowed.</li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}

--- a/webapp/templates/team/partials/submit_scripts.html.twig
+++ b/webapp/templates/team/partials/submit_scripts.html.twig
@@ -16,15 +16,135 @@
         }
     }
 
-    function maybeShowEntryPoint() {
-        let filename = $('#submit_problem_code').val() ?? '';
-        filename = filename.replace(/^.*[\\\/]/, '');
+    // Derives a default entry point value from a filename and language ID.
+    function deriveEntryPoint(filename, langid) {
+        if (!filename) return '';
+        switch (langid) {
+            case 'java':
+                return entryPointDetectJava(filename);
+            case 'kotlin':
+                return entryPointDetectKotlin(filename);
+            default:
+                return filename;
+        }
+    }
 
-        var langid = $('#submit_problem_language').val();
+    // Map DOMjudge language externalid to its first file extension.
+    // Uses getMainExtension() from javascript_language_detect.html.twig for the
+    // reverse mapping (extension -> langid); this provides langid -> extension.
+    var langExtensionMap = {
+        {% for language in submission_languages %}
+        '{{ language.externalid }}': '{{ language.extensions[0] | default('') }}'{% if not loop.last %},{% endif %}
+
+        {% endfor %}
+    };
+    function getLangExtension(langid) {
+        return langExtensionMap[langid] || '';
+    }
+
+    // Derive a Monaco editor language from a file extension.
+    function getMonacoLanguageForExtension(ext) {
+        if (typeof monaco === 'undefined') return '';
+        var dotExt = '.' + ext;
+        var langs = monaco.languages.getLanguages();
+        for (var i = 0; i < langs.length; i++) {
+            if (langs[i].extensions) {
+                for (var j = 0; j < langs[i].extensions.length; j++) {
+                    if (langs[i].extensions[j] === dotExt) {
+                        return langs[i].id;
+                    }
+                }
+            }
+        }
+        return 'plaintext';
+    }
+
+    // Update the Monaco editor language for paste editors.
+    function updatePasteEditorLanguage(ext) {
+        if (typeof monaco === 'undefined') return;
+        var monacoLang = getMonacoLanguageForExtension(ext);
+        var editors = monaco.editor.getEditors();
+        for (var i = 0; i < editors.length; i++) {
+            var el = editors[i].getDomNode();
+            if (el && el.closest('.paste-editor-container')) {
+                monaco.editor.setModelLanguage(editors[i].getModel(), monacoLang);
+            }
+        }
+    }
+
+    // Get problem shortname from problem select (text is "SHORT - Name").
+    function getProblemShortname(formPrefix) {
+        var probSelect = document.getElementById(formPrefix + '_problem');
+        if (!probSelect || probSelect.selectedIndex < 0) return '';
+        var text = probSelect.options[probSelect.selectedIndex].text;
+        var parts = text.split(/ - /);
+        return parts[0] || '';
+    }
+
+    // Derive filename and entry point for the paste form, update display.
+    function updatePasteDerivedFilename(formPrefix) {
+        var langSelect = document.getElementById(formPrefix + '_language');
+        if (!langSelect) return;
+        var langid = langSelect.value;
+        var ext = getLangExtension(langid);
+        var shortname = getProblemShortname(formPrefix);
+        var filenameEl = document.querySelector('.paste-derived-filename[data-form-prefix="' + formPrefix + '"]');
+
+        if (!langid || !shortname || !ext) {
+            if (filenameEl) filenameEl.textContent = '-';
+            return;
+        }
+
+        var filename = shortname + '.' + ext;
+
+        // Show/hide entry point and derive its value from the filename.
+        // The paste toolbar uses [data-entry-point-toolbar] as wrapper;
+        // fall back to form-rendered [data-entry-point] for the row wrapper.
+        var $form = $(langSelect).closest('form');
+        var $entryPointToolbar = $form.find('[data-entry-point-toolbar]');
+        var $entryPointRow = $form.find('[data-entry-point]');
+        var $entryPointInput = $form.find('#' + formPrefix + '_entry_point');
+        var $entryPointLabel = ($entryPointToolbar.length ? $entryPointToolbar : $entryPointRow).find('label');
+        var entryPointDescription = getEntryPoint(langid);
+
+        if (entryPointDescription) {
+            $entryPointToolbar.show();
+            $entryPointRow.show();
+            var $labelChildren = $entryPointLabel.children();
+            $entryPointLabel.text(entryPointDescription).append($labelChildren);
+            $entryPointInput.attr('required', 'required');
+
+            // Auto-detect entry point from derived filename
+            $entryPointInput.val(deriveEntryPoint(filename, langid));
+        } else {
+            $entryPointToolbar.hide();
+            $entryPointRow.hide();
+            $entryPointInput.attr('required', null);
+            $entryPointInput.val('');
+        }
+
+        if (filenameEl) filenameEl.textContent = filename;
+
+        // Update Monaco syntax highlighting
+        updatePasteEditorLanguage(ext);
+    }
+
+    function maybeShowEntryPoint(formPrefix) {
+        formPrefix = formPrefix || 'submit_problem';
+        let fileInput = document.getElementById(formPrefix + '_code');
+        let filename = '';
+        if (fileInput) {
+            filename = $(fileInput).val() ?? '';
+            filename = filename.replace(/^.*[\\\/]/, '');
+        }
+
+        var langSelect = document.getElementById(formPrefix + '_language');
+        if (!langSelect) return;
+        var langid = langSelect.value;
         if (langid === "") {
             return;
         }
-        var $entryPoint = $('[data-entry-point]');
+        var $entryPoint = $(langSelect).closest('form').find('[data-entry-point]');
         var $entryPointLabel = $entryPoint.find('label');
         var $entryPointInput = $entryPoint.find('input');
         var entryPointDescription = getEntryPoint(langid);
@@ -43,24 +163,31 @@
         }
 
         if (entryPointDescription && filename) {
-            switch (langid) {
-                case 'java':
-                    $entryPointInput.val(entryPointDetectJava(filename));
-                    break;
-                case 'kotlin':
-                    $entryPointInput.val(entryPointDetectKotlin(filename));
-                    break;
-                default:
-                    $entryPointInput.val(filename);
-            }
-        } else {
+            $entryPointInput.val(deriveEntryPoint(filename, langid));
+        } else if (!entryPointDescription) {
             $entryPointInput.val('');
         }
     }
 
+    // Show the correct nav submit button based on the remembered submit tab.
+    function updateSubmitButton() {
+        var modalBtn = document.getElementById('submit-btn-modal');
+        var pasteBtn = document.getElementById('submit-btn-paste');
+        if (!modalBtn || !pasteBtn) return;
+        if (getCookie('domjudge_submit_tab') === 'paste') {
+            modalBtn.classList.add('d-none');
+            pasteBtn.classList.remove('d-none');
+        } else {
+            modalBtn.classList.remove('d-none');
+            pasteBtn.classList.add('d-none');
+        }
+    }
+
     $(function () {
-        var $entryPoint = $('[data-entry-point]');
-        $entryPoint.hide();
+        updateSubmitButton();
+
+        // Hide all entry point fields initially
+        $('[data-entry-point]').hide();
 
         var processFile = function () {
             var filename = $('#submit_problem_code').val();
@@ -71,7 +198,6 @@
                 var lcParts = [parts[0].toLowerCase(), parts[1].toLowerCase()];
 
                 // language ID
-
                 var language = document.getElementById('submit_problem_language');
                 // the "autodetect" option has empty value
                 if (language.value !== '') return;
@@ -83,10 +209,9 @@
                     }
                 }
 
-                maybeShowEntryPoint();
+                maybeShowEntryPoint('submit_problem');
 
                 // Problem ID
-
                 var problem = document.getElementById('submit_problem_problem');
                 // the "autodetect" option has empty value
                 if (problem.value !== '') {
@@ -104,7 +229,12 @@
         var $body = $('body');
         $body.on('change', '#submit_problem_code', processFile);
         $body.on('change', '#submit_problem_language', function () {
-            maybeShowEntryPoint();
+            maybeShowEntryPoint('submit_problem');
+        });
+
+        // Paste form: problem or language change -> update derived filename, entry point, highlighting
+        $body.on('change', '#submit_problem_paste_language, #submit_problem_paste_problem', function () {
+            updatePasteDerivedFilename('submit_problem_paste');
         });
 
         $body.on('submit', 'form[name=submit_problem]', function () {
@@ -154,11 +284,66 @@
             return confirm(question);
         });
 
+        $body.on('submit', 'form[name=submit_problem_paste]', function () {
+            var langelt = document.getElementById("submit_problem_paste_language");
+            var language = langelt.options[langelt.selectedIndex].value;
+            var languagetxt = langelt.options[langelt.selectedIndex].text;
+            var probelt = document.getElementById("submit_problem_paste_problem");
+            var problem = probelt.options[probelt.selectedIndex].value;
+            var problemtxt = probelt.options[probelt.selectedIndex].text;
+            var codeContent = document.getElementById("submit_problem_paste_code_content").value;
+
+            var error = false;
+            if (language === "") {
+                langelt.focus();
+                langelt.className = langelt.className + " errorfield";
+                error = true;
+            }
+            if (problem === "") {
+                probelt.focus();
+                probelt.className = probelt.className + " errorfield";
+                error = true;
+            }
+            if (!codeContent || codeContent.trim() === "") {
+                alert("Please paste your source code in the editor.");
+                error = true;
+            }
+            if (error) return false;
+
+            var filenameEl = document.querySelector('.paste-derived-filename[data-form-prefix="submit_problem_paste"]');
+            var filename = filenameEl ? filenameEl.textContent : '';
+            var question =
+                'File: ' + filename + '\n' +
+                'Problem: ' + problemtxt + '\n' +
+                'Language: ' + languagetxt + '\n' +
+                '\nMake submission?';
+            return confirm(question);
+        });
+
         processFile();
-        maybeShowEntryPoint();
+        maybeShowEntryPoint('submit_problem');
+        updatePasteDerivedFilename('submit_problem_paste');
 
         window.initSubmitModal = function ($elem) {
             $('[data-entry-point]').hide();
         };
+
+        // Tab persistence for standalone page (query param takes priority over cookie)
+        var urlParams = new URLSearchParams(window.location.search);
+        var activeTab = urlParams.get('tab') || getCookie('domjudge_submit_tab');
+        if (activeTab === 'paste') {
+            var pasteTabBtn = document.getElementById('paste-tab-page');
+            if (pasteTabBtn) {
+                var tab = new bootstrap.Tab(pasteTabBtn);
+                tab.show();
+            }
+        }
+        document.querySelectorAll('#upload-tab-page, #paste-tab-page').forEach(function(tabBtn) {
+            tabBtn.addEventListener('shown.bs.tab', function(e) {
+                var tabId = e.target.id.indexOf('paste') >= 0 ? 'paste' : 'upload';
+                setCookie('domjudge_submit_tab', tabId);
+                updateSubmitButton();
+            });
+        });
     });
 </script>

--- a/webapp/templates/team/submit.html.twig
+++ b/webapp/templates/team/submit.html.twig
@@ -2,42 +2,84 @@
 
 {% block title %}Submit - {{ parent() }}{% endblock %}
 
+{% block team_scripts %}
+    {% if 'paste' in submit_methods %}
+        <script src="{{ asset('js/monaco/vs/loader.js') }}"></script>
+        <script>
+            {# A bit ugly to do the replace, but Symfony adds a version to any asset URLs so remove it again #}
+            require.config({ paths: { vs: '{{ asset('js/monaco/vs') }}'.replace(/\?.*/, '') } });
+            window.editorThemeFolder = '{{ asset('js/monaco/themes') }}'.replace(/\?.*/, '');
+        </script>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
-    <div class="container submitform pt-5">
-        {% if current_team_contest is not empty and not current_team_contest.allowSubmit %}
+    {% if current_team_contest is not empty and not current_team_contest.allowSubmit %}
+        <div class="container submitform pt-5">
             {% include 'partials/alert.html.twig' with {'type': 'danger', 'message': 'Submissions (temporarily) disabled.'} %}
-        {% else %}
-            <h1 class="text-center">Submit {% if problem is not null %}problem {{ problem.name }}{% endif %}</h1>
-            {% if current_team_contest is empty or (not is_granted('ROLE_JURY') and not current_team_contest.freezeData.started) %}
-                <div class="container submitform">
-                    <div class="alert alert-danger" role="alert">Contest has not yet started - cannot submit.</div>
-                </div>
-            {% else %}
+        </div>
+    {% elseif current_team_contest is empty or (not is_granted('ROLE_JURY') and not current_team_contest.freezeData.started) %}
+        <div class="container submitform pt-5">
+            <div class="alert alert-danger" role="alert">Contest has not yet started - cannot submit.</div>
+        </div>
+    {% else %}
+        {% set has_upload = 'upload' in submit_methods %}
+        {% set has_paste = 'paste' in submit_methods %}
 
-                {{ form_start(form) }}
-                {% if rateLimitStatus is not empty %}
-                    <div class="alert alert-warning">
-                        <i class="fas fa-exclamation-triangle"></i>
-                        <strong>Submission limit reached - if you submit now, it will likely be rejected:</strong>
-                        <ul class="mb-0">
-                            {% for limit in rateLimitStatus %}
-                                <li>Maximum of {{ limit.limit }} submission(s) per {{ limit.period }} allowed.</li>
-                            {% endfor %}
-                        </ul>
+        {% if has_upload and has_paste %}
+            <div class="paste-submit-page">
+                <ul class="nav nav-tabs px-3 pt-2" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="upload-tab-page" data-bs-toggle="tab" data-bs-target="#upload-pane-page" type="button" role="tab" aria-controls="upload-pane-page" aria-selected="true">
+                            <i class="fas fa-file-upload"></i> Upload File
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="paste-tab-page" data-bs-toggle="tab" data-bs-target="#paste-pane-page" type="button" role="tab" aria-controls="paste-pane-page" aria-selected="false">
+                            <i class="fas fa-paste"></i> Paste Code
+                        </button>
+                    </li>
+                </ul>
+                <div class="tab-content flex-fill d-flex">
+                    <div class="tab-pane fade show active w-100" id="upload-pane-page" role="tabpanel" aria-labelledby="upload-tab-page">
+                        <div class="container submitform pt-3">
+                            {% set uform = upload_form %}
+                            {{ form_start(uform) }}
+                            {% include 'team/partials/rate_limit_warning.html.twig' %}
+                            {{ form_row(uform.code) }}
+                            {{ form_row(uform.problem) }}
+                            {{ form_row(uform.language) }}
+                            {{ form_row(uform.entry_point) }}
+                            <div class="mb-3">
+                                <button type="submit" class="btn-success btn"><i class="fas fa-cloud-upload-alt"></i> Submit</button>
+                            </div>
+                            {{ form_end(uform) }}
+                        </div>
                     </div>
-                {% endif %}
-                {{ form_row(form.code) }}
-                {{ form_row(form.problem) }}
-                {{ form_row(form.language) }}
-                {{ form_row(form.entry_point) }}
-                <div class="mb-3">
-                    <button type="submit" class="btn-success btn"><i class="fas fa-cloud-upload-alt"></i> Submit
-                    </button>
+                    <div class="tab-pane fade d-flex flex-column w-100" id="paste-pane-page" role="tabpanel" aria-labelledby="paste-tab-page">
+                        {% include 'team/partials/paste_form.html.twig' %}
+                    </div>
                 </div>
-                {{ form_end(form) }}
-
-            {% endif %}
+            </div>
+        {% elseif has_upload %}
+            <div class="container submitform pt-5">
+                <h1 class="text-center">Submit {% if problem is not null %}problem {{ problem.name }}{% endif %}</h1>
+                {% set uform = upload_form %}
+                {{ form_start(uform) }}
+                {% include 'team/partials/rate_limit_warning.html.twig' %}
+                {{ form_row(uform.code) }}
+                {{ form_row(uform.problem) }}
+                {{ form_row(uform.language) }}
+                {{ form_row(uform.entry_point) }}
+                <div class="mb-3">
+                    <button type="submit" class="btn-success btn"><i class="fas fa-cloud-upload-alt"></i> Submit</button>
+                </div>
+                {{ form_end(uform) }}
+            </div>
+        {% elseif has_paste %}
+            <div class="paste-submit-page">
+                {% include 'team/partials/paste_form.html.twig' %}
+            </div>
         {% endif %}
-
-    </div>
+    {% endif %}
 {% endblock %}

--- a/webapp/templates/team/submit_modal.html.twig
+++ b/webapp/templates/team/submit_modal.html.twig
@@ -18,25 +18,32 @@
                 <div class="modal-body">
                     {% include 'partials/alert.html.twig' with {'type': 'danger', 'message': 'Submissions (temporarily) disabled.'} %}
                 </div>
-            {% else %}
-                {{ form_start(form) }}
+            {% elseif upload_form is defined and upload_form is not null %}
+                {% set uform = upload_form %}
+
+                {% if 'paste' in submit_methods %}
+                    <ul class="nav nav-tabs px-3 pt-2">
+                        <li class="nav-item">
+                            <span class="nav-link active">
+                                <i class="fas fa-file-upload"></i> Upload File
+                            </span>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ path('team_submit') }}?tab=paste">
+                                <i class="fas fa-paste"></i> Paste Code
+                            </a>
+                        </li>
+                    </ul>
+                {% endif %}
+
+                {{ form_start(uform) }}
                 <div class="modal-body">
-                    {% if rateLimitStatus is not empty %}
-                        <div class="alert alert-warning">
-                            <i class="fas fa-exclamation-triangle"></i>
-                            <strong>Submission limit reached - if you submit now, it will likely be rejected:</strong>
-                            <ul class="mb-0">
-                                {% for limit in rateLimitStatus %}
-                                    <li>Maximum of {{ limit.limit }} submission(s) per {{ limit.period }} allowed.</li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    {% endif %}
-                    {{ form_row(form.code) }}
+                    {% include 'team/partials/rate_limit_warning.html.twig' %}
+                    {{ form_row(uform.code) }}
                     <div class="alert d-none" id="files_selected"></div>
-                    {{ form_row(form.problem) }}
-                    {{ form_row(form.language) }}
-                    {{ form_row(form.entry_point) }}
+                    {{ form_row(uform.problem) }}
+                    {{ form_row(uform.language) }}
+                    {{ form_row(uform.entry_point) }}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -44,51 +51,62 @@
                         <i class="fas fa-cloud-upload-alt"></i> Submit
                     </button>
                 </div>
-                {{ form_end(form) }}
+                {{ form_end(uform) }}
+            {% else %}
+                <div class="modal-body">
+                    <p>Use the <a href="{{ path('team_submit') }}">full submit page</a> to submit via the code editor.</p>
+                </div>
             {% endif %}
         </div>
     </div>
 
     <script>
-        const fileInput = document.getElementById('submit_problem_code');
-        fileInput.addEventListener('change', (event) => {
-            const filenameRegex = {{ validFilenameRegex }};
-            const five_minutes_in_ms = 5 * 60 * 1000;
-            const now = Date.now();
-            filesSelected = $('#files_selected');
-            filesSelected.addClass('d-none');
+        {% if upload_form is defined and upload_form is not null %}
+        (function() {
+            const formPrefix = '{{ upload_form.vars.id }}';
+            const fileInput = document.getElementById(formPrefix + '_code');
+            if (fileInput) {
+                fileInput.addEventListener('change', (event) => {
+                    const filenameRegex = {{ validFilenameRegex }};
+                    const five_minutes_in_ms = 5 * 60 * 1000;
+                    const now = Date.now();
+                    const filesSelected = $('#files_selected');
+                    filesSelected.addClass('d-none');
 
-            var fileInfoHtml = '';
-            const files = event.target.files;
-            atLeastOneFileRecent = false;
-            for (let file of files) {
-                const date = new Date(file.lastModified);
-                const ago = humanReadableTimeDiff((now - date)/1000) + ' ago';
-                if(date > now - five_minutes_in_ms) {
-                    atLeastOneFileRecent = true;
-                }
-                fileValidChars = file.name.match(filenameRegex);
-                size = humanReadableBytes(file.size);
+                    var fileInfoHtml = '';
+                    const files = event.target.files;
+                    let atLeastOneFileRecent = false;
+                    for (let file of files) {
+                        const date = new Date(file.lastModified);
+                        const ago = humanReadableTimeDiff((now - date)/1000) + ' ago';
+                        if(date > now - five_minutes_in_ms) {
+                            atLeastOneFileRecent = true;
+                        }
+                        const fileValidChars = file.name.match(filenameRegex);
+                        const size = humanReadableBytes(file.size);
 
-                className = '';
-                message = `size ${size}`;
-                message += `, last modified ${ago}`;
-                if(!fileValidChars) {
-                    className = 'bg-danger';
-                    message += ', invalid filename';
-                }
-                if(file.size == 0) {
-                    className = 'bg-warning';
-                    message += ', empty file';
-                }
-                fileInfoHtml += `<li class="${className}"><span class="filename">${file.name}</span> ${message}</li>`;
+                        let className = '';
+                        let message = `size ${size}`;
+                        message += `, last modified ${ago}`;
+                        if(!fileValidChars) {
+                            className = 'bg-danger';
+                            message += ', invalid filename';
+                        }
+                        if(file.size == 0) {
+                            className = 'bg-warning';
+                            message += ', empty file';
+                        }
+                        fileInfoHtml += `<li class="${className}"><span class="filename">${file.name}</span> ${message}</li>`;
+                    }
+                    let result = '<ul>' + fileInfoHtml + '</ul>';
+                    if(!atLeastOneFileRecent) {
+                        result += '<div class="alert alert-warning">None of the selected files have been recently modified</div>';
+                    }
+                    filesSelected.html(result);
+                    filesSelected.removeClass('d-none');
+                });
             }
-            result = '<ul>' + fileInfoHtml + '</ul>';
-            if(!atLeastOneFileRecent) {
-                result += '<div class="alert alert-warning">None of the selected files have been recently modified</div>';
-            }
-            filesSelected.html(result);
-            filesSelected.removeClass('d-none');
-        });
+        })();
+        {% endif %}
     </script>
 </div>

--- a/webapp/tests/Unit/BaseTestCase.php
+++ b/webapp/tests/Unit/BaseTestCase.php
@@ -4,9 +4,9 @@ namespace App\Tests\Unit;
 
 use App\Entity\Role;
 use App\Entity\User;
+use App\Entity\Configuration;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
-use App\Service\EventLogService;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
@@ -201,18 +201,61 @@ abstract class BaseTestCase extends WebTestCase
         mixed $configValue,
         callable $callback
     ): void {
-        $config = self::getContainer()->get(ConfigurationService::class);
-        $eventLog = self::getContainer()->get(EventLogService::class);
-        $dj = self::getContainer()->get(DOMJudgeService::class);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $configService = self::getContainer()->get(ConfigurationService::class);
 
-        // Build up the data to set.
-        $dataToSet = [$configKey => $configValue];
+        // Validate the value against the config specification.
+        $specs = $configService->getConfigSpecification();
+        $errors = [];
+        if (isset($specs[$configKey]) && isset($specs[$configKey]->regex)) {
+            if (preg_match($specs[$configKey]->regex, (string)$configValue) === 0) {
+                $errors[$configKey] = $specs[$configKey]->errorMessage ?? 'This is not a valid value';
+            }
+        }
 
-        // Save the changes.
-        $errors = $config->saveChanges($dataToSet, $eventLog, $dj);
+        // Find or create the configuration entity for this key.
+        $option = $em->getRepository(Configuration::class)->findOneBy(['name' => $configKey]);
+        if ($option === null) {
+            $option = new Configuration();
+            $option->setName($configKey);
+            $em->persist($option);
+        }
+        $oldValue = $option->getValue();
 
-        // Call the callback with the errors.
-        $callback($errors);
+        // Only apply the change if validation passed.
+        if (empty($errors)) {
+            $option->setValue($configValue);
+            $em->flush();
+        }
+
+        // Clear the cached DB values so the new value is picked up.
+        $reflection = new ReflectionClass($configService);
+        $cacheProperty = $reflection->getProperty('dbConfigCache');
+        $cacheProperty->setAccessible(true);
+        $cacheProperty->setValue($configService, null);
+
+        try {
+            $callback($errors);
+        } finally {
+            // Re-fetch the entity manager and config in case the kernel rebooted.
+            $em = self::getContainer()->get(EntityManagerInterface::class);
+            $configService = self::getContainer()->get(ConfigurationService::class);
+            $reflection = new ReflectionClass($configService);
+            $cacheProperty = $reflection->getProperty('dbConfigCache');
+            $cacheProperty->setAccessible(true);
+
+            // Restore the old value.
+            $option = $em->getRepository(Configuration::class)->findOneBy(['name' => $configKey]);
+            if ($option !== null) {
+                if ($oldValue === null) {
+                    $em->remove($option);
+                } else {
+                    $option->setValue($oldValue);
+                }
+                $em->flush();
+            }
+            $cacheProperty->setValue($configService, null);
+        }
     }
 
     protected function verifyPageResponse(

--- a/webapp/tests/Unit/Controller/Team/SubmitPageTest.php
+++ b/webapp/tests/Unit/Controller/Team/SubmitPageTest.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\Team;
+
+use App\Tests\Unit\BaseTestCase;
+
+class SubmitPageTest extends BaseTestCase
+{
+    protected array $roles = ['team'];
+
+    public function testSubmitPageDefaultShowsUploadForm(): void
+    {
+        $this->verifyPageResponse('GET', '/team/submit', 200);
+        $content = $this->client->getResponse()->getContent();
+
+        // Default config has 'upload' only, so upload form should be present
+        static::assertStringContainsString('submit_problem', $content);
+    }
+
+    public function testSubmitPageUploadOnlyHasNoTabs(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200);
+            $crawler = $this->getCurrentCrawler();
+
+            // No tab UI should be present
+            static::assertCount(0, $crawler->filter('#upload-tab-page'));
+            static::assertCount(0, $crawler->filter('#paste-tab-page'));
+        });
+    }
+
+    public function testSubmitPagePasteOnlyShowsPasteForm(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200);
+            $crawler = $this->getCurrentCrawler();
+
+            // Paste form should be present
+            static::assertCount(1, $crawler->filter('form[name="submit_problem_paste"]'));
+            // Upload form should not be present
+            static::assertCount(0, $crawler->filter('form[name="submit_problem"]'));
+            // No file upload input
+            static::assertCount(0, $crawler->filter('#submit_problem_code'));
+        });
+    }
+
+    public function testSubmitPageBothMethodsShowsTabs(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload', 'paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200);
+            $content = $this->client->getResponse()->getContent();
+
+            static::assertStringContainsString('upload-tab-page', $content);
+            static::assertStringContainsString('paste-tab-page', $content);
+            static::assertStringContainsString('Upload File', $content);
+            static::assertStringContainsString('Paste Code', $content);
+        });
+    }
+
+    public function testSubmitPageBothMethodsHasUploadAndPasteForms(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload', 'paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200);
+            $content = $this->client->getResponse()->getContent();
+
+            // Upload form
+            static::assertStringContainsString('submit_problem', $content);
+            // Paste form
+            static::assertStringContainsString('submit_problem_paste', $content);
+        });
+    }
+
+    public function testSubmitModalOnlyHasUploadForm(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload', 'paste'], function (): void {
+            // AJAX request returns the modal
+            $this->verifyPageResponse('GET', '/team/submit', 200, null, true);
+            $content = $this->client->getResponse()->getContent();
+
+            // Modal should have upload form
+            static::assertStringContainsString('submit_problem', $content);
+            // Modal should NOT have paste form (paste is full-page only)
+            static::assertStringNotContainsString('submit_problem_paste_code_content', $content);
+        });
+    }
+
+    public function testSubmitModalPasteOnlyShowsFallbackLink(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200, null, true);
+            $content = $this->client->getResponse()->getContent();
+
+            // Should show fallback message linking to the full page
+            static::assertStringContainsString('full submit page', $content);
+        });
+    }
+
+    public function testSubmitModalBothMethodsShowsPasteTabLink(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload', 'paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team/submit', 200, null, true);
+            $content = $this->client->getResponse()->getContent();
+
+            // Modal should have a tab linking to the paste page
+            static::assertStringContainsString('Paste Code', $content);
+            static::assertStringContainsString('tab=paste', $content);
+        });
+    }
+
+    public function testMenuShowsUploadModalWhenUploadEnabled(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload'], function (): void {
+            $this->verifyPageResponse('GET', '/team', 200);
+            $content = $this->client->getResponse()->getContent();
+
+            static::assertStringContainsString('data-ajax-modal', $content);
+        });
+    }
+
+    public function testMenuShowsBothSubmitButtonsWhenBothMethodsEnabled(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['upload', 'paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team', 200);
+            $crawler = $this->getCurrentCrawler();
+
+            // Modal button (default, visible)
+            static::assertCount(1, $crawler->filter('#submit-btn-modal'));
+            // Paste direct link (hidden by default, shown via JS when cookie is set)
+            static::assertCount(1, $crawler->filter('#submit-btn-paste'));
+        });
+    }
+
+    public function testMenuShowsDirectLinkWhenPasteOnly(): void
+    {
+        $this->withChangedConfiguration('submit_methods', ['paste'], function (): void {
+            $this->verifyPageResponse('GET', '/team', 200);
+            $content = $this->client->getResponse()->getContent();
+
+            // Should link directly to submit page, not use modal
+            $crawler = $this->getCurrentCrawler();
+            $submitLinks = $crawler->filter('a[href*="team/submit"]');
+            static::assertGreaterThan(0, $submitLinks->count());
+
+            // Should NOT have modal trigger
+            $modalLinks = $crawler->filter('a[data-ajax-modal][href*="team/submit"]');
+            static::assertCount(0, $modalLinks);
+        });
+    }
+}


### PR DESCRIPTION
The filename of the uploaded file is derived from the problem letter and language.
If the language specifies an entry point, it is derived from the derived filename.

The syntax highlighting is done according to the selected language.

The last submit method (upload vs paste/online editor) is remembered and selected for future submits.

The online editor is a full screen page, the upload stays a modal.

----

Example screenshots:

<img width="1037" height="752" alt="image" src="https://github.com/user-attachments/assets/e1e4794d-96de-47b9-b7f2-7fe2c4904895" />


<img width="2255" height="349" alt="image" src="https://github.com/user-attachments/assets/7bedc515-9747-464c-8c0c-f5fa392b3597" />



