### PR TITLE
Fix `upload_file` crashing on empty API response body.

### DIFF
--- a/misc-tools/dj_utils.py
+++ b/misc-tools/dj_utils.py
@@ -147,12 +147,14 @@ def upload_file(name: str, apifilename: str, file: str, data: dict = {}):
 
         result = parse_api_response(name, response)
 
-    if result is not None:
+    if result is not None and result.strip():
         try:
             result = json.loads(result)
         except json.decoder.JSONDecodeError as e:
             print(result)
             raise RuntimeError(f'Failed to JSON decode the response for API file upload request {name}')
+    else:
+        result = None
 
     return result
 


### PR DESCRIPTION
The API can return an empty body on success, which caused a `JSONDecodeError` when trying to parse it.