### PR TITLE
Allow compilation & running in a different chroot

### DIFF
--- a/judge/chroot-startstop.sh.in
+++ b/judge/chroot-startstop.sh.in
@@ -39,7 +39,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # Location of the pre-built chroot tree and where to bind mount from:
-CHROOTORIGINAL="@judgehost_chrootdir@"
+CHROOTDIR="@judgehost_chrootdir@"
 
 dj_umount() {
 	set +e
@@ -56,20 +56,20 @@ dj_umount() {
 
 case "$1" in
 	check)
-		if [ ! -d "$CHROOTORIGINAL" ]; then
-			>&2 echo "chroot dir '$CHROOTORIGINAL' does not exist, run dj_make_chroot"
+		if [ ! -d "$CHROOTDIR" ]; then
+			>&2 echo "chroot dir '$CHROOTDIR' does not exist, run dj_make_chroot"
 			exit 2
 		fi
 		for i in $SUBDIRMOUNTS ; do
-			if [ ! -e "$CHROOTORIGINAL/$i" ]; then
-				>&2 echo "chroot subdir '$CHROOTORIGINAL/$i' not found, rerun dj_make_chroot"
+			if [ ! -e "$CHROOTDIR/$i" ]; then
+				>&2 echo "chroot subdir '$CHROOTDIR/$i' not found, rerun dj_make_chroot"
 				exit 2
 			fi
 		done
 		# This directory is removed at the very end of the debootstrap run, if it's
 		# still present, building the chroot did not complete.
-		if [ -d "$CHROOTORIGINAL/debootstrap" ]; then
-			>&2 echo "chroot dir '$CHROOTORIGINAL' incomplete, rerun dj_make_chroot"
+		if [ -d "$CHROOTDIR/debootstrap" ]; then
+			>&2 echo "chroot dir '$CHROOTDIR' incomplete, rerun dj_make_chroot"
 			exit 2
 		fi
 		# Check that sudo works
@@ -94,11 +94,11 @@ case "$1" in
 
 			# Some dirs may be links to others, e.g. /lib64 -> /lib.
 			# Preserve those; bind mount the others.
-			if [ -L "$CHROOTORIGINAL/$i" ]; then
-				ln -s "$(readlink "$CHROOTORIGINAL/$i")" "$i"
-			elif [ -d "$CHROOTORIGINAL/$i" ]; then
+			if [ -L "$CHROOTDIR/$i" ]; then
+				ln -s "$(readlink "$CHROOTDIR/$i")" "$i"
+			elif [ -d "$CHROOTDIR/$i" ]; then
 				mkdir -p $i
-				sudo -n mount --bind "$CHROOTORIGINAL/$i" "$i" < /dev/null
+				sudo -n mount --bind "$CHROOTDIR/$i" "$i" < /dev/null
 				# Mount read-only for extra security. Note that this
 				# must be executed separately from the bind mount.
 				sudo -n mount -o remount,ro,bind "$PWD/$i" < /dev/null
@@ -119,9 +119,9 @@ case "$1" in
 		rmdir dev || true
 
 		for i in $SUBDIRMOUNTS ; do
-			if [ -L "$CHROOTORIGINAL/$i" ]; then
+			if [ -L "$CHROOTDIR/$i" ]; then
 				rm -f "$i"
-			elif [ -d "$CHROOTORIGINAL/$i" ]; then
+			elif [ -d "$CHROOTDIR/$i" ]; then
 				dj_umount "$PWD/$i"
 			fi
 		done

--- a/judge/chroot-startstop.sh.in
+++ b/judge/chroot-startstop.sh.in
@@ -54,6 +54,23 @@ dj_umount() {
 	set -e
 }
 
+CHROOTDIR_OPT=""
+while getopts "c:" opt; do
+  case $opt in
+    c)
+      CHROOTDIR="${CHROOTDIR//domjudge/$OPTARG}"
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      ;;
+    *)
+      echo "Invalid option specified." >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 case "$1" in
 	check)
 		if [ ! -d "$CHROOTDIR" ]; then
