### PR TITLE
Fix testcases UI for empty testcase descriptions

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -632,6 +632,10 @@ class ProblemController extends BaseController
                 }
 
                 $newDescription = $request->request->all('description')[$rank];
+                $newDescription = str_replace("\r\n", "\n", $newDescription);
+                if ($newDescription === '') {
+                    $newDescription = null;
+                }
                 if ($newDescription !== $testcase->getDescription(true)) {
                     $testcase->setDescription($newDescription);
                     $messages[] = sprintf('Updated description of testcase %d ', $rank);
@@ -746,12 +750,16 @@ class ProblemController extends BaseController
             if ($inputOrOutputSpecified && $allOk) {
                 $newTestcase        = new Testcase();
                 $newTestcaseContent = new TestcaseContent();
+                $newTestcaseDescription = $request->request->get('add_desc');
                 $newTestcase
                     ->setContent($newTestcaseContent)
                     ->setRank($maxrank)
                     ->setProblem($problem)
-                    ->setDescription($request->request->get('add_desc'))
                     ->setSample($request->request->has('add_sample'));
+                if (is_string($newTestcaseDescription) && $newTestcaseDescription !== '') {
+                    $newTestcaseDescription = str_replace("\r\n", "\n", $newTestcaseDescription);
+                    $newTestcase->setDescription($newTestcaseDescription);
+                }
                 foreach (['input', 'output'] as $type) {
                     $file          = $request->files->get('add_' . $type);
                     $content       = file_get_contents($file->getRealPath());


### PR DESCRIPTION
We had a couple of issues:
- Remove \r\n as we would update the description with those This can be tested with having 1.desc, the description for testcase 1. We all use unix line endings, but the http spec wants \r\n endings. So when you save the testcases we would update testcase 1 but nothing (really) changed.
- When a new testcase was added we would also update the description of the other testcases with the empty string as it was `null` before. Alternative is to always fill the description with the empty string and make it non-nullable.

This contains some commits from https://github.com/DOMjudge/domjudge/pull/3623 and an additional fix. 