### PR TITLE
Initial trivial implementation of some `draft` problempackage spec options.

### DIFF
--- a/webapp/src/Entity/Problem.php
+++ b/webapp/src/Entity/Problem.php
@@ -331,7 +331,10 @@ class Problem extends BaseApiEntity implements
         return $this;
     }
 
-    public function getTypesAsString(): string
+    /**
+     * @return list<string>
+     */
+    public function getTypesAsStringArray(): array
     {
         $typeConstants = $this->getTypes();
         $typeStrings = [];
@@ -341,7 +344,12 @@ class Problem extends BaseApiEntity implements
             }
             $typeStrings[] = $this->typesToString[$type];
         }
-        return implode(', ', $typeStrings);
+        return $typeStrings;
+    }
+
+    public function getTypesAsString(): string
+    {
+        return implode(', ', $this->getTypesAsStringArray());
     }
 
     /**

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -1206,6 +1206,27 @@ readonly class ImportProblemService
     }
 
     /**
+     * Allow to import the types both as arrays and as strings. Due
+     * to the recursion to make parsing of the strings easier this now
+     * also works for arrays inside arrays.
+     *
+     * @param string|array<mixed, mixed> $input
+     * @return string[]
+     */
+    private static function parseTypes(string|array $input): array
+    {
+        $final = [];
+        if (is_array($input)) {
+            foreach ($input as $possibleType) {
+                $final = array_merge($final, self::parseTypes($possibleType));
+            }
+        } else {
+            $final = array_merge($final, preg_split("/[\s,;]+/", $input));
+        }
+        return $final;
+    }
+
+    /**
      * Returns true iff the yaml could be parsed correctly.
      *
      * @param array{danger?: string[], info?: string[]} $messages
@@ -1241,7 +1262,7 @@ readonly class ImportProblemService
 
         $validationMode = 'default';
         if (isset($yamlData['type'])) {
-            $types = explode(' ', $yamlData['type']);
+            $types = self::parseTypes($yamlData['type']);
             // Validation happens later when we set the properties.
             $yamlProblemProperties['typesAsString'] = $types;
             if (in_array('interactive', $types)) {

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -1293,6 +1293,20 @@ readonly class ImportProblemService
             }
         }
 
+        if (isset($yamlData['problem_format_version'])) {
+            $version = $yamlData['problem_format_version'];
+            if (in_array($version, ['legacy', '2025-09-draft', 'draft', '2025-09', '2023-07-draft'])) {
+                $messages['info'][] = sprintf("Problem format version '%s' support still experimental.", $version);
+            } elseif ($version !== 'icpc-legacy') {
+                // 2023-07-draft used in Unit tests
+                $messages['warning'][] = sprintf("Unknown problem format version '%s'.", $version);
+                return false;
+            }
+            // TODO: At the moment we only warn the user about unknown problem specifications and the experimental support.
+            // In the future we should either be more strict on only allowing properties available in the spec or warn the
+            // user on properties/values outside of the specified specification.
+        }
+
         foreach ($yamlProblemProperties as $key => $value) {
             try {
                 $propertyAccessor->setValue($problem, $key, $value);

--- a/webapp/tests/Unit/Service/ImportProblemServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportProblemServiceTest.php
@@ -135,6 +135,53 @@ YAML;
         }
     }
 
+    #[DataProvider('provideAlternativeTypeNotations')]
+    public function testTypesStringWithAlternativeChars(string $separator): void
+    {
+        $expectedTypes = ['pass-fail', 'interactive'];
+        $typesAsString = implode($separator, $expectedTypes);
+        $specVersion = 'draft';
+        $yaml = <<<YAML
+name: test
+problem_format_version: $specVersion
+type: $typesAsString
+YAML;
+
+        $messages = [];
+        $validationMode = 'xxx';
+        $problem = new Problem();
+
+        $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
+        $messageString = var_export($messages, true);
+        $this->assertTrue($ret, 'Parsing failed for type: ' . $typesAsString . ', messages: ' . $messageString);
+        $problemTypes = $problem->getTypesAsStringArray();
+        $this->assertEquals(
+            $expectedTypes, $problemTypes,
+            'Found: "' . implode(' ', $problemTypes) . '" vs Expected: "' . implode(' ', $expectedTypes) . '"'
+        );
+    }
+
+    /**
+     * @param string[] $expectedTypes
+     */
+    #[DataProvider('provideAlternativeArrayNotations')]
+    public function testTypesSequenceStrings(string $yaml, array $expectedTypes): void
+    {
+        $messages = [];
+        $validationMode = 'xxx';
+        $problem = new Problem();
+        $typesAsString = implode(', ', $expectedTypes);
+
+        $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
+        $messageString = var_export($messages, true);
+        $this->assertTrue($ret, 'Parsing failed for type: ' . $typesAsString . ', messages: ' . $messageString);
+        $problemTypes = $problem->getTypesAsStringArray();
+        $this->assertEquals(
+            $expectedTypes, $problemTypes,
+            'Found: "' . implode(' ', $problemTypes) . '" vs Expected: "' . implode(' ', $expectedTypes) . '"'
+        );
+    }
+
     public function testUnknownProblemType(): void
     {
         $yaml = <<<YAML
@@ -795,5 +842,52 @@ YAML;
         yield ['legacy'];
         yield ['icpc-legacy'];
         yield ['2025-09'];
+    }
+
+
+    public static function provideAlternativeTypeNotations(): Generator
+    {
+        yield ["\t"];
+        yield [", "];
+        yield ["; "];
+    }
+
+    public static function provideAlternativeArrayNotations(): Generator
+    {
+        $specVersion = 'draft';
+        $yamlBasic = <<<YAML
+name: test
+problem_format_version: $specVersion
+YAML;
+        $simpleArray = <<<YAML
+$yamlBasic
+type:
+  - pass-fail
+YAML;
+        $mappedArray = <<<YAML
+$yamlBasic
+type:
+  pass-fail: pass-fail
+YAML;
+        $oneLineArray = <<<YAML
+$yamlBasic
+type: [pass-fail]
+YAML;
+        $malformedArray = <<<YAML
+$yamlBasic
+type: [pass-fail, [multi-pass, interactive]]
+YAML;
+        $combinedStringArray = <<<YAML
+$yamlBasic
+type:
+ - pass-fail
+ - multi-pass, interactive
+YAML;
+
+        foreach ([$simpleArray, $mappedArray, $oneLineArray] as $yamlFile) {
+            yield [$yamlFile, ['pass-fail']];
+        }
+        yield [$malformedArray, ['pass-fail', 'multi-pass', 'interactive']];
+        yield [$combinedStringArray, ['pass-fail', 'multi-pass', 'interactive']];
     }
 }

