### PR TITLE
Demote CodeQL to do the test on release branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,9 @@
 name: "CodeQL"
 on:
-  merge_group:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The GitHub Actions runners are very flacky the last months. As a flacky test breaks merging as there is not an easy way to retry such tests we have to enter the mergequeue a couple of times.

By moving this test out of the required checks we (hopefully) limit the number incorrectly failing mergequeues. This test hasn´t found a lot of issues so has a high ratio of blocking often for the wrong reason.

Instead of completely taking it out there is the middle route to allow CI to become red on main in case we missed something in review which CodeQL does find (on main). As the CodeQL tests do run on the PR itself we can easily fix those in a follow up PR. It would (wrongly) flag new PRs with those findings though.