### PR TITLE
fix import:eventfeed crash when external source does not provide balloon color

### DIFF
--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -1192,7 +1192,7 @@ class ExternalContestSourceService
             );
             $contestProblem->setShortname($data->label);
         }
-        if (preg_match('/^#[[:xdigit:]]{3}(?:[[:xdigit:]]{3}){0,2}$/', $data->rgb)) {
+        if ($data->rgb && preg_match('/^#[[:xdigit:]]{3}(?:[[:xdigit:]]{3}){0,2}$/', $data->rgb)) {
             $this->logger->warning(
                 'Contest problem color does not match between feed (%s) and local (%s), but feed is invalid.',
                 [$data->rgb, $contestProblem->getColor()]


### PR DESCRIPTION
Fix the error when the external source does not provide balloon color:

    preg_match(): Argument #2 ($subject) must be of type string, null given