### PR TITLE
Fix #3143: Restore task routing and judgehost penalty on compilation contradiction

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -358,7 +358,7 @@ class JudgehostController extends AbstractFOSRestController
                 } elseif ($judging->getResult() === Judging::RESULT_COMPILER_ERROR) {
                     // The new result contradicts a former one, that's not good.
                     // Since the other judgehosts were not successful, but we were, assume that the other judgehosts
-                    // are broken and disable it.
+                    // are broken and disable them.
                     $disableHostnames = [];
                     /** @var JudgingRun $run */
                     foreach ($judging->getRuns() as $run) {
@@ -371,20 +371,13 @@ class JudgehostController extends AbstractFOSRestController
                     }
 
                     foreach ($disableHostnames as $disableHostname) {
-                        $disabled = [
-                            'kind' => 'judgehost',
-                            'hostname' => $disableHostname,
-                        ];
-                        $error = new InternalError();
-                        $error
-                            ->setJudging($judging)
-                            ->setContest($judging->getContest())
-                            ->setDescription('Compilation results are different for j' . $judging->getJudgingid())
-                            ->setJudgehostlog(base64_encode('New compilation output: ' . $output_compile))
-                            ->setTime(Utils::now())
-                            ->setDisabled($disabled);
-                        $this->em->persist($error);
+                        $this->disableJudgehostForContradiction(
+                            $judging,
+                            $disableHostname,
+                            (string)$judging->getOutputCompile(true)
+                        );
                     }
+                    $this->em->flush();
                 }
             } else {
                 $compileMetadata = $request->request->get('compile_metadata');
@@ -429,19 +422,13 @@ class JudgehostController extends AbstractFOSRestController
                         // The new result contradicts a former one, that's not good.
                         // Since at least one other judgehost was successful, but we were not, assume that the
                         // current judgehost is broken and disable it.
-                        $disabled = [
-                            'kind' => 'judgehost',
-                            'hostname' => $judgehost->getHostname(),
-                        ];
-                        $error = new InternalError();
-                        $error
-                            ->setJudging($judging)
-                            ->setContest($judging->getContest())
-                            ->setDescription('Compilation results are different for j' . $judging->getJudgingid())
-                            ->setJudgehostlog(base64_encode('New compilation output: ' . $output_compile))
-                            ->setTime(Utils::now())
-                            ->setDisabled($disabled);
-                        $this->em->persist($error);
+                        $this->disableJudgehostForContradiction(
+                            $judging,
+                            $judgehost->getHostname(),
+                            (string)$output_compile
+                        );
+
+                        $this->em->flush();
                     }
 
                     $judgingId = $judging->getJudgingid();
@@ -2042,5 +2029,36 @@ class JudgehostController extends AbstractFOSRestController
             return $this->serializeJudgeTasks($judgetasks, $judgehost);
         }
         return null;
+    }
+
+    private function disableJudgehostForContradiction(Judging $judging, string $hostname, string $outputCompile): void
+    {
+        $disabled = [
+            'kind' => 'judgehost',
+            'hostname' => $hostname,
+        ];
+
+        $error = new InternalError();
+        $error
+            ->setJudging($judging)
+            ->setContest($judging->getContest())
+            ->setDescription('Compilation results are different for j' . $judging->getJudgingid())
+            ->setJudgehostlog(base64_encode($outputCompile))
+            ->setTime(Utils::now())
+            ->setDisabled($disabled);
+        $this->em->persist($error);
+
+        // Link the error to the judging so the system knows
+        // this judging needs attention.
+        $judging->setInternalError($error);
+
+        $this->dj->setInternalError($disabled, $judging->getContest(), false);
+
+        // Re-route pending tasks from the disabled judgehost back to the queue
+        // so they are not stuck forever in an infinite processing loop.
+        $judgehost = $this->em->getRepository(Judgehost::class)->findOneBy(['hostname' => $hostname]);
+        if ($judgehost) {
+            $this->giveBackJudging($judging->getJudgingid(), $judgehost);
+        }
     }
 }


### PR DESCRIPTION
# Fixes
_It can be manually fix by shutting down the affected judgehost and rejudge the submission. But this can takes time under busy server load and creates unfair experience for participants_

This PR fixes two issues in `JudgehostController.php`:

+ **Infinite judging loop (#3143)**: Restores compilation contradiction logic missing since the parallel judging rewrite. It now correctly links the internal error (`$judging->setInternalError()`), disables the broken judgehost (`$judgehost->setEnabled(false)`), and unassigns its tasks (`SET judgehostid=NULL`). This stops error spam and allows healthy judgehosts to finish the submission.
~~**Broken log snippets**: Uses `is_resource()` and `stream_get_contents()` to properly read compiler error streams, fixing the `Resource id #15` display bug.~~
_Edit: Use_ `$judging->getOutputCompile(true)` _instead_

**Note on Task Routing Race Condition:**
The submission's final verdict currently depends on which judgehost picks up the *first* compile task:
- **Healthy first:** Compiles successfully. The broken judgehost is later caught and disabled, tasks are re-routed, and the submission succeeds.
- **Broken first:** Fails compilation immediately. The submission is permanently marked `Compiler Error` before healthy judgehosts can attempt it.

## Reproducing Issues
### Test on Domjudge main - Docker Bleeding Ver.

### Containers
<img width="311" height="199" alt="Containers" src="https://github.com/user-attachments/assets/8507921f-8ddc-4d7f-8ede-96223c8e4906" />

_Note: My screenshot shows a locally built `domserver` container used for developing this fix. To reproduce the bug on your end, simply use the official `domjudge/domserver:bleeding` image._

Make the `g++` compiler on `judgehost-1` non-existent to replicate compiler error using:

`docker exec -it judgehost-1 mv /chroot/domjudge/usr/bin/g++ /chroot/domjudge/usr/bin/g++-disabled`

Generate a new problem that has a lot of testcases to trigger parallel judging using Python

```python
import zipfile
import random

def generate_problem_archive():
    filename = "a_plus_b.zip"
    print(f"Generating DOMjudge problem archive: {filename}...")

    with zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED) as zf:
        # 1. Write the mandatory problem.yaml configuration
        yaml_content = """name: A+B
validation: default
"""
        zf.writestr("problem.yaml", yaml_content)

        # 2. Write the DOMjudge-specific ini
        ini_content = """probid=aplusb
name=A+B
timelimit=5
"""
        zf.writestr("domjudge-problem.ini", ini_content)

        # 3. Generate 100 distinct testcases in the required data/secret/ directory
        for i in range(1, 101):
            a = random.randint(1, 1000)
            b = random.randint(1, 1000)
            
            # Input file: Two integers
            zf.writestr(f"data/secret/{i}.in", f"{a} {b}\n")
            # Output file: Their sum
            zf.writestr(f"data/secret/{i}.ans", f"{a + b}\n")

    print(f"Done: {filename}")

if __name__ == "__main__":
    generate_problem_archive()
```

The answer for the following problem
```cpp
#include <iostream>
using namespace std;

int main() {
    int a, b;
    if (cin >> a >> b) {
        cout << a + b << "\n";
    }
    return 0;
}
```

### Reproduce Step
+ Upload `a_plus_b.zip` through Import archive with active contest
<img width="804" height="372" alt="upload a problem" src="https://github.com/user-attachments/assets/8b2e40bd-3c92-47c8-af3f-f93d11e82b43" />

+ Stop the affected compiler container `(judgehost-1)`, so that `judgehost-0` can begin judging the testcases first. This prevents the server from throwing compilation error and stop the judging.
<img width="315" height="205" alt="stop a container" src="https://github.com/user-attachments/assets/055970dd-c23d-4bf5-bc33-279455684183" />

+ Login with a `demo` account and submit the answer through `a_plus_b` problem

<img width="502" height="590" alt="submit an answer" src="https://github.com/user-attachments/assets/1677f4bd-0356-4a8e-b449-e87144201d81" />

+ While `judgehost-0` is running testcases, start the `judgehost-1` container.

<img width="766" height="91" alt="start judgehost-1" src="https://github.com/user-attachments/assets/19679e10-e335-40fe-b69f-4d1b59d41114" />

And you will see that internal error have appeared

<img width="658" height="416" alt="internal error" src="https://github.com/user-attachments/assets/33c97ffd-b98f-4d31-aab1-7b6b2f37c34a" />

However, submission is still judging infinitely instead of terminating or passing remaining testcases to other healthy judgehosts

<img width="1631" height="178" alt="infinite judging" src="https://github.com/user-attachments/assets/bd0f03c4-5b90-486e-abb8-00b258a75310" />

Thank you to @alessiojr for reporting the issues and your analysis