### PR TITLE
Fix contest problemset replacement and deletion handling

### DIFF
--- a/webapp/src/Entity/Contest.php
+++ b/webapp/src/Entity/Contest.php
@@ -1699,10 +1699,16 @@ class Contest extends BaseApiEntity implements
 
     public function setContestProblemsetContent(?ContestProblemsetContent $content): self
     {
-        $this->contestProblemsetContent = new ArrayCollection();
-        if ($content) {
-            $this->contestProblemsetContent->add($content);
+        foreach ($this->contestProblemsetContent->toArray() as $existingContent) {
+            if ($existingContent !== $content) {
+                $this->contestProblemsetContent->removeElement($existingContent);
+            }
+        }
+        if ($content !== null) {
             $content->setContest($this);
+            if (!$this->contestProblemsetContent->contains($content)) {
+                $this->contestProblemsetContent->add($content);
+            }
         }
 
         return $this;
@@ -1721,7 +1727,13 @@ class Contest extends BaseApiEntity implements
             $this
                 ->setContestProblemsetContent(null)
                 ->setContestProblemsetType(null);
-        } elseif ($this->getContestProblemsetFile()) {
+
+            $this->contestProblemsetFile = null;
+            $this->clearContestProblemset = false;
+            return;
+        }
+
+        if ($this->getContestProblemsetFile()) {
             $content               = file_get_contents($this->getContestProblemsetFile()->getRealPath());
             $clientName            = $this->getContestProblemsetFile()->getClientOriginalName();
             $contestProblemsetType = Utils::getTextType($clientName, $this->getContestProblemsetFile()->getRealPath());
@@ -1730,11 +1742,15 @@ class Contest extends BaseApiEntity implements
                 throw new Exception('Contest problemset has unknown file type.');
             }
 
-            $contestProblemsetContent = (new ContestProblemsetContent())
-                ->setContent($content);
+            $contestProblemsetContent = $this->getContestProblemsetContent()
+                ?? (new ContestProblemsetContent())->setContest($this);
+            $contestProblemsetContent->setContent($content);
             $this
                 ->setContestProblemsetContent($contestProblemsetContent)
                 ->setContestProblemsetType($contestProblemsetType);
+
+            $this->contestProblemsetFile = null;
+            $this->clearContestProblemset = false;
         }
     }
 
@@ -1795,16 +1811,12 @@ class Contest extends BaseApiEntity implements
     {
         $this->contestProblemsetFile = $contestProblemsetFile;
 
-        // Clear the contest text to make sure the entity is modified.
-        $this->setContestProblemsetContent(null);
-
         return $this;
     }
 
     public function setClearContestProblemset(bool $clearContestProblemset): Contest
     {
         $this->clearContestProblemset = $clearContestProblemset;
-        $this->setContestProblemsetContent(null);
 
         return $this;
     }

--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -424,16 +424,12 @@ class Problem extends BaseApiEntity implements
     {
         $this->problemstatementFile = $problemstatementFile;
 
-        // Clear the problem statement to make sure the entity is modified.
-        $this->setProblemStatementContent(null);
-
         return $this;
     }
 
     public function setClearProblemstatement(bool $clearProblemstatement): Problem
     {
         $this->clearProblemstatement = $clearProblemstatement;
-        $this->setProblemStatementContent(null);
 
         return $this;
     }
