### PR TITLE
Rewrite code to get all clarification from a dedicated ClarificationService

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -7,7 +7,13 @@ use App\Entity\Clarification;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Team;
+use App\Service\AuthorizedUserService;
+use App\Service\ClarificationService;
+use App\Service\ConfigurationService;
+use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
 use App\Utils\Utils;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\QueryBuilder;
 use Exception;
@@ -34,6 +40,17 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Response(ref: '#/components/responses/NotFound', response: 404)]
 class ClarificationController extends AbstractRestController
 {
+    public function __construct(
+        AuthorizedUserService $authService,
+        EntityManagerInterface $em,
+        DOMJudgeService $dj,
+        ConfigurationService $config,
+        EventLogService $eventLogService,
+        protected readonly ClarificationService $clarificationService,
+    ) {
+        parent::__construct($authService, $em, $dj, $config, $eventLogService);
+    }
+
     /**
      * Get all the clarifications for this contest.
      *
@@ -115,7 +132,7 @@ class ClarificationController extends AbstractRestController
         Request $request,
         ?string $id
     ): Response {
-        $maxLength = $this->config->get('clar_max_body_length');
+        $maxLength = $this->clarificationService->getClarificationMaximumBodyLength();
         if ($maxLength > 0 && mb_strlen($clarificationPost->text) > $maxLength) {
             throw new BadRequestHttpException(
                 sprintf('Clarification body is too long: %d characters, maximum is %d.', mb_strlen($clarificationPost->text), $maxLength)
@@ -258,9 +275,9 @@ class ClarificationController extends AbstractRestController
 
         $clarification
             ->setExternalid($clarificationId)
-            ->setQueue($this->config->get('clar_default_problem_queue'));
+            ->setQueue($this->clarificationService->getClarificationDefaultProblemQueue());
 
-        if (!$clarification->getProblem() && $clarificationCategories = $this->config->get('clar_categories')) {
+        if (!$clarification->getProblem() && $clarificationCategories = $this->clarificationService->getClarificationCategories()) {
             $clarificationCategoryNames = array_keys($clarificationCategories);
             $clarification->setCategory(reset($clarificationCategoryNames));
         }

--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -206,18 +206,9 @@ class ClarificationController extends AbstractRestController
         }
 
         if ($replyToId = $clarificationPost->replyToId) {
-            $qb = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'c')
-                ->select('c')
-                ->andWhere('c.externalid = :clarification')
-                ->andWhere('c.contest = :contest')
-                ->setParameter('clarification', $replyToId)
-                ->setParameter('contest', $contestId);
-            if ($this->authService->checkRole('team')) {
-                $qb
-                    ->andWhere('c.sender = :team OR c.recipient = :team OR (c.sender IS NULL AND c.recipient IS NULL)')
-                    ->setParameter('team', $fromTeam);
-            }
+            $qb = $this->clarificationService->getQueryBuilder(internalContestId: $contestId, externalClarificationId: $replyToId)
+                ->select('clar');
+
             // Load the clarification.
             /** @var Clarification|null $replyTo */
             $replyTo = $qb->getQuery()->getOneOrNullResult();
@@ -256,13 +247,8 @@ class ClarificationController extends AbstractRestController
                 throw new BadRequestHttpException('ID does not match URI.');
             } elseif ($this->isGranted('ROLE_API_WRITER')) {
                 // Check if we already have a clarification with this ID
-                $existingClarification = $this->em->createQueryBuilder()
-                    ->from(Clarification::class, 'c')
-                    ->select('c')
-                    ->andWhere('(c.externalid IS NULL AND c.clarid = :clarid) OR c.externalid = :clarid')
-                    ->andWhere('c.contest = :contest')
-                    ->setParameter('clarid', $clarificationId)
-                    ->setParameter('contest', $contestId)
+                $existingClarification = $this->clarificationService->getQueryBuilder(internalContestId: $contestId, externalClarificationId: $clarificationId)
+                    ->select('clar')
                     ->getQuery()
                     ->getOneOrNullResult();
                 if ($existingClarification !== null) {
@@ -307,48 +293,11 @@ class ClarificationController extends AbstractRestController
 
     protected function getQueryBuilder(Request $request): QueryBuilder
     {
-        $queryBuilder = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'clar')
-            ->join('clar.contest', 'c')
-            ->leftJoin('clar.in_reply_to', 'reply')
-            ->leftJoin('clar.sender', 's')
-            ->leftJoin('clar.recipient', 'r')
-            ->leftJoin('clar.problem', 'p')
-            ->innerJoin('c.problems', 'cp')
+        $contestId = $this->getContestId($request);
+        $problem = $request->query->get('problem');
+        return $this->clarificationService->getQueryBuilder(internalContestId: $contestId, problem: $problem)
             ->select('clar, c, r, reply, p')
-            ->andWhere('clar.contest = :cid')
-            ->andWhere('clar.problem IS NULL OR clar.problem = cp.problem')
-            ->setParameter('cid', $this->getContestId($request))
             ->orderBy('clar.clarid');
-
-        if (!$this->authService->checkRole('api_reader') &&
-            !$this->authService->checkRole('judgehost')) {
-            if ($this->authService->checkRole('team')) {
-                $queryBuilder
-                    ->andWhere('clar.sender = :team OR clar.recipient = :team OR (clar.sender IS NULL AND clar.recipient IS NULL)')
-                    ->setParameter('team', $this->authService->getUser()->getTeam());
-            } else {
-                $queryBuilder
-                    ->andWhere('clar.sender IS NULL')
-                    ->andWhere('clar.recipient IS NULL');
-            }
-        }
-
-        // For non-API-reader users, only expose the problems after the contest has started.
-        // `WF Access Policy` allows for clarifications before the contest, but not to disclose the problem
-        // so referencing them in clarifications would violate referential integrity.
-        if (!$this->authService->checkRole('api_reader')) {
-            $queryBuilder->andWhere('c.starttime < :now OR clar.problem IS NULL')
-                ->setParameter('now', Utils::now());
-        }
-
-        if ($request->query->has('problem')) {
-            $queryBuilder
-                ->andWhere('clar.problem = :problem')
-                ->setParameter('problem', $request->query->get('problem'));
-        }
-
-        return $queryBuilder;
     }
 
     protected function getIdField(): string

--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -9,7 +9,7 @@ use App\Entity\Problem;
 use App\Entity\Team;
 use App\Entity\User;
 use App\Form\Type\JuryClarificationType;
-use App\Service\ConfigurationService;
+use App\Service\ClarificationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
@@ -32,9 +32,9 @@ class ClarificationController extends BaseController
     public function __construct(
         EntityManagerInterface $em,
         DOMJudgeService $dj,
-        protected readonly ConfigurationService $config,
         EventLogService $eventLogService,
         KernelInterface $kernel,
+        protected readonly ClarificationService $clarificationService,
     ) {
         parent::__construct($em, $eventLogService, $dj, $kernel);
     }
@@ -63,7 +63,7 @@ class ClarificationController extends BaseController
         string $currentQueue = 'all',
     ): Response {
         $contest = $this->dj->getContestByExternalId($contestId);
-        $categories = $this->config->get('clar_categories');
+        $categories = $this->clarificationService->getClarificationCategories();
 
         if ($currentFilter === 'all') {
             $currentFilter = null;
@@ -114,7 +114,7 @@ class ClarificationController extends BaseController
             }
         }
 
