### PR TITLE
Allow storing input/answer validator files

### DIFF
--- a/example_problems/fltcmp/input_validator/checktest_example_fltcmp.ctd
+++ b/example_problems/fltcmp/input_validator/checktest_example_fltcmp.ctd
@@ -1,0 +1,12 @@
+# This checktestdata script tests output of the "float compare"
+# example problem from DOMjudge. The expected output is a single
+# integer between 1 and 100 on the first line, followed by that many
+# lines, each containing a floating point number, which is possibly
+# "nan" (not a number) or "Inf" (infinity).
+#
+# For up-to-date version see: edu.nl/8fbar
+INT(1,100,n) NEWLINE
+REP(n)
+	REGEX("(Inf|nan|(\\+|-)?([0-9\.])+((E|e)(\\+|-)?[0-9]+)?)") NEWLINE
+END
+EOF

--- a/example_problems/hello/answer_validator/hello_world_answer_file.cpp
+++ b/example_problems/hello/answer_validator/hello_world_answer_file.cpp
@@ -1,0 +1,24 @@
+#include <cstddef>
+#include <iostream>
+#include <regex>
+#include <string>
+ 
+int main()
+{
+    std::string line;
+    int lines = 0;
+    std::string expected = "hello world!";
+
+    while (std::getline(std::cin, line)) {
+        lines += 1;
+        if (line.compare(expected)) {
+            exit 43;
+        }
+    }
+
+    if (lines != 1) {
+        exit 43;
+    }
+
+    exit 42;
+}

--- a/example_problems/hello/input_validator/any_input/build
+++ b/example_problems/hello/input_validator/any_input/build
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# POSIX shell build wrapper-script for input validation.
+#
+# This script does not actually "compile" the source, but writes a
+# shell script that will function as the executable: when called, it
+# will execute the source with the correct interpreter syntax, thus
+# allowing this interpreted source to be used transparently as if it
+# was compiled to a standalone binary.
+
+cat > "$DEST" <<EOF
+#!/bin/sh
+# Generated shell-script to execute shell interpreter on source.
+
+# Detect dirname and change dir to prevent file not found errors.
+if [ "\${0%/*}" != "\$0" ]; then
+	cd "\${0%/*}"
+fi
+
+# Uncomment the line below if you want it make easier for teams to do local
+# debugging.
+
+exec sh $RUNOPTIONS "$MAINSOURCE" "\$@"
+EOF
+
+chmod a+x "$DEST"
+
+exit 0

--- a/example_problems/hello/input_validator/any_input/run
+++ b/example_problems/hello/input_validator/any_input/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+MAINSOURCE="${ENTRY_POINT:-$1}"
+
+exec sh "$MAINSOURCE" "\$@"
+
+exit 0

--- a/example_problems/hello/input_validator/any_input/the_program
+++ b/example_problems/hello/input_validator/any_input/the_program
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Runas: <input_validator_program> [arguments] < inputfile
+# No arguments expected
+
+# Allow any inputfile
+exit 42

--- a/webapp/migrations/Version20260404091207.php
+++ b/webapp/migrations/Version20260404091207.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260404091207 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow storing the testcase .in/.ans validators.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE problem ADD input_validator VARCHAR(32) DEFAULT NULL COMMENT \'Executable ID (string)\', ADD answer_validator VARCHAR(32) DEFAULT NULL COMMENT \'Executable ID (string)\'');
+        $this->addSql('ALTER TABLE problem ADD CONSTRAINT FK_D7E7CCC8B88B7970 FOREIGN KEY (input_validator) REFERENCES executable (execid) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE problem ADD CONSTRAINT FK_D7E7CCC8C75D4F1E FOREIGN KEY (answer_validator) REFERENCES executable (execid) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_D7E7CCC8B88B7970 ON problem (input_validator)');
+        $this->addSql('CREATE INDEX IDX_D7E7CCC8C75D4F1E ON problem (answer_validator)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE problem DROP FOREIGN KEY FK_D7E7CCC8B88B7970');
+        $this->addSql('ALTER TABLE problem DROP FOREIGN KEY FK_D7E7CCC8C75D4F1E');
+        $this->addSql('DROP INDEX IDX_D7E7CCC8B88B7970 ON problem');
+        $this->addSql('DROP INDEX IDX_D7E7CCC8C75D4F1E ON problem');
+        $this->addSql('ALTER TABLE problem DROP input_validator, DROP answer_validator');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -90,17 +90,23 @@ class ExecutableController extends BaseController
                 ->join('cp.problem', 'p')
                 ->leftJoin('p.compare_executable', 'ecomp')
                 ->leftJoin('p.run_executable', 'erun')
