### PR TITLE
Put external ID constraint on the field, so it is also honored in the API

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @extends AbstractRestController<User, User>
@@ -41,7 +42,8 @@ class UserController extends AbstractRestController
         DOMJudgeService $dj,
         ConfigurationService $config,
         EventLogService $eventLogService,
-        protected readonly ImportExportService $importExportService
+        protected readonly ImportExportService $importExportService,
+        protected readonly ValidatorInterface $validator,
     ) {
         parent::__construct($entityManager, $dj, $config, $eventLogService);
     }
@@ -413,6 +415,15 @@ class UserController extends AbstractRestController
                 throw new BadRequestHttpException(sprintf("Role %s not found", $djRole));
             }
             $user->addUserRole($role);
+        }
+
+        $errors = $this->validator->validate($user);
+        if ($errors->count()) {
+            $messages = [];
+            foreach ($errors as $error) {
+                $messages[] = sprintf('%s: %s', $error->getPropertyPath(), $error->getMessage());
+            }
+            throw new BadRequestHttpException(implode("\n", $messages));
         }
 
         $this->em->persist($user);

--- a/webapp/src/Entity/Clarification.php
+++ b/webapp/src/Entity/Clarification.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
@@ -55,6 +56,7 @@ class Clarification extends BaseApiEntity implements
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -9,6 +9,7 @@ use App\DataTransferObject\ImageFile;
 use App\Repository\ContestRepository;
 use App\Utils\FreezeData;
 use App\Utils\Utils;
+use App\Validator\Constraints as AppAssert;
 use App\Validator\Constraints\Identifier;
 use App\Validator\Constraints\TimeString;
 use DateTime;
@@ -65,6 +66,7 @@ class Contest extends BaseApiEntity implements
         options: ['comment' => 'Contest ID in an external system', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(options: ['comment' => 'Descriptive name'])]

--- a/webapp/src/Entity/ExternalJudgement.php
+++ b/webapp/src/Entity/ExternalJudgement.php
@@ -6,6 +6,7 @@ use App\Controller\API\AbstractRestController as ARC;
 use App\Utils\Utils;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use App\Validator\Constraints as AppAssert;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -39,6 +40,7 @@ class ExternalJudgement extends AbstractJudgement
         options: ['comment' => 'Judgement ID in external system, should be unique inside a single contest', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected string $externalid;
 
     #[ORM\Column(

--- a/webapp/src/Entity/ExternalRun.php
+++ b/webapp/src/Entity/ExternalRun.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Utils\Utils;
+use App\Validator\Constraints as AppAssert;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -35,6 +36,7 @@ class ExternalRun extends AbstractRun
         options: ['comment' => 'Run ID in external system, should be unique inside a single contest', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -38,6 +39,7 @@ class Language extends BaseApiEntity implements
     #[ORM\Column(nullable: true, options: ['comment' => 'Language ID to expose in the REST API'])]
     #[Serializer\SerializedName('id')]
     #[Serializer\Groups([ARC::GROUP_DEFAULT, ARC::GROUP_NONSTRICT])]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(options: ['comment' => 'Descriptive language name'])]

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -14,6 +14,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -49,6 +50,7 @@ class Problem extends BaseApiEntity implements
         ]
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(options: ['comment' => 'Descriptive name'])]

--- a/webapp/src/Entity/Submission.php
+++ b/webapp/src/Entity/Submission.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
@@ -57,6 +58,7 @@ class Submission extends BaseApiEntity implements
     )]
     #[OA\Property(nullable: true)]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/Team.php