--- a/webapp/tests/Unit/Service/ImportProblemServiceTest.php
+++ b/webapp/tests/Unit/Service/ImportProblemServiceTest.php
@@ -7,6 +7,7 @@ use App\Entity\ProblemStatementContent;
 use App\Service\ImportProblemService;
 use App\Tests\Unit\BaseTestCase;
 use Doctrine\ORM\EntityManagerInterface;
+use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use ZipArchive;
@@ -55,6 +56,47 @@ YAML;
         $this->assertEquals(null, $problem->getMemlimit());
         $this->assertEquals(null, $problem->getOutputlimit());
         $this->assertEquals(null, $problem->getSpecialCompareArgs());
+    }
+
+    /**
+     * @param array{info?: string[], warning?: string[], danger?: string[]} $messages
+     * @param string[] $expected
+     */
+    private function assertProblemSpecWarning(string $version, array $messages, array $expected = ['info']): void
+    {
+        foreach (['danger', 'warning'] as $type) {
+            if (!in_array($type, $expected)) {
+                if (isset($messages[$type])) {
+                    $this->assertEmpty($messages[$type]);
+                }
+            }
+        }
+        $this->assertNotEmpty($messages['info']);
+        $this->assertStringContainsString(
+            sprintf("Problem format version '%s' support still experimental.", $version),
+            $messages['info'][0]
+        );
+    }
+
+    #[DataProvider('problemSpecVersionProvider')]
+    public function testProblemPackageFormatTest(string $problemSpecificationVersion): void
+    {
+        $yaml = <<<YAML
+problem_format_version: $problemSpecificationVersion
+name: test
+YAML;
+
+        $messages = [];
+        $validationMode = 'xxx';
+        $problem = new Problem();
+
+        $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
+        $this->assertTrue($ret);
+        if ($problemSpecificationVersion === 'icpc-legacy') {
+            $this->assertEmpty($messages);
+        } else {
+            $this->assertProblemSpecWarning($problemSpecificationVersion, $messages);
+        }
     }
 
     public function testTypesYamlTest(): void
@@ -418,7 +460,7 @@ YAML;
 
         $ret = ImportProblemService::parseYaml($yaml, $messages, $validationMode, PropertyAccess::createPropertyAccessor(), $problem);
         $this->assertTrue($ret);
-        $this->assertEmpty($messages);
+        $this->assertProblemSpecWarning('2023-07-draft', $messages);
         $this->assertEquals('Guess the Number', $problem->getName());
         $this->assertEquals('pass-fail, interactive', $problem->getTypesAsString());
         $this->assertEquals('custom interactive', $validationMode);
@@ -744,5 +786,14 @@ YAML;
         $this->assertNull($result);
         $this->assertNotEmpty($messages['danger']);
         $this->assertStringContainsString("Invalid range '100 101 102'", $messages['danger'][0]);
+    }
+
+    public static function problemSpecVersionProvider(): Generator
+    {
+        yield ['2025-09-draft'];
+        yield ['draft'];
+        yield ['legacy'];
+        yield ['icpc-legacy'];
+        yield ['2025-09'];
     }
 }


### PR DESCRIPTION
This is some progress from https://github.com/DOMjudge/domjudge/pull/3664 in reworked format ready to be discussed.

I plan to implement some of the trivial parts of the different problemspecs to get discussion started on how much we want to implement. As we have people in the wild using `main` I added a warning for all problemspecs which I'm not reasonably sure of that we implement those. In other words, anything besides `icpc-legacy` will get a warning on imports via the API.

I did not look into uploads via the UI yet as that complicates the work quite a lot.