### PR TITLE
Fix internal/external issue for problems

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -269,11 +269,11 @@ class PublicController extends BaseController
     {
         $contest = $this->dj->getCurrentContest(onlyPublic: true);
         if (!$contest || !$contest->getFreezeData()->started()) {
-            throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
+            throw new NotFoundHttpException(sprintf('Problem %s not found or not available', $probId));
         }
         $contestProblem = $this->em->getRepository(ContestProblem::class)->findByProblemAndContest($contest, $probId);
         if (!$contestProblem) {
-            throw new NotFoundHttpException(sprintf('Problem p%d not found or not available', $probId));
+            throw new NotFoundHttpException(sprintf('Problem %s not found or not available', $probId));
         }
 
         return $response($probId, $contest, $contestProblem);


### PR DESCRIPTION
We moved to using the externalID everywhere, which changed the type from an int (internal) to an string (external).

Sentry received an error (https://domjudge.sentry.io/issues/6920763161/?query=is%3Aunresolved&referrer=issue-stream) for another place where we forgot this.