### PR TITLE
Add missing testcase separator for sample only case

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -350,8 +350,10 @@ class TwigExtension
         }
 
         $total = count($testcases);
+        $separator = '<span class="tc-sep"></span>';
+        $tcBar = '<span class="tc-bar">%s</span>';
         if ($total === 0) {
-            return '';
+            return sprintf($tcBar, $separator);
         }
 
         $segments = '';
@@ -359,7 +361,7 @@ class TwigExtension
 
         foreach ($testcases as $key => $testcase) {
             if ($testcase['sample'] != $lastTypeSample) {
-                $segments       .= '<span class="tc-sep"></span>';
+                $segments       .= $separator;
                 $lastTypeSample = $testcase['sample'];
             }
 
@@ -392,8 +394,11 @@ class TwigExtension
 
             $segments .= sprintf('<span class="tc-seg %s" title="%s"></span>', $class, $title);
         }
+        if (!str_contains($segments, $separator)) {
+            $segments .= $separator;
+        }
 
-        return sprintf('<span class="tc-bar">%s</span>', $segments);
+        return sprintf($tcBar, $segments);
     }
 
     // TODO: this function shares a lot with the above one, unify them?


### PR DESCRIPTION
<img width="606" height="1014" alt="Screenshot_2026-04-05_10-08-52" src="https://github.com/user-attachments/assets/eefd8af5-a8f7-4c65-aadd-e082a31bfd27" />

The 2nd commit handles the case of no testcase. It looks kinda ugly but as this should never happen and we have cases where we don't display the testcase box it might be better to explicit explain this situation?