+++ b/webapp/src/Entity/Team.php
@@ -13,6 +13,7 @@ use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -46,6 +47,7 @@ class Team extends BaseApiEntity implements
         options: ['comment' => 'Team ID in an external system', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/TeamAffiliation.php
+++ b/webapp/src/Entity/TeamAffiliation.php
@@ -3,6 +3,7 @@ namespace App\Entity;
 
 use App\DataTransferObject\ImageFile;
 use App\Repository\TeamAffiliationRepository;
+use App\Validator\Constraints as AppAssert;
 use App\Validator\Constraints\Country;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -52,6 +53,7 @@ class TeamAffiliation extends BaseApiEntity implements
         options: ['comment' => 'Team affiliation ID in an external system', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/TeamCategory.php
+++ b/webapp/src/Entity/TeamCategory.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
 use Stringable;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -47,6 +48,7 @@ class TeamCategory extends BaseApiEntity implements
         options: ['comment' => 'Team category ID in an external system', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(

--- a/webapp/src/Entity/User.php
+++ b/webapp/src/Entity/User.php
@@ -14,6 +14,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use App\Validator\Constraints as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -47,6 +48,7 @@ class User extends BaseApiEntity implements
         options: ['comment' => 'User ID in an external system', 'collation' => 'utf8mb4_bin']
     )]
     #[Serializer\SerializedName('id')]
+    #[AppAssert\Identifier]
     protected ?string $externalid = null;
 
     #[ORM\Column(options: ['comment' => 'User login name'])]

--- a/webapp/src/Form/Type/AbstractExternalIdEntityType.php
+++ b/webapp/src/Form/Type/AbstractExternalIdEntityType.php
@@ -2,12 +2,10 @@
 
 namespace App\Form\Type;
 
-use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Base class that can be used to automatically add an external ID field to forms that need them.
@@ -28,12 +26,6 @@ class AbstractExternalIdEntityType extends AbstractType
             'help' => 'Leave empty to generate automatically.',
             'required' => false,
             'empty_data' => '',
-            'constraints' => [
-                new Regex(
-                    pattern: DOMJudgeService::EXTERNAL_IDENTIFIER_REGEX,
-                    message: 'Only letters, numbers, dashes, underscores and dots are allowed.',
-                ),
-            ]
         ]);
     }
 }

--- a/webapp/src/Service/ImportExportService.php
+++ b/webapp/src/Service/ImportExportService.php
@@ -1456,11 +1456,6 @@ readonly class ImportExportService
                 return -1;
             }
 
-            if (preg_match('/^([a-zA-Z0-9]{1}([a-zA-Z0-9._-]{0,34}[a-zA-Z0-9])?)$/', $teamItem['team']['teamid']) === 0) {
-                $message = 'ID not in CLICS format';
-                return -1;
-            }
-
             $team->setExternalid($teamItem['team']['teamid']);
             unset($teamItem['team']['teamid']);
 
@@ -1627,9 +1622,24 @@ readonly class ImportExportService
                         $team
                             ->setExternalid((string)$teamId)
                             ->setName($teamId . ' - auto-create during import');
-                        $this->em->persist($team);
-                        $this->dj->auditlog('team', $team->getExternalid(),
-                            'added', 'imported from tsv');
+                        $errors = $this->validator->validate($team);
+                        if ($errors->count()) {
+                            $messages = [];
+                            /** @var ConstraintViolationInterface $error */
+                            foreach ($errors as $error) {
+                                $messages[] = sprintf('  • `%s`: %s', $error->getPropertyPath(), $error->getMessage());
+                            }
+
+                            $message .= sprintf("Auto-created team for user at index %d (%s) has errors:\n%s\n\n",
+                                $index,
+                                json_encode($accountItem),
+                                implode("\n", $messages));
+                            $anyErrors = true;
+                        } else {
+                            $this->em->persist($team);
+                            $this->dj->auditlog('team', $team->getExternalid(),
+                                'added', 'imported from tsv');
+                        }
                     }
                 }
                 $accountItem['user']['team'] = $team;

--- a/webapp/src/Validator/Constraints/Identifier.php
+++ b/webapp/src/Validator/Constraints/Identifier.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
 class Identifier extends Constraint
 {
     public function __construct(
-        public string $message = 'Only alphanumeric characters and ._- are allowed',
+        public string $message = 'Only letters, numbers, dashes, underscores and dots are allowed.',
     ) {
         parent::__construct();
     }

--- a/webapp/tests/Unit/Controller/API/GroupControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/GroupControllerTest.php
@@ -129,4 +129,12 @@ class GroupControllerTest extends BaseTestCase
             yield [$group];
         }
     }
