### PR TITLE
Fix native checkbox alignment in contest forms

### DIFF
--- a/webapp/public/style_jury.css
+++ b/webapp/public/style_jury.css
@@ -231,7 +231,13 @@ div.submission-summary > span {
     font-size: 0.8rem;
     margin-top: 0.15rem;
 }
-.contest-fields-table td .form-check { padding-left: 0; }
+/* Keep Bootstrap's .form-check padding for native checkboxes. Bootstrap pairs
+ * that padding with a negative margin on .form-check-input; removing only the
+ * padding moves non-toggle checkboxes out of their table cell. bootstrap-toggle
+ * wraps toggle checkboxes in a visible .toggle element, so align only that
+ * generated control with the table-cell edge.
+ */
+.contest-fields-table td .form-check > .toggle[data-toggle="toggle"] { margin-left: -1.5em; }
 .contest-form .page-header-bar {
     background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
     border: 1px solid #dee2e6;


### PR DESCRIPTION
The contest form removed left padding from all .form-check elements to keep bootstrap-toggle controls aligned with the table cell edge. Native Bootstrap checkboxes rely on that padding to balance the negative margin on the checkbox input, so removing it moved them out of their table cell.

This made long-label checkboxes such as "Delete contest problemset document" hard or impossible to select.

Keep the default Bootstrap layout for native checkboxes and only compensate the generated bootstrap-toggle control alignment instead.

Part of #3633.

Co-developed-by: GPT 5.5 <noreply@openai.com>

---

Before this patch:

<img width="736" height="119" alt="Image-Before" src="https://github.com/user-attachments/assets/e1e6eb0a-8cb3-4789-a33a-13c9f1dc1d26" />

After this patch:

<img width="1402" height="367" alt="Image-After" src="https://github.com/user-attachments/assets/55eea899-c387-48bd-9c55-4f6a9bc6cb3c" />
