### PR TITLE
Better handle disk space errors during compilation.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1663,7 +1663,19 @@ class JudgeDaemon
             $compile_output .= "\n--------------------------------------------------------------------------------\n\n" .
                 "Internal errors reported:\n" . $internalError;
 
-            if (str_starts_with($internalError, 'compile script: ')) {
+            $diskSpacePattern = '/no space left on device/i';
+            $isDiskSpaceError = preg_match($diskSpacePattern, $internalError) ||
+                preg_match($diskSpacePattern, $compile_output);
+
+            if ($isDiskSpaceError) {
+                $free_space = disk_free_space(JUDGEDIR);
+                $free_abs = $free_space !== false
+                    ? sprintf("%01.2fGB", $free_space / (1024 * 1024 * 1024))
+                    : 'unknown';
+                $description = "Out of disk space during compilation on $this->myhost ($free_abs free). " .
+                    "Clean up or increase 'diskspace_error' threshold.";
+                $this->disable('judgehost', 'hostname', $this->myhost, $description, $judgeTask['judgetaskid'], $compile_output);
+            } elseif (str_starts_with($internalError, 'compile script: ')) {
                 $internalError = preg_replace('/^compile script: /', '', $internalError);
                 $description = "The compile script returned an error: $internalError";
                 $this->disable('compile_script', 'compile_script_id', $judgeTask['compile_script_id'], $description, $judgeTask['judgetaskid'], $compile_output);

--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -64,6 +64,7 @@ readonly class CheckConfigService
             'adminpass' => $this->checkAdminPass(),
             'comparerun' => $this->checkDefaultCompareRunExist(),
             'filesizememlimit' => $this->checkScriptFilesizevsMemoryLimit(),
+            'diskspacescriptfilesize' => $this->checkDiskspaceErrorVsScriptFilesizeLimit(),
             'debugdisabled' => $this->checkDebugDisabled(),
             'tmpdirwritable' => $this->checkTmpdirWritable(),
             'hashtime' => $this->checkHashTime(),
@@ -369,6 +370,29 @@ readonly class CheckConfigService
             'recommend to include a margin to be on the safe side. The current ' .
             '`script_filesize_limit` = `' . $this->config->get('script_filesize_limit') . '` ' .
             'while `memory_limit` = `' . $this->config->get('memory_limit') . '`.'
+        );
+    }
+
+    public function checkDiskspaceErrorVsScriptFilesizeLimit(): ConfigCheckItem
+    {
+        $this->stopwatch->start(__FUNCTION__);
+        $diskspace_error = $this->config->get('diskspace_error');
+        $script_filesize_limit = $this->config->get('script_filesize_limit');
+        // Both values are in kB.
+        if ($diskspace_error < $script_filesize_limit) {
+            $result = 'W';
+        } else {
+            $result = 'O';
+        }
+        $this->stopwatch->stop(__FUNCTION__);
+        return new ConfigCheckItem(
+            caption: 'Disk space error threshold vs. script filesize limit',
+            result: $result,
+            desc: 'If the disk space error threshold is lower than the script filesize limit, ' .
+            'the judgehost may run out of disk space during compilation without triggering ' .
+            'the disk space check. We recommend `diskspace_error` >= `script_filesize_limit`. ' .
+            'The current `diskspace_error` = `' . $diskspace_error . '` kB ' .
+            'while `script_filesize_limit` = `' . $script_filesize_limit . '` kB.'
         );
     }
 


### PR DESCRIPTION
- Add a warning to the config checker if allowed file size > minimum free disk space.
- Look for disk space errors when compiling and handle them more explicitly.

Fixes #2454