### PR TITLE
Remove more forks from the judgedaemon

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1079,6 +1079,36 @@ class JudgeDaemon
     }
 
     /**
+     * Recursively hardlink all entries from $src directory into $dst directory.
+     * Preserves symlinks (no dereference) and recreates subdirectories.
+     */
+    private function hardlinkRecursive(string $src, string $dst): void
+    {
+        foreach (scandir($src) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $srcPath = "$src/$entry";
+            $dstPath = "$dst/$entry";
+            if (is_link($srcPath)) {
+                $target = readlink($srcPath);
+                if (!symlink($target, $dstPath)) {
+                    error("Could not symlink '$srcPath' to '$dstPath'");
+                }
+            } elseif (is_dir($srcPath)) {
+                if (!mkdir($dstPath, 0755, true)) {
+                    error("Could not create directory '$dstPath'");
+                }
+                $this->hardlinkRecursive($srcPath, $dstPath);
+            } else {
+                if (!link($srcPath, $dstPath)) {
+                    error("Could not hardlink '$srcPath' to '$dstPath'");
+                }
+            }
+        }
+    }
+
+    /**
      * @param string[] $command_parts
      * @param int|DONT_CARE $retval
      */
@@ -2350,15 +2380,12 @@ class JudgeDaemon
             // Copy program with all possible additional files to testcase
             // dir. Use hardlinks to preserve space with big executables.
             $programdir = $passdir . '/execdir';
-            if (!$this->runCommandSafe(['mkdir', '-p', $programdir])) {
+            if (!mkdir($programdir, 0755, true)) {
                 error("Could not create directory '$programdir'");
             }
 
-            foreach (glob("$workdir/compile/*") as $compile_file) {
-                if (!$this->runCommandSafe(['cp', '-PRl', $compile_file, $programdir])) {
-                    error("Could not copy program to '$programdir'");
-                }
-            }
+            // Use PHP-native hardlinks instead of forking 'cp -PRl' per file.
+            $this->hardlinkRecursive("$workdir/compile", $programdir);
 
             $verdict = $this->testcaseRunInternal(
                 $input,


### PR DESCRIPTION
Forking is expensive, in particular if all we are doing is doing
syscalls.
    
On a NWERC problem, for a submission with neglible runtime and 178 test
cases we see a speed up of ~1.1.
    
Detailed data on 10 runs each:
    
 ```
     ┌─────────┬──────────────────┬─────────────────┐
     │ Run     │ Before (#3536)   │ After (this)    │
     ├─────────┼──────────────────┼─────────────────┤
     │ 1       │ 9.8359 s         │ 8.4377 s        │
     │ 2       │ 9.6929 s         │ 8.8294 s        │
     │ 3       │ 9.9222 s         │ 8.3613 s        │
     │ 4       │ 9.6892 s         │ 8.5255 s        │
     │ 5       │ 9.5744 s         │ 9.0087 s        │
     │ 6       │ 9.4608 s         │ 8.9731 s        │
     │ 7       │ 8.9538 s         │ 8.4106 s        │
     │ 8       │ 9.6721 s         │ 8.4514 s        │
     │ 9       │ 9.5694 s         │ 8.5090 s        │
     │ 10      │ 9.7593 s         │ 8.4230 s        │
     │ Average │ 9.6130 s         │ 8.5930 s        │
     └─────────┴──────────────────┴─────────────────┘
```
    
Total speedup including #3536: 1.7x