@@ -133,6 +150,8 @@ case "$1" in
 
 	*)
 		echo "Unknown argument '$1' given."
+		echo "Valid arguments: check, start & stop."
+		echo "Valid options: -c <custom_chroot>."
 		exit 1
 esac
 

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -158,11 +158,11 @@ readonly class VerdictInput
  *      team_message?: string, score?: string
  * }
  * @phpstan-type RunConfig array{time_limit: float, memory_limit: int, output_limit: int,
- *      process_limit: int, entry_point: ?string, pass_limit: int, hash: string, overshoot: int
+ *      process_limit: int, entry_point: ?string, pass_limit: int, hash: string, overshoot: int, chroot?: string
  * }
  * @phpstan-type CompareConfig array{script_timelimit: int, script_memory_limit: int,
  *      script_filesize_limit: int, compare_args: string, combined_run_compare: bool,
- *      hash: string, is_scoring_problem: bool
+ *      hash: string, is_scoring_problem: bool, chroot?: string
  * }
  * @phpstan-import-type MetaData_Compare from CompareMetaData
  * @phpstan-import-type MetaData_Program from ProgramMetaData
@@ -218,7 +218,6 @@ class JudgeDaemon
     /** @var string[] */
     private array $chroots_checked = [];
 
-    private string $chroot_old = 'default';
     private string $chroot_current = 'default';
 
     /** @var ?resource */
@@ -1529,7 +1528,7 @@ class JudgeDaemon
 
     /**
      * @param JudgeTask $judgeTask
-     * @param array{script_timelimit: int, script_memory_limit: int, language_extensions: array<string>, filter_compiler_files: bool, hash: string} $compile_config
+     * @param array{script_timelimit: int, script_memory_limit: int, language_extensions: array<string>, filter_compiler_files: bool, hash: string, chroot?: string} $compile_config
      */
     private function compile(
         array   $judgeTask,
@@ -1962,7 +1961,7 @@ class JudgeDaemon
                 if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'stop'], $retval)) {
                     logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
                     $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
-                    return false;
+                    return Verdict::INTERNAL_ERROR;
                     // Leaving this here for the review, I think we can decide to leave here as we know we didn´t compile yet and we failed.
                     // rm: Just continue here: even though we might continue a current
                     // rm: compile/test-run cycle, we don't know whether we're in one here,
@@ -1983,7 +1982,7 @@ class JudgeDaemon
                 if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_run, 'start'], $retval)) {
                     logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
                     $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
-                    return false;
+                    return Verdict::INTERNAL_ERROR;
                 }
                 sleep(1);
             }
