### PR TITLE
Fix previous submission testcase comparison

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -554,6 +554,8 @@ class SubmissionController extends BaseController
         $lastJudging = null;
         /** @var Testcase[] $lastRuns */
         $lastRuns = [];
+        /** @var array<int, JudgingRun> $lastRunsByTestcaseId */
+        $lastRunsByTestcaseId = [];
         if ($lastSubmission !== null) {
             $lastJudging = $this->em->createQueryBuilder()
                 ->from(Judging::class, 'j')
@@ -569,14 +571,22 @@ class SubmissionController extends BaseController
             if ($lastJudging !== null) {
                 $lastRuns = $this->em->createQueryBuilder()
                     ->from(Testcase::class, 't')
-                    ->leftJoin('t.judging_runs', 'jr', Join::WITH, 'jr.judging = :judging')
-                    ->select('t', 'jr')
+                    ->select('t')
                     ->andWhere('t.problem = :problem')
-                    ->setParameter('judging', $lastJudging)
                     ->setParameter('problem', $submission->getProblem())
                     ->orderBy('t.ranknumber')
                     ->getQuery()
                     ->getResult();
+
+                // Testcase entities may already have judging_runs hydrated for the current judging,
+                // so fetch previous runs separately and index them explicitly.
+                /** @var JudgingRun[] $previousRuns */
+                $previousRuns = $this->em->getRepository(JudgingRun::class)->findBy([
+                    'judging' => $lastJudging,
+                ]);
+                foreach ($previousRuns as $previousRun) {
+                    $lastRunsByTestcaseId[$previousRun->getTestcase()->getTestcaseid()] = $previousRun;
+                }
             }
         }
 
@@ -643,6 +653,7 @@ class SubmissionController extends BaseController
             'externalRuns' => $externalRuns,
             'runsOutput' => $runsOutput,
             'lastRuns' => $lastRuns,
+            'lastRunsByTestcaseId' => $lastRunsByTestcaseId,
             'unjudgableReasons' => $unjudgableReasons,
             'verificationRequired' => (bool)$this->config->get('verification_required'),
             'claimWarning' => $claimWarning,

--- a/webapp/src/DataFixtures/Test/PreviousSubmissionTestcaseRunsFixture.php
+++ b/webapp/src/DataFixtures/Test/PreviousSubmissionTestcaseRunsFixture.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\JudgingRun;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Entity\Testcase;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+class PreviousSubmissionTestcaseRunsFixture extends AbstractTestDataFixture
+{
+    public const CURRENT_SUBMISSION_REFERENCE = self::class . ':current';
+
+    public function load(ObjectManager $manager): void
+    {
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        /** @var Team $team */
+        $team = $manager->getRepository(Team::class)->findOneBy(['name' => 'Example teamname']);
+        /** @var Language $language */
+        $language = $manager->getRepository(Language::class)->findByExternalId('cpp');
+
+        /** @var ContestProblem $contestProblem */
+        $contestProblem = $contest->getProblems()
+            ->filter(fn (ContestProblem $problem) => $problem->getShortname() === 'A')
+            ->first();
+        /** @var Testcase $testcase */
+        $testcase = $contestProblem->getProblem()->getTestcases()->first();
+
+        $this->createSubmissionWithRun(
+            $manager,
+            $contest,
+            $contestProblem,
+            $team,
+            $language,
+            $testcase,
+            'issue3627-previous',
+            '2030-01-10 12:00:00',
+            'wrong-answer',
+        );
+        $currentSubmission = $this->createSubmissionWithRun(
+            $manager,
+            $contest,
+            $contestProblem,
+            $team,
+            $language,
+            $testcase,
+            'issue3627-current',
+            '2030-01-10 12:05:00',
+            Judging::RESULT_CORRECT,
+        );
+
+        $manager->flush();
+        $this->addReference(self::CURRENT_SUBMISSION_REFERENCE, $currentSubmission);
+    }
+
+    private function createSubmissionWithRun(
+        ObjectManager $manager,
+        Contest $contest,
+        ContestProblem $contestProblem,
+        Team $team,
+        Language $language,
+        Testcase $testcase,
+        string $externalId,
+        string $submittime,
+        string $result,
+    ): Submission {
+        $submission = (new Submission())
+            ->setExternalid($externalId)
+            ->setContest($contest)
+            ->setTeam($team)
+            ->setContestProblem($contestProblem)
+            ->setLanguage($language)
+            ->setSubmittime(Utils::toEpochFloat($submittime));
+        $judging = (new Judging())
+            ->setContest($contest)
+            ->setStarttime(Utils::toEpochFloat($submittime))
+            ->setEndtime(Utils::toEpochFloat($submittime) + 5)
+            ->setValid(true)
+            ->setSubmission($submission)
+            ->setResult($result);
+        $judgingRun = (new JudgingRun())
+            ->setJudging($judging)
+            ->setTestcase($testcase)
+            ->setStarttime(Utils::toEpochFloat($submittime))
+            ->setEndtime(Utils::toEpochFloat($submittime) + 1)
+            ->setRunresult($result)
+            ->setRuntime(0.01);
+
+        $submission->addJudging($judging);
+        $judging->addRun($judgingRun);
+        $testcase->addJudgingRun($judgingRun);
+        $manager->persist($submission);
+        $manager->persist($judging);
+        $manager->persist($judgingRun);
+
+        return $submission;
+    }
+}

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -404,10 +404,15 @@ class TwigExtension
     // TODO: this function shares a lot with the above one, unify them?
     /**
      * @param Testcase[] $testcases
+     * @param array<int, JudgingRun>|null $judgingRunsByTestcaseId
      */
     #[AsTwigFilter('displayTestcaseResults', isSafe: ['html'])]
