### PR TITLE
Global general public clarifications on public pages

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -409,4 +409,100 @@ class PublicController extends BaseController
             return $this->render('clarification.html.twig', $data);
         }
     }
+
+    #[Route(path: '/clarifications/by-problem/{probId}', name: 'public_clarification_by_prob')]
+    public function viewByProblemAction(Request $request, string $probId): Response
+    {
+        $contest = $this->dj->getCurrentContest();
+        if (!$contest) {
+            throw new NotFoundHttpException('No active contest');
+        }
+
+        $problem = $this->em->getRepository(Problem::class)->findByExternalId($probId);
+        if ($problem === null) {
+            throw new NotFoundHttpException(sprintf('Problem %s not found', $probId));
+        }
+        $contestProblem = $problem->getContestProblems();
+        $foundProblemInContest = false;
+        foreach ($contestProblem as $cp) {
+            if ($cp->getContest()->getCid() === $contest->getCid()) {
+                $foundProblemInContest = true;
+                break;
+            }
+        }
+        if (!$foundProblemInContest) {
+            throw new NotFoundHttpException(sprintf('Problem %s not in current contest', $probId));
+        }
+
+        /** @var Clarification[] $clarifications */
+        $clarifications = [];
+        if ($contest->getStartTimeObject()?->getTimestamp() <= time()) {
+            $clarifications = $this->em->createQueryBuilder()
+                ->from(Clarification::class, 'c')
+                ->leftJoin('c.problem', 'p')
+                ->leftJoin('c.sender', 's')
+                ->leftJoin('c.recipient', 'r')
+                ->select('c', 'p')
+                ->andWhere('c.contest = :contest')
+                ->andWhere('c.sender IS NULL')
+                ->andWhere('c.recipient IS NULL')
+                ->andWhere('c.problem = :problem')
+                ->setParameter('contest', $contest)
+                ->setParameter('problem', $problem)
+                ->addOrderBy('c.submittime', 'DESC')
+                ->addOrderBy('c.clarid', 'DESC')
+                ->getQuery()
+                ->getResult();
+        }
+
+        $data = [
+            'clarifications' => $clarifications,
+            'problem' => $problem,
+        ];
+        if ($request->isXmlHttpRequest()) {
+            return $this->render('clarifications_by_problem_modal.html.twig', $data);
+        } else {
+            return $this->render('clarifications_by_problem.html.twig', $data);
+        }
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    #[Route(path: '/clarifications/{clarId}', name: 'public_clarification')]
+    public function viewAction(Request $request, string $clarId): Response
+    {
+        $categories = $this->config->get('clar_categories');
+        $contest    = $this->dj->getCurrentContest();
+        /** @var Clarification|null $clarification */
+        $clarification = $this->em->createQueryBuilder()
+            ->from(Clarification::class, 'c')
+            ->leftJoin('c.problem', 'p')
+            ->leftJoin('c.contest', 'co')
+            ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
+            ->select('c, p, co')
+            ->andWhere('c.contest = :contest')
+            ->andWhere('c.externalid = :clarId')
+            ->andWhere('c.sender IS NULL')
+            ->andWhere('c.recipient IS NULL')
+            ->setParameter('contest', $contest)
+            ->setParameter('clarId', $clarId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    
+        if ($clarification === null) {
+            throw new NotFoundHttpException(sprintf('Clarification %s not found', $clarId));
+        }
+    
+        $data = [
+            'clarification' => $clarification,
+            'categories' => $categories,
+        ];
+    
+        if ($request->isXmlHttpRequest()) {
+            return $this->render('clarification_modal.html.twig', $data);
+        } else {
+            return $this->render('clarification.html.twig', $data);
+        }
+    }
 }

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -49,6 +49,32 @@ class PublicController extends BaseController
         parent::__construct($em, $eventLog, $dj, $kernel);
     }
 
+    /**
+     * @return Clarification[]
+     */
+    protected function getGlobalClarifications(?Contest $contest): array
+    {
+        if ($contest) {
+            return $this->em->createQueryBuilder()
+                ->from(Clarification::class, 'c')
+                ->leftJoin('c.problem', 'p')
+                ->leftJoin('c.sender', 's')
+                ->leftJoin('c.recipient', 'r')
+                ->select('c', 'p')
+                ->andWhere('c.contest = :contest')
+                ->andWhere('c.sender IS NULL')
+                ->andWhere('c.recipient IS NULL')
+                ->andWhere('c.submittime <= :time')
+                ->andWhere('c.problem IS NULL')
+                ->setParameter('contest', $contest)
+                ->setparameter('time', time())
+                ->addOrderBy('c.submittime', 'DESC')
+                ->addOrderBy('c.clarid', 'DESC')
+                ->getQuery()->getResult();
+        }
+        return [];
+    }
+
     #[Route(path: '', name: 'public_index')]
     #[Route(path: '/scoreboard')]
     public function scoreboardAction(
@@ -67,7 +93,6 @@ class PublicController extends BaseController
             // but since self registration is enabled, it's not a big deal.
             return $this->redirectToRoute('register');
         }
