### PR TITLE
runguard: do not attempt to get username in error handling

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -687,19 +687,6 @@ int groupid(char *name)
 	return (int) grp->gr_gid;
 }
 
-char *username()
-{
-	int saved_errno = errno;
-	errno = 0; /* per the linux GETPWNAM(3) man-page */
-
-	struct passwd *pwd;
-	pwd = getpwuid(getuid());
-
-	if ( pwd==nullptr || errno ) die(errno,"failed to get username");
-	errno = saved_errno;
-
-	return pwd->pw_name;
-}
 
 long read_optarg_int(const char *desc, long minval, long maxval)
 {
@@ -1283,7 +1270,7 @@ int main(int argc, char **argv)
 
 		/* And execute child command. */
 		execvp(cmdname,cmdargs);
-		die(errno,"cannot start `{}' as user `{}'", cmdname, username());
+		die(errno,"cannot start `{}' as user `{}'", cmdname, getuid());
 
 	default: /* become watchdog */
 		logmsg(LOG_DEBUG, "child pid = {}", child_pid);


### PR DESCRIPTION
This error handling code is executed as the domjudge-run-X user in the chroot, but the /etc/passwd file in the chroot does not contain an entry for the user.  Thus username() always fail and the "failed to get username" message always cover the real error, making the debugging process very frusturating.

Drop the username() thing and simply print the user ID instead.