-        $queues = $this->config->get('clar_queues');
+        $queues = $this->clarificationService->getClarificationQueues();
 
         return $this->render('jury/clarifications.html.twig', [
             'contestId' => $contestId,
@@ -212,8 +212,8 @@ class ClarificationController extends BaseController
             }
         }
         $parameters['subjects'] = $groupedCategories;
-        $queues = $this->config->get('clar_queues');
-        $clarificationAnswers = $this->config->get('clar_answers');
+        $queues = $this->clarificationService->getClarificationQueues();
+        $clarificationAnswers = $this->clarificationService->getClarificationDefaultAnswers();
 
         foreach ($clarificationList as $clar) {
             $data = ['clarid' => $clar->getClarid(), 'externalid' => $clar->getExternalid()];
@@ -481,7 +481,7 @@ class ClarificationController extends BaseController
         if ($inReplTo) {
             $queue = $inReplTo->getQueue();
         } else {
-            $queue = $this->config->get('clar_default_problem_queue');
+            $queue = $this->clarificationService->getClarificationDefaultProblemQueue();
             if ($queue === "") {
                 $queue = null;
             }

--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -69,31 +69,7 @@ class ClarificationController extends BaseController
             $currentFilter = null;
         }
 
-        $queryBuilder = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'clar')
-            ->leftJoin('clar.problem', 'p')
-            ->innerJoin('clar.contest', 'c')
-            ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = clar.contest')
-            ->select('clar', 'p', 'cp')
-            ->andWhere('c.externalid = :contestId')
-            ->setParameter('contestId', $contestId)
-            ->orderBy('clar.submittime', 'DESC')
-            ->addOrderBy('clar.clarid', 'DESC');
-
-        if ($currentQueue === "unassigned") {
-            $queryBuilder->andWhere($queryBuilder->expr()->orX(
-                $queryBuilder->expr()->isNull('clar.queue'),
-                $queryBuilder->expr()->eq('clar.queue', ':queue')
-            ))
-                ->setParameter('queue', $currentQueue);
-        } elseif ($currentQueue !== "all") {
-            $queryBuilder->andWhere('clar.queue = :queue')
-                ->setParameter('queue', $currentQueue);
-        }
-
-        $clarifications = $queryBuilder
-            ->getQuery()
-            ->getResult();
+        $clarifications = $this->clarificationService->getClarifications($contestId, $currentQueue);
 
         /** @var Clarification[] $newClarifications */
         $newClarifications = [];
