### PR TITLE
Speed up problems page, in particular the problems heatmap.

### DIFF
--- a/webapp/src/Service/StatisticsService.php
+++ b/webapp/src/Service/StatisticsService.php
@@ -417,14 +417,37 @@ class StatisticsService
             'problems' => [],
             'numBuckets' => static::NUM_GROUPED_BINS,
         ];
-        // Get a whole bunch of judgings (and related objects).
-        // Where:
-        //   - The judging is valid
-        //   - The judging submission is part of the selected contest
-        //   - The judging submission matches the problem we're analyzing
-        //   - The submission was made by a team in a visible category
-        $judgingsQueryBuilder = $this->em->createQueryBuilder()
-            ->select('COUNT(j) AS count, p.probid')
+
+        // Determine the bins to use.
+        $contestStart = $contest->getStarttime(false);
+        $duration = $contest->getEndtime() - $contestStart;
+        $binDuration = round($duration / static::NUM_GROUPED_BINS, 0);
+
+        // Pre-compute bin boundaries.
+        $binStarts = [];
+        $binEnds = [];
+        for ($bin = 0; $bin < static::NUM_GROUPED_BINS; $bin++) {
+            $binStarts[$bin] = new DateTime(Utils::absTime($contestStart + $bin * $binDuration));
+            $binEnds[$bin] = (clone $binStarts[$bin])->add(new DateInterval(sprintf('PT%dS', $binDuration)));
+        }
+
+        // Determine which bin the freeze starts in. Bins before this have
+        // separate correct/incorrect counts; bins from this index onward
+        // get the same total for both (shown as "frozen" by the template).
+        $freezeBin = static::NUM_GROUPED_BINS; // default: no freeze
+        if (!$showVerdictsInFreeze && $contest->getFreezetime() !== null) {
+            for ($bin = 0; $bin < static::NUM_GROUPED_BINS; $bin++) {
+                if ($binEnds[$bin]->getTimestamp() > $contest->getFreezetime()) {
+                    $freezeBin = $bin;
+                    break;
+                }
+            }
+        }
+
+        // Fetch all judging counts in a single query, grouped by problem
+        // and whether the result is correct.
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('p.probid, j.result, s.submittime')
             ->from(Judging::class, 'j')
             ->join('j.submission', 's')
             ->join('s.problem', 'p')
@@ -436,77 +459,60 @@ class StatisticsService
             ->andWhere('s.problem IN (:problems)')
             ->andWhere('tc.visible = true')
             ->setParameter('problems', $problems)
-            ->setParameter('contest', $contest)
-            ->groupBy('s.problem');
+            ->setParameter('contest', $contest);
 
         if ($verificationRequired) {
-            $judgingsQueryBuilder->andWhere('j.verified = true');
+            $queryBuilder->andWhere('j.verified = true');
         }
 
-        // Determine the bins to use.
-        $duration = $contest->getEndtime() - $contest->getStarttime(false);
-        $binDuration = round($duration / static::NUM_GROUPED_BINS, 0);
+        $rows = $queryBuilder->getQuery()->getArrayResult();
 
