### PR TITLE
Handle retries when adding judging runs more gracefully.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -975,8 +975,11 @@ class JudgehostController extends AbstractFOSRestController
                 throw new BadRequestHttpException(
                     'Inconsistent data, no judging run known with judgetaskid = ' . $judgeTaskId . '.');
             }
-            $judgingRunOutput = new JudgingRunOutput();
-            $judgingRun->setOutput($judgingRunOutput);
+            $judgingRunOutput = $judgingRun->getOutput();
+            if ($judgingRunOutput === null) {
+                $judgingRunOutput = new JudgingRunOutput();
+                $judgingRun->setOutput($judgingRunOutput);
+            }
             $judgingRun
                 ->setRunresult($runResult)
                 ->setRuntime((float)$runTime)


### PR DESCRIPTION
This should never happen in practice, but it did at NAC due to another bug. It is better to handle this defensively.