### PR TITLE
Improve jury/languages page.

### DIFF
--- a/webapp/src/Controller/Jury/LanguageController.php
+++ b/webapp/src/Controller/Jury/LanguageController.php
@@ -50,15 +50,35 @@ class LanguageController extends BaseController
             ->from(Language::class, 'lang')
             ->orderBy('lang.name', 'ASC')
             ->getQuery()->getResult();
+        $hasNonDefaultTimefactor = false;
+        $hasEntryPoint = false;
+        foreach ($languages as $lang) {
+            if ($lang->getTimeFactor() != 1) {
+                $hasNonDefaultTimefactor = true;
+            }
+            if ($lang->getRequireEntryPoint()) {
+                $hasEntryPoint = true;
+            }
+            if ($hasNonDefaultTimefactor && $hasEntryPoint) {
+                break;
+            }
+        }
+
         $table_fields = [
             'externalid' => ['title' => 'ID', 'sort' => true],
             'name' => ['title' => 'name', 'sort' => true, 'default_sort' => true],
-            'entrypoint' => ['title' => 'entry point', 'sort' => true],
+            'allowsubmit' => ['title' => 'allow submit', 'sort' => true],
             'allowjudge' => ['title' => 'allow judge', 'sort' => true],
-            'timefactor' => ['title' => 'timefactor', 'sort' => true],
-            'extensions' => ['title' => 'extensions', 'sort' => true],
-            'executable' => ['title' => 'executable', 'sort' => true],
         ];
+        if ($hasEntryPoint) {
+            $table_fields['entrypoint'] = ['title' => 'entry point', 'sort' => true];
+            $table_fields['entrypointdescription'] = ['title' => 'entry point description', 'sort' => true];
+        }
+        if ($hasNonDefaultTimefactor) {
+            $table_fields['timefactor'] = ['title' => 'timefactor', 'sort' => true];
+        }
+        $table_fields['extensions'] = ['title' => 'extensions', 'sort' => true];
+        $table_fields['executable'] = ['title' => 'executable', 'sort' => true];
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $enabled_languages  = [];
@@ -93,6 +113,15 @@ class LanguageController extends BaseController
 
             $executable = $lang->getCompileExecutable();
 