-    public function displayTestcaseResults(array $testcases, bool $submissionDone, bool $isExternal = false): string
-    {
+    public function displayTestcaseResults(
+        array $testcases,
+        bool $submissionDone,
+        bool $isExternal = false,
+        ?array $judgingRunsByTestcaseId = null,
+    ): string {
         $results = '';
         $lastTypeSample = true;
         foreach ($testcases as $testcase) {
@@ -420,7 +425,13 @@ class TwigExtension
             $text      = '?';
             $isCorrect = false;
             /** @var JudgingRun|ExternalRun|null $run */
-            $run = $isExternal ? $testcase->getFirstExternalRun() : $testcase->getFirstJudgingRun();
+            if ($isExternal) {
+                $run = $testcase->getFirstExternalRun();
+            } elseif ($judgingRunsByTestcaseId !== null) {
+                $run = $judgingRunsByTestcaseId[$testcase->getTestcaseid()] ?? null;
+            } else {
+                $run = $testcase->getFirstJudgingRun();
+            }
             if ($isExternal) {
                 $runResult = $run?->getResult();
             } else {

--- a/webapp/templates/jury/submission.html.twig
+++ b/webapp/templates/jury/submission.html.twig
@@ -687,7 +687,11 @@
                     {% if lastJudging is not null %}
                         <tr class="lasttcruns">
                             <td>
-                                {{ lastRuns | displayTestcaseResults(lastJudging.endtime is not empty) }}
+                                {{ lastRuns | displayTestcaseResults(
+                                    lastJudging.endtime is not empty,
+                                    false,
+                                    lastRunsByTestcaseId
+                                ) }}
                             </td>
                             <td>
                                 <a href="{{ lastSubmissionLink }}">previous {{ lastSubmission.externalid }}</a>

--- a/webapp/tests/Unit/Controller/Jury/SubmissionPreviousComparisonTest.php
+++ b/webapp/tests/Unit/Controller/Jury/SubmissionPreviousComparisonTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\Jury;
+
+use App\DataFixtures\Test\PreviousSubmissionTestcaseRunsFixture;
+use App\Entity\Judging;
+use App\Entity\Submission;
+use App\Tests\Unit\BaseTestCase;
+
+class SubmissionPreviousComparisonTest extends BaseTestCase
+{
+    protected array $roles = ['jury'];
+
+    public function testPreviousSubmissionTestcaseResultsDifferFromCurrent(): void
+    {
+        $this->loadFixture(PreviousSubmissionTestcaseRunsFixture::class);
+        $submitId = $this->resolveReference(
+            PreviousSubmissionTestcaseRunsFixture::CURRENT_SUBMISSION_REFERENCE,
+            Submission::class,
+            true,
+        );
+
+        $this->verifyPageResponse('GET', sprintf('/jury/contests/demo/submissions/%s', $submitId), 200);
+
+        $currentRows = '//tr[not(contains(concat(" ", normalize-space(@class), " "), " lasttcruns "))]';
+        $previousRows = '//tr[contains(concat(" ", normalize-space(@class), " "), " lasttcruns ")]';
+
+        self::assertGreaterThan(0, $this->countResultLinksInRows($currentRows, Judging::RESULT_CORRECT));
+        self::assertGreaterThan(0, $this->countResultLinksInRows($previousRows, 'wrong-answer'));
+        self::assertSame(0, $this->countResultLinksInRows($previousRows, Judging::RESULT_CORRECT));
+    }
+
+    private function countResultLinksInRows(string $rowXPath, string $result): int
+    {
+        return $this->getCurrentCrawler()
+            ->filterXPath(sprintf('%s//a[contains(@title, "result: %s")]', $rowXPath, $result))
+            ->count();
+    }
+}


### PR DESCRIPTION
Avoid relying on the partially hydrated Testcase::judging_runs collection when rendering the previous submission.

Load the previous judging runs separately, index them by testcase ID, and pass that explicit mapping to displayTestcaseResults.

Add a regression test covering different current/previous results and the missing previous-run case.

Fixes #3627

Co-developed-by: GPT 5.5 <noreply@openai.com>