### PR TITLE
Fix pre-contest non-scoreboard page layout.

### DIFF
--- a/webapp/templates/partials/scoreboard.html.twig
+++ b/webapp/templates/partials/scoreboard.html.twig
@@ -73,17 +73,21 @@
                                         {% else %}
                                             {% set colorClass = affiliation.color | replace({"#": "_"}) %}
                                         {% endif %}
-                                        <li class="list-group-item cl{{ colorClass }}">
+                                        <li class="list-group-item cl{{ colorClass }} d-flex align-items-center">
                                             {% if showFlags and affiliation.country is defined %}
-                                                {{ affiliation.country|countryFlag }}
+                                                <span class="d-inline-flex justify-content-center" style="min-width: 25px;">
+                                                    {{ affiliation.country|countryFlag }}
+                                                </span>
                                             {% endif %}
                                             {% set affiliationLogo = affiliation.id | assetPath('affiliation') %}
-                                            {% if affiliationLogo %}
-                                                <img loading="lazy" class="affiliation-logo"
-                                                     src="{{ asset(affiliationLogo) }}" alt="{{ affiliation.name }}"
-                                                     title="{{ affiliation.name }}">
-                                            {% endif %}
-                                            {{ affiliation.name }}
+                                            <span class="d-inline-flex justify-content-center" style="min-width: 40px;">
+                                                {% if affiliationLogo %}
+                                                    <img loading="lazy" class="affiliation-logo"
+                                                         src="{{ asset(affiliationLogo) }}" alt="{{ affiliation.name }}"
+                                                         title="{{ affiliation.name }}">
+                                                {% endif %}
+                                            </span>
+                                            <span class="ms-2">{{ affiliation.name }}</span>
                                         </li>
                                     {% endfor %}
                                 </ul>


### PR DESCRIPTION
Previously, with differently sized logos (especially different horizontal width), the team names were dancing left and right.

Now team names should be properly aligned.