### PR TITLE
Add default test for output validator flags in problem.yaml & testdata.yaml + display

### DIFF
--- a/example_problems/hangman/data/secret/testdata.yaml
+++ b/example_problems/hangman/data/secret/testdata.yaml
@@ -1,0 +1,1 @@
+output_validator_flags: --secret

--- a/example_problems/hangman/data/secret/with_spaces/testdata.yaml
+++ b/example_problems/hangman/data/secret/with_spaces/testdata.yaml
@@ -1,0 +1,1 @@
+output_validator_flags: --secret --judgemessage "This group checks for sentences instead of words"

--- a/example_problems/hangman/output_validator/validator.py
+++ b/example_problems/hangman/output_validator/validator.py
@@ -3,11 +3,34 @@
 # <output_validator_program> input_file answer_file feedback_dir [additional_arguments] < team_output [ > team_input ]
 
 import _io
+import argparse
 import os
 import random
 import string
 import sys
 import tempfile
+
+
+def write_message(message: str, singular = False) -> None:
+    with open(os.path.join(feedback_dir, 'judgemessage.txt'), 'a') as judgemessage:
+        print("Team" + message, file=judgemessage)
+    if not arguments.secret:
+        teammessage_file = os.path.join(feedback_dir, 'teammessage.txt')
+        # Explicit overwrite the earlier hint
+        with open(teammessage_file, 'w') as teammessage:
+            print(("You" if singular else "Your") + message, file=teammessage)
+
+
+def write_generic_message(message: str, feedback_file: str) -> None:
+    message_file_path = os.path.join(feedback_dir, feedback_file)
+    try:
+        with open(message_file_path, 'r+') as message_file:
+            if message not in message_file.read():
+                print(message, file=message_file)
+    except FileNotFoundError:
+        # Overwrite in case the file got created in between
+        with open(message_file_path, 'w') as message_file:
+            print(message, file=message_file)
 
 
 def strip_newline(raw: _io.TextIOWrapper) -> list[str]:
@@ -43,6 +66,16 @@ def check_writable(path: str) -> bool:
         return False
 
 
+parser = argparse.ArgumentParser(
+    prog='Hangman output validator',
+    description='Example output validator for DOMjudge Hangmang multi-pass problem',
+    epilog='This output validator is crafted in such a way that multiple facets can be tested, most of the options are not needed for a normal problem')
+parser.add_argument('--judgemessage')
+parser.add_argument('--teammessage')
+parser.add_argument('--secret', action='store_true')
+
+arguments = parser.parse_args(sys.argv[4:])
+
 input_file = sys.argv[1]
 answer_file = sys.argv[2]
 feedback_dir = sys.argv[3]
@@ -62,19 +95,16 @@ INPUT_FILE_ERROR = 54
 DIRECTORY_ERROR = 55
 
 if len(team_output) != 1:
-    with open(os.path.join(feedback_dir, 'judgemessage.txt'), 'a') as judgemessage:
-        print("Team output must only contain 1 line.", file=judgemessage)
+    write_message(" output must only contain 1 line.")
     exit(WA)
 else:
     team_output = team_output[0]
 
 if len(team_output) != 1:
-    with open(os.path.join(feedback_dir, 'judgemessage.txt'), 'a') as judgemessage:
-        print("Team output must only contain 1 symbol.", file=judgemessage)
+    write_message(" output must only contain 1 symbol.")
     exit(WA)
 if team_output[0] not in string.ascii_lowercase:
-    with open(os.path.join(feedback_dir, 'judgemessage.txt'), 'a') as judgemessage:
-        print("Team output must only contain 1 lowercase letter.", file=judgemessage)
+    write_message(" output must only contain 1 lowercase letter ([a-z]{1}).")
     exit(WA)
 
 inp = check_readable(input_file, 0)
@@ -105,8 +135,7 @@ guessed_total = inp[0]
 guessed_progress = inp[1]
 
 if team_output in guessed_total:
-    with open(os.path.join(feedback_dir, 'judgemessage.txt'), 'a') as judgemessage:
-        print("Team guessed the same letter before.", file=judgemessage)
+    write_message(" guessed the same letter before.", singular=True)
     exit(WA)
 
 new = ''
