### PR TITLE
Install composer from upstream in debian:testing

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -111,11 +111,11 @@ compiler_assertions () {
     assert_line "checking whether the linker accepts -Wl,-z,relro... yes"
     assert_line "checking whether the linker accepts -Wl,-z,now... yes"
     assert_line "checking whether $1 accepts -g... yes"
-    assert_regex "^checking for $1 option to (enable C11 features|accept ISO C89)\.\.\. none needed$"
+    assert_regex "^checking for $1 option to (enable C11 features|enable C23 features|accept ISO C89)\.\.\. (none needed|-std=gnu23)$"
     assert_line "checking whether $1 accepts -g... (cached) yes"
     if [ -n "$2" ]; then
         assert_line "checking whether $2 accepts -g... yes"
-        assert_line "checking how to run the C preprocessor... $1 -E"
+        assert_regex "^checking how to run the C preprocessor... $1( -std=gnu23|) -E$"
         assert_line "checking how to run the C++ preprocessor... $2 -E"
     fi
 }

--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -44,12 +44,28 @@ run_configure () {
     su $u -c "./configure $*"
 }
 
+composer-install () {
+    repo-install curl
+    curl "https://getcomposer.org/download/latest-stable/composer.phar" -o /usr/local/bin/composer
+    chmod +x /usr/local/bin/composer
+}
+
 repo-install () {
     args=$(translate $@)
+    if [ "$distro_id" = "ID=debian" ] && [[ "$args" == *"composer"* ]]; then
+        args=${args/composer/}
+        if ! apt-get install -qq -y composer; then
+            composer-install
+        fi
+    fi
     ${cmd} install $args -y >/dev/null
 }
 repo-remove () {
     args=$(translate $@)
+    if [ "$distro_id" = "ID=debian" ] && [[ "$args" == *"composer"* ]]; then
+        args=${args/composer/}
+        apt-get remove -y composer; rm -rf /usr/local/bin/composer
+    fi
     ${cmd} remove $args -y #>/dev/null
     if [ "$distro_id" != "ID=fedora" ]; then
         apt-get autoremove -y 2>/dev/null

--- a/.github/jobs/configure-checks/setup_configure_image.sh
+++ b/.github/jobs/configure-checks/setup_configure_image.sh
@@ -11,8 +11,8 @@ case $distro_id in
     *)
         apt-get update; apt-get full-upgrade -y
         # Install g++-12 to make sure we can use -std=c++20
-        version=$(g++ -dumpversion 2>/dev/null | awk -F'.' '{print $1}' 2>/dev/null || echo 0); [ "${version}" -lt 12 ] && apt install -y g++-12
-        apt-get install pkg-config make bats autoconf -y ;;
+        version=$(g++ -dumpversion 2>/dev/null | awk -F'.' '{print $1}' 2>/dev/null || echo 0); [ "${version}" -lt 12 ] && apt-get install -y g++-12
+        apt-get install pkg-config make bats autoconf php -y ;;
 esac
 
 # Build the configure file


### PR DESCRIPTION
The package is temporarily not available, so we fall-back to installing the upstream version as we did when we needed composer 2 and 1 was only available in the repo's.

I did not test this yet, so triggering CI now.