@@ -586,10 +582,16 @@ class Problem extends BaseApiEntity implements
 
     public function setProblemStatementContent(?ProblemStatementContent $content): self
     {
-        $this->problemStatementContent = new ArrayCollection();
-        if ($content) {
-            $this->problemStatementContent->add($content);
+        foreach ($this->problemStatementContent->toArray() as $existingContent) {
+            if ($existingContent !== $content) {
+                $this->problemStatementContent->removeElement($existingContent);
+            }
+        }
+        if ($content !== null) {
             $content->setProblem($this);
+            if (!$this->problemStatementContent->contains($content)) {
+                $this->problemStatementContent->add($content);
+            }
         }
 
         return $this;
@@ -608,20 +610,31 @@ class Problem extends BaseApiEntity implements
             $this
                 ->setProblemStatementContent(null)
                 ->setProblemstatementType(null);
-        } elseif ($this->getProblemstatementFile()) {
-            $content              = file_get_contents($this->getProblemstatementFile()->getRealPath());
-            $clientName           = $this->getProblemstatementFile()->getClientOriginalName();
-            $problemStatementType = Utils::getTextType($clientName, $this->getProblemstatementFile()->getRealPath());
+
+            $this->problemstatementFile = null;
+            $this->clearProblemstatement = false;
+            return;
+        }
+
+        if ($this->getProblemstatementFile()) {
+            $file                 = $this->getProblemstatementFile();
+            $content              = file_get_contents($file->getRealPath());
+            $clientName           = $file->getClientOriginalName();
+            $problemStatementType = Utils::getTextType($clientName, $file->getRealPath());
 
             if (!isset($problemStatementType)) {
                 throw new Exception('Problem statement has unknown file type.');
             }
 
-            $problemStatementContent = (new ProblemStatementContent())
-                ->setContent($content);
+            $problemStatementContent = $this->getProblemStatementContent()
+                ?? (new ProblemStatementContent())->setProblem($this);
+            $problemStatementContent->setContent($content);
             $this
                 ->setProblemStatementContent($problemStatementContent)
                 ->setProblemstatementType($problemStatementType);
+
+            $this->problemstatementFile = null;
+            $this->clearProblemstatement = false;
         }
     }
 

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -230,9 +230,7 @@ readonly class ImportProblemService
                 ->setSpecialCompareArgs('')
                 ->setRunExecutable()
                 ->setMemlimit(null)
-                ->setOutputlimit(null)
-                ->setProblemStatementContent(null)
-                ->setProblemstatementType(null);
+                ->setOutputlimit(null);
 
             $contestProblem
                 ?->setPoints(1)
@@ -303,20 +301,27 @@ readonly class ImportProblemService
         }
 
         // Add problem statement, also look in obsolete location.
+        $statementFound = false;
         foreach (['problem_statement/', ''] as $dir) {
             foreach (['pdf', 'html', 'txt'] as $type) {
                 $filename = sprintf('%sproblem.%s', $dir, $type);
                 $text     = $zip->getFromName($filename);
                 if ($text !== false) {
-                    $content = (new ProblemStatementContent())
-                        ->setContent($text);
+                    $content = $problem->getProblemStatementContent() ?? new ProblemStatementContent();
+                    $content->setContent($text);
                     $problem
                         ->setProblemStatementContent($content)
                         ->setProblemstatementType($type);
+                    $statementFound = true;
                     $messages['info'][] = "Added/updated problem statement from: $filename";
                     break 2;
                 }
             }
+        }
+        if (!$statementFound) {
+            $problem
+                ->setProblemStatementContent(null)
+                ->setProblemstatementType(null);
         }
 
         $this->em->persist($problem);

--- a/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
+++ b/webapp/tests/Unit/Controller/API/ContestControllerAdminTest.php
@@ -8,6 +8,7 @@ use App\DataFixtures\Test\DemoPostUnfreezeContestFixture;
 use App\DataFixtures\Test\DemoPreEndContestFixture;
 use App\DataFixtures\Test\DemoPreStartContestFixture;
 use App\Entity\Contest;
+use App\Entity\ContestProblemsetContent;
 use App\Utils\Utils;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -158,6 +159,33 @@ EOF;
         return static::getContainer()->get(EntityManagerInterface::class)->getRepository(Contest::class)->findOneBy(['externalid' => $cid]);
     }
 
