### PR TITLE
Make webstandard errors on CI more useful.

### DIFF
--- a/.github/jobs/jsontogha.py
+++ b/.github/jobs/jsontogha.py
@@ -1,14 +1,21 @@
+import argparse
 import json
 import sys
 import time
 import hashlib
 import os
 
+parser = argparse.ArgumentParser()
+parser.add_argument('input', help='JSON file to process')
+parser.add_argument('--summary-file', help='Write a concise error summary to this file')
+args = parser.parse_args()
+
 storage1 = {}
 storage2 = {}
 
 # Get the base directory to make file paths relative
 base_dir = os.getcwd()
+summary_lines = []
 
 
 def cleanHash(toHash):
@@ -23,7 +30,7 @@ def sec_end(job):
     print('section_end\r\033[0K')
 
 
-with open(sys.argv[1], 'r') as f:
+with open(args.input, 'r') as f:
     data = json.load(f)
     # Handle both vnu format {"messages": [...]} and pa11y format [...]
     if isinstance(data, dict) and 'messages' in data:
@@ -47,7 +54,9 @@ with open(sys.argv[1], 'r') as f:
             file_path = os.path.relpath(file_path, base_dir)
 
         # Emit GNU-style error for standard logs
-        print(f"{file_path}:{line}.{col}: {mtyp}: {mmes}")
+        gnu_line = f"{file_path}:{line}.{col}: {mtyp}: {mmes}"
+        print(gnu_line)
+        summary_lines.append(gnu_line)
 
         # Emit GHA error annotation
         if mtyp == 'error':
@@ -72,6 +81,10 @@ with open(sys.argv[1], 'r') as f:
         storage2[mtyp]["urls"][murl]["messages"][mmes] += 1
         storage2[mtyp]["urls"][murl]["cnt"] += 1
         storage2[mtyp]["cnt"] += 1
+
+if args.summary_file and summary_lines:
+    with open(args.summary_file, 'w') as sf:
+        sf.write('\n'.join(summary_lines) + '\n')
 
 for key, value in sorted(storage1.items(), key=lambda x: x[1]['cnt']):
     print("Type:  {}, Totalfound:  {}".format(key, value["cnt"]))

--- a/.github/jobs/webstandard.sh
+++ b/.github/jobs/webstandard.sh
@@ -116,16 +116,18 @@ w3c_analyse () {
         # shellcheck disable=SC2086
         "$DIR"/vnu-runtime-image/bin/vnu --errors-only --exit-zero-always --skip-non-$typ --format json $FLTR "$URL" 2> result.json
 
-        # Count errors from JSON
+        # Count errors from JSON and produce gnu-format log
         NEWFOUNDERRORS=$(python3 -c "import json; print(len(json.load(open('result.json'))['messages']))")
         FOUNDERR=$((NEWFOUNDERRORS+FOUNDERR))
 
         python3 -m "json.tool" < result.json > "$ARTIFACTS/w3c$typ$URL${LOGID}.json"
-        trace_off; python3 .github/jobs/jsontogha.py "$ARTIFACTS/w3c$typ$URL${LOGID}.json"; trace_on
+        SUMMARYFILE="$ARTIFACTS/w3c_${typ}_${URL}_${LOGID}_summary.log"
+        trace_off; python3 .github/jobs/jsontogha.py --summary-file "$SUMMARYFILE" "$ARTIFACTS/w3c$typ$URL${LOGID}.json"; trace_on
         section_end
 
         if [ "$NEWFOUNDERRORS" -gt 0 ]; then
             echo "::error::$typ validation ($LOGID): found $NEWFOUNDERRORS error(s)"
+            cat "$SUMMARYFILE"
         else
             echo "$typ validation ($LOGID): OK"
         fi
@@ -185,11 +187,13 @@ else
 
         LOGNAME=$(echo "$file" | tr '/' '_')
         cp result.json "$ARTIFACTS/pa11y_${LOGNAME}.json"
-        trace_off; python3 .github/jobs/jsontogha.py result.json; trace_on
+        SUMMARYFILE="$ARTIFACTS/pa11y_${LOGNAME}_summary.log"
+        trace_off; python3 .github/jobs/jsontogha.py --summary-file "$SUMMARYFILE" result.json; trace_on
         section_end
 
         if [ "$NEWFOUNDERRORS" -gt 0 ]; then
             echo "::error::pa11y found $NEWFOUNDERRORS error(s) in $file"
+            cat "$SUMMARYFILE"
         fi
     done
 fi


### PR DESCRIPTION
This helps understanding the error without downloading the logs in many cases.