+            $allowSubmitOptions = [
+                'toggle_partial' => 'language_toggle.html.twig',
+                'partial_arguments' => [
+                    'path' => 'jury_language_toggle_submit',
+                    'language' => $lang,
+                    'value' => $lang->getAllowSubmit(),
+                ],
+            ];
+
             $allowJudgeOptions = [
                 'toggle_partial' => 'language_toggle.html.twig',
                 'partial_arguments' => [
@@ -108,8 +137,8 @@ class LanguageController extends BaseController
 
             // Merge in the rest of the data.
             $langdata = array_merge($langdata, [
-                'entrypoint' => ['value' => $lang->getRequireEntryPoint() ? 'yes' : 'no'],
-                'extensions' => ['value' => implode(', ', $lang->getExtensions())],
+                'allowsubmit' => $allowSubmitOptions,
+                'extensions' => ['value' => implode(', ', $lang->getExtensions()), 'cssclass' => 'font-monospace'],
                 'allowjudge' => $allowJudgeOptions,
                 'executable' => [
                     'value' => $executable === null ? '-' : $executable->getShortDescription(),
@@ -119,6 +148,22 @@ class LanguageController extends BaseController
                     'showlink' => true,
                     ],
             ]);
+
+            if ($hasEntryPoint) {
+                $langdata['entrypoint'] = [
+                    'toggle_partial' => 'language_toggle.html.twig',
+                    'partial_arguments' => [
+                        'path' => 'jury_language_toggle_require_entry_point',
+                        'language' => $lang,
+                        'value' => $lang->getRequireEntryPoint(),
+                    ],
+                ];
+                $langdata['entrypointdescription'] = [
+                    'value' => $lang->getRequireEntryPoint() && $lang->getEntryPointDescription()
+                        ? $lang->getEntryPointDescription()
+                        : '',
+                ];
+            }
 
             if ($lang->getAllowSubmit()) {
                 $enabled_languages[] = [
@@ -222,7 +267,7 @@ class LanguageController extends BaseController
     }
 
     #[Route(path: '/{langId}/toggle-submit', name: 'jury_language_toggle_submit')]
-    public function toggleSubmitAction(Request $request, string $langId): Response
+    public function toggleSubmitAction(RouterInterface $router, Request $request, string $langId): Response
     {
         $language = $this->em->getRepository(Language::class)->findByExternalId($langId);
         if (!$language) {
@@ -234,7 +279,11 @@ class LanguageController extends BaseController
 
         $this->dj->auditlog('language', $language->getExternalid(), 'set allow submit',
                                          $request->request->getBoolean('value') ? 'yes' : 'no');
-        return $this->redirectToRoute('jury_language', ['langId' => $langId]);
+        return $this->redirectToLocalReferrer(
+            $router,
+            $request,
+            $this->generateUrl('jury_language', ['langId' => $langId])
+        );
     }
 
     #[Route(path: '/{langId}/toggle-judge', name: 'jury_language_toggle_judge')]
@@ -283,7 +332,7 @@ class LanguageController extends BaseController
     }
 
     #[Route(path: '/{langId}/toggle-require-entry-point', name: 'jury_language_toggle_require_entry_point')]
-    public function toggleRequireEntryPointAction(Request $request, string $langId): Response
+    public function toggleRequireEntryPointAction(RouterInterface $router, Request $request, string $langId): Response
     {
         $language = $this->em->getRepository(Language::class)->findByExternalId($langId);
         if (!$language) {
@@ -296,7 +345,11 @@ class LanguageController extends BaseController
 
         $this->dj->auditlog('language', $language->getExternalid(), 'set require entry point',
             $enabled ? 'yes' : 'no');
-        return $this->redirectToRoute('jury_language', ['langId' => $langId]);
+        return $this->redirectToLocalReferrer(
+            $router,
+            $request,
+            $this->generateUrl('jury_language', ['langId' => $langId])
+        );
     }
 
     #[IsGranted('ROLE_ADMIN')]

--- a/webapp/templates/jury/analysis/languages.html.twig
+++ b/webapp/templates/jury/analysis/languages.html.twig
@@ -69,7 +69,7 @@
                         <i class="fas fa-check fa-fw"></i> {{ language.solved }} submission{% if language.solved != 1 %}s{% endif %} solved problems
                         for {{ language.problems_solved_count }} problem{% if language.problems_solved_count != 1 %}s{% endif %}:<br/>
                         {% for problem in problems %}
-                            <a href="{{ path('jury_problem', {'probId': problem.probid}) }}">
+                            <a href="{{ path('jury_problem', {'probId': problem.externalid}) }}">
                                 {{ problem | problemBadge(language.problems_solved[problem.probid] is not defined) }}
                             </a>
                         {% endfor %}

--- a/webapp/templates/jury/jury_macros.twig
+++ b/webapp/templates/jury/jury_macros.twig
@@ -179,6 +179,7 @@
                 {%- elseif row.link is defined and not item.toggle_partial is defined %}<a href="{{ row.link }}">{% endif %}
                 {% if item.toggle_partial is defined %}
                     {% include 'jury/partials/' ~ item.toggle_partial with item.partial_arguments %}
+                    {% if item.suffix is defined and item.suffix %} {{ item.suffix }}{% endif %}
                 {% elseif key == "status" %}
                     {{- (item.value|default(item.default|default('')))|statusIcon -}}
                 {% elseif key == "country" %}

--- a/webapp/templates/jury/languages.html.twig
+++ b/webapp/templates/jury/languages.html.twig
@@ -22,11 +22,13 @@
 
     {{ macros.table(disabled_languages, table_fields) }}
 
-    {% if is_granted('ROLE_ADMIN') %}
-        <p>
+    <p>
+        {% if is_granted('ROLE_ADMIN') %}
             {{ button(path('jury_language_add'), 'Add new language', 'primary', 'plus') }}
-        </p>
-    {% endif %}
+        {% endif %}
+        {{ button(path('jury_versions'), 'Compiler/runner versions', 'outline-secondary', 'server') }}
+        {{ button(path('analysis_languages'), 'Language analysis', 'outline-secondary', 'chart-bar') }}
+    </p>
 
 {% endblock %}
 

--- a/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/LanguagesControllerTest.php
@@ -14,7 +14,7 @@ class LanguagesControllerTest extends JuryControllerTestCase
     protected static string  $identifyingEditAttribute = 'name';
     protected static ?string $defaultEditEntityName    = 'Java';
     protected static string  $baseUrl                  = '/jury/languages';
-    protected static array   $exampleEntries           = ['c', 'csharp', 'Haskell', 'Bash shell', "pas, p", 'no', 'yes', 'R', 'r'];
+    protected static array   $exampleEntries           = ['c', 'csharp', 'Haskell', 'Bash shell', "pas, p", 'R', 'r'];
     protected static string  $shortTag                 = 'language';
     protected static array   $deleteEntities           = ['C++','C#','C','Kotlin'];
     protected static string  $deleteEntityIdentifier   = 'name';


### PR DESCRIPTION
- Add links to compiler/runner version overview, lang stats pages
- Add more direct toggles
- Remove time factor column if all langs use the time factor of 1 (default)
- Inline entry point field description
- Make extensions code font

-------

Before:
<img width="1430" height="1046" alt="image" src="https://github.com/user-attachments/assets/552c69a0-00b1-4856-b3f7-0d70930c2e8f" />


After:
<img width="1483" height="1104" alt="image" src="https://github.com/user-attachments/assets/971e547d-b361-4154-9ef8-0b56b20ccb2f" />