@@ -2212,7 +2211,7 @@ class JudgeDaemon
                     if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'stop'], $retval)) {
                         logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
                         $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
-                        return false;
+                        return Verdict::INTERNAL_ERROR;
                         // Leaving this here for the review, I think we can decide to leave here as we know we didn´t compile yet and we failed.
                         // rm: Just continue here: even though we might continue a current
                         // rm: compile/test-run cycle, we don't know whether we're in one here,
@@ -2233,7 +2232,7 @@ class JudgeDaemon
                     if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_compare, 'start'], $retval)) {
                         logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
                         $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
-                        return false;
+                        return Verdict::INTERNAL_ERROR;
                     }
                     sleep(1);
                 }

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -616,6 +616,12 @@ class JudgeDaemon
         if ($lastWorkdir !== $workdir) {
             // create chroot environment
             logmsg(LOG_INFO, "  🔒 Executing chroot script: '" . self::CHROOT_SCRIPT . " start'");
+            // Reset the value to the default chroot, this should already be set by startup or cleanup at the end.
+            if ($this->current_chroot !== 'default') {
+                logmsg(LOG_INFO, "Found 'current_chroot' to not be the default, either setup or cleanup failed.");
+                $this->current_chroot = 'default';
+            }
+            logmsg(LOG_DEBUG, "Currently working from '" . getcwd() . "' directory.");
             if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'start'], $retval)) {
                 logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
                 $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -215,6 +215,12 @@ class JudgeDaemon
     /** @var array<string, string[]> */
     private array $langexts = [];
 
+    /** @var string[] */
+    private array $chroots_checked = [];
+
+    private string $chroot_old = 'default';
+    private string $chroot_current = 'default';
+
     /** @var ?resource */
     private $lockfile;
     /** @var array<int, string> */
@@ -412,6 +418,8 @@ class JudgeDaemon
         logmsg(LOG_INFO, "🔏 Executing chroot script: '" . self::CHROOT_SCRIPT . " check'");
         if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'check'])) {
             error("chroot validation check failed");
+        } else {
+            $this->chroots_checked = ['default'];
         }
 
         $this->registerJudgehost();

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -617,9 +617,9 @@ class JudgeDaemon
             // create chroot environment
             logmsg(LOG_INFO, "  🔒 Executing chroot script: '" . self::CHROOT_SCRIPT . " start'");
             // Reset the value to the default chroot, this should already be set by startup or cleanup at the end.
-            if ($this->current_chroot !== 'default') {
-                logmsg(LOG_INFO, "Found 'current_chroot' to not be the default, either setup or cleanup failed.");
-                $this->current_chroot = 'default';
+            if ($this->chroot_current !== 'default') {
+                logmsg(LOG_INFO, "Found 'chroot_current' to not be the default, either setup or cleanup failed.");
+                $this->chroot_current = 'default';
             }
             logmsg(LOG_DEBUG, "Currently working from '" . getcwd() . "' directory.");
             if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'start'], $retval)) {
@@ -1544,6 +1544,41 @@ class JudgeDaemon
             return true;
         }
 
+        $chroot_compile = $compile_config['chroot'] ?? 'default';
+        if ($chroot_compile !== $this->chroot_current) {
+            logmsg(LOG_INFO, "  🔏 Submission should be done in different chroot '" . $chroot_compile . "', leaving chroot '" . $this->chroot_current . "'");
+            logmsg(LOG_INFO, "  🔓 Executing chroot script: '" . self::CHROOT_SCRIPT . " stop'");
+            sleep(1);
+            if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'stop'], $retval)) {
+                logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                return false;
+                // Leaving this here for the review, I think we can decide to leave here as we know we didn´t compile yet and we failed.
+                // rm: Just continue here: even though we might continue a current
+                // rm: compile/test-run cycle, we don't know whether we're in one here,
+                // rm: and worst case, the chroot script will fail the next time when
+                // rm: starting.
+            }
+            sleep(1);
+            if (!in_array($chroot_compile, $this->chroots_checked)) {
+                logmsg(LOG_INFO, " 🔏 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_compile . " check'");
+                if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_compile, 'check'])) {
+                    error("chroot validation check failed");
+                } else {
+                    $this->chroots_checked[] = $chroot_compile;
+                }
+            }
+            sleep(1);
+            logmsg(LOG_INFO, "  🔒 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_compile . " start'");
+            if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_compile, 'start'], $retval)) {
+                logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                return false;
+            }
+            sleep(1);
+            $this->chroot_current = $chroot_compile;
+        }
+
         // Verify compile and runner versions.
         $judgeTaskId = $judgeTask['judgetaskid'];
         $version_verification = dj_json_decode($this->request('judgehosts/get_version_commands/' . $judgeTaskId, 'GET'));
