### PR TITLE
Change language upload flow in configure-domjudge.

### DIFF
--- a/misc-tools/configure-domjudge.in
+++ b/misc-tools/configure-domjudge.in
@@ -121,6 +121,8 @@ if os.path.exists('languages.json'):
         if missing_keys:
             print(f'  - missing keys from expected config = {missing_keys}')
         if diffs or new_keys or missing_keys:
+            if dj_utils.confirm('  - Upload language configuration changes?', True):
+                dj_utils.upload_file(f'languages', 'json', f'languages.json')
             if os.path.exists('executables'):
                 executables = []
                 for file in os.listdir('executables'):
@@ -134,16 +136,22 @@ if os.path.exists('languages.json'):
                             dj_utils.upload_file(f'languages/{langid}/executable', 'executable', f'executables/{langid}.zip')
                     for langid in executables:
                         os.remove(f'executables/{langid}.zip')
-            if dj_utils.confirm('  - Upload language configuration changes?', True):
-                actual_config = _keyify_list(dj_utils.upload_file(f'languages', 'json', f'languages.json'))
-                diffs, new_keys, missing_keys = compare_configs(
-                        actual_config=actual_config,
-                        expected_config=expected_config
-                )
+            actual_config = _keyify_list(dj_utils.do_api_request('languages'))
+            diffs, new_keys, missing_keys = compare_configs(
+                    actual_config=actual_config,
+                    expected_config=expected_config
+            )
+            if diffs or new_keys or missing_keys:
                 if diffs:
                     print('  - There are still configuration differences after uploading:')
                     for d in diffs:
                         print(d)
+                if new_keys:
+                    print(f'  - still missing keys from actual config = {new_keys}')
+                if missing_keys:
+                    print(f'  - still missing keys from expected config = {missing_keys}')
+                if dj_utils.confirm('  - Re-upload language configuration?', True):
+                    dj_utils.upload_file(f'languages', 'json', f'languages.json')
         else:
             print('  - Language configuration is already up-to-date, nothing to update.')
 else:


### PR DESCRIPTION
Language definitions must exist before their executables can be uploaded. That includes enabling them before we upload executables.

Post upload we check again against server state to verify.