### PR TITLE
Fixes correct link when clicking on shadow difference result cell

### DIFF
--- a/webapp/templates/jury/partials/shadow_matrix.html.twig
+++ b/webapp/templates/jury/partials/shadow_matrix.html.twig
@@ -23,7 +23,7 @@
                                 {% set class = 'zero' %}
                             {% else %}
                                 {% set class = 'changed' %}
-                                {% set link = path('jury_shadow_differences', {view: 'all', external: externalVerdict, local: localVerdict}) %}
+                                {% set link = path('jury_shadow_differences', {view: 'all', external: externalVerdict, local: localVerdict, verificationview: 'all'}) %}
                             {% endif %}
                             <td class="{{ class }}">
                                 {% if link is not null %}


### PR DESCRIPTION
The assumption was that 'all' was the default value, which it wasn't anymore. This makes sure that clicking a cell in the differences matrix automatically selects "all" instead of "unverified".