### PR TITLE
Speed up ControllerRolesTraversalTest.

### DIFF
--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -121,9 +121,6 @@ class ControllerRolesTraversalTest extends BaseTestCase
         foreach ($tmp as $possUrl) {
             if (!$this->urlExcluded($possUrl, $skip)) {
                 $ret[] = $possUrl;
-                if (!str_contains($possUrl, '#')) {
-                    $ret[] = $possUrl.'#';
-                }
             }
         }
         return $ret;


### PR DESCRIPTION
We crawled every URL twice, once by adding `#`. While probably well intended, this does nothing in Symfony, resulting in a lot of unnecessary work.

Verified by applying this diff:

```
--- a/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
+++ b/webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php
@@ -95,6 +95,15 @@ class ControllerRolesTraversalTest extends BaseTestCase
             self::fail('The URL should already have been filtered away.');
         }
         $crawler = $this->client->request('GET', $url);
+        if (str_ends_with($url, '#')) {
+            fwrite(STDERR, sprintf(
+                "DEBUG # URL: input=%s requestUri=%s pathInfo=%s\n",
+                $url,
+                $this->client->getRequest()->getRequestUri(),
+                $this->client->getRequest()->getPathInfo()
+            ));
+        }
+
         $response = $this->client->getResponse();
         if (($statusCode === 403 || $statusCode === 401) && $response->isRedirection()) {
             self::assertEquals($response->headers->get('location'), $this::$loginURL);
```

and then running `phpunit`:
```
$ php webapp/vendor/bin/phpunit -c webapp/phpunit.xml.dist --filter="testRoleAccess" webapp/tests/E2E/Controller/ControllerRolesTraversalTest.php

PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

Testing App\Tests\E2E\Controller\ControllerRolesTraversalTest
DEBUG # URL: input=/jury# requestUri=/jury pathInfo=/jury
DEBUG # URL: input=/jury/judgehosts# requestUri=/jury/judgehosts pathInfo=/jury/judgehosts
DEBUG # URL: input=/jury/internal-errors# requestUri=/jury/internal-errors pathInfo=/jury/internal-errors
DEBUG # URL: input=/jury/clarifications# requestUri=/jury/clarifications pathInfo=/jury/clarifications
DEBUG # URL: input=/jury/submissions# requestUri=/jury/submissions pathInfo=/jury/submissions
DEBUG # URL: input=/jury/rejudgings# requestUri=/jury/rejudgings pathInfo=/jury/rejudgings
...
```