@@ -127,4 +156,9 @@ guessed_total = ''.join(guessed_total)
 with open(os.path.join(feedback_dir, 'nextpass.in'), 'w') as nextpass:
     print(guessed_total, file=nextpass)
     print(new, file=nextpass)
+
+if arguments.judgemessage:
+    write_generic_message(arguments.judgemessage, 'judgemessage.txt')
+if arguments.teammessage and not arguments.secret:
+    write_generic_message(arguments.teammessage, 'teammessage.txt')
 exit(AC)

--- a/example_problems/hangman/problem.yaml
+++ b/example_problems/hangman/problem.yaml
@@ -1,4 +1,5 @@
 name: Hangman
 validation: custom multi-pass
+validator_flags: --teammessage "There are more testcases besides those given in the problemstatement."
 limits:
   validation_passes: 26

--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -2180,7 +2180,7 @@ class JudgeDaemon
                 // TODO: Perhaps we should change this in the database to be an array of args?
                 $orig_compare_args = [];
                 if ($compare_args !== null && strlen($compare_args) > 0) {
-                    $orig_compare_args = explode(' ', $compare_args);
+                    $orig_compare_args = str_getcsv($compare_args, separator: ' ', escape: '');
                 }
 
                 $compare_args = array_merge(

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -1205,8 +1205,12 @@ readonly class ImportProblemService
                     join(', ', $unknown_flags), $name);
             }
         }
