### PR TITLE
Validate that URL id matches payload id for user update API endpoint.

### DIFF
--- a/webapp/src/Controller/API/UserController.php
+++ b/webapp/src/Controller/API/UserController.php
@@ -338,8 +338,12 @@ class UserController extends AbstractRestController
     public function updateAction(
         #[MapRequestPayload(validationFailedStatusCode: Response::HTTP_BAD_REQUEST)]
         UpdateUser $updateUser,
-        Request $request
+        Request $request,
+        string $id,
     ): Response {
+        if ($id !== $updateUser->id) {
+            throw new BadRequestHttpException('ID in URL does not match ID in payload');
+        }
         return $this->addOrUpdateUser($updateUser, $request);
     }
 


### PR DESCRIPTION
The `PUT /api/users/{id}` endpoint ignored the id from the URL path, using only the id from the request body. Add validation to ensure they match, consistent with the groups endpoint.

See #3170.