### PR TITLE
Fix pasting/submitting code via online editor.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -74,6 +74,9 @@ function disableKeys()
 function getEditorThemes()
 {
     const element = document.querySelector('[data-editor-themes]');
+    if (element === null) {
+        return {};
+    }
     return JSON.parse(element.dataset.editorThemes);
 }
 
@@ -81,7 +84,9 @@ function getCurrentEditorTheme()
 {
     const theme = localStorage.getItem('domjudge_editor_theme');
     if (theme === null) {
-        return Object.keys(getEditorThemes())[0];
+        const themes = getEditorThemes();
+        const keys = Object.keys(themes);
+        return keys.length > 0 ? keys[0] : 'vs';
     }
     return theme;
 }


### PR DESCRIPTION
This only worked if you also had a jury role, not for regular teams.

Teams don't have a way currently to set a theme, and we failed to handle that gracefully. Now we do handle it gracefully, falling back to the `vs` theme.

If we decide later to add themes for teams (which we currently don't do because it would clutter the already full menu bar), this change won't be harmful.

For the record, this was the error we saw.
```
Uncaught TypeError: Cannot read properties of null (reading 'dataset')
    at getEditorThemes (domjudge.js?v=10.0.0DEV/634f510fe:77:31)
    at getCurrentEditorTheme (domjudge.js?v=10.0.0DEV/634f510fe:84:28)
    at submit?tab=paste:189:20
    at m._invokeFactory (loader.js?v=10.0.0DEV/634f510fe:797:27)
    at m.complete (loader.js?v=10.0.0DEV/634f510fe:806:16)
    at c._onModuleComplete (loader.js?v=10.0.0DEV/634f510fe:1271:6)
    at c._onModuleComplete (loader.js?v=10.0.0DEV/634f510fe:1278:51)
    at c._onModuleComplete (loader.js?v=10.0.0DEV/634f510fe:1278:51)
    at c._onModuleComplete (loader.js?v=10.0.0DEV/634f510fe:1278:51)
    at c._resolve (loader.js?v=10.0.0DEV/634f510fe:1240:48
```