-        for ($bin = 0; $bin < static::NUM_GROUPED_BINS; $bin++) {
-            $start = new DateTime(Utils::absTime($contest->getStarttime(false) + $bin * $binDuration));
-            $end = (clone $start)->add(new DateInterval(sprintf('PT%dS',
-                $binDuration)));
-            foreach ([true, false] as $correct) {
-                $queryBuilder = clone $judgingsQueryBuilder;
-                $queryBuilder->andWhere('s.submittime >= :starttime');
-                $queryBuilder->andWhere('s.submittime < :endtime');
-                if ($showVerdictsInFreeze || $end->getTimestamp() <= $contest->getFreezetime()) {
-                    // When we don't want to show frozen correct/incorrect submissions,
-                    // get the same data for both correct and incorrect.
-                    // This logic assumes the freeze matches with the start of a bucket.
-                    // If this is not the case, the whole bucket that contains the freeze
-                    // will be showed as frozen.
-                    if ($correct) {
-                        $queryBuilder->andWhere('j.result = :correct');
-                    } else {
-                        $queryBuilder->andWhere('j.result != :correct');
-                    }
-                    $queryBuilder->setParameter('correct', 'correct');
-                }
-                $queryBuilder
-                    ->setParameter('starttime', $start->getTimestamp())
-                    ->setParameter('endtime', $end->getTimestamp());
+        // Bin the results in PHP.
+        $counts = [];
+        foreach ($rows as $row) {
+            $bin = (int)floor(((float)$row['submittime'] - $contestStart) / $binDuration);
+            $bin = min($bin, static::NUM_GROUPED_BINS - 1);
 
-                $statsIndex = $correct ? 'correct' : 'incorrect';
-
-                $result = $queryBuilder->getQuery()->getArrayResult();
-                foreach ($result as $resultItem) {
-                    $stats['problems'][$resultItem['probid']][$statsIndex][$bin] = [
-                        'start' => $start,
-                        'end' => $end,
-                        'count' => $resultItem['count'],
-                    ];
-                }
-
-                foreach ($problems as $problem) {
-                    if (!isset($stats['problems'][$problem->getProbid()][$statsIndex][$bin])) {
-                        $stats['problems'][$problem->getProbid()][$statsIndex][$bin] = [
-                            'start' => $start,
-                            'end' => $end,
-                            'count' => 0,
-                        ];
-                    }
-                }
+            $isCorrect = ($row['result'] === 'correct');
+            if ($bin < $freezeBin) {
+                $statsIndex = $isCorrect ? 'correct' : 'incorrect';
+                $counts[$row['probid']][$bin][$statsIndex]
+                    = ($counts[$row['probid']][$bin][$statsIndex] ?? 0) + 1;
+            } else {
+                // In frozen bins, both correct and incorrect get the same total.
+                $counts[$row['probid']][$bin]['frozen']
+                    = ($counts[$row['probid']][$bin]['frozen'] ?? 0) + 1;
             }
         }
 
+        // Build the output structure expected by the template.
         $maxBucketSizeCorrect = 0;
         $maxBucketSizeIncorrect = 0;
-        foreach ($stats['problems'] as $problemStats) {
-            foreach ([true, false] as $correct) {
-                $statsIndex = $correct ? 'correct' : 'incorrect';
-                foreach ($problemStats[$statsIndex] as $statItem) {
-                    if ($correct) {
-                        $maxBucketSizeCorrect = max($maxBucketSizeCorrect, $statItem['count']);
-                    } else {
-                        $maxBucketSizeIncorrect = max($maxBucketSizeIncorrect, $statItem['count']);
-                    }
+        foreach ($problems as $problem) {
+            $probid = $problem->getProbid();
+            for ($bin = 0; $bin < static::NUM_GROUPED_BINS; $bin++) {
+                if ($bin < $freezeBin) {
+                    $correctCount = $counts[$probid][$bin]['correct'] ?? 0;
+                    $incorrectCount = $counts[$probid][$bin]['incorrect'] ?? 0;
+                } else {
+                    $frozenCount = $counts[$probid][$bin]['frozen'] ?? 0;
+                    $correctCount = $frozenCount;
+                    $incorrectCount = $frozenCount;
                 }
+
+                $stats['problems'][$probid]['correct'][$bin] = [
+                    'start' => $binStarts[$bin],
+                    'end' => $binEnds[$bin],
+                    'count' => $correctCount,
+                ];
+                $stats['problems'][$probid]['incorrect'][$bin] = [
+                    'start' => $binStarts[$bin],
+                    'end' => $binEnds[$bin],
+                    'count' => $incorrectCount,
+                ];
+
+                $maxBucketSizeCorrect = max($maxBucketSizeCorrect, $correctCount);
+                $maxBucketSizeIncorrect = max($maxBucketSizeIncorrect, $incorrectCount);
             }
         }
 


### PR DESCRIPTION
Part of https://github.com/DOMjudge/domjudge/issues/3542

This replaces ~40 DB queries with a single one with some pre- and post-processing happening in PHP.

For a normal sized NWERC, this reduces the doctrine part of the page request from ~81ms to ~17ms on my machine.