### PR TITLE
Cache config specifications to avoid repeated file loads.

### DIFF
--- a/webapp/src/Service/ConfigurationService.php
+++ b/webapp/src/Service/ConfigurationService.php
@@ -27,6 +27,9 @@ class ConfigurationService
     /** @var array<string, array<string, string>> $dbConfigCache */
     protected ?array $dbConfigCache = null;
 
+    /** @var array<string, ConfigurationSpecification>|null */
+    private ?array $specCache = null;
+
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly LoggerInterface $logger,
@@ -116,6 +119,10 @@ class ConfigurationService
      */
     public function getConfigSpecification(): array
     {
+        if ($this->specCache !== null) {
+            return $this->specCache;
+        }
+
         // We use Symfony resource caching so we can load the config on every
         // request without having a performance impact.
         // See https://symfony.com/doc/4.3/components/config/caching.html for
@@ -150,7 +157,7 @@ EOF;
                 // @codeCoverageIgnoreEnd
             });
 
-        return array_map(
+        return $this->specCache = array_map(
             ConfigurationSpecification::fromArray(...),
             require $cacheFile
         );


### PR DESCRIPTION
Micro-benchmarking showed that this is ~3000 times faster than before, and since we have multiple config heavy code paths (like scoreboard, judging) it is worth optimizing to reduce overall server load.

Mentioned in https://403f.cafe/p/icpc-2025-regional-review/ as optimization opportunity.