+    /**
+     * @return array{0: UploadedFile, 1: string}
+     */
+    private function temporaryProblemsetFile(string $content, string $originalName = 'problemset.txt'): array
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'contest-problemset-');
+        self::assertIsString($tempFile);
+        self::assertNotFalse(file_put_contents($tempFile, $content));
+
+        return [new UploadedFile($tempFile, $originalName, 'text/plain', null, true), $tempFile];
+    }
+
+    private function getSingleProblemsetContent(int|string $cid): ContestProblemsetContent
+    {
+        $contest = $this->getContest($cid);
+
+        /** @var ContestProblemsetContent[] $contents */
+        $contents = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(ContestProblemsetContent::class)
+            ->findBy(['contest' => $contest]);
+
+        self::assertCount(1, $contents);
+        self::assertInstanceOf(ContestProblemsetContent::class, $contents[0] ?? null);
+
+        return $contents[0];
+    }
+
     public function testBannerManagement(): void
     {
         // First, make sure we have no banner
@@ -258,6 +286,66 @@ EOF;
         // Verify we have no problemset anymore
         $object = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
         self::assertArrayNotHasKey('problemset', $object);
+    }
+
+    public function testProblemsetReplacementUpdatesExistingContent(): void
+    {
+        $id = 1;
+        if ($this->objectClassForExternalId !== null) {
+            $id = $this->resolveEntityId($this->objectClassForExternalId, (string)$id);
+        }
+
+        $url = $this->helperGetEndpointURL($this->apiEndpoint, (string)$id);
+        $firstContent = "first problemset document\n";
+        $secondContent = "second problemset document\n";
+
+        [$firstProblemset, $firstPath] = $this->temporaryProblemsetFile($firstContent);
+        try {
+            $this->verifyApiJsonResponse(
+                'POST',
+                $url . '/problemset',
+                204,
+                $this->apiUser,
+                null,
+                ['problemset' => $firstProblemset]
+            );
+        } finally {
+            @unlink($firstPath);
+        }
+
+        $problemsetContent = $this->getSingleProblemsetContent($id);
+        self::assertSame($firstContent, $problemsetContent->getContent());
+
+        [$secondProblemset, $secondPath] = $this->temporaryProblemsetFile($secondContent);
+        try {
+            $this->verifyApiJsonResponse(
+                'PUT',
+                $url . '/problemset',
+                204,
+                $this->apiUser,
+                null,
+                ['problemset' => $secondProblemset]
+            );
+        } finally {
+            @unlink($secondPath);
+        }
+
+        $problemsetContent = $this->getSingleProblemsetContent($id);
+        self::assertSame($secondContent, $problemsetContent->getContent());
+
+        $contest = $this->getContest($id);
+        self::assertSame('txt', $contest->getContestProblemsetType());
+
+        $this->client->request('GET', '/api' . $url . '/problemset');
+        /** @var StreamedResponse $response */
+        $response = $this->client->getResponse();
+        self::assertSame(200, $response->getStatusCode());
+
+        ob_start();
+        $response->getCallback()();
+        $callbackData = ob_get_clean();
+
+        self::assertSame($secondContent, $callbackData);
     }
 
     #[DataProvider('provideChangeTimes')]

--- a/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
@@ -3,10 +3,12 @@
 namespace App\Tests\Unit\Controller\Jury;
 
 use App\Entity\Contest;