+
+    public function testNewAddedGroupWithInvalidId(): void
+    {
+        $url = $this->helperGetEndpointURL($this->apiEndpoint);
+        $data = ['id' => 'invalid id!', 'name' => 'newGroup', 'hidden' => false, 'sortorder' => 1, 'color' => '#0077B3'];
+        $response = $this->verifyApiJsonResponse('PUT', $url . '/invalid%20id!', 400, 'admin', $data);
+        self::assertStringContainsString('Only letters, numbers, dashes, underscores and dots are allowed.', $response['message']);
+    }
 }

--- a/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/OrganizationControllerTest.php
@@ -239,4 +239,12 @@ class OrganizationControllerTest extends BaseTestCase
             self::assertEquals($newItems[$listKey][$key], $value);
         }
     }
+
+    public function testNewAddedOrganizationWithInvalidId(): void
+    {
+        $url = $this->helperGetEndpointURL('organizations');
+        $data = ['id' => 'invalid id!', 'shortname' => 'newOrg', 'formal_name' => 'newOrgWithName', 'country' => 'NLD'];
+        $response = $this->verifyApiJsonResponse('POST', $url, 400, 'admin', $data);
+        self::assertStringContainsString('Only letters, numbers, dashes, underscores and dots are allowed.', $response['message']);
+    }
 }

--- a/webapp/tests/Unit/Controller/API/TeamControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/TeamControllerTest.php
@@ -91,4 +91,12 @@ class TeamControllerTest extends BaseTestCase
         $object = $this->verifyApiJsonResponse('GET', $url, 200, 'admin');
         self::assertArrayNotHasKey('photo', $object);
     }
+
+    public function testNewAddedTeamWithInvalidId(): void
+    {
+        $url = $this->helperGetEndpointURL($this->apiEndpoint);
+        $data = ['id' => 'invalid id!', 'name' => 'Test Team', 'group_ids' => ['participants']];
+        $response = $this->verifyApiJsonResponse('POST', $url, 400, 'admin', $data);
+        self::assertStringContainsString('Only letters, numbers, dashes, underscores and dots are allowed.', $response['message']);
+    }
 }

--- a/webapp/tests/Unit/Controller/API/UserControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/UserControllerTest.php
@@ -88,4 +88,18 @@ class UserControllerTest extends AccountBaseTestCase
         $response = $this->verifyApiJsonResponse('PUT', $this->helperGetEndpointURL($this->apiEndpoint) . '/someid', 400, 'admin', $data);
         static::assertMatchesRegularExpression('/id:\n.*This value should be of type string./', $response['message']);
     }
+
+    public function testUpdateWithInvalidExternalId(): void
+    {
+        $data = [
+            'id' => 'invalid id!',
+            'username' => 'testuser',
+            'name' => 'Test User',
+            'roles' => ['team'],
+            'password' => 'testpassword',
+        ];
+
+        $response = $this->verifyApiJsonResponse('PUT', $this->helperGetEndpointURL($this->apiEndpoint) . '/invalid%20id!', 400, 'admin', $data);
+        self::assertStringContainsString('Only letters, numbers, dashes, underscores and dots are allowed.', $response['message']);
+    }
 }

--- a/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
@@ -314,7 +314,7 @@ class ContestControllerTest extends JuryControllerTestCase
                                                                                                                         'allowJudge' => '1',
                                                                                                                         'color' => '#000000',
                                                                                                                         'lazyEvalResults' => '0']], 'name' => 'No known problem']],
-                                                          'Only alphanumeric characters and ._- are allowed' => [['shortname' => '"quoted"']]];
+                                                          'Only letters, numbers, dashes, underscores and dots are allowed.' => [['shortname' => '"quoted"']]];
 
     protected function helperProvideTranslateAddEntity(array $entity, array $expected): array
     {


### PR DESCRIPTION
During NAC we had the issue that for the online judge we generated external IDs that aren't valid in the UI. This makes this impossible.