### PR TITLE
runguard: set the no_new_privs attribute before dropping the root privilege

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -72,6 +72,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <linux/prctl.h>
+#include <sys/prctl.h>
 
 #define PROGRAM "runguard"
 #define VERSION DOMJUDGE_VERSION "/" REVISION
@@ -869,6 +871,9 @@ void setrestrictions()
 	}
 	/* Set user-id (must be root for this). */
 	if ( use_user ) {
+		if ( prctl(PR_SET_NO_NEW_PRIVS, 1L, 0L, 0L, 0L) ) {
+			die(errno, "cannot set no_new_privs attribute");
+		}
 		if ( setuid(runuid) ) die(errno,"cannot set user ID to `{}'",runuid);
 		logmsg(LOG_DEBUG, "using user ID `{}' for command",runuid);
 	} else {


### PR DESCRIPTION
Currently the only measure to prevent the domjudge-run-X user from regaining the root privilege is sanitizing the setuid executables in dj_make_chroot.  It's not complete and it causes difficulties to use a custom rootfs tree.  Even simply upgrading an exist rootfs created by dj_make_chroot using "dj_run_chroot apt upgrade" can bring those setuid executables back if a package containing such an executable is upgraded.

Use the idomatic method, the no_new_privs attribute provided by the Linux kernel to prevent regaining the root privilege all at once.