+use App\Entity\ContestProblemsetContent;
 use App\Entity\JudgeTask;
 use App\Entity\QueueTask;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ContestControllerTest extends JuryControllerTestCase
 {
@@ -319,6 +321,242 @@ class ContestControllerTest extends JuryControllerTestCase
     protected function helperProvideTranslateAddEntity(array $entity, array $expected): array
     {
         return [$entity, $expected];
+    }
+
+    /**
+     * @return array{0: UploadedFile, 1: string}
+     */
+    private static function temporaryProblemsetFile(string $content, string $originalName = 'problemset.txt'): array
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'contest-problemset-');
+        self::assertIsString($tempFile);
+        self::assertNotFalse(file_put_contents($tempFile, $content));
+
+        return [new UploadedFile($tempFile, $originalName, 'text/plain', null, true), $tempFile];
+    }
+
+    /**
+     * Submit the normal add-contest form, but inject a file upload for the
+     * transient contestProblemsetFile field. The generic add helper does not
+     * support file uploads.
+     *
+     * @param array<string, mixed> $element
+     */
+    private function submitAddContestFormWithProblemset(array $element, UploadedFile $problemset): void
+    {
+        self::assertSelectorExists('a:contains(' . $this->addButton . ')');
+
+        $formFields = [];
+        foreach ($element as $id => $field) {
+            if (is_bool($field) || $id === static::$addPlus) {
+                continue;
+            }
+
+            $formId = str_replace('.', '][', $id);
+            $formFields[static::$addForm . $formId . ']'] = $field;
+        }
+
+        $this->verifyPageResponse('GET', static::$baseUrl . static::$add, 200);
+
+        $button = $this->client->getCrawler()->selectButton('Save');
+        $form = $button->form($formFields, 'POST');
+        $formName = str_replace('[', '', static::$addForm);
+
+        foreach ($element as $id => $field) {
+            if (!is_bool($field)) {
+                continue;
+            }
+
+            if ($field) {
+                $form[$formName][$id]->tick();
+            } else {
+                $form[$formName][$id]->untick();
+            }
+        }
+
+        $rawValues = $form->getPhpValues();
+        if (static::$addPlus !== null && array_key_exists(static::$addPlus, $element)) {
+            $rawValues[$formName][static::$addPlus] = $element[static::$addPlus];
+        }
+
+        $rawFiles = $form->getPhpFiles();
+        $rawFiles[$formName] ??= [];
+        $rawFiles[$formName]['contestProblemsetFile'] = $problemset;
+
+        $this->client->request($form->getMethod(), $form->getUri(), $rawValues, $rawFiles);
+    }
+
+    public function testAddContestWithProblemsetDocument(): void
+    {
+        $this->roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+
+        $shortname = 'psdoc';
+        $problemsetContent = "problemset created with contest\n";
+        [$problemset, $tempFile] = self::temporaryProblemsetFile($problemsetContent);
+
+        try {
+            $element = static::$addEntities[0];
+            $element['shortname'] = $shortname;
+            $element['name'] = 'Contest with problemset';
+
+            $this->verifyPageResponse('GET', static::$baseUrl, 200);
+            $this->submitAddContestFormWithProblemset($element, $problemset);
+
+            self::assertNotSame(
+                500,
+                $this->client->getResponse()->getStatusCode(),
+                $this->client->getResponse()->getContent() ?: ''
+            );
+            self::assertTrue(
+                $this->client->getResponse()->isRedirect(),
+                $this->client->getResponse()->getContent() ?: ''
+            );
+            $this->client->followRedirect();
+            self::assertTrue(
+                $this->client->getResponse()->isSuccessful(),
+                $this->client->getResponse()->getContent() ?: ''
+            );
+        } finally {
+            @unlink($tempFile);
+        }
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $em->clear();
+
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => $shortname]);
+        self::assertInstanceOf(Contest::class, $contest);
+        self::assertSame('txt', $contest->getContestProblemsetType());
+
+        /** @var ContestProblemsetContent[] $contents */
+        $contents = $em->getRepository(ContestProblemsetContent::class)
+            ->findBy(['contest' => $contest]);
+
+        self::assertCount(1, $contents);
+        self::assertSame($problemsetContent, $contents[0]->getContent());
+        self::assertSame($contest->getCid(), $contents[0]->getContest()->getCid());
+    }
+
+    public function testEditContestProblemsetReplacement(): void
+    {
+        $this->roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        self::assertInstanceOf(Contest::class, $contest);
+        $oldContent = (new ContestProblemsetContent())
+            ->setContest($contest)
+            ->setContent("old problemset document\n");
+        $contest
+            ->setContestProblemsetContent($oldContent)
+            ->setContestProblemsetType('txt');
+        $em->persist($oldContent);
+        $em->flush();
+        $em->clear();
+
+        $replacementContent = "replacement problemset document\n";
+        [$replacement, $tempFile] = self::temporaryProblemsetFile($replacementContent);
+        try {
+            $this->verifyPageResponse('GET', '/jury/contests/demo/edit', 200);
+            $form = $this->getCurrentCrawler()->selectButton('Save')->form();
+            $formName = str_replace('[', '', static::$addForm);
+            $rawValues = $form->getPhpValues();
+            $rawFiles = $form->getPhpFiles();
+            $rawFiles[$formName] ??= [];
+            $rawFiles[$formName]['contestProblemsetFile'] = $replacement;
+
+            $this->client->request($form->getMethod(), $form->getUri(), $rawValues, $rawFiles);
+            self::assertTrue(
+                $this->client->getResponse()->isRedirect(),
+                $this->client->getResponse()->getContent() ?: ''
+            );
+        } finally {
+            @unlink($tempFile);
+        }
+
+        $em->clear();
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        self::assertInstanceOf(Contest::class, $contest);
+        self::assertSame('txt', $contest->getContestProblemsetType());
+
+        /** @var ContestProblemsetContent[] $contents */
+        $contents = $em->getRepository(ContestProblemsetContent::class)
+            ->findBy(['contest' => $contest]);
+        self::assertCount(1, $contents);
+        self::assertSame($replacementContent, $contents[0]->getContent());
+    }
+
+    public function testEditContestProblemsetDeleteCheckbox(): void
+    {
+        $this->roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $problemsetContent = "problemset to keep, then delete\n";
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        self::assertInstanceOf(Contest::class, $contest);
+
+        $content = (new ContestProblemsetContent())
+            ->setContest($contest)
+            ->setContent($problemsetContent);
+        $contest
+            ->setContestProblemsetContent($content)
+            ->setContestProblemsetType('txt');
+        $em->persist($content);
+        $em->flush();
+        $em->clear();
+
+        $contestId = 'demo';
+        $this->verifyPageResponse('GET', "/jury/contests/$contestId/edit", 200);
+
+        self::assertSelectorExists('#contest_clearContestProblemset:not([disabled])');
+        self::assertSelectorExists('label[for="contest_clearContestProblemset"]');
+
+        $crawler = $this->getCurrentCrawler();
+        $form = $crawler->selectButton('Save')->form();
+        $this->client->submit($form);
+
+        self::assertTrue(
+            $this->client->getResponse()->isRedirect(),
+            $this->client->getResponse()->getContent() ?: ''
+        );
+
+        $em->clear();
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        self::assertInstanceOf(Contest::class, $contest);
+        self::assertSame($problemsetContent, $contest->getContestProblemset());
+        self::assertSame('txt', $contest->getContestProblemsetType());
+
+        $this->verifyPageResponse('GET', "/jury/contests/$contestId/edit", 200);
+        $crawler = $this->getCurrentCrawler();
+        $form = $crawler->selectButton('Save')->form();
+        $formName = str_replace('[', '', static::$addForm);
+        $form[$formName]['clearContestProblemset']->tick();
+        $this->client->submit($form);
+
+        self::assertTrue(
+            $this->client->getResponse()->isRedirect(),
+            $this->client->getResponse()->getContent() ?: ''
+        );
+
+        $em->clear();
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        self::assertInstanceOf(Contest::class, $contest);
+        self::assertNull($contest->getContestProblemsetContent());
+        self::assertNull($contest->getContestProblemsetType());
+
+        $contents = $em->getRepository(ContestProblemsetContent::class)
+            ->findBy(['contest' => $contest]);
+        self::assertCount(0, $contents);
     }
 
     public function testUnlockJudgeTasks(): void

