### PR TITLE
Add required status checks to document current settings.

### DIFF
--- a/.github/checks.json
+++ b/.github/checks.json
@@ -1,0 +1,201 @@
+{
+  "strict": true,
+  "checks": [
+    {
+      "app_id": 15368,
+      "context": "Analyze (cpp)"
+    },
+    {
+      "app_id": 15368,
+      "context": "Analyze (java)"
+    },
+    {
+      "app_id": 15368,
+      "context": "Analyze (javascript)"
+    },
+    {
+      "app_id": 15368,
+      "context": "Analyze (python)"
+    },
+    {
+      "app_id": 46505,
+      "context": "GitGuardian Security Checks"
+    },
+    {
+      "app_id": 15368,
+      "context": "Post results assuming forks"
+    },
+    {
+      "app_id": 15368,
+      "context": "Scan-Build"
+    },
+    {
+      "app_id": 15368,
+      "context": "check-chroot-arch (amd64)"
+    },
+    {
+      "app_id": 15368,
+      "context": "check-chroot-arch (default)"
+    },
+    {
+      "app_id": 15368,
+      "context": "codespell"
+    },
+    {
+      "app_id": 15368,
+      "context": "compare"
+    },
+    {
+      "app_id": 15368,
+      "context": "debian-family (debian, stable)"
+    },
+    {
+      "app_id": 15368,
+      "context": "debian-family (debian, testing)"
+    },
+    {
+      "app_id": 15368,
+      "context": "detect-dump"
+    },
+    {
+      "app_id": 15368,
+      "context": "integration (default, demo, check-full, 2, 1)"
+    },
+    {
+      "app_id": 15368,
+      "context": "integration (scoring, scoringdemo, 1, check, 0, 0, -scoring)"
+    },
+    {
+      "app_id": 15368,
+      "context": "judge-unit-tests (8.2)"
+    },
+    {
+      "app_id": 15368,
+      "context": "judge-unit-tests (8.5)"
+    },
+    {
+      "app_id": 15368,
+      "context": "php-linter"
+    },
+    {
+      "app_id": 15368,
+      "context": "phpcs"
+    },
+    {
+      "app_id": 15368,
+      "context": "phpcs_compatibility (8.2)"
+    },
+    {
+      "app_id": 15368,
+      "context": "phpcs_compatibility (8.5)"
+    },
+    {
+      "app_id": 15368,
+      "context": "phpstan"
+    },
+    {
+      "app_id": 15368,
+      "context": "pycodestyle"
+    },
+    {
+      "app_id": 15368,
+      "context": "pyright"
+    },
+    {
+      "app_id": 15368,
+      "context": "redhat-family (latest, fedora)"
+    },
+    {
+      "app_id": 15368,
+      "context": "runpipe"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (admin, w3cval, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (admin, w3cval, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (balloon, WCAG2AA, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (balloon, WCAG2AA, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (balloon, w3cval, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (balloon, w3cval, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (jury, w3cval, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (jury, w3cval, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (public, WCAG2AA, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (public, WCAG2AA, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (public, w3cval, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (public, w3cval, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (team, WCAG2AA, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (team, WCAG2AA, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (team, w3cval, bare-install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "standards (team, w3cval, install)"
+    },
+    {
+      "app_id": 15368,
+      "context": "syntax-job"
+    },
+    {
+      "app_id": 15368,
+      "context": "unit-tests (8.2, E2E)"
+    },
+    {
+      "app_id": 15368,
+      "context": "unit-tests (8.2, Unit)"
+    },
+    {
+      "app_id": 15368,
+      "context": "unit-tests (8.5, E2E)"
+    },
+    {
+      "app_id": 15368,
+      "context": "unit-tests (8.5, Unit)"
+    },
+    {
+      "app_id": 15368,
+      "context": "upgrade_test"
+    }
+  ]
+}


### PR DESCRIPTION
This can be downloaded via gh API for a specific commit in the past like this:

```
SHA="16320c4d9ec24e31b16994e78ea49d6f762d469c"

gh api repos/domjudge/domjudge/commits/$SHA/check-runs \
  --paginate \
  --jq '.check_runs[] | { context: .name, app_id: .app.id }' \
  | jq -s '{ strict: true, checks: (. | unique_by(.context)) }' \
  > .github/checks.json
```

And then you can update the required checks via:
```
gh api \
  -X PATCH \
  repos/domjudge/domjudge/branches/main/protection/required_status_checks \
  --input .github/checks.json
```