@@ -269,11 +245,8 @@ class ClarificationController extends BaseController
 
         $parameters['queues'] = $queues;
         $parameters['answers'] = $clarificationAnswers;
-        $parameters['jurymember'] = $this->em->createQueryBuilder()
+        $parameters['jurymember'] = $this->clarificationService->getQueryBuilder(externalClarificationId: $clarification->getExternalid())
             ->select('clar.jury_member')
-            ->from(Clarification::class, 'clar')
-            ->where('clar.clarid = :clarid')
-            ->setParameter('clarid', $clarification->getClarid())
             ->getQuery()
             ->getSingleResult()['jury_member'];
 

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -795,7 +795,7 @@ class ContestController extends BaseController
         }
 
         /** @var int[] $clarificationIds */
-        $clarificationIds = array_map(fn(array $data) => $data['clarid'], $this->em->createQueryBuilder()
+        $clarificationIds = array_map(fn(array $data) => $data['externalid'], $this->em->createQueryBuilder()
             ->from(Clarification::class, 'c')
             ->select('c.externalid')
             ->andWhere('c.contest = :contest')

--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Jury;
 
 use App\Controller\BaseController;
 use App\Doctrine\DBAL\Types\JudgeTaskType;
-use App\Entity\Clarification;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Judgehost;
@@ -22,6 +21,7 @@ use App\Form\Type\FinalizeContestType;
 use App\Form\Type\RemovedIntervalType;
 use App\Service\AssetUpdateService;
 use App\Service\AuthorizedUserService;
+use App\Service\ClarificationService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -57,6 +57,7 @@ class ContestController extends BaseController
         protected readonly AuthorizedUserService $authService,
         EntityManagerInterface $em,
         DOMJudgeService $dj,
+        protected readonly ClarificationService $clarificationService,
         protected readonly ConfigurationService $config,
         KernelInterface $kernel,
         protected readonly EventLogService $eventLogService,
@@ -795,12 +796,9 @@ class ContestController extends BaseController
         }
 
         /** @var int[] $clarificationIds */
-        $clarificationIds = array_map(fn(array $data) => $data['externalid'], $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'c')
-            ->select('c.externalid')
-            ->andWhere('c.contest = :contest')
-            ->andWhere('c.answered = false')
-            ->setParameter('contest', $contest)
+        $clarificationIds = array_map(fn(array $data) => $data['externalid'], $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+            ->select('clar.externalid')
+            ->andWhere('clar.answered = false')
             ->getQuery()
             ->getResult()
         );

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -16,6 +16,7 @@ use App\Form\Type\JsonImportType;
 use App\Form\Type\ProblemsImportType;
 use App\Form\Type\ProblemUploadType;
 use App\Form\Type\TsvImportType;
+use App\Service\ClarificationService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -57,6 +58,7 @@ class ImportExportController extends BaseController
         EntityManagerInterface $em,
         protected readonly ScoreboardService $scoreboardService,
         DOMJudgeService $dj,
+        protected readonly ClarificationService $clarificationService,
         protected readonly ConfigurationService $config,
         protected readonly EventLogService $eventLogService,
         protected readonly ImportProblemService $importProblemService,
@@ -522,13 +524,13 @@ class ImportExportController extends BaseController
             throw new BadRequestHttpException('No current contest');
         }
 
-        $queues              = (array)$this->config->get('clar_queues');
+        $queues              = (array)$this->clarificationService->getClarificationQueues();
         $clarificationQueues = ['' => 'Unassigned issues'];
         foreach ($queues as $key => $val) {
             $clarificationQueues[$key] = $val;
         }
 
-        $categories = (array)$this->config->get('clar_categories');
+        $categories = (array)$this->clarificationService->getClarificationCategories();
 
         $clarificationCategories = [];
         foreach ($categories as $key => $val) {

--- a/webapp/src/Controller/Jury/ImportExportController.php
+++ b/webapp/src/Controller/Jury/ImportExportController.php
@@ -538,16 +538,12 @@ class ImportExportController extends BaseController
         }
 
         /** @var Clarification[] $clarifications */
