### PR TITLE
Make mitration Version20250309122806 work with MySQL

### DIFF
--- a/webapp/migrations/Version20250309122806.php
+++ b/webapp/migrations/Version20250309122806.php
@@ -21,7 +21,7 @@ final class Version20250309122806 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE rankcache ADD sort_key_public TEXT DEFAULT \'\' NOT NULL COMMENT \'Opaque sort key for public audience.\', ADD sort_key_restricted TEXT DEFAULT \'\' NOT NULL COMMENT \'Opaque sort key for restricted audience.\'');
+        $this->addSql('ALTER TABLE rankcache ADD sort_key_public TEXT DEFAULT (\'\') NOT NULL COMMENT \'Opaque sort key for public audience.\', ADD sort_key_restricted TEXT DEFAULT (\'\') NOT NULL COMMENT \'Opaque sort key for restricted audience.\'');
         $this->addSql(sprintf('CREATE INDEX sortKeyPublic ON rankcache (sort_key_public(%s))', RankCache::SORT_KEY_INDEX_SIZE));
         $this->addSql(sprintf('CREATE INDEX sortKeyRestricted ON rankcache (sort_key_restricted(%s))', RankCache::SORT_KEY_INDEX_SIZE));
     }


### PR DESCRIPTION
In MySQL, a default value can be assigned only if the value is written as an expression, even if the expression value is a literal.

Fixes #3599