### PR TITLE
Cleanup installed libraries after `make dist`

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -117,6 +117,7 @@ maintainer-clean-l:
 			rm -rf var/$$d/$$t ; \
 		done ; \
 	done
+	-rm -rf vendor node_modules LICENSES.txt
 
 .PHONY: composer-dump-autoload composer-dump-autoload-dev copy-bundle-assets \
         composer-dependencies composer-dependencies-dev node-dependencies


### PR DESCRIPTION
It is always hard on how to name targets, for now I went with the logic that when your run:
`make dist` or `make maintainer-conf` and `make maintainer-clean`  afterwards you still endup with a clean checkout.

From naming you would expect that `make distclean` would cleanup after `make dist` but that doesn't seem to be the convention so the next logical target without creating a new one is `make maintainer-clean`.