-        $clarifications = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'c')
-            ->leftJoin('c.problem', 'p')
-            ->select('c')
-            ->andWhere('c.contest = :contest')
-            ->setParameter('contest', $contest)
-            ->addOrderBy('c.category')
+        $clarifications = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+            ->select('clar')
+            ->addOrderBy('clar.category')
             ->addOrderBy('p.probid')
-            ->addOrderBy('c.submittime')
-            ->addOrderBy('c.clarid')
+            ->addOrderBy('clar.submittime')
+            ->addOrderBy('clar.clarid')
             ->getQuery()
             ->getResult();
 

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -8,6 +8,7 @@ use App\Entity\ContestProblem;
 use App\Entity\Problem;
 use App\Entity\Team;
 use App\Entity\TeamCategory;
+use App\Service\ClarificationService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -37,6 +38,7 @@ class PublicController extends BaseController
     use ScoreboardSubmissionsTrait;
     public function __construct(
         DOMJudgeService $dj,
+        protected readonly ClarificationService $clarificationService,
         protected readonly ConfigurationService $config,
         protected readonly ScoreboardService $scoreboardService,
         protected readonly StatisticsService $stats,
@@ -341,20 +343,12 @@ class PublicController extends BaseController
         /** @var Clarification[] $clarifications */
         $clarifications = [];
         if ($contest->getStartTimeObject()?->getTimestamp() <= time()) {
-            $clarifications = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'c')
-                ->leftJoin('c.problem', 'p')
-                ->leftJoin('c.sender', 's')
-                ->leftJoin('c.recipient', 'r')
-                ->select('c', 'p')
-                ->andWhere('c.contest = :contest')
-                ->andWhere('c.sender IS NULL')
-                ->andWhere('c.recipient IS NULL')
-                ->andWhere('c.problem = :problem')
-                ->setParameter('contest', $contest)
-                ->setParameter('problem', $problem)
-                ->addOrderBy('c.submittime', 'DESC')
-                ->addOrderBy('c.clarid', 'DESC')
+            $clarifications = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid(), problem: strval($problem->getProbid()))
+                ->select('clar', 'p')
+                ->andWhere('clar.sender IS NULL')
+                ->andWhere('clar.recipient IS NULL')
+                ->addOrderBy('clar.submittime', 'DESC')
+                ->addOrderBy('clar.clarid', 'DESC')
                 ->getQuery()
                 ->getResult();
         }
@@ -379,30 +373,22 @@ class PublicController extends BaseController
         $categories = $this->config->get('clar_categories');
         $contest    = $this->dj->getCurrentContest();
         /** @var Clarification|null $clarification */
-        $clarification = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'c')
-            ->leftJoin('c.problem', 'p')
-            ->leftJoin('c.contest', 'co')
-            ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
-            ->select('c, p, co')
-            ->andWhere('c.contest = :contest')
-            ->andWhere('c.externalid = :clarId')
-            ->andWhere('c.sender IS NULL')
-            ->andWhere('c.recipient IS NULL')
-            ->setParameter('contest', $contest)
-            ->setParameter('clarId', $clarId)
+        $clarification = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid(), externalClarificationId: $clarId)
+            ->select('clar, p, c')
+            ->andWhere('clar.sender IS NULL')
+            ->andWhere('clar.recipient IS NULL')
             ->getQuery()
             ->getOneOrNullResult();
-    
+
         if ($clarification === null) {
             throw new NotFoundHttpException(sprintf('Clarification %s not found', $clarId));
         }
-    
+
         $data = [
             'clarification' => $clarification,
             'categories' => $categories,
         ];
-    
+
         if ($request->isXmlHttpRequest()) {
             return $this->render('clarification_modal.html.twig', $data);
         } else {

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -77,21 +77,12 @@ class ClarificationController extends BaseController
         }
 
         /** @var Clarification[] $clarifications */
-        $clarifications = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'c')
-            ->leftJoin('c.problem', 'p')
-            ->leftJoin('c.sender', 's')
-            ->leftJoin('c.recipient', 'r')
-            ->select('c', 'p')
-            ->andWhere('c.contest = :contest')
-            ->andWhere('c.sender IS NULL')
-            ->andWhere('c.recipient = :team OR c.recipient IS NULL')
-            ->andWhere('c.problem = :problem')
-            ->setParameter('contest', $contest)
-            ->setParameter('team', $team)
-            ->setParameter('problem', $problem)
-            ->addOrderBy('c.submittime', 'DESC')
-            ->addOrderBy('c.clarid', 'DESC')
+        $clarifications = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid(), problem: strval($problem->getProbid()))
+            ->select('clar', 'p')
+            // Needed to filter out team clarification requests.
+            ->andWhere('clar.sender IS NULL')
+            ->addOrderBy('clar.submittime', 'DESC')
+            ->addOrderBy('clar.clarid', 'DESC')
             ->getQuery()
             ->getResult();
 