-                ->andWhere('ecomp IS NOT NULL OR erun IS NOT NULL')
+                ->leftJoin('p.input_validator_executable', 'einp')
+                ->leftJoin('p.answer_validator_executable', 'eans')
+                ->andWhere('ecomp IS NOT NULL OR erun IS NOT NULL OR einp IS NOT NULL OR eans IS NOT NULL')
                 ->getQuery()->getResult();
             $executablesWithContestProblems = $em->createQueryBuilder()
                 ->select('e')
                 ->from(Executable::class, 'e')
                 ->leftJoin('e.problems_compare', 'pcomp')
                 ->leftJoin('e.problems_run', 'prun')
-                ->where('pcomp IS NOT NULL OR prun IS NOT NULL')
+                ->leftJoin('e.problems_input_validator', 'pinp')
+                ->leftJoin('e.problems_answer_validator', 'pans')
+                ->where('pcomp IS NOT NULL OR prun IS NOT NULL OR pinp IS NOT NULL OR pans IS NOT NULL')
                 ->leftJoin('pcomp.contest_problems', 'cpcomp')
                 ->leftJoin('prun.contest_problems', 'cprun')
-                ->andWhere('cprun.contest = :contest OR cpcomp.contest = :contest')
+                ->leftJoin('pinp.contest_problems', 'cpinp')
+                ->leftJoin('pans.contest_problems', 'cpans')
+                ->andWhere('cprun.contest = :contest OR cpcomp.contest = :contest OR cpinp.contest = :contest OR cpans.contest = :contest')
                 ->setParameter('contest', $this->dj->getCurrentContest())
                 ->getQuery()->getResult();
         }
