### PR TITLE
Fix unfrozen static scoreboard submission verdicts

### DIFF
--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -295,12 +295,19 @@ class PublicController extends BaseController
     #[Route(path: '/submissions-data/team/{teamId}/problem/{problemId}.json', name: 'public_submissions_data_cell')]
     public function submissionsDataAction(Request $request, ?string $teamId, ?string $problemId): JsonResponse
     {
-        $contest = $this->dj->getCurrentContest(onlyPublic: true);
+        /** @var Contest|null $contest */
+        $contest = $request->attributes->get('_domjudge_static_scoreboard_contest')
+            ?? $this->dj->getCurrentContest(onlyPublic: true);
 
         if (!$contest) {
             throw $this->createNotFoundException('No active contest found');
         }
 
-        return $this->getSubmissionsDataResponse($contest, $teamId, $problemId);
+        $forceUnfrozen = (bool)$request->attributes->get(
+            '_domjudge_static_scoreboard_force_unfrozen',
+            false
+        );
+
+        return $this->getSubmissionsDataResponse($contest, $teamId, $problemId, $forceUnfrozen);
     }
 }

--- a/webapp/src/Controller/ScoreboardSubmissionsTrait.php
+++ b/webapp/src/Controller/ScoreboardSubmissionsTrait.php
@@ -50,9 +50,13 @@ trait ScoreboardSubmissionsTrait
         ]);
     }
 
-    protected function getSubmissionsDataResponse(Contest $contest, ?string $teamId, ?string $problemId): JsonResponse
-    {
-        $scoreboard = $this->scoreboardService->getScoreboard($contest);
+    protected function getSubmissionsDataResponse(
+        Contest $contest,
+        ?string $teamId,
+        ?string $problemId,
+        bool $forceUnfrozen = false
+    ): JsonResponse {
+        $scoreboard = $this->scoreboardService->getScoreboard($contest, forceUnfrozen: $forceUnfrozen);
 
         if ($scoreboard === null) {
             throw $this->createNotFoundException('No submission data found');
@@ -108,7 +112,12 @@ trait ScoreboardSubmissionsTrait
             $item = [
                 'time' => $this->twigExtension->printtime($submission->getSubmittime(), contest: $contest),
                 'language' => $submission->getLanguage()->getName(),
-                'verdict' => $this->submissionVerdict($submission, $contest, $verificationRequired),
+                'verdict' => $this->submissionVerdict(
+                    $submission,
+                    $contest,
+                    $verificationRequired,
+                    $forceUnfrozen
+                ),
             ];
             if ($contest->getScoreboardType() === ScoreboardType::SCORE) {
                 $item['score'] = $submission->getScore();
@@ -124,12 +133,13 @@ trait ScoreboardSubmissionsTrait
     protected function submissionVerdict(
         Submission $submission,
         Contest $contest,
-        bool $verificationRequired
+        bool $verificationRequired,
+        bool $forceUnfrozen = false
     ): string {
         if ($submission->getSubmittime() >= $contest->getEndtime()) {
             return $this->twigExtension->printResult('too-late');
         }
-        if ($contest->getFreezetime() && $submission->getSubmittime() >= $contest->getFreezetime() && !$contest->getFreezeData()->showFinal()) {
+        if (!$forceUnfrozen && $contest->getFreezetime() && $submission->getSubmittime() >= $contest->getFreezetime() && !$contest->getFreezeData()->showFinal()) {
             return $this->twigExtension->printResult('');
         }
         if ($contest->isExternalSourceUseJudgements()) {

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -1693,6 +1693,13 @@ class DOMJudgeService
         $zip->addFromString('index.html', $contestPage);
 
         $submissionsDataRequest  = Request::create('/public/submissions-data.json', Request::METHOD_GET);
+        if ($contest !== null) {
+            $submissionsDataRequest->attributes->set('_domjudge_static_scoreboard_contest', $contest);
+        }
+        $submissionsDataRequest->attributes->set(
+            '_domjudge_static_scoreboard_force_unfrozen',
+            $forceUnfrozen
+        );
         $submissionsDataRequest->setSession($this->requestStack->getSession());
         /** @var JsonResponse $response */
         $response = $this->httpKernel->handle($submissionsDataRequest, HttpKernelInterface::SUB_REQUEST);

--- a/webapp/tests/Unit/Controller/Jury/StaticScoreboardZipTest.php
+++ b/webapp/tests/Unit/Controller/Jury/StaticScoreboardZipTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\Jury;
+
+use App\DataFixtures\Test\SampleSubmissionsInBucketsFixture;
+use App\Tests\Unit\BaseTestCase;
+
+class StaticScoreboardZipTest extends BaseTestCase
+{
+    protected array $roles = ['admin'];
+
+    protected static array $fixtures = [
+        SampleSubmissionsInBucketsFixture::class,
+    ];
+
+    public function testUnfrozenStaticScoreboardZipCarriesUnfrozenSubmissionData(): void
+    {
+        $publicSubmissionData = $this->getSubmissionsDataFromStaticScoreboardZip('public');
+        $unfrozenSubmissionData = $this->getSubmissionsDataFromStaticScoreboardZip('unfrozen');
+
+        $publicPendingCount = substr_count($publicSubmissionData, 'sol_queued');
+        $unfrozenPendingCount = substr_count($unfrozenSubmissionData, 'sol_queued');
+
+        self::assertGreaterThan(
+            0,
+            $publicPendingCount,
+            'The fixture should contain submissions hidden by the public scoreboard freeze.'
+        );
+        self::assertEquals(
+            0,
+            $unfrozenPendingCount,
+            'Unfrozen static scoreboard ZIP should reveal final verdicts in submissions-data.json.'
+        );
+    }
+
+    private function getSubmissionsDataFromStaticScoreboardZip(string $type): string
+    {
+        $uri = sprintf('/jury/contests/demo/%s-scoreboard.zip', $type);
+        $this->client->request('GET', $uri);
+
+        $response = $this->client->getInternalResponse();
+        $content = $response->getContent();
+
+        self::assertEquals(200, $response->getStatusCode(), $content . "\nURI = $uri");
+        self::assertStringStartsWith('PK', $content, 'Expected a ZIP response.');
+
+        $zipContents = $this->unzipString($content);
+        self::assertArrayHasKey(
+            'submissions-data.json',
+            $zipContents,
+            'ZIP entries: ' . implode(', ', array_keys($zipContents))
+        );
+        self::assertIsString($zipContents['submissions-data.json']);
+
+        return $zipContents['submissions-data.json'];
+    }
+}


### PR DESCRIPTION
The static scoreboard ZIP renders index.html with forceUnfrozen, but the generated submissions-data.json is fetched through a public subrequest that did not receive the same flag. As a result judged submissions after the freeze were still serialized as pending in the unfrozen ZIP.

Carry the selected contest and an internal force-unfrozen flag into the subrequest, and use that flag when building submissions-data.json.

Fixes #3629.

Co-developed-by: GPT 5.5 <noreply@openai.com>