@@ -118,16 +109,8 @@ class ClarificationController extends BaseController
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
         /** @var Clarification|null $clarification */
-        $clarification = $this->em->createQueryBuilder()
-            ->from(Clarification::class, 'c')
-            ->leftJoin('c.problem', 'p')
-            ->leftJoin('c.contest', 'co')
-            ->leftJoin('p.contest_problems', 'cp', Join::WITH, 'cp.contest = :contest')
-            ->select('c, p, co')
-            ->andWhere('c.contest = :contest')
-            ->andWhere('c.externalid = :clarId')
-            ->setParameter('contest', $contest)
-            ->setParameter('clarId', $clarId)
+        $clarification = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid(), externalClarificationId: $clarId)
+            ->select('clar, p, c')
             ->getQuery()
             ->getOneOrNullResult();
 

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -9,6 +9,7 @@ use App\Entity\Problem;
 use App\Entity\Team;
 use App\Form\Type\TeamClarificationType;
 use App\Service\AuthorizedUserService;
+use App\Service\ClarificationService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -38,11 +39,12 @@ class ClarificationController extends BaseController
     public function __construct(
         protected readonly AuthorizedUserService $authService,
         DOMJudgeService $dj,
-        protected readonly ConfigurationService $config,
         EntityManagerInterface $em,
+        KernelInterface $kernel,
+        protected readonly ClarificationService $clarificationService,
+        protected readonly ConfigurationService $config,
         protected readonly EventLogService $eventLogService,
         protected readonly FormFactoryInterface $formFactory,
-        KernelInterface $kernel,
     ) {
         parent::__construct($em, $eventLogService, $dj, $kernel);
     }
@@ -111,7 +113,7 @@ class ClarificationController extends BaseController
     #[Route(path: '/clarifications/{clarId}', name: 'team_clarification')]
     public function viewAction(Request $request, string $clarId): Response
     {
-        $categories = $this->config->get('clar_categories');
+        $categories = $this->clarificationService->getClarificationCategories();
         $user       = $this->authService->getUser();
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
@@ -192,7 +194,7 @@ class ClarificationController extends BaseController
     #[Route(path: '/clarifications/add', name: 'team_clarification_add', priority: 1)]
     public function addAction(Request $request): Response
     {
-        $categories = $this->config->get('clar_categories');
+        $categories = $this->clarificationService->getClarificationCategories();
         $user       = $this->authService->getUser();
         $team       = $user->getTeam();
         $contest    = $this->dj->getCurrentContest($team->getTeamid());
@@ -243,7 +245,7 @@ class ClarificationController extends BaseController
         } else {
             [, $problemId] = explode(Clarification::PROBLEM_BASED_SEPARATOR, $formData['subject']);
             $problem = $this->em->getRepository(Problem::class)->findByExternalId($problemId);
-            $queue = $this->config->get('clar_default_problem_queue');
+            $queue = $this->clarificationService->getClarificationDefaultProblemQueue();
             if ($queue === "") {
                 $queue = null;
             }

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -95,41 +95,27 @@ class MiscController extends BaseController
                 paginated: false
             )[0];
 
-            $qb = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'c')
-                ->leftJoin('c.problem', 'p')
-                ->leftJoin('c.sender', 's')
-                ->leftJoin('c.recipient', 'r')
-                ->select('c', 'p')
-                ->andWhere('c.contest = :contest')
-                ->andWhere('c.sender IS NULL')
-                ->andWhere('c.recipient = :teamId OR c.recipient IS NULL')
-                ->andWhere('c.submittime <= :time')
-                ->setParameter('contest', $contest)
-                ->setParameter('teamId', $teamId)
-                ->setparameter('time', time())
-                ->addOrderBy('c.submittime', 'DESC')
-                ->addOrderBy('c.clarid', 'DESC');
+            $qb = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+                ->select('clar', 'p')
+                // Needed to filter out team clarification requests.
+                ->andWhere('clar.sender IS NULL')
+                ->addOrderBy('clar.submittime', 'DESC')
+                ->addOrderBy('clar.clarid', 'DESC');
             if ($contest->getStartTimeObject()?->getTimestamp() > time()) {
-                $qb->andWhere('c.problem IS NULL');
+                $qb->andWhere('clar.problem IS NULL');
             }
 
             /** @var Clarification[] $clarifications */
             $clarifications = $qb->getQuery()->getResult();
 
             /** @var Clarification[] $clarificationRequests */
