### PR TITLE
Refine Monaco editor resizing to fix jumping cursor issue.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -1635,11 +1635,21 @@ function initDiffEditorTab(editorId, diffId, submissionId, models) {
 // Force a recompute of the monaco editor height when the display size changes.
 if ('ResizeObserver' in window) {
     $(() => {
-        var monacoObserver = new ResizeObserver(() => {
+        let bodyWidth = document.body.offsetWidth;
+        let bodyHeight = document.body.offsetHeight;
+        var monacoObserver = new ResizeObserver($.debounce(function() {
+            const newWidth = document.body.offsetWidth;
+            const newHeight = document.body.offsetHeight;
+            if (newWidth === bodyWidth && newHeight === bodyHeight) {
+                return;
+            }
+            bodyWidth = newWidth;
+            bodyHeight = newHeight;
+
             document.querySelectorAll('.monaco-editor').forEach(e => {
                 e.style.height = "0";
             });
-        });
+        }, 100));
         monacoObserver.observe(document.body);
     });
 }

--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -883,6 +883,7 @@ blockquote {
     height: 0;
     min-height: 100px; /* Prefer a double scrollbar over not displaying code at all */
     width: 100%;
+    overflow: hidden;
 }
 
 .paste-submit-page {


### PR DESCRIPTION
Commit b5f2352df4 introduced a `ResizeObserver` that resets the Monaco editor's height to 0 on every body resize to force a flexbox layout recompute. However, this immediate reset was too aggressive and would trigger during minor layout "changes", in particular also clicking or focusing elements, causing Monaco to miscalculate click coordinates and jump the cursor to the top of the file.

This change improves the fix in two ways:
- Adds `overflow: hidden` to the `.editor` container. This is the standard CSS way to allow a flex item to shrink even when it contains a child with a fixed height (like Monaco), addressing the root cause more natively.
- Make sure the `ResizeObserver` only fires if the editor size actually changes.