--- a/webapp/tests/Unit/Controller/Jury/ProblemControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ProblemControllerTest.php
@@ -6,9 +6,11 @@ use App\DataFixtures\Test\AddProblemAttachmentFixture;
 use App\Entity\Contest;
 use App\Entity\Problem;
 use App\Entity\ProblemAttachment;
+use App\Entity\ProblemStatementContent;
 use App\Entity\ContestProblem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ProblemControllerTest extends JuryControllerTestCase
 {
@@ -69,12 +71,114 @@ class ProblemControllerTest extends JuryControllerTestCase
         return [$entity, $expected];
     }
 
+    /**
+     * @return array{0: UploadedFile, 1: string}
+     */
+    private static function temporaryProblemStatementFile(string $content): array
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'problem-statement-');
+        self::assertIsString($tempFile);
+        self::assertNotFalse(file_put_contents($tempFile, $content));
+
+        return [new UploadedFile($tempFile, 'problem.txt', 'text/plain', null, true), $tempFile];
+    }
+
+    private function submitProblemEditForm(
+        string $problemId,
+        ?UploadedFile $statement = null,
+        bool $clearStatement = false
+    ): void {
+        $this->verifyPageResponse('GET', static::$baseUrl . "/$problemId/edit", 200);
+        $form = $this->getCurrentCrawler()->selectButton('Save')->form();
+        $formName = str_replace('[', '', static::$addForm);
+        if ($clearStatement) {
+            $form[$formName]['clearProblemstatement']->tick();
+        }
+
+        $rawValues = $form->getPhpValues();
+        $rawFiles = $form->getPhpFiles();
+        if ($statement !== null) {
+            $rawFiles[$formName] ??= [];
+            $rawFiles[$formName]['problemstatementFile'] = $statement;
+        }
+
+        $this->client->request($form->getMethod(), $form->getUri(), $rawValues, $rawFiles);
+        self::assertTrue(
+            $this->client->getResponse()->isRedirect(),
+            $this->client->getResponse()->getContent() ?: ''
+        );
+    }
+
     public function testDeleteExtraEntity(): void
     {
         $this->loadFixture(AddProblemAttachmentFixture::class);
         $attachmentId = $this->resolveReference(AddProblemAttachmentFixture::class . ':attachment', ProblemAttachment::class);
         static::$deleteExtra['deleteurl'] = "/jury/problems/attachments/$attachmentId/delete";
         parent::testDeleteExtraEntity();
+    }
+
+    public function testProblemStatementUploadPreserveReplaceAndDelete(): void
+    {
+        $this->roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $problemId = 'statement-regression';
+        $problem = (new Problem())
+            ->setExternalid($problemId)
+            ->setName('Statement regression')
+            ->setTimelimit(1);
+        $em->persist($problem);
+        $em->flush();
+        $em->clear();
+
+        $firstContent = "first problem statement\n";
+        [$firstStatement, $firstPath] = self::temporaryProblemStatementFile($firstContent);
+        try {
+            $this->submitProblemEditForm($problemId, $firstStatement);
+        } finally {
+            @unlink($firstPath);
+        }
+
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertSame($firstContent, $problem->getProblemstatement());
+        self::assertSame('txt', $problem->getProblemstatementType());
+        self::assertCount(1, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
+
+        // A normal edit without a new file must preserve the managed statement.
+        $this->submitProblemEditForm($problemId);
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertSame($firstContent, $problem->getProblemstatement());
+        self::assertCount(1, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
+
+        $secondContent = "replacement problem statement\n";
+        [$secondStatement, $secondPath] = self::temporaryProblemStatementFile($secondContent);
+        try {
+            $this->submitProblemEditForm($problemId, $secondStatement);
+        } finally {
+            @unlink($secondPath);
+        }
+
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertSame($secondContent, $problem->getProblemstatement());
+        self::assertSame('txt', $problem->getProblemstatementType());
+        self::assertCount(1, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
+
+        $this->submitProblemEditForm($problemId, clearStatement: true);
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertNull($problem->getProblemStatementContent());
+        self::assertNull($problem->getProblemstatementType());
+        self::assertCount(0, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
     }
 
     public function testLockedContest(): void

--- a/webapp/tests/Unit/Service/ImportProblemServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportProblemServiceTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\Unit\Service;
 
 use App\Entity\Problem;
+use App\Entity\ProblemStatementContent;
 use App\Service\ImportProblemService;
 use App\Tests\Unit\BaseTestCase;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use ZipArchive;
@@ -657,6 +659,79 @@ YAML;
         $this->assertInstanceOf(Problem::class, $result);
         $this->assertEmpty($messages['danger']);
         $this->assertEquals(5, $result->getTimelimit());
+    }
+
+    public function testProblemStatementReplacementOnReimport(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        /** @var ImportProblemService $service */
+        $service = static::getContainer()->get(ImportProblemService::class);
+
+        $problemId = 'statement-import';
+        $problem = (new Problem())
+            ->setExternalid($problemId)
+            ->setName('Statement import')
+            ->setTimelimit(1);
+        $statement = (new ProblemStatementContent())
+            ->setProblem($problem)
+            ->setContent("old statement\n");
+        $problem
+            ->setProblemStatementContent($statement)
+            ->setProblemstatementType('txt');
+        $em->persist($problem);
+        $em->flush();
+
+        $yaml = <<<YAML
+name: Statement import
+limits:
+  time_limit: 1
+YAML;
+        $newContent = "new statement from zip\n";
+        $zipFile = $this->createZipWithContents([
+            'problem.yaml' => $yaml,
+            'problem.txt' => $newContent,
+        ]);
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($zipFile));
+        /** @var array{info: string[], warning: string[], danger: string[]} $messages */
+        $messages = ['info' => [], 'warning' => [], 'danger' => []];
+        try {
+            $result = $service->importZippedProblem($zip, "$problemId.zip", $problem, null, $messages);
+        } finally {
+            $zip->close();
+            @unlink($zipFile);
+        }
+        self::assertInstanceOf(Problem::class, $result);
+        self::assertEmpty($messages['danger']);
+
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertSame($newContent, $problem->getProblemstatement());
+        self::assertSame('txt', $problem->getProblemstatementType());
+        self::assertCount(1, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
+
+        // Re-importing without a statement keeps the existing reset semantics.
+        $zipFile = $this->createZipWithContents(['problem.yaml' => $yaml]);
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($zipFile));
+        $messages = ['info' => [], 'warning' => [], 'danger' => []];
+        try {
+            $result = $service->importZippedProblem($zip, "$problemId.zip", $problem, null, $messages);
+        } finally {
+            $zip->close();
+            @unlink($zipFile);
+        }
+        self::assertInstanceOf(Problem::class, $result);
+        self::assertEmpty($messages['danger']);
+
+        $em->clear();
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => $problemId]);
+        self::assertInstanceOf(Problem::class, $problem);
+        self::assertNull($problem->getProblemStatementContent());
+        self::assertNull($problem->getProblemstatementType());
+        self::assertCount(0, $em->getRepository(ProblemStatementContent::class)->findBy(['problem' => $problem]));
     }
 
     public function testParseTestCaseGroupMetaInvalidRangeTooManyValuesRejected(): void


### PR DESCRIPTION
Contest problemsets and problem statements use transient form fields for uploads and deletion. Do not clear persisted content when no file is submitted or a delete checkbox is false. Otherwise, normal edits can remove the existing document.

Preserve managed Doctrine collections when replacing documents. Update the existing shared-primary-key content entity instead of creating a new one. Clear transient upload and delete state after processing so repeated lifecycle callbacks are idempotent.

Reuse existing problem statement content during ZIP re-import. Keep the current behavior that removes an old statement when an archive has none.

Rely on the existing lifecycle and saveEntity handling in Jury contest paths. Do not call processContestProblemset() explicitly. Add regressions for upload, preservation, replacement, deletion, and ZIP re-import of contest and problem documents.

Fixes #3633.

Co-developed-by: GPT 5.5 <noreply@openai.com>