-        if (isset($yamlData['output_validator_flags'])) {
-            $testcaseGroup->setOutputValidatorFlags($yamlData['output_validator_flags']);
+        foreach(['flags', 'args'] as $postFix) {
+            $output_validator_flags_key = 'output_validator_' . $postFix;
+            if (isset($yamlData[$output_validator_flags_key])) {
+                $testcaseGroup->setOutputValidatorFlags($yamlData[$output_validator_flags_key]);
+                break;
+            }
         }
         if (isset($yamlData['on_reject'])) {
             $testcaseGroup->setOnRejectContinue($yamlData['on_reject'] === 'continue');
@@ -1292,8 +1296,12 @@ readonly class ImportProblemService
             $yamlProblemProperties['typesAsString'] = ['pass-fail'];
         }
 
-        if (isset($yamlData['validator_flags'])) {
-            $yamlProblemProperties['special_compare_args'] = $yamlData['validator_flags'];
+        foreach (['flags', 'args'] as $postFix) {
+            $validator_flags_key = 'validator_' . $postFix;
+            if (isset($yamlData[$validator_flags_key])) {
+                $yamlProblemProperties['special_compare_args'] = $yamlData[$validator_flags_key];
+                break;
+            }
         }
 
         if (isset($yamlData['validation'])

--- a/webapp/templates/jury/executable.html.twig
+++ b/webapp/templates/jury/executable.html.twig
@@ -51,6 +51,9 @@
                                 <a href="{{ path('jury_problem', {'probId': problem.externalid}) }}">
                                     {{ problem.externalid }} {{ problem | problemBadgeForContest }}
                                 </a>
+                                {% if problem.specialCompareArgs %}
+                                    (<code>{{ problem.specialCompareArgs }}</code>)
+                                {% endif %}
                                 {% set used = true %}
                             {% endfor %}
                         {% elseif executable.type == 'run' %}

--- a/webapp/templates/jury/problem_testcases.html.twig
+++ b/webapp/templates/jury/problem_testcases.html.twig
@@ -51,6 +51,9 @@
                             {% if group.acceptScore is not null %}
                                 <span class="badge ms-2 scoring-accept-badge">Accept score: {{ (group.acceptScore + 0) }}</span>
                             {% endif %}
+                            {% if group.outputValidatorFlags %}
+                                <i class="fas fa-code-compare"></i><code>{{ group.outputValidatorFlags }}</code>
+                            {% endif %}
                         </td>
                     </tr>
                 {% elseif row.type == 'no_group' %}

--- a/webapp/tests/Unit/Service/ImportProblemServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportProblemServiceTest.php
@@ -150,6 +150,41 @@ YAML;
         $this->assertEquals('float_tolerance 1E-6', $problem->getSpecialCompareArgs());
     }
 
+    public function testValidatorArgs(): void
+    {
+        $yaml = <<<YAML
+name: test
+type: pass-fail
+validator_args: 'float_tolerance 1E-7'
+YAML;
+        $messages = [];
+        $validationMode = 'xxx';
+        $problem = new Problem();
+
+        $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
+        $this->assertTrue($ret);
+        $this->assertEmpty($messages);
+        $this->assertEquals('float_tolerance 1E-7', $problem->getSpecialCompareArgs());
+    }
+
+    public function testValidatorFlagsAndArgs(): void
+    {
+        $yaml = <<<YAML
+name: test
+type: pass-fail
+validator_flags: 'float_tolerance 1E-8'
+validator_args: 'float_tolerance 1E-9'
+YAML;
+        $messages = [];
+        $validationMode = 'xxx';
+        $problem = new Problem();
+
+        $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
+        $this->assertTrue($ret);
+        $this->assertEmpty($messages);
+        $this->assertEquals('float_tolerance 1E-8', $problem->getSpecialCompareArgs());
+    }
+
     public function testCustomValidation(): void
     {
         foreach (['custom', 'custom interactive', 'custom multi-pass'] as $mode) {
@@ -525,6 +560,49 @@ YAML;
         $this->assertNotEmpty($messages['danger']);
         $this->assertStringContainsString("Invalid range '100'", $messages['danger'][0]);
     }
+
+    public function testParseTestCaseGroupMetaProblemSpecSpecifiedOutputValidatorFlagsAccepted(): void
+    {
+        $yaml = "output_validator_flags: --any arg -x should work";
+        $messages = [];
+
+        $result = ImportProblemService::parseTestCaseGroupMeta($yaml, 'test-group', $messages);
+
+        $this->assertNotNull($result);
+        $danger_messages = $messages['danger'] ?? [];
+        $this->assertEmpty($danger_messages, "Failed with: " . implode(', ', $danger_messages));
+        $this->assertEquals('--any arg -x should work', $result->getOutputValidatorFlags());
+    }
+
+    public function testParseTestCaseGroupMetaUnspecifiedOutputValidatorArgsAccepted(): void
+    {
+        $yaml = "output_validator_args: --any arg -x should work";
+        $messages = [];
+
+        $result = ImportProblemService::parseTestCaseGroupMeta($yaml, 'test-group', $messages);
+
+        $this->assertNotNull($result);
+        $danger_messages = $messages['danger'] ?? [];
+        $this->assertEmpty($danger_messages, "Failed with: " . implode(', ', $danger_messages));
+        $this->assertEquals('--any arg -x should work', $result->getOutputValidatorFlags());
+    }
+
+    public function testParseTestCaseGroupMetaProblemSpecSpecifiedOutputValidatorFlagsAndArgsSpecified(): void
+    {
+        $yaml = <<<YAML
+output_validator_flags: --any arg -x should work
+output_validator_args: --those args -must not work
+YAML;
+        $messages = [];
+
+        $result = ImportProblemService::parseTestCaseGroupMeta($yaml, 'test-group', $messages);
+
+        $this->assertNotNull($result);
+        $danger_messages = $messages['danger'] ?? [];
+        $this->assertEmpty($danger_messages, "Failed with: " . implode(', ', $danger_messages));
+        $this->assertEquals('--any arg -x should work', $result->getOutputValidatorFlags());
+    }
+
 
     /**
      * Create a temporary zip file with the given contents.


### PR DESCRIPTION
<img width="2659" height="1501" alt="image" src="https://github.com/user-attachments/assets/2cab143b-e8e3-4ba3-8d3a-4769ae22a279" />

Extracted some parts of https://github.com/DOMjudge/domjudge/pull/3623 but also extended from there with the usage of the options in the testcase group.

This adds:
- the options to a default problem
- usage in the custom validator
- unit tests for usage
- display of those options in the testcases UI.