### PR TITLE
Fix judgedaemon time logging.

### DIFF
--- a/lib/lib.error.php
+++ b/lib/lib.error.php
@@ -48,7 +48,7 @@ function logmsg(int $msglevel, string $string): void
     // Trim $string to reasonable length
     $string = substr($string, 0, 10000);
 
-    $msec = sprintf("%03d", (int)(explode(' ', microtime()))[0]*1000);
+    $msec = sprintf("%03d", (float)(explode(' ', microtime()))[0]*1000);
     $stamp = "[" . date('M d H:i:s') . ".$msec] " . SCRIPT_ID .
         (function_exists('posix_getpid') ? "[" . posix_getpid() . "]" : "") .
         ": ";


### PR DESCRIPTION
Commit 8171b16a9 broke things, after which times were logged at second granularity, e.g.

```
$ judge/judgedaemon -n 0
[Mar 14 21:35:55.000] judgedaemon[1276234]: Judge started on goo-0 [DOMjudge/10.0.0DEV/df498521d]
[Mar 14 21:35:55.000] judgedaemon[1276234]: 🔏 Executing chroot script: 'chroot-startstop.sh check'
[Mar 14 21:35:55.000] judgedaemon[1276234]: Registering judgehost on endpoint default: http://localhost/domjudge/api
[Mar 14 21:35:56.000] judgedaemon[1276234]: ⇝ Received 7 'judging_run' judge tasks (endpoint default)
[Mar 14 21:35:56.000] judgedaemon[1276234]:   Working directory: /home/sitowert/domjudge/output/judgings/goo-0/endpoint-default/1/1
[Mar 14 21:35:56.000] judgedaemon[1276234]:   🔒 Executing chroot script: 'chroot-startstop.sh start'
[Mar 14 21:35:56.000] judgedaemon[1276234]:   📋 Verifying versions.
[Mar 14 21:35:56.000] judgedaemon[1276234]:   💾 Fetching new executable 'compile/20' with hash '4e301e4bc46ab73673e209ee3437707d'.
[Mar 14 21:35:57.000] judgedaemon[1276234]:   💻 Compilation: (addone-medium-only.py) 'correct'
[Mar 14 21:35:57.000] judgedaemon[1276234]:   🏃 Running testcase 1...
...
```

After this fix, we are back to normal:
```
judge/judgedaemon -n 0
[Mar 14 21:38:19.244] judgedaemon[1291523]: Judge started on goo-0 [DOMjudge/10.0.0DEV/df498521d]
[Mar 14 21:38:19.244] judgedaemon[1291523]: 🔏 Executing chroot script: 'chroot-startstop.sh check'
[Mar 14 21:38:19.259] judgedaemon[1291523]: Registering judgehost on endpoint default: http://localhost/domjudge/api
[Mar 14 21:38:19.487] judgedaemon[1291523]: No submissions in queue (for endpoint default), waiting...
```