### PR TITLE
Speed up our E2E tests.

### DIFF
--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -48,14 +48,19 @@ class ControllerRolesTraversalTest extends BaseTestCase
      */
     protected function roleCombinations(array $start_roles, array $possible_roles): array
     {
-        // Initialize by adding the empty set.
+        // Base roles alone.
         $results = [$start_roles];
 
+        // Base roles + each optional role individually.
         foreach ($possible_roles as $element) {
-            foreach ($results as $combination) {
-                $results[] = [$element, ...$combination];
-            }
+            $results[] = [$element, ...$start_roles];
         }
+
+        // Base roles + all optional roles together.
+        if (count($possible_roles) > 1) {
+            $results[] = [...$possible_roles, ...$start_roles];
+        }
+
         return $results;
     }
 


### PR DESCRIPTION
... by reducing role combinations from `2^n` to `n+2`.

Replace power set expansion in `roleCombinations()` with targeted sampling (`1 + n + 1 = n+2`):
- base roles alone,
- base + each optional individually,
- and base + all optionals together.

This cuts total combinations drastically for our typical cases and should speed up this test significantly.

Note that this does lose a little bit of test coverage, but the likelihood that two roles interfere in isolation but not in the full combination is basically 0.