### PR TITLE
Remove useless sleep in runguard.

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -100,7 +100,6 @@ const int soft_timelimit = 1;
 const int hard_timelimit = 2;
 
 const struct timespec killdelay = { 0, 100000000L }; /* 0.1 seconds */
-const struct timespec cg_delete_delay = { 0, 10000000L }; /* 0.01 seconds */
 
 extern int verbose;
 
@@ -584,10 +583,19 @@ void cgroup_delete()
 	if ( cpuset!=nullptr && strlen(cpuset)>0 ) {
 		if ( cgroup_add_controller(cg, "cpuset")==nullptr ) die(0,"cgroup_add_controller cpuset");
 	}
-	/* Clean up our cgroup */
-	nanosleep(&cg_delete_delay,nullptr);
-	int ret = cgroup_delete_cgroup_ext(cg, CGFLAG_DELETE_IGNORE_MIGRATION | CGFLAG_DELETE_RECURSIVE);
-	// TODO: is this actually benign to ignore ECGOTHER here?
+	/* Clean up our cgroup. Try immediately; if the kernel hasn't
+	   finished cleaning up yet, retry with short sleeps. */
+	const struct timespec retry_delay = { 0, 1000000L }; /* 1ms */
+	const int max_retries = 10;
+	int ret;
+	for (int attempt = 0; attempt <= max_retries; attempt++) {
+		if (attempt > 0) nanosleep(&retry_delay, nullptr);
+		ret = cgroup_delete_cgroup_ext(cg, CGFLAG_DELETE_IGNORE_MIGRATION | CGFLAG_DELETE_RECURSIVE);
+		if (ret == 0 || ret == ECGOTHER) break;
+		if (attempt < max_retries) {
+			logmsg(LOG_DEBUG, "cgroup delete attempt {} failed ({}), retrying...", attempt + 1, ret);
+		}
+	}
 	if ( ret!=0 && ret!=ECGOTHER ) die(ret,"deleting cgroup");
 
 	cgroup_free(&cg);


### PR DESCRIPTION
This drastically reduces cgroup deletion overhead by replacing the previously unconditional sleep with retry loop and a much shorter sleep.

We were previously sleeping as a safety margin for kernel cleanup, but `cgroup_kill()` already ensures all processes are dead.

Try the delete immediately; only sleep `1ms` and retry (up to 10 times) if it fails transiently.

On a NWERC problem, for a submission with neglible runtime and 178 test cases we see a speed up of ~1.5.

Detailed data on 10 runs each:

```
  ┌─────────┬──────────────────────┬──────────────────────┐
  │ Run     │ Before               │ After                │
  ├─────────┼──────────────────────┼──────────────────────┤
  │ 1       │ 15.0005 s            │ 9.8359 s             │
  │ 2       │ 14.5482 s            │ 9.6929 s             │
  │ 3       │ 14.8524 s            │ 9.9222 s             │
  │ 4       │ 15.2142 s            │ 9.6892 s             │
  │ 5       │ 14.9637 s            │ 9.5744 s             │
  │ 6       │ 14.9070 s            │ 9.4608 s             │
  │ 7       │ 14.6514 s            │ 8.9538 s             │
  │ 8       │ 14.4622 s            │ 9.6721 s             │
  │ 9       │ 14.5102 s            │ 9.5694 s             │
  │ 10      │ 14.3839 s            │ 9.7593 s             │
  │ Average │ 14.7494 s            │ 9.6130 s             │
  └─────────┴──────────────────────┴──────────────────────┘
```