### PR TITLE
The judgedaemon only uses C++ code

### DIFF
--- a/.github/jobs/configure-checks/all.bats
+++ b/.github/jobs/configure-checks/all.bats
@@ -72,58 +72,35 @@ repo-remove () {
     fi
 }
 
-@test "Default empty configure" {
-    # cleanup from earlier runs
-    repo-remove gcc g++ clang
+compiler_c_only_assertions () {
     run ./configure
-    assert_failure 1
-    assert_line "checking whether configure should try to set CFLAGS... yes"
+    assert_failure
     assert_line "checking whether configure should try to set CXXFLAGS... yes"
     assert_line "checking whether configure should try to set LDFLAGS... yes"
-    assert_line "checking for gcc... no"
-    assert_line "checking for cc... no"
+    assert_line "checking for g++... no"
+    assert_line "checking for c++... no"
+    assert_line "checking for gpp... no"
+    assert_line "checking for aCC... no"
+    assert_line "checking for CC... no"
+    assert_line "checking for cxx... no"
+    assert_line "checking for cc++... no"
     assert_line "checking for cl.exe... no"
+    assert_line "checking for FCC... no"
+    assert_line "checking for KCC... no"
+    assert_line "checking for RCC... no"
+    assert_line "checking for xlC_r... no"
+    assert_line "checking for xlC... no"
+    assert_line "checking for clang++... no"
+    assert_line "checking whether the C++ compiler works... no"
     assert_regex "configure: error: in .${test_path}':"
-    assert_line 'configure: error: no acceptable C compiler found in $PATH'
+    assert_line "configure: error: C++ compiler cannot create executables"
     assert_regex "See [\`']config.log' for more details"
 }
 
-compiler_assertions () {
-    run run_configure
-    # Depending on where we run this we might runas wrong user or lack libraries
-    # so we can't expect either success or failure.
-    assert_line "checking baseurl... https://example.com/domjudge/"
-    assert_line "checking whether configure should try to set CFLAGS... yes"
-    assert_line "checking whether configure should try to set CXXFLAGS... yes"
-    assert_line "checking whether configure should try to set LDFLAGS... yes"
-    assert_line "checking whether the C compiler works... yes"
-    assert_line "checking for C compiler default output file name... a.out"
-    assert_line "checking for suffix of executables... "
-    assert_line "checking whether we are cross compiling... no"
-    assert_line "checking for suffix of object files... o"
-    assert_regex "checking whether .*GNU C.*\.\.\. yes"
-    assert_line "checking whether C compiler accepts -Wall... yes"
-    assert_line "checking whether C compiler accepts -fstack-protector... yes"
-    assert_line "checking whether C compiler accepts -fPIE... yes"
-    assert_line "checking whether C compiler accepts -D_FORTIFY_SOURCE=2... yes"
-    assert_line "checking whether the linker accepts -fPIE... yes"
-    assert_line "checking whether the linker accepts -pie... yes"
-    assert_line "checking whether the linker accepts -Wl,-z,relro... yes"
-    assert_line "checking whether the linker accepts -Wl,-z,now... yes"
-    assert_line "checking whether $1 accepts -g... yes"
-    assert_regex "^checking for $1 option to (enable C11 features|enable C23 features|accept ISO C89)\.\.\. (none needed|-std=gnu23)$"
-    assert_line "checking whether $1 accepts -g... (cached) yes"
-    if [ -n "$2" ]; then
-        assert_line "checking whether $2 accepts -g... yes"
-        assert_regex "^checking how to run the C preprocessor... $1( -std=gnu23|) -E$"
-        assert_line "checking how to run the C++ preprocessor... $2 -E"
-    fi
-}
-
-compile_assertions_finished () {
-    assert_line " * CFLAGS..............: -g -O2 -Wall -Wformat -Wformat-security -pedantic -fstack-protector -fPIE -D_FORTIFY_SOURCE=2 -std=c11"
-    assert_line " * CXXFLAGS............: -g -O2 -Wall -Wformat -Wformat-security -pedantic -fstack-protector -fPIE -D_FORTIFY_SOURCE=2 -std=c++20"
-    assert_line " * LDFLAGS.............:  -fPIE -pie -Wl,-z,relro -Wl,-z,now"
+@test "Default empty configure" {
+    # cleanup from earlier runs
+    repo-remove gcc g++ clang
+    compiler_c_only_assertions
 }
 
 @test "Install GNU C only" {
@@ -133,10 +110,45 @@ compile_assertions_finished () {
     fi
     repo-remove clang g++
     repo-install gcc libcgroup-dev
-    compiler_assertions gcc ''
-    assert_line "checking for gcc... gcc"
-    assert_line "checking whether gcc accepts -g... yes"
-    assert_line "configure: error: C++ preprocessor \"/lib/cpp\" fails sanity check"
+    compiler_c_only_assertions
+}
+
+compiler_assertions () {
+    run run_configure
+    # Depending on where we run this we might runas wrong user or lack libraries
+    # so we can't expect either success or failure.
+    assert_line "checking baseurl... https://example.com/domjudge/"
+    assert_line "checking whether configure should try to set CXXFLAGS... yes"
+    assert_line "checking whether configure should try to set LDFLAGS... yes"
+    assert_line "checking for C++ compiler default output file name... a.out"
+    assert_line "checking whether we are cross compiling... no"
+    assert_line "checking for suffix of object files... o"
+    assert_line "checking whether the compiler supports GNU C++... yes"
+    assert_line "checking whether C++ compiler accepts -Wall... yes"
+    assert_line "checking whether C++ compiler accepts -Wformat... yes"
+    assert_line "checking whether C++ compiler accepts -Wformat-security... yes"
+    assert_line "checking whether C++ compiler accepts -pedantic... yes"
+    assert_line "checking whether C++ compiler accepts -fstack-protector... yes"
+    assert_line "checking whether C++ compiler accepts -fPIE... yes"
+    assert_line "checking whether C++ compiler accepts -D_FORTIFY_SOURCE=2... yes"
+    assert_regex "checking whether .*GNU C.*\.\.\. yes"
+    assert_line "checking whether the linker accepts -fPIE... yes"
+    assert_line "checking whether the linker accepts -pie... yes"
+    assert_line "checking whether the linker accepts -Wl,-z,relro... yes"
+    assert_line "checking whether the linker accepts -Wl,-z,now... yes"
+    assert_line "checking whether $1 accepts -g... yes"
+    assert_regex "^checking for $1 option to (enable C11 features|enable C23 features|accept ISO C89)\.\.\. (none needed|-std=gnu23)$"
+    if [ -n "$2" ]; then
+        assert_line "checking whether $2 accepts -g... yes"
+        assert_regex "^checking how to run the C preprocessor... $1( -std=gnu23|) -E$"
+        assert_line "checking how to run the C++ preprocessor... $2 -E"
+    fi
+}
+
+compile_assertions_finished () {
+    assert_line "checking whether the C++ compiler works... yes"
+    assert_line " * CXXFLAGS............: -g -O2 -Wall -Wformat -Wformat-security -pedantic -fstack-protector -fPIE -D_FORTIFY_SOURCE=2 -std=c++20"
+    assert_line " * LDFLAGS.............:  -fPIE -pie -Wl,-z,relro -Wl,-z,now"
 }
 
 @test "Install GNU C++ only" {

--- a/configure.ac
+++ b/configure.ac
@@ -47,10 +47,12 @@ AC_ARG_ENABLE([judgehost-build],AS_HELP_STRING([--enable-judgehost-build],
 [if test "x$enableval" = xno ; then AC_SUBST(JUDGEHOST_BUILD_ENABLED,no) fi])
 
 if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
-	# Set default {C,CXX,LD}FLAGS. This might screw up portability, but
+	# The judgedaemon only uses C++ code
+	AC_LANG([C++])
+	# Set default {CXX,LD}FLAGS. This might screw up portability, but
 	# adds important security. Only set these flags when none are supplied
 	# by the user.
-	for flag in CFLAGS CXXFLAGS LDFLAGS ; do
+	for flag in CXXFLAGS LDFLAGS ; do
 		AC_MSG_CHECKING([whether configure should try to set $flag])
 		if test x`eval echo '${'$flag'+set}'` = xset ; then res=no ; else res=yes ; fi
 		eval enable_${flag}_setting=$res
@@ -71,7 +73,6 @@ if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
 	AX_APPEND_LINK_FLAGS([-Wl,-z,relro], DEF_LDFLAGS)
 	AX_APPEND_LINK_FLAGS([-Wl,-z,now],   DEF_LDFLAGS)
 
-	test "x$enable_CFLAGS_setting"   = xyes && AC_SUBST(CFLAGS,   "$DEF_CXFLAGS -std=c11")
 	test "x$enable_CXXFLAGS_setting" = xyes && AC_SUBST(CXXFLAGS, "$DEF_CXFLAGS -std=c++20")
 	test "x$enable_LDFLAGS_setting"  = xyes && AC_SUBST(LDFLAGS,  $DEF_LDFLAGS)
 fi
@@ -267,7 +268,6 @@ AC_MSG_RESULT($BASEURL)
 # Checks for programs.
 if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
 AC_PROG_CXX
-AC_PROG_CC
 AC_PROG_CXXCPP
 AC_PROG_CPP
 fi
@@ -342,7 +342,6 @@ echo " * installation source.: $INSTALL_METHOD"
 echo " * prefix..............: $prefix"
 if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
 echo " * CPPFLAGS............: $CPPFLAGS"
-echo " * CFLAGS..............: $CFLAGS"
 echo " * CXXFLAGS............: $CXXFLAGS"
 echo " * LDFLAGS.............: $LDFLAGS"
 fi


### PR DESCRIPTION
This seems to work and I can´t find another `.c` file anymore.

If we still use `C` code somewhere the `inplace-{conf,install}` targets don´t properly error out on it.

CI will fail for unrelated errors & for some errors in debian testing where some parts have updated. I rather agree we want to ditch the `C` checks before fixing the tests.