### PR TITLE
remove a stray dash in external_contest.html.swig

### DIFF
--- a/webapp/templates/jury/external_contest.html.twig
+++ b/webapp/templates/jury/external_contest.html.twig
@@ -32,7 +32,7 @@
 
     <div class="mb-3">
         <div class="btn-group" role="group">
-            <input type="checkbox" class="btn-check" id="filter-toggle" {-% if hasFilters %} checked{% endif %}>
+            <input type="checkbox" class="btn-check" id="filter-toggle" {% if hasFilters %} checked{% endif %}>
             <label for="filter-toggle" class="btn btn-outline-secondary">
                 <i class="fas fa-filter"></i> Filter
             </label>


### PR DESCRIPTION
This typo causes the external contest interface to return 500 Internal Error.