@@ -108,7 +114,10 @@ class ExecutableController extends BaseController
         foreach ($executables as $e) {
             $badges = [];
             if (in_array($e, $executablesWithContestProblems)) {
-                foreach (array_merge($e->getProblemsRun()->toArray(), $e->getProblemsCompare()->toArray()) as $execProblem) {
+                foreach (array_merge(
+                    $e->getProblemsRun()->toArray(), $e->getProblemsCompare()->toArray(),
+                    $e->getProblemsInputValidator()->toArray(), $e->getProblemsAnswerValidator()->toArray()
+                ) as $execProblem) {
                     $execContestProblems = $execProblem->getContestProblems();
                     foreach ($contestProblemsWithExecutables as $cp) {
                         if ($execContestProblems->contains($cp)) {

--- a/webapp/src/Controller/Jury/ExecutableController.php
+++ b/webapp/src/Controller/Jury/ExecutableController.php
@@ -130,9 +130,11 @@ class ExecutableController extends BaseController
             $execdata['execid']['cssclass'] = 'execid';
             $type = $execdata['type']['value'];
             $execdata['icon']['icon'] = match ($type) {
+                'answer' => 'spell-check',
                 'compare' => 'code-compare',
                 'compile' => 'language',
                 'debug' => 'bug',
+                'input' => 'i',
                 'run' => 'person-running',
                 default => 'question',
             };

--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -341,15 +341,21 @@ class ProblemController extends BaseController
                 $problem->getProblemstatement());
         }
 
+        $inputValidatorExecutable = $problem->getInputValidatorExecutable() ?? null;
+        $answerValidatorExecutable = $problem->getAnswerValidatorExecutable() ?? null;
         $compareExecutable = null;
         if ($problem->getCompareExecutable()) {
             $compareExecutable = $problem->getCompareExecutable();
         } elseif ($problem->isInteractiveProblem()) {
             $compareExecutable = $problem->getRunExecutable();
         }
-        if ($compareExecutable) {
-            foreach ($compareExecutable->getImmutableExecutable()->getFiles() as $file) {
-                $filename = sprintf('output_validators/%s/%s', $compareExecutable->getExecid(), $file->getFilename());
+
+        foreach (['input' => $inputValidatorExecutable, 'answer' => $answerValidatorExecutable, 'output' => $compareExecutable] as $type => $validatorExecutable) {
+            if (!$validatorExecutable) {
+                continue;
+            }
+            foreach ($validatorExecutable->getImmutableExecutable()->getFiles() as $file) {
+                $filename = sprintf($type . '_validators/%s/%s', $validatorExecutable->getExecid(), $file->getFilename());
                 $zip->addFromString($filename, $file->getFileContent());
                 if ($file->isExecutable()) {
                     // 100755 = regular file, executable

--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -47,6 +47,18 @@ class Executable
     /**
      * @var Collection<int, Problem>
      */
+    #[ORM\OneToMany(targetEntity: Problem::class, mappedBy: 'answer_validator_executable')]
+    private Collection $problems_answer_validator;
+
+    /**
+     * @var Collection<int, Problem>
+     */
+    #[ORM\OneToMany(targetEntity: Problem::class, mappedBy: 'input_validator_executable')]
+    private Collection $problems_input_validator;
+
+    /**
+     * @var Collection<int, Problem>
+     */
     #[ORM\OneToMany(targetEntity: Problem::class, mappedBy: 'compare_executable')]
     private Collection $problems_compare;
 
@@ -58,9 +70,11 @@ class Executable
 
     public function __construct()
     {
-        $this->languages        = new ArrayCollection();
-        $this->problems_compare = new ArrayCollection();
-        $this->problems_run     = new ArrayCollection();
+        $this->languages                 = new ArrayCollection();
+        $this->problems_answer_validator = new ArrayCollection();
+        $this->problems_compare          = new ArrayCollection();
+        $this->problems_input_validator  = new ArrayCollection();
+        $this->problems_run              = new ArrayCollection();
     }
 
     public function setExecid(string $execid): Executable
@@ -113,6 +127,34 @@ class Executable
     public function getLanguages(): Collection
     {
         return $this->languages;
+    }
+
+    public function addProblemsAnswerValidator(Problem $problemsAnswerValidator): Executable
+    {
+        $this->problems_answer_validator[] = $problemsAnswerValidator;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Problem>
+     */
+    public function getProblemsAnswerValidator(): Collection
+    {
+        return $this->problems_answer_validator;
+    }
+
+    public function addProblemsInputValidator(Problem $problemsInputValidator): Executable
+    {
+        $this->problems_input_validator[] = $problemsInputValidator;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Problem>
+     */
+    public function getProblemsInputValidator(): Collection
+    {
+        return $this->problems_input_validator;
     }
 
     public function addProblemsCompare(Problem $problemsCompare): Executable
@@ -190,7 +232,7 @@ class Executable
         if (in_array($this->execid, $configScripts, true)) {
             return true;
         }
-        if (count($this->problems_compare) || count($this->problems_run)) {
+        if (count($this->problems_compare) || count($this->problems_run) || count($this->problems_input_validator) || count($this->problems_answer_validator)) {
             return true;
         }
         foreach ($this->languages as $lang) {

--- a/webapp/src/Entity/Executable.php
+++ b/webapp/src/Entity/Executable.php
@@ -16,7 +16,7 @@ use ZipArchive;
 #[ORM\Table(options: [
     'collation' => 'utf8mb4_unicode_ci',
     'charset' => 'utf8mb4',
-    'comment' => 'Compile, compare, and run script executable bundles',
+    'comment' => 'Answer, compile, compare, input and run script executable bundles',
 ])]
 class Executable
 {
@@ -31,7 +31,7 @@ class Executable
     private ?string $description = null;
 
     #[ORM\Column(length: 32, options: ['comment' => 'Type of executable'])]
-    #[Assert\Choice(['compare', 'compile', 'debug', 'run'])]
+    #[Assert\Choice(['answer', 'compare', 'compile', 'debug', 'input', 'run'])]
     private string $type;
 
     #[ORM\OneToOne(targetEntity: ImmutableExecutable::class)]

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -156,6 +156,16 @@ class Problem extends BaseApiEntity implements
     #[Serializer\Exclude]
     private Collection $contest_problems;
 
+    #[ORM\ManyToOne(inversedBy: 'problems_input_validator')]
+    #[ORM\JoinColumn(name: 'input_validator', referencedColumnName: 'execid', onDelete: 'SET NULL')]
+    #[Serializer\Exclude]
+    private ?Executable $input_validator_executable = null;
+
+    #[ORM\ManyToOne(inversedBy: 'problems_answer_validator')]
+    #[ORM\JoinColumn(name: 'answer_validator', referencedColumnName: 'execid', onDelete: 'SET NULL')]
+    #[Serializer\Exclude]
+    private ?Executable $answer_validator_executable = null;
+
     #[ORM\ManyToOne(inversedBy: 'problems_compare')]
     #[ORM\JoinColumn(name: 'special_compare', referencedColumnName: 'execid', onDelete: 'SET NULL')]
     #[Serializer\Exclude]
@@ -462,6 +472,28 @@ class Problem extends BaseApiEntity implements
     public function getProblemstatementType(): ?string
     {
         return $this->problemstatement_type;
+    }
+
+    public function setInputValidatorExecutable(?Executable $inputValidatorExecutable = null): Problem
+    {
+        $this->input_validator_executable = $inputValidatorExecutable;
+        return $this;
+    }
+
+    public function getInputValidatorExecutable(): ?Executable
+    {
+        return $this->input_validator_executable;
+    }
+
+    public function setAnswerValidatorExecutable(?Executable $answerValidatorExecutable = null): Problem
+    {
+        $this->answer_validator_executable = $answerValidatorExecutable;
+        return $this;
+    }
+
+    public function getAnswerValidatorExecutable(): ?Executable
+    {
+        return $this->answer_validator_executable;
     }
 
     public function setCompareExecutable(?Executable $compareExecutable = null): Problem

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -1131,7 +1131,11 @@ readonly class ImportProblemService
                 ->setType($validatorType);
             $this->em->persist($executable);
 
-            if ($validatorTag === 'output') {
+            if ($validatorTag === 'answer') {
+                $problem->setAnswerValidatorExecutable($executable);
+            } elseif ($validatorTag === 'input') {
+                $problem->setInputValidatorExecutable($executable);
+            } elseif ($validatorTag === 'output') {
                 if ($combinedRunCompare) {
                     $problem->setRunExecutable($executable);
                 } else {

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -297,7 +297,15 @@ readonly class ImportProblemService
             return null;
         }
 
-        if (!$this->searchAndAddValidator($zip, $zipEntries, $messages, $externalId, $validationMode, $problem)) {
+        if (!$this->searchAndAddValidator($zip, $zipEntries, $messages, $externalId, 'input', $problem, 'input')) {
+            return null;
+        }
+
+        if (!$this->searchAndAddValidator($zip, $zipEntries, $messages, $externalId, 'answer', $problem, 'answer')) {
+            return null;
+        }
+
+        if (!$this->searchAndAddValidator($zip, $zipEntries, $messages, $externalId, $validationMode, $problem, 'output')) {
             return null;
         }
 
@@ -1019,11 +1027,14 @@ readonly class ImportProblemService
      * @param array<int, string> $zipEntries
      * @param array{danger?: string[], info?: string[]} $messages
      */
-    private function searchAndAddValidator(ZipArchive $zip, array $zipEntries, array &$messages, string $externalId, string $validationMode, ?Problem $problem): bool
-    {
+    private function searchAndAddValidator(
+        ZipArchive $zip, array $zipEntries, array &$messages, string $externalId,
+        string $validationMode, ?Problem $problem, string $validatorTag
+    ): bool {
         $validatorFiles = [];
+        $validatorDirs = [$validatorTag . '_validator', $validatorTag . '_validators'];
         foreach ($zipEntries as $filename) {
-            foreach (['output_validators/', 'output_validator'] as $dir) {
+            foreach ($validatorDirs as $dir) {
                 if (Utils::startsWith($filename, $dir) &&
                     !Utils::endsWith($filename, '/')) {
                     $validatorFiles[] = $filename;
@@ -1031,7 +1042,7 @@ readonly class ImportProblemService
             }
         }
         if (count($validatorFiles) == 0) {
-            if ($validationMode === 'default') {
+            if (in_array($validationMode, ['default', 'input', 'answer'])) {
                 return true;
             } else {
                 $messages['danger'][] = 'Custom validator specified but not found.';
@@ -1051,7 +1062,7 @@ readonly class ImportProblemService
             }
         }
         if (!$sameDir) {
-            $messages['danger'][] = 'Found multiple custom output validators.';
+            $messages['danger'][] = 'Found multiple custom ' . $validatorTag . ' validators.';
             return false;
         } else {
             $tmpzipfiledir = exec("mktemp -d --tmpdir=" .
@@ -1074,50 +1085,61 @@ readonly class ImportProblemService
                 }
             }
 
-            exec("zip -r -j '$tmpzipfiledir/outputvalidator.zip' '$tmpzipfiledir'",
+            exec("zip -r -j '$tmpzipfiledir/" . $validatorTag . "validator.zip' '$tmpzipfiledir'",
                 $dontcare, $retval);
             if ($retval != 0) {
                 throw new ServiceUnavailableHttpException(
-                    null, 'Failed to create ZIP file for output validator.'
+                    null, 'Failed to create ZIP file for ' . $validatorTag . ' validator.'
                 );
             }
 
-            $outputValidatorZip = file_get_contents($tmpzipfiledir . '/outputvalidator.zip');
-            $outputValidatorName = substr($externalId, 0, 20) . '_cmp';
-            if ($this->em->getRepository(Executable::class)->find($outputValidatorName)) {
+            $validatorZip = file_get_contents($tmpzipfiledir . '/' . $validatorTag . 'validator.zip');
+            $validatorName = substr($externalId, 0, 20) . '_cmp';
+            if (in_array($validatorTag, ['input', 'answer'])) {
+                $validatorName = substr($externalId, 0, 20) . '_tc';
+            }
+            if ($this->em->getRepository(Executable::class)->find($validatorName)) {
                 // Avoid name clash.
                 $clashCount = 2;
                 while ($this->em->getRepository(Executable::class)->find(
-                    $outputValidatorName . '_' . $clashCount)) {
+                    $validatorName . '_' . $clashCount)) {
                     $clashCount++;
                 }
-                $outputValidatorName = $outputValidatorName . "_" . $clashCount;
+                $validatorName = $validatorName . "_" . $clashCount;
             }
-
-            $combinedRunCompare = $validationMode == 'custom interactive';
 
             if (!($tempzipFile = tempnam($this->dj->getDomjudgeTmpDir(), "/executable-"))) {
                 throw new ServiceUnavailableHttpException(null, 'Failed to create temporary file.');
             }
-            file_put_contents($tempzipFile, $outputValidatorZip);
+            file_put_contents($tempzipFile, $validatorZip);
             $zipArchive = new ZipArchive();
             $zipArchive->open($tempzipFile, ZipArchive::CREATE);
 
-            $executable = new Executable();
-            $executable
-                ->setExecid($outputValidatorName)
-                ->setImmutableExecutable($this->dj->createImmutableExecutable($zipArchive))
-                ->setDescription(sprintf('output validator for %s', $problem->getName()))
-                ->setType($combinedRunCompare ? 'run' : 'compare');
-            $this->em->persist($executable);
+            // Only relevant for output_validator
+            $combinedRunCompare = $validationMode == 'custom interactive';
 
-            if ($combinedRunCompare) {
-                $problem->setRunExecutable($executable);
-            } else {
-                $problem->setCompareExecutable($executable);
+            $validatorType = $combinedRunCompare ? 'run' : 'compare';
+            if (in_array($validationMode, ['input', 'answer'])) {
+                $validatorType = $validatorTag;
             }
 
-            $messages['info'][] = "Added output validator '$outputValidatorName'.";
+            $executable = new Executable();
+            $executable
+                ->setExecid($validatorName)
+                ->setImmutableExecutable($this->dj->createImmutableExecutable($zipArchive))
+                ->setDescription(sprintf($validatorTag . ' validator for %s', $problem->getName()))
+                ->setType($validatorType);
+            $this->em->persist($executable);
+
+            if ($validatorTag === 'output') {
+                if ($combinedRunCompare) {
+                    $problem->setRunExecutable($executable);
+                } else {
+                    $problem->setCompareExecutable($executable);
+                }
+            }
+
+            $messages['info'][] = "Added " . $validatorTag . " validator '$validatorName'.";
         }
         return true;
     }

--- a/webapp/templates/jury/executable.html.twig
+++ b/webapp/templates/jury/executable.html.twig
@@ -46,8 +46,22 @@
                             <em>default full debug</em>
                             {% set used = true %}
                         {% endif %}
-                        {% if executable.type == 'compare' %}
+                        {% if executable.type == 'answer' %}
+                            {% for problem in executable.problemsAnswerValidator %}
+                                <a href="{{ path('jury_problem', {'probId': problem.externalid}) }}">
+                                    {{ problem.externalid }} {{ problem | problemBadgeForContest }}
+                                </a>
+                                {% set used = true %}
+                            {% endfor %}
+                        {% elseif executable.type == 'compare' %}
                             {% for problem in executable.problemsCompare %}
+                                <a href="{{ path('jury_problem', {'probId': problem.externalid}) }}">
+                                    {{ problem.externalid }} {{ problem | problemBadgeForContest }}
+                                </a>
+                                {% set used = true %}
+                            {% endfor %}
+                        {% elseif executable.type == 'input' %}
+                            {% for problem in executable.problemsInputValidator %}
                                 <a href="{{ path('jury_problem', {'probId': problem.externalid}) }}">
                                     {{ problem.externalid }} {{ problem | problemBadgeForContest }}
                                 </a>

--- a/webapp/templates/jury/problem.html.twig
+++ b/webapp/templates/jury/problem.html.twig
@@ -47,6 +47,22 @@
                             </a>
                         </td>
                     </tr>
+                    {% if problem.answerValidatorExecutable is not empty %}
+                        <tr>
+                            <th>Answer file validator script</th>
+                            <td class="filename">
+                                <a href="{{ path('jury_executable', {'execId': problem.answerValidatorExecutable.execid}) }}">{{ problem.answerValidatorExecutable.execid }}</a>
+                            </td>
+                        </tr>
+                    {% endif %}
+                    {% if problem.inputValidatorExecutable is not empty %}
+                        <tr>
+                            <th>Input file validator script</th>
+                            <td class="filename">
+                                <a href="{{ path('jury_executable', {'execId': problem.inputValidatorExecutable.execid}) }}">{{ problem.inputValidatorExecutable.execid }}</a>
+                            </td>
+                        </tr>
+                    {% endif %}
                     {{ _self.section_header('tachometer-alt', 'Limits') }}
                     <tr>
                         <th>Time</th>

--- a/webapp/tests/Unit/Integration/ProblemExportImportTest.php
+++ b/webapp/tests/Unit/Integration/ProblemExportImportTest.php
@@ -138,14 +138,16 @@ class ProblemExportImportTest extends BaseTestCase
                 continue;
             }
 
-            // Normalize output_validators/ directory names: on re-import the
+            // Normalize {answer,input,output}_validators/ directory names: on re-import the
             // executable ID is derived from the zip filename, so the
             // subdirectory would change. Normalize to a hardcoded placeholder.
-            $filename = preg_replace(
-                '#^output_validators/[^/]+/#',
-                'output_validators/_normalized_/',
-                $filename
-            );
+            foreach (['answer', 'input', 'output'] as $validatorType) {
+                $filename = preg_replace(
+                    '#^' . $validatorType . '_validators/[^/]+/#',
+                    $validatorType . '_validators/_normalized_/',
+                    $filename
+                );
+            }
 
             $normalized[$filename] = $content;
         }


### PR DESCRIPTION
In the next step I want to run those on the judgehost to validate the different input/answer files as extra information for the config checker. This might be controversial but:
- I think there are a couple of jury members who use DOMjudge to do problem development adding this is a relatively simple thing todo and would help them.
- It is a good usecase for the separate chroot folders and to develop this further
- It prevents us from losing this information when we export a problem.

Before I spend more time on this I would like to know if we have any objections. Currently the input validator scripts themselves are probably broken but that's a feature for the future work I proposed. If we decide to merge this I'll take them out.