### PR TITLE
Cache max score per problem for scoring problems.

### DIFF
--- a/webapp/src/Utils/Scoreboard/Scoreboard.php
+++ b/webapp/src/Utils/Scoreboard/Scoreboard.php
@@ -22,6 +22,8 @@ class Scoreboard
 
     /** @var TeamScore[] */
     protected array $scores = [];
+    /** @var array<int, float> probid => max score */
+    protected array $maxScorePerProblem = [];
     /** @var int[]|null */
     protected ?array $bestInCategoryData = null;
 
@@ -163,8 +165,9 @@ class Scoreboard
      */
     protected function calculateScoreboard(): void
     {
-        // Calculate matrix and update scores.
+        // Calculate matrix, update scores, and track max score per problem.
         $this->matrix = [];
+        $this->maxScorePerProblem = [];
         foreach ($this->scoreCache as $scoreCell) {
             $teamId = $scoreCell->getTeam()->getTeamid();
             $probId = $scoreCell->getProblem()->getProbid();
@@ -191,7 +194,7 @@ class Scoreboard
                 );
             }
 
-            $this->matrix[$teamId][$probId] = new ScoreboardMatrixItem(
+            $matrixItem = new ScoreboardMatrixItem(
                 isCorrect: $isCorrect,
                 isFirst: $isCorrect && $scoreCell->getIsFirstToSolve(),
                 numSubmissions: $scoreCell->getSubmissions($this->restricted),
@@ -201,6 +204,11 @@ class Scoreboard
                 runtime: $scoreCell->getRuntime($this->restricted),
                 numSubmissionsInFreeze: $scoreCell->getPending(false),
                 points: $points,
+            );
+            $this->matrix[$teamId][$probId] = $matrixItem;
+            $this->maxScorePerProblem[$probId] = max(
+                $this->maxScorePerProblem[$probId] ?? 0.0,
+                $matrixItem->getScore()
             );
         }
 
@@ -398,17 +406,7 @@ class Scoreboard
      */
     public function getMaxScoreForProblem(ContestProblem $problem): float
     {
-        $maxScore = 0.0;
-        $problemId = $problem->getProbid();
-
-        foreach ($this->scores as $teamScore) {
-            $teamId = $teamScore->team->getTeamid();
-            if (isset($this->matrix[$teamId][$problemId])) {
-                $maxScore = max($maxScore, $this->matrix[$teamId][$problemId]->getScore());
-            }
-        }
-
-        return $maxScore;
+        return $this->maxScorePerProblem[$problem->getProbid()] ?? 0.0;
     }
 
     /**


### PR DESCRIPTION
Otherwise this would loop over all teams per cell on the scoreboard, so for 10 problems and 1000 teams we would do `1000*1000*10 = 100k` iterations.