### PR TITLE
Redesigned shadow matrix to be easier to read

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -477,20 +477,37 @@ td.scorenc { border-color: silver; border-right: 0; }
 
 table.rejudgetable td {
     text-align: center;
+    min-width: min(5rem, 14vw - 0.5rem);
     padding: .5rem;
 }
-table.rejudgetable td,th {
+
+table.rejudgetable td, table.rejudgetable th {
     padding: .5rem;
+    border: .4rem white solid;
+    font-weight: normal;
+    text-align: center;
+    border-radius: .8rem;
 }
+
+table.rejudgetable th {
+    font-size: 0.8rem;
+}
+
 table.rejudgetable td.changed {
-    background-color: #fdd;
+    background-color: #dc26260f;
     font-weight: bold;
 }
-table.rejudgetable td.identical {
-    background-color: #dfd;
+
+table.rejudgetable td.changed a {
+    color: #dc2626;
 }
+table.rejudgetable td.identical {
+    background-color: #15ad3d10;
+    color: #15803d;
+}
+
 table.rejudgetable td.zero {
-    background-color: #f0f8ff;
+    color: gray;
 }
 
 tr.ignore td, td.ignore, span.ignore {

--- a/webapp/templates/jury/partials/shadow_matrix.html.twig
+++ b/webapp/templates/jury/partials/shadow_matrix.html.twig
@@ -28,8 +28,10 @@
                             <td class="{{ class }}">
                                 {% if link is not null %}
                                     <a href="{{ link }}">{{ numSubmissions }}</a>
-                                {% else %}
+                                {% elseif numSubmissions > 0 %}
                                     {{ numSubmissions }}
+                                {% else %}
+                                    &centerdot;
                                 {% endif %}
                             </td>
                         {% endif %}


### PR DESCRIPTION
This element is also used on the rejudging page, so this page gets the same improvements.

Before:
<img width="4608" height="2822" alt="Screenshot From 2026-03-22 13-06-10" src="https://github.com/user-attachments/assets/a4ef8e0e-025f-4335-81d1-a52f3d5ed9f5" />

After:
<img width="4608" height="2822" alt="Screenshot From 2026-03-22 13-05-39" src="https://github.com/user-attachments/assets/ab314055-401b-46f3-bfad-5f16d3e963a6" />