-
 
         if ($static) {
             $refreshParams = [
@@ -88,6 +113,8 @@ class PublicController extends BaseController
 
         if ($static) {
             $data['hide_menu'] = true;
+        } else {
+            $data['global_clarifications'] = $this->getGlobalClarifications($contest);
         }
 
         $data['current_contest'] = $contest;
@@ -96,6 +123,51 @@ class PublicController extends BaseController
             return $this->render('partials/scoreboard.html.twig', $data, $response);
         }
         return $this->render('public/scoreboard.html.twig', $data, $response);
+    }
+
+    #[Route(path: '/clarifications', name: 'public_clarifications')]
+    public function clarificationsAction(
+        RequestStack $requestStack,
+        Request $request,
+        #[MapQueryParameter(name: 'contest')]
+        ?string $contestId = null
+    ): Response {
+        $contest = $this->getContestFromRequest($contestId) ?? $this->dj->getCurrentContest(onlyPublic: true);
+        if (!$contest) {
+            throw new NotFoundHttpException('No active contest');
+        }
+
+        /** @var Clarification[] $clarifications */
+        $clarifications = [];
+        if ($contest->getStartTimeObject()?->getTimestamp() <= time()) {
+            $clarifications = $this->em->createQueryBuilder()
+                ->from(Clarification::class, 'c')
+                ->leftJoin('c.problem', 'p')
+                ->leftJoin('c.sender', 's')
+                ->leftJoin('c.recipient', 'r')
+                ->select('c', 'p')
+                ->andWhere('c.contest = :contest')
+                ->andWhere('c.sender IS NULL')
+                ->andWhere('c.recipient IS NULL')
+                ->andWhere('c.problem IS NULL')
+                ->andWhere('c.submittime <= :time')
+                ->setParameter('contest', $contest)
+                ->setParameter('time', time())
+                ->addOrderBy('c.submittime', 'DESC')
+                ->addOrderBy('c.clarid', 'DESC')
+                ->getQuery()
+                ->getResult();
+        }
+
+        $data = [
+            'contest' => $contest,
+            'global_clarifications' => $clarifications
+        ];
+        if ($request->isXmlHttpRequest()) {
+            return $this->render('public/clarifications_general_modal.html.twig', $data);
+        } else {
+            return $this->render('public/clarifications_general.html.twig', $data);
+        }
     }
 
     #[Route(path: '/scoreboard.zip', name: 'public_scoreboard_data_zip')]
@@ -194,6 +266,7 @@ class PublicController extends BaseController
             'team' => $team,
             'showFlags' => $showFlags,
             'showAffiliations' => $showAffiliations,
+            'global_clarifications' => $this->getGlobalClarifications($this->dj->getCurrentContest()),
         ];
 
         if ($request->isXmlHttpRequest()) {
@@ -474,6 +547,10 @@ class PublicController extends BaseController
     {
         $categories = $this->config->get('clar_categories');
         $contest    = $this->dj->getCurrentContest();
+        if (!$contest) {
+            throw new NotFoundHttpException('No active contest');
+        }
+
         /** @var Clarification|null $clarification */
         $clarification = $this->em->createQueryBuilder()
             ->from(Clarification::class, 'c')

--- a/webapp/templates/public/clarifications_general.html.twig
+++ b/webapp/templates/public/clarifications_general.html.twig
@@ -1,0 +1,36 @@
+{% extends 'public/base.html.twig' %}
+
+{% import 'macros.html.twig' as macros %}
+
+{% block title %}View announcements for {{ contest.name }}{% endblock %}
+
+{% block extrahead %}
+    {{ parent() }}
+    {{ macros.mathjax_head() }}
+    <style>
+        .data-table td a, .data-table td a:hover {
+            display: block;
+            text-decoration: none;
+            color: inherit;
+            padding: 3px 5px;
+        }
+
+        .data-table tr {
+            border-bottom: 1px solid silver;
+        }
+
+        .data-table tr:hover {
+            background: #ffffcc !important;
+        }
+    </style>
+{% endblock %}
+
+{% block content %}
+    <h2 class="text-center mt-4">General announcements for {{ contest.name }}</h2>
+
+    {% if global_clarifications is empty %}
+        <p class="nodata">No announcements.</p>
+    {% else %}
+        {% include 'partials/clarification_list.html.twig' with {clarifications: global_clarifications} %}
+    {% endif %}
+{% endblock %}

--- a/webapp/templates/public/clarifications_general_modal.html.twig
+++ b/webapp/templates/public/clarifications_general_modal.html.twig
@@ -1,0 +1,11 @@
+{% extends "partials/modal.html.twig" %}
+
+{% block title %}View announcements for {{ contest.name }}{% endblock %}
+
+{% block content %}
+    {% if general_clarifications is empty %}
+        <p class="nodata">No announcements.</p>
+    {% else %}
+        {% include 'partials/clarification_list.html.twig' with {clarifications: general_clarifications} %}
+    {% endif %}
+{% endblock %}

--- a/webapp/templates/public/menu.html.twig
+++ b/webapp/templates/public/menu.html.twig
@@ -25,6 +25,16 @@
                 {% endif %}
             </li>
 
+            {% if global_clarifications is defined and global_clarifications %}
+                <li class="nav-item">
+                    <a class="nav-link{% if current_route starts with 'public_clarifications' %} active{% endif %}"
+                       href="{{ path('public_clarifications') }}"
+                       id="menu_clarifications">
+                        <i class="fas fa-comments"></i> Announcements
+                    </a>
+                </li>
+            {% endif %}
+
             {% if is_granted('ROLE_TEAM') %}
                 <li class="nav-item">
                     <a class="nav-link" href="{{ path('team_index') }}">


### PR DESCRIPTION
Builds on https://github.com/DOMjudge/domjudge/pull/3651 but has 1 commit which I suspect will require more discussion on:
- if we want it
- when we would need it
- when should it not be there
- for which pages would we need it.

So this does need input but should pass CI.