-            $clarificationRequests = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'c')
-                ->leftJoin('c.problem', 'p')
-                ->leftJoin('c.sender', 's')
-                ->leftJoin('c.recipient', 'r')
-                ->select('c', 'p')
-                ->andWhere('c.contest = :contest')
-                ->andWhere('c.sender = :teamId')
-                ->setParameter('contest', $contest)
+            $clarificationRequests = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+                ->select('clar', 'p')
+                // Where is needed to only retrieve clarification requests, not the responses.
+                ->andWhere('clar.sender = :teamId')
                 ->setParameter('teamId', $teamId)
-                ->addOrderBy('c.submittime', 'DESC')
-                ->addOrderBy('c.clarid', 'DESC')
+                ->addOrderBy('clar.submittime', 'DESC')
+                ->addOrderBy('clar.clarid', 'DESC')
                 ->getQuery()
                 ->getResult();
 

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -7,6 +7,7 @@ use App\DataTransferObject\SubmissionRestriction;
 use App\Entity\Clarification;
 use App\Form\Type\PrintType;
 use App\Service\AuthorizedUserService;
+use App\Service\ClarificationService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
@@ -40,6 +41,7 @@ class MiscController extends BaseController
     public function __construct(
         protected readonly AuthorizedUserService $authService,
         DOMJudgeService $dj,
+        protected readonly ClarificationService $clarificationService,
         protected readonly ConfigurationService $config,
         EntityManagerInterface $em,
         protected readonly ScoreboardService $scoreboardService,
@@ -133,7 +135,7 @@ class MiscController extends BaseController
 
             $data['clarifications']        = $clarifications;
             $data['clarificationRequests'] = $clarificationRequests;
-            $data['categories']            = $this->config->get('clar_categories');
+            $data['categories']            = $this->clarificationService->getClarificationCategories();
             $data['allowDownload']         = (bool)$this->config->get('allow_team_submission_download');
             $data['showTooLateResult']     = $this->config->get('show_too_late_result');
         }

