### PR TITLE
Add 'bcmath' to required PHP extensions check

### DIFF
--- a/webapp/src/Service/CheckConfigService.php
+++ b/webapp/src/Service/CheckConfigService.php
@@ -132,7 +132,7 @@ readonly class CheckConfigService
     public function checkPhpExtensions(): ConfigCheckItem
     {
         $this->stopwatch->start(__FUNCTION__);
-        $required = ['ds', 'gd', 'intl', 'json', 'mbstring', 'mysqli', 'zip'];
+        $required = ['bcmath', 'ds', 'gd', 'intl', 'json', 'mbstring', 'mysqli', 'zip'];
         $state = 'O';
         $remark = '';
         $missing = [];


### PR DESCRIPTION
`php-bcmath` is needed when running the contest. Add this to the checklist.

P.S. In the [installation manual](https://www.domjudge.org/snapshot/manual/install-domserver.html#installation), `bcmath` extension is not mentioned. And `curl` and `xml` are not checked, either.

UPD: `php-curl` seems used in judgehost only, not in domserver.