@@ -2365,6 +2400,7 @@ class JudgeDaemon
             // compare script
             $compare_runpath = '';
         } else {
+            // Debug, are we actually in the chroot here? Test by breaking the underlying fetchExectuable code?
             [$compare_runpath, $error] = $this->fetchExecutable(
                 $workdirpath,
                 'compare',

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1954,6 +1954,39 @@ class JudgeDaemon
                 return Verdict::INTERNAL_ERROR;
             }
 
+            $chroot_run = $run_config['chroot'] ?? 'default';
+            if ($chroot_run !== $this->chroot_current) {
+                logmsg(LOG_INFO, "  🔏 Submission should be done in different chroot '" . $chroot_run . "', leaving chroot '" . $this->chroot_current . "'");
+                logmsg(LOG_INFO, "  🔓 Executing chroot script: '" . self::CHROOT_SCRIPT . " stop'");
+                sleep(1);
+                if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'stop'], $retval)) {
+                    logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                    $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                    return false;
+                    // Leaving this here for the review, I think we can decide to leave here as we know we didn´t compile yet and we failed.
+                    // rm: Just continue here: even though we might continue a current
+                    // rm: compile/test-run cycle, we don't know whether we're in one here,
+                    // rm: and worst case, the chroot script will fail the next time when
+                    // rm: starting.
+                }
+                sleep(1);
+                if (!in_array($chroot_run, $this->chroots_checked)) {
+                    logmsg(LOG_INFO, " 🔏 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_run . " check'");
+                    if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_run, 'check'])) {
+                        error("chroot validation check failed");
+                    } else {
+                        $this->chroots_checked[] = $chroot_run;
+                    }
+                }
+                sleep(1);
+                logmsg(LOG_INFO, "  🔒 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_run . " start'");
+                if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_run, 'start'], $retval)) {
+                    logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                    $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                    return false;
+                }
+                sleep(1);
+            }
             $realWorkdir = realpath($passdir);
             $prefix = '/' . basename(dirname($realWorkdir)) . '/' . basename($realWorkdir);
             if (!chdir($realWorkdir)) {
@@ -2171,6 +2204,39 @@ class JudgeDaemon
                     $orig_compare_args = explode(' ', $compare_args);
                 }
 
+                $chroot_compare = $run_config['chroot'] ?? 'default';
+                if ($chroot_compare !== $this->chroot_current) {
+                    logmsg(LOG_INFO, "  🔏 Submission comparisan should be done in different chroot '" . $chroot_compare . "', leaving chroot '" . $this->chroot_current . "'");
+                    logmsg(LOG_INFO, "  🔓 Executing chroot script: '" . self::CHROOT_SCRIPT . " stop'");
+                    sleep(1);
+                    if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, 'stop'], $retval)) {
+                        logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                        $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                        return false;
+                        // Leaving this here for the review, I think we can decide to leave here as we know we didn´t compile yet and we failed.
+                        // rm: Just continue here: even though we might continue a current
+                        // rm: compile/test-run cycle, we don't know whether we're in one here,
+                        // rm: and worst case, the chroot script will fail the next time when
+                        // rm: starting.
+                    }
+                    sleep(1);
+                    if (!in_array($chroot_compare, $this->chroots_checked)) {
+                        logmsg(LOG_INFO, " 🔏 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_compare . " check'");
+                        if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_compare, 'check'])) {
+                            error("chroot validation check failed");
+                        } else {
+                            $this->chroots_checked[] = $chroot_compare;
+                        }
+                    }
+                    sleep(1);
+                    logmsg(LOG_INFO, "  🔒 Executing chroot script: '" . self::CHROOT_SCRIPT . " -c " . $chroot_compare . " start'");
+                    if (!$this->runCommandSafe([LIBJUDGEDIR . '/' . self::CHROOT_SCRIPT, '-c', $chroot_compare, 'start'], $retval)) {
+                        logmsg(LOG_ERR, "chroot script exited with exitcode $retval");
+                        $this->disable('judgehost', 'hostname', $this->myhost, "chroot script exited with exitcode $retval on $this->myhost");
+                        return false;
+                    }
+                    sleep(1);
+                }
                 $compare_args = array_merge(
                     $gainroot,
                     [BINDIR . "/runguard"],

--- a/webapp/migrations/Version20260602175403.php
+++ b/webapp/migrations/Version20260602175403.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260602175403 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Install extra optional chroot directory option for a language.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE language ADD chroot_directory VARCHAR(32) DEFAULT NULL COMMENT \'Custom chroot for executable\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE language DROP chroot_directory');
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/webapp/src/Entity/Language.php
+++ b/webapp/src/Entity/Language.php
@@ -163,6 +163,9 @@ class Language extends BaseApiEntity implements
     #[Serializer\Exclude]
     private Collection $problems;
 
