### PR TITLE
Display program_err in multiple columns

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -173,6 +173,10 @@ a {
     white-space: pre;
 }
 
+.output_text_truncate_columns {
+    column-rule: 1px solid #c0c0c0;
+}
+
 .clarificationform pre {
     border-top: 1px dotted #c0c0c0;
     border-bottom: 1px dotted #c0c0c0;

--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -527,6 +527,13 @@ class SubmissionController extends BaseController
                 if ($firstJudgingRun) {
                     $runResult['testcasedir'] = $firstJudgingRun->getTestcaseDir();
                 }
+                foreach(['output_run', 'output_error'] as $field) {
+                    $colwidth = 0;
+                    foreach (explode("\n", $runResult[$field] ?? '') as $line) {
+                        $colwidth = max(strlen($line), $colwidth);
+                    }
+                    $runResult[$field . '_colwidth'] = $colwidth;
+                }
                 $runsOutput[] = $runResult;
             }
         }

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -25,6 +25,14 @@
             max-height: {{ thumbnailSize }}px;
         }
 
+        {% for runIdx in runsOutput | keys %}
+            {% for colname in ['output_run_colwidth', 'output_error_colwidth'] %}
+                .output_text_truncate_columns_{{ colname }}_{{ runIdx }} {
+                    column-width: {{ runsOutput[runIdx][colname] }}ch;
+                }
+            {% endfor %}
+        {% endfor %}
+
         .scoring-details-container .full-precision { display: none; }
         .scoring-details-container.show-full .rounded-precision { display: none; }
         .scoring-details-container.show-full .full-precision { display: inline; }
@@ -956,7 +964,7 @@
                                 {% if runsOutput[runIdx].output_run is empty %}
                                     <p class="nodata">There was no program output.</p>
                                 {% else %}
-                                    <pre class="output_text">{{ runsOutput[runIdx].output_run | convertUnprintableChars }}</pre>
+                                    <pre class="output_text output_text_truncate_columns output_text_truncate_columns_output_run_colwidth_{{ runIdx }}">{{ runsOutput[runIdx].output_run | convertUnprintableChars }}</pre>
                                 {% endif %}
                             {% endif %}
 
@@ -964,7 +972,7 @@
                             {% if runsOutput[runIdx].output_error is empty %}
                                 <p class="nodata">There was no stderr output.</p>
                             {% else %}
-                                <pre class="output_text">{{ runsOutput[runIdx].output_error | convertUnprintableChars }}</pre>
+                                <pre class="output_text output_text_truncate_columns output_text_truncate_columns_output_error_colwidth_{{ runIdx }}">{{ runsOutput[runIdx].output_error | convertUnprintableChars }}</pre>
                             {% endif %}
 
                             <h5>Judging system output (info/debug/errors)</h5>


### PR DESCRIPTION
Most of those lines are short so we can use the extra horizontal space.

<img width="3718" height="1514" alt="image" src="https://github.com/user-attachments/assets/fb51f729-f12a-4c4a-a8b8-f96ce01a8d8c" />

For the rest of the output the user gets a horizontal scrollbar, I think that is easy enough to follow the program without taking up the whole page.

Just as a pitch, if we want this I can apply it to the other outputs also.