--- a/webapp/src/Form/Type/JuryClarificationType.php
+++ b/webapp/src/Form/Type/JuryClarificationType.php
@@ -147,11 +147,8 @@ class JuryClarificationType extends AbstractType
     public function checkJuryMember(mixed $value, ExecutionContextInterface $context, mixed $payload): void
     {
         if ($this->clarid) {
-            $juryMember = $this->em->createQueryBuilder()
+            $juryMember = $this->clarificationService->getQueryBuilder(externalClarificationId: $this->clarid)
                 ->select('clar.jury_member')
-                ->from(Clarification::class, 'clar')
-                ->where('clar.externalid = :clarid')
-                ->setParameter('clarid', $this->clarid)
                 ->getQuery()
                 ->getSingleResult()['jury_member'];
 

--- a/webapp/src/Form/Type/JuryClarificationType.php
+++ b/webapp/src/Form/Type/JuryClarificationType.php
@@ -6,7 +6,7 @@ use App\Entity\Clarification;
 use App\Entity\ContestProblem;
 use App\Entity\Team;
 use App\Service\AuthorizedUserService;
-use App\Service\ConfigurationService;
+use App\Service\ClarificationService;
 use App\Service\DOMJudgeService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\AbstractType;
@@ -30,7 +30,7 @@ class JuryClarificationType extends AbstractType
     public function __construct(
         private readonly AuthorizedUserService $authService,
         private readonly EntityManagerInterface $em,
-        private readonly ConfigurationService $config,
+        private readonly ClarificationService $clarificationService,
         private readonly DOMJudgeService $dj,
     ) {}
 
@@ -56,7 +56,7 @@ class JuryClarificationType extends AbstractType
         $subjectOptions = [];
         $subjectGroupBy = null;
 
-        $categories = $this->config->get('clar_categories');
+        $categories = $this->clarificationService->getClarificationCategories();
         $contest = $this->dj->getCurrentContest();
         $hasCurrentContest = $contest !== null;
         if ($hasCurrentContest) {
@@ -109,7 +109,7 @@ class JuryClarificationType extends AbstractType
             'group_by' => $subjectGroupBy,
         ]);
 
-        $maxLength = $this->config->get('clar_max_body_length');
+        $maxLength = $this->clarificationService->getClarificationMaximumBodyLength();
         $constraints = [];
         if ($maxLength > 0) {
             $constraints[] = new Length(max: $maxLength, maxMessage: 'Clarification body is too long: {{ value }} characters, maximum is {{ limit }}.');

--- a/webapp/src/Form/Type/TeamClarificationType.php
+++ b/webapp/src/Form/Type/TeamClarificationType.php
@@ -4,8 +4,8 @@ namespace App\Form\Type;
 
 use App\Entity\Clarification;
 use App\Entity\ContestProblem;
-use App\Service\ConfigurationService;
 use App\Service\AuthorizedUserService;
+use App\Service\ClarificationService;
 use App\Service\DOMJudgeService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -19,7 +19,7 @@ class TeamClarificationType extends AbstractType
     public function __construct(
         protected readonly AuthorizedUserService $authService,
         protected readonly DOMJudgeService $dj,
-        protected readonly ConfigurationService $config
+        protected readonly ClarificationService $clarificationService
     ) {}
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -31,7 +31,7 @@ class TeamClarificationType extends AbstractType
 
         $subjects = [];
         /** @var string[] $categories */
-        $categories = $this->config->get('clar_categories');
+        $categories = $this->clarificationService->getClarificationCategories();
         $user = $this->authService->getUser();
         $contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid());
         if ($contest) {
@@ -53,7 +53,7 @@ class TeamClarificationType extends AbstractType
         $builder->add('subject', ChoiceType::class, [
             'choices' => $subjects,
         ]);
-        $maxLength = $this->config->get('clar_max_body_length');
+        $maxLength = $this->clarificationService->getClarificationMaximumBodyLength();
         $constraints = [];
         if ($maxLength > 0) {
             $constraints[] = new Length(max: $maxLength, maxMessage: 'Clarification body is too long: {{ value }} characters, maximum is {{ limit }}.');

--- a/webapp/src/Service/ClarificationService.php
+++ b/webapp/src/Service/ClarificationService.php
@@ -3,12 +3,17 @@
 namespace App\Service;
 
 use App\Entity\Clarification;
-use App\Entity\Contest;
+use App\Utils\Utils;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
 
 readonly class ClarificationService
 {
     public function __construct(
+        protected AuthorizedUserService $authService,
         protected ConfigurationService $config,
+        protected EntityManagerInterface $em,
     ) {}
 
     /**
@@ -43,5 +48,94 @@ readonly class ClarificationService
     public function getClarificationMaximumBodyLength(): int
     {
         return $this->config->get('clar_max_body_length');
+    }
+
+    /**
+     * @return Clarification[]
+     */
+    public function getClarifications(?string $externalContestId, string $currentQueue): array
+    {
+        $queryBuilder = $this->getQueryBuilder(externalContestId: $externalContestId)
+            ->select('clar', 'c', 'cp')
+            ->orderBy('clar.submittime', 'DESC')
+            ->addOrderBy('clar.clarid', 'DESC');
+
+        if ($currentQueue === "unassigned") {
+            $queryBuilder->andWhere($queryBuilder->expr()->orX(
+                $queryBuilder->expr()->isNull('clar.queue'),
+                $queryBuilder->expr()->eq('clar.queue', ':queue')
+            ))
+                ->setParameter('queue', $currentQueue);
+        } elseif ($currentQueue !== "all") {
+            $queryBuilder->andWhere('clar.queue = :queue')
+                ->setParameter('queue', $currentQueue);
+        }
+
+        return $queryBuilder
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function getQueryBuilder(?string $externalContestId = null, ?int $internalContestId = null,
+                                    ?string $externalClarificationId = null,
+                                    ?string $problem = null
+    ): QueryBuilder {
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->from(Clarification::class, 'clar')
+            ->join('clar.contest', 'c')
+            ->leftJoin('clar.in_reply_to', 'reply')
+            ->leftJoin('clar.sender', 's')
+            ->leftJoin('clar.recipient', 'r')
+            ->leftJoin('clar.problem', 'p')
+            ->leftJoin('c.problems', 'cp', Join::WITH, 'cp.problem = clar.problem');
+
+        if (!is_null($internalContestId)) {
+            $queryBuilder
+                ->andWhere('clar.contest = :cid')
+                ->setParameter('cid', $internalContestId);
+        }
+        if (!is_null($externalContestId)) {
+            $queryBuilder
+                ->andWhere('c.externalid = :contestId')
+                ->setParameter('contestId', $externalContestId);
+        }
+
+        if (!is_null($externalClarificationId)) {
+            $queryBuilder
+                ->andWhere('clar.externalid = :clarification')
+                ->setParameter('clarification', $externalClarificationId);
+        }
+
+        if (!$this->authService->checkRole('api_reader') &&
+            !$this->authService->checkRole('judgehost')) {
+            if ($this->authService->checkRole('team')) {
+                $queryBuilder
+                    ->andWhere('clar.sender = :team OR clar.recipient = :team OR (clar.sender IS NULL AND clar.recipient IS NULL)')
+                    ->setParameter('team', $this->authService->getUser()->getTeam());
+            } else {
+                $queryBuilder
+                    ->andWhere('clar.sender IS NULL')
+                    ->andWhere('clar.recipient IS NULL');
+            }
+        }
+
+        if (!$this->authService->checkRole('api_reader')) {
+            $queryBuilder
+                // For non-API-reader users, only expose the problems after the contest has started.
+                // `WF Access Policy` allows for clarifications before the contest, but not to disclose the problem
+                // so referencing them in clarifications would violate referential integrity.
+                ->andWhere('c.starttime < :now OR clar.problem IS NULL')
+                ->setParameter('now', Utils::now())
+                // Don't display future clarifications to non-jury users.
+                ->andWhere('clar.submittime <= :now');
+        }
+
+        if (!is_null($problem)) {
+            $queryBuilder
+                ->andWhere('clar.problem = :problem')
+                ->setParameter('problem', $problem);
+        }
+
+        return $queryBuilder;
     }
 }

--- a/webapp/src/Service/ClarificationService.php
+++ b/webapp/src/Service/ClarificationService.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Clarification;
+use App\Entity\Contest;
+
+readonly class ClarificationService
+{
+    public function __construct(
+        protected ConfigurationService $config,
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function getClarificationCategories(): array
+    {
+        return $this->config->get('clar_categories');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getClarificationDefaultAnswers(): array
+    {
+        return $this->config->get('clar_answers');
+    }
+
+    public function getClarificationDefaultProblemQueue(): string
+    {
+        return $this->config->get('clar_default_problem_queue');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getClarificationQueues(): array
+    {
+        return $this->config->get('clar_queues');
+    }
+
+    public function getClarificationMaximumBodyLength(): int
+    {
+        return $this->config->get('clar_max_body_length');
+    }
+}

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -103,6 +103,7 @@ class DOMJudgeService
 
     public function __construct(
         protected readonly AuthorizedUserService $authService,
+        protected readonly ClarificationService $clarificationService,
         protected readonly EntityManagerInterface $em,
         protected readonly BalloonService $balloonService,
         protected readonly LoggerInterface $logger,
@@ -387,13 +388,10 @@ class DOMJudgeService
 
         if ($this->authService->checkRole('jury')) {
             if ($contest) {
-                $clarifications = $this->em->createQueryBuilder()
+                $clarifications = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
                     ->select('clar.externalid', 'clar.body')
-                    ->from(Clarification::class, 'clar')
-                    ->andWhere('clar.contest = :contest')
-                    ->andWhere('clar.sender is not null')
-                    ->andWhere('clar.answered = 0')
-                    ->setParameter('contest', $contest)
+                    ->andWhere('clar.sender IS NOT NULL')
+                    ->andWhere('clar.answered = false')
                     ->getQuery()->getResult();
             }
 
@@ -1156,17 +1154,15 @@ class DOMJudgeService
                 $samples[$sample['probid']] = $sample['numsamples'];
             }
 
-            $raw_clars = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'clar')
+            $raw_clars = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
                 ->select('clar')
-                ->andWhere('clar.contest = :cid')
                 // Only clars associated with a problem.
                 ->andWhere('clar.problem IS NOT NULL')
                 // Only clars send from the jury.
                 ->andWhere('clar.sender IS NULL')
                 // Only clars send to all teams or just this team.
+                // Even for jury/admin we don't want to show all clarifications to all teams
                 ->andWhere('clar.recipient IS NULL OR clar.recipient = :teamid')
-                ->setParameter('cid', $contest->getCid())
                 ->setParameter('teamid', $teamId)
                 ->orderBy('clar.submittime', 'DESC')
                 ->getQuery()

--- a/webapp/src/Service/ExternalContestSourceService.php
+++ b/webapp/src/Service/ExternalContestSourceService.php
@@ -151,6 +151,7 @@ class ExternalContestSourceService
         HttpClientInterface $httpClient,
         protected readonly DOMJudgeService $dj,
         protected readonly EntityManagerInterface $em,
+        protected readonly ClarificationService $clarificationService,
         protected readonly ConfigurationService $config,
         protected readonly EventLogService $eventLog,
         protected readonly SubmissionService $submissionService,
@@ -1418,7 +1419,7 @@ class ExternalContestSourceService
         $submitTime = Utils::toEpochFloat($data->time);
 
         $body = $data->text;
-        $maxLength = $this->config->get('clar_max_body_length');
+        $maxLength = $this->clarificationService->getClarificationMaximumBodyLength();
         if ($maxLength > 0 && mb_strlen($body) > $maxLength) {
             $dropped = mb_strlen($body) - $maxLength;
             $suffix = sprintf("\n[... body truncated, %d characters dropped]", $dropped);


### PR DESCRIPTION
During NWERC I discussed with @nickygerritsen to extract more logic to dedicated services. This is a start to see how much work it is and if the code will look better with it.

Personally I think the code does become better as it's now clear in the Controller what selections we make (the where clauses) and all default guarding is done in the QueryBuilder. There are still some calls where we basically have the same queries which could be merged in their own functions to remove further duplication.