+    #[ORM\Column(length: 32, nullable: true, options: ['comment' => 'Custom chroot for executable'])]
+    private ?string $chroot_directory;
+
     /**
      * @param Collection<int, Version> $versions
      */
@@ -470,5 +473,16 @@ class Language extends BaseApiEntity implements
     public function getProblems(): Collection
     {
         return $this->problems;
+    }
+
+    public function setChrootDirectory(?string $chrootDirectory): self
+    {
+        $this->chroot_directory = $chrootDirectory;
+        return $this;
+    }
+
+    public function getChrootDirectory(): ?string
+    {
+        return $this->chroot_directory;
     }
 }

--- a/webapp/src/Form/Type/LanguageType.php
+++ b/webapp/src/Form/Type/LanguageType.php
@@ -34,6 +34,9 @@ class LanguageType extends AbstractExternalIdEntityType
         $builder->add('entryPointDescription', TextType::class, [
             'required' => false,
         ]);
+        $builder->add('chrootDirectory', TextType::class, [
+            'required' => false,
+        ]);
         $builder->add('allowSubmit', CheckboxType::class, [
             'required' => false,
             'attr' => self::TOGGLE_ATTRS,

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1599,18 +1599,20 @@ class DOMJudgeService
         }
         $runExecutable = $this->getImmutableRunExecutable($problem);
 
-        return Utils::jsonEncode(
-            [
-                'time_limit' => $problem->getProblem()->getTimelimit() * $submission->getLanguage()->getTimeFactor(),
-                'memory_limit' => $memoryLimit,
-                'output_limit' => $outputLimit,
-                'process_limit' => $this->config->get('process_limit'),
-                'entry_point' => $submission->getEntryPoint(),
-                'pass_limit' => $problem->getProblem()->getMultipassLimit(),
-                'hash' => $runExecutable->getHash(),
-                'overshoot' => $overshoot,
-            ]
-        );
+        $settings = [
+            'time_limit' => $problem->getProblem()->getTimelimit() * $submission->getLanguage()->getTimeFactor(),
+            'memory_limit' => $memoryLimit,
+            'output_limit' => $outputLimit,
+            'process_limit' => $this->config->get('process_limit'),
+            'entry_point' => $submission->getEntryPoint(),
+            'pass_limit' => $problem->getProblem()->getMultipassLimit(),
+            'hash' => $runExecutable->getHash(),
+            'overshoot' => $overshoot,
+        ];
+        if ($submission->getLanguage()->getChrootDirectory()) {
+            $settings['chroot'] = $submission->getLanguage()->getChrootDirectory();
+        }
+        return Utils::jsonEncode($settings);
     }
 
     public function getCompareConfig(ContestProblem $contestProblem, ?string $outputValidatorFlags = null): string
@@ -1618,32 +1620,34 @@ class DOMJudgeService
         $compareExecutable = $this->getImmutableCompareExecutable($contestProblem);
         $problem = $contestProblem->getProblem();
         $outputValidatorFlags ??= $problem->getSpecialCompareArgs();
-        return Utils::jsonEncode(
-            [
-                'script_timelimit' => $this->config->get('script_timelimit'),
-                'script_memory_limit' => $this->config->get('script_memory_limit'),
-                'script_filesize_limit' => $this->config->get('script_filesize_limit'),
-                'compare_args' => $outputValidatorFlags,
-                'combined_run_compare' => $problem->isInteractiveProblem(),
-                'hash' => $compareExecutable->getHash(),
-                'is_scoring_problem' => $problem->isScoringProblem(),
-            ]
-        );
+        // Passing the chroot here would require knowing the language (so also the submission), for now we'll assume
+        // that run and compare are done with the same chroot.
+        return Utils::jsonEncode([
+            'script_timelimit' => $this->config->get('script_timelimit'),
+            'script_memory_limit' => $this->config->get('script_memory_limit'),
+            'script_filesize_limit' => $this->config->get('script_filesize_limit'),
+            'compare_args' => $outputValidatorFlags,
+            'combined_run_compare' => $problem->isInteractiveProblem(),
+            'hash' => $compareExecutable->getHash(),
+            'is_scoring_problem' => $problem->isScoringProblem(),
+        ]);
     }
 
     public function getCompileConfig(Submission $submission): string
     {
         $compileExecutable = $submission->getLanguage()->getCompileExecutable()->getImmutableExecutable();
-        return Utils::jsonEncode(
-            [
-                'script_timelimit' => $this->config->get('script_timelimit'),
-                'script_memory_limit' => $this->config->get('script_memory_limit'),
-                'script_filesize_limit' => $this->config->get('script_filesize_limit'),
-                'language_extensions' => $submission->getLanguage()->getExtensions(),
-                'filter_compiler_files' => $submission->getLanguage()->getFilterCompilerFiles(),
-                'hash' => $compileExecutable->getHash(),
-            ]
-        );
+        $settings = [
+            'script_timelimit' => $this->config->get('script_timelimit'),
+            'script_memory_limit' => $this->config->get('script_memory_limit'),
+            'script_filesize_limit' => $this->config->get('script_filesize_limit'),
+            'language_extensions' => $submission->getLanguage()->getExtensions(),
+            'filter_compiler_files' => $submission->getLanguage()->getFilterCompilerFiles(),
+            'hash' => $compileExecutable->getHash(),
+        ];
+        if ($submission->getLanguage()->getChrootDirectory()) {
+            $settings['chroot'] = $submission->getLanguage()->getChrootDirectory();
+        }
+        return Utils::jsonEncode($settings);
     }
 
     public function getScoreboardZip(

--- a/webapp/templates/jury/language.html.twig
+++ b/webapp/templates/jury/language.html.twig
@@ -57,6 +57,16 @@
                             {% endif %}
                         </td>
                     </tr>
+                    <tr>
+                        <th>Custom chroot</th>
+                        <td>
+                            {% if language.chrootDirectory %}
+                                <code>{{ language.chrootDirectory }}</code>
+                            {% else %}
+                                <p class="nodata">No custom chroot specified.</p>
+                            {% endif %}
+                        </td>
+                    </tr>
                     {{ _self.section_header('cogs', 'Compilation') }}
                     <tr>
                         <th>Compile script</th>

--- a/webapp/templates/jury/partials/language_form.html.twig
+++ b/webapp/templates/jury/partials/language_form.html.twig
@@ -35,6 +35,7 @@
                 {{ _self.form_table_row(form.timeFactor) }}
                 {{ _self.form_table_row(form.requireEntryPoint) }}
                 {{ _self.form_table_row(form.entryPointDescription) }}
+                {{ _self.form_table_row(form.chrootDirectory) }}
 
                 {{ _self.section_header('cogs', 'Compilation') }}
                 {{ _self.form_table_row(form.compileExecutable) }}


### PR DESCRIPTION
We discussed this a bit during NWERC, it would be nice to have a different chroot for specific problems or languages, this is the first step towards that goal.

It does uncover an interesting thing with either my setup or a race condition (with this or old code) somewhere. In case you shut down the judgedaemon with `ctrl+c` even if the judgedaemon is idle it complains that the `chroot-start-stop` can´t remove all directories.