### PR TITLE
Add notifications for submissions.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -666,7 +666,7 @@ function toggleRefresh($url, $after, usingAjax) {
     $('#refresh-toggle').text(text);
 }
 
-function updateClarifications()
+function updateTeamNotifications()
 {
     $.ajax({
         url: $('#menuDefault').data('update-url'),
@@ -675,13 +675,31 @@ function updateClarifications()
         if (jqXHR.getResponseHeader('X-Login-Page')) {
             window.location = jqXHR.getResponseHeader('X-Login-Page');
         } else {
-            let data = json['unread_clarifications'];
-            let num = data.length;
-            for (let i = 0; i < num; i++) {
+            let clarData = json['unread_clarifications'];
+            if (clarData) for (let i = 0; i < clarData.length; i++) {
                 sendNotification('New clarification',
-                 {'tag': 'clar_' + data[i].clarid,
-                        'link': domjudge_base_url + '/team/clarifications/'+data[i].clarid,
-                        'body': data[i].body });
+                 {'tag': 'clar_' + clarData[i].clarid,
+                        'link': domjudge_base_url + '/team/clarifications/'+clarData[i].clarid,
+                        'body': clarData[i].body });
+            }
+
+            let subData = json['unread_submissions'];
+            if (subData) {
+                for (let i = 0; i < subData.length; i++) {
+                    let agoText = '';
+                    if (subData[i].submittime) {
+                        let secsAgo = Math.floor(Date.now() / 1000 - subData[i].submittime);
+                        if (secsAgo < 60) {
+                            agoText = ' (submitted ' + secsAgo + ' seconds ago)';
+                        } else {
+                            agoText = ' (submitted ' + Math.floor(secsAgo / 60) + ' minutes ago)';
+                        }
+                    }
+                    sendNotification('Submission judged: ' + subData[i].result,
+                     {'tag': 'c' + subData[i].cid + '_sub_' + subData[i].submitid + '_judge_' + subData[i].judgingid,
+                            'link': domjudge_base_url + '/team/submission/' + subData[i].submitid,
+                            'body': 'Problem ' + subData[i].probname + ': ' + subData[i].result + agoText });
+                }
             }
         }
     })

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -147,7 +147,10 @@ class MiscController extends BaseController
     #[Route(path: '/updates', name: 'team_ajax_updates', methods: ['GET'])]
     public function updatesAction(): JsonResponse
     {
-        return $this->json(['unread_clarifications' => $this->dj->getUnreadClarifications()]);
+        return $this->json([
+            'unread_clarifications' => $this->dj->getUnreadClarifications(),
+            'unread_submissions' => $this->dj->getJudgingNotifications(),
+        ]);
     }
 
     #[Route(path: '/change-contest/{contestId}', name: 'team_change_contest')]

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -358,6 +358,43 @@ class DOMJudgeService
     }
 
     /**
+     * @return list<array{submitid: int, judgingid: int, cid: int, result: string, probname: string, submittime: float}>
+     */
+    public function getJudgingNotifications(): array
+    {
+        $user    = $this->getUser();
+        $team    = $user->getTeam();
+        if ($team === null) {
+            return [];
+        }
+        $contest = $this->getCurrentContest($team->getTeamId());
+        if ($contest === null) {
+            return [];
+        }
+
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('s.submitid', 'j.judgingid', 'IDENTITY(s.contest) AS cid', 'j.result', 'p.name AS probname', 's.submittime')
+            ->from(Judging::class, 'j')
+            ->join('j.submission', 's')
+            ->join('s.contest_problem', 'cp')
+            ->join('cp.problem', 'p')
+            ->andWhere('j.valid = true')
+            ->andWhere('j.result IS NOT NULL')
+            ->andWhere('j.endtime > :since')
+            ->andWhere('s.team = :team')
+            ->andWhere('s.contest = :contest')
+            ->setParameter('since', time() - 10 * 60)
+            ->setParameter('team', $team)
+            ->setParameter('contest', $contest);
+
+        if ($this->config->get('verification_required')) {
+            $queryBuilder->andWhere('j.verified = 1');
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
      * @return array{clarifications: array<array{clarid: int, body: string}>,
      *               judgehosts: array<array{hostname: string, polltime: float}>,
      *               rejudgings: array<array{rejudgingid: int, starttime: string, endtime: string|float}>,

--- a/webapp/templates/team/base.html.twig
+++ b/webapp/templates/team/base.html.twig
@@ -43,8 +43,8 @@
                     $('#notify_disable').removeClass('d-none');
                 }
             }
-            updateClarifications();
-            setInterval(updateClarifications, 20000);
+            updateTeamNotifications();
+            setInterval(updateTeamNotifications, 20000);
         });
 
     </script>


### PR DESCRIPTION
Compared to #3018, this PR has the following relevant changes:
- no filter on j.seen = 0 which has a different meaning
- scalar query to avoid hydrating full entities
- include problem name in the notification to increase usefulness