### PR TITLE
Fixes ctrl/middle click for dropdown menus

### DIFF
--- a/webapp/templates/jury/menu.html.twig
+++ b/webapp/templates/jury/menu.html.twig
@@ -21,7 +21,7 @@
 
             {% if is_granted('ROLE_ADMIN') %}
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle{% if current_route starts with 'jury_judgehost' or current_route == 'jury_internal_errors' %} active{% endif %}" href="#" id="navbarDropdownJudgehosts" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle{% if current_route starts with 'jury_judgehost' or current_route == 'jury_internal_errors' %} active{% endif %}" href="{{ path('jury_judgehosts') }}" id="navbarDropdownJudgehosts" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class="fas fa-gavel"></i> judgehosts
                         <span class="badge text-bg-warning" id="num-alerts-judgehosts"></span>
                         <span class="badge text-bg-danger" id="num-alerts-internalerrors"></span>
@@ -51,18 +51,18 @@
                 {% if show_shadow_differences %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle{% if current_route == 'jury_shadow_differences' or current_route starts with 'jury_external_contest' %} active{% endif %}"
-                            href="#" id="navbarDropdownShadow" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            href="{{ path('jury_shadow_differences') }}" id="navbarDropdownShadow" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-copy"></i> shadowing
                             <span class="badge text-bg-danger" id="num-alerts-shadowdifferences"></span>
                             <span class="badge text-bg-warning" id="num-alerts-externalcontest"></span>
                         </a>
                         <div role="menuitem" class="dropdown-menu" aria-labelledby="navbarDropdown">
                             <a class="dropdown-item {% if current_contest is null %}dropdown-disabled{% endif %} {% if current_route == 'jury_shadow_differences' %}active{% endif %}"
-                                {% if current_contest is not null %}href="{{ path('jury_shadow_differences') }}"{% endif %} id="menu_shadow_differences">
+                               href="{{ path('jury_shadow_differences') }}" id="menu_shadow_differences">
                                 <i class="fas fa-not-equal fa-fw"></i> shadow differences <span class="badge text-bg-danger" id="num-alerts-shadowdifferences-sub"></span>
                             </a>
-                            <a class="dropdown-item {% if current_contest is null %}dropdown-disabled{% endif %} {% if current_route starts with 'jury_external_contest' %}active{% endif %}"
-                                {% if current_contest is not null %}href="{{ path('jury_external_contest') }}"{% endif%} id="menu_external_contest">
+                            <a class="dropdown-item {% if current_route starts with 'jury_external_contest' %}active{% endif %}"
+                                href="{{ path('jury_external_contest') }}" id="menu_external_contest">
                                 <i class="fas fa-laptop-code fa-fw"></i> external contest <span class="badge text-bg-warning" id="num-alerts-externalcontest-sub"></span>
                             </a>
                         </div>
@@ -99,23 +99,23 @@
             {# Render user information + logout button #}
             {% if is_granted('IS_AUTHENTICATED_FULLY') %}
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class="fas fa-user"></i> {{ app.user.getUsername() }}
                     </a>
                     <div role="menuitem" class="dropdown-menu" aria-labelledby="navbarDropdown">
                         {% if app.user and app.user.getName() %}
-                            <a class="dropdown-item disabled" href="#">{{ app.user.getName() }}</a>
+                            <a class="dropdown-item disabled">{{ app.user.getName() }}</a>
                         {% endif %}
 
-                        <a class="dropdown-item d-none" href="#" id="notify_disable">
+                        <a class="dropdown-item d-none" id="notify_disable">
                             <i class="fas fa-bell-slash fa-fw"></i> Disable Notifications
                         </a>
-                        <a class="dropdown-item d-none" href="#" id="notify_enable">
+                        <a class="dropdown-item d-none" id="notify_enable">
                             <i class="fas fa-bell fa-fw"></i> Enable Notifications
                         </a>
 
                         {% if refresh is defined and refresh %}
-                            <a class="dropdown-item" href="#" id="refresh-navitem">
+                            <a class="dropdown-item" id="refresh-navitem">
                                 <i class="fas fa-sync-alt fa-fw"></i>
                                 <span id="refresh-toggle">
                                     {% if refresh_flag %}
@@ -128,10 +128,10 @@
                             </a>
                         {% endif %}
 
-                        <a class="dropdown-item d-none" href="#" id="keys_disable">
+                        <a class="dropdown-item d-none" id="keys_disable">
                             <i class="fas fa-keyboard fa-fw"></i> Disable keyboard shortcuts
                         </a>
-                        <a class="dropdown-item d-none" href="#" id="keys_enable">
+                        <a class="dropdown-item d-none" id="keys_enable">
                             <i class="fas fa-keyboard fa-fw"></i> Enable keyboard shortcuts
                         </a>
 
@@ -139,14 +139,13 @@
                             <div class="dropstart">
                                 <div role="menuitem" class="dropdown-menu" aria-labelledby="themeDropdown">
                                     {% for theme, config in editor_themes %}
-                                        <a class="dropdown-item" href="#" data-editor-theme="{{ theme }}" onclick="applyEditorTheme('{{ theme }}', {{ config.external | default(false) }})">{{ config.name }}</a>
+                                        <a class="dropdown-item" data-editor-theme="{{ theme }}" onclick="applyEditorTheme('{{ theme }}', {{ config.external | default(false) }})">{{ config.name }}</a>
                                     {% endfor %}
                                 </div>
                             </div>
 
                             <a
                                 class="dropdown-item dropdown-toggle"
-                                href="#"
                                 data-editor-themes="{{ editor_themes | json_encode | escape('html_attr') }}"
                                 role="button"
                                 data-bs-toggle="dropdown"

--- a/webapp/templates/partials/menu_change_contest.html.twig
+++ b/webapp/templates/partials/menu_change_contest.html.twig
@@ -1,10 +1,10 @@
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownContests" role="button" data-bs-toggle="dropdown"
+    <a class="nav-link dropdown-toggle" id="navbarDropdownContests" role="button" data-bs-toggle="dropdown"
        aria-haspopup="true" aria-expanded="false">
         <i class="fas fa-trophy"></i> {{ contest.shortname|default('no contest') }}
     </a>
     <div role="menuitem" class="dropdown-menu scrollable-menu" aria-labelledby="navbarDropdown" data-current-contest="{{ current_contest_id }}">
-        <a class="dropdown-item disabled" href="#">Change Contest</a>
+        <a class="dropdown-item disabled">Change Contest</a>
         {% if show_no_contest and contest is not empty %}
             <a class="dropdown-item" href="{{ path(change_path, {'contestId': -1}) }}">no contest</a>
             <div class="dropdown-divider"></div>


### PR DESCRIPTION
These used to point to "#", which is ok when simply clicking on them while on a different page. While "open in new tab" type behaviors opened the current page instead of any page of the dropdown menu.

This happens to simplify the shadowing menu too since `show_shadow_differences` is only true when selecting a contest with shadowing enabled.

By removing all `href="#"` the links still work while they cannot be opened in new tabs.