### PR TITLE
Make handling of booleans in config more consistent.

### DIFF
--- a/webapp/src/Entity/Configuration.php
+++ b/webapp/src/Entity/Configuration.php
@@ -47,13 +47,6 @@ class Configuration
 
     public function setValue(mixed $value): Configuration
     {
-        // Do not use 'True'/'False' but 1/0 since the former cannot be parsed by the old code.
-        if ($value === true) {
-            $value = 1;
-        } elseif ($value === false) {
-            $value = 0;
-        }
-
         $this->value = $value;
         return $this;
     }

--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -102,6 +102,10 @@ class ConfigurationService
             }
             // $result[$name] exists iff it should be visible.
             if (isset($result[$name])) {
+                // Cast legacy 0/1 values to proper booleans for bool-typed configs.
+                if (isset($specs[$name]) && $specs[$name]->type === 'bool') {
+                    $value = (bool)$value;
+                }
                 $result[$name] = $value;
             }
         }

--- a/webapp/tests/Unit/Service/ConfigurationServiceTest.php
+++ b/webapp/tests/Unit/Service/ConfigurationServiceTest.php
@@ -191,7 +191,7 @@ class ConfigurationServiceTest extends KernelTestCase
 
     public function provideConfigFromDatabase(): Generator
     {
-        yield ['compile_penalty', true, 1];
+        yield ['compile_penalty', true];
         yield ['results_prio', ['no-output' => 37, 'correct' => 1]];
         yield ['clar_categories', ['Category 1', 'Category 2']];
         yield ['show_compile', 1];


### PR DESCRIPTION
When using the api/config endpoint, we previously saw a mix of 0/1 and false/true values, depending on whether they were default or changed.

After this change, we should only see `false`/`true` for booleans.