### PR TITLE
Fix selection of active tab in source code view.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -1550,7 +1550,17 @@ function initDiffEditorTab(editorId, diffId, submissionId, models) {
         if (isDeleted) {
             document.getElementById(diffId).parentElement.style.display = exists ? '' : 'none';
             navItem.style.display = exists ? '' : 'none';
-            if (!exists) return;
+            if (!exists) {
+                // If the hidden tab was active, activate the first tab that belongs to the current submission.
+                if (navItem.classList.contains('active')) {
+                    const nav = navItem.closest('ul');
+                    const firstOwned = nav.querySelector('.nav-link[data-rank]:not([data-rank=""])');
+                    if (firstOwned) {
+                        bootstrap.Tab.getOrCreateInstance(firstOwned).show();
+                    }
+                }
+                return;
+            }
         }
 
         const model = models[submitId];

--- a/webapp/templates/jury/partials/submission_diff.html.twig
+++ b/webapp/templates/jury/partials/submission_diff.html.twig
@@ -1,6 +1,11 @@
 <div id="{{ editor_id }}-wrapper" class="flex-pass">
-    {# Mark the first tab that is shown as active. #}
-    {% set extra_css_classes = "active" %}
+    {# Find the first file that belongs to the current submission to mark as active. #}
+    {% set active_name = null %}
+    {% for name, name_files in files %}
+        {% if active_name is null and name_files[submission.externalid] is defined %}
+            {% set active_name = name %}
+        {% endif %}
+    {% endfor %}
     <ul class="nav nav-tabs source-tab-nav align-items-end">
         {%- for name, name_files in files %}
             {% set diff_id = "diff-" ~ name %}
@@ -10,9 +15,8 @@
                 {% set rank = null %}
             {% endif %}
             <li class="nav-item">
-                <a id="{{ diff_id }}-link" class="nav-link {{ extra_css_classes }}" data-bs-toggle="tab" data-rank="{{ rank }}" href="#{{ diff_id }}-tab"><i class="fas fa-fw fa-file"></i> {{ name }}</a>
+                <a id="{{ diff_id }}-link" class="nav-link {{ name == active_name ? 'active' : '' }}" data-bs-toggle="tab" data-rank="{{ rank }}" href="#{{ diff_id }}-tab"><i class="fas fa-fw fa-file"></i> {{ name }}</a>
             </li>
-            {% set extra_css_classes = "" %}
         {%- endfor %}
 
         <li class="nav-item flex-grow-1 text-end mb-1">
@@ -51,14 +55,12 @@
             });
         });
     </script>
-    {% set extra_css_classes = "show active" %}
     <div class="tab-content source-tab flex-pass">
         {%- for name, name_files in files %}
             {% set diff_id = "diff-" ~ name %}
-            <div class="tab-pane fade flex-pass {{ extra_css_classes }}" id="{{ diff_id }}-tab" role="tabpanel">
+            <div class="tab-pane fade flex-pass {{ name == active_name ? 'show active' : '' }}" id="{{ diff_id }}-tab" role="tabpanel">
                 {{ showDiff(editor_id, diff_id, submission.externalid, name, name_files) }}
             </div>
-            {% set extra_css_classes = "" %}
         {%- endfor %}
     </div>
 </div>


### PR DESCRIPTION
Imagine a situation where we first create one submission with files A.java and B.java, and then a submission with C.java.

Previously, the active tab would be A.java (as the alphabetically first one), but in no-diff mode we would not display A.java (nor B.java), so no tab is active (not even the single tab that exists C.java). The editor would be empty. Clicking on the tab would show the source code though.

Now, we explicitly set one of the visible tabs as active.

Manually tested and verified on some example submissions.