### PR TITLE
More actively handle the failure to call fetch work.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -502,6 +502,13 @@ class JudgeDaemon
 
             // If $row is null, an error occurred; we marked the endpoint already as errorred above.
             if (is_null($row)) {
+                // If fetching work failed, it might still have been assigned to us.
+                // To be sure, we give it back.
+                logmsg(LOG_WARNING, "Fetching work failed, giving back any potentially assigned work.");
+                // As a side-effect, registerJudgehost will
+                // - give back any work that has been assigned to us,
+                // - and set up a new curl handle (which is what we want in these situations anyway).
+                $this->registerJudgehost();
                 continue;
             } else {
                 $row = dj_json_decode($row);


### PR DESCRIPTION
Previously, we would just silently tolerate it.
Now we log an error, try to give back work that has been assigned to us and set up a new curl handle.