### PR TITLE
runguard_test: Do not race the CPU-time limit against the command.

### DIFF
--- a/judge/runguard_test/runguard_test.sh
+++ b/judge/runguard_test/runguard_test.sh
@@ -86,8 +86,11 @@ test_cputime_limit() {
 	# Now also limiting wall time to 2s.
 	exec_check_success sudo $RUNGUARD $RUNGUARD_OPTIONS -C 3.1 -t 2 ./threads 2 3
 
-	# Some failing cases.
-	exec_check_fail sudo $RUNGUARD $RUNGUARD_OPTIONS -C 2.9 ./threads 2 3
+	# Some failing cases. The command is killed by the RLIMIT_CPU we set to
+	# the CPU-time limit rounded up, so stay a whole second below the ~3s it
+	# spends: at `-C 2.9' that limit is the 3s it takes, and whether it is
+	# killed comes down to which of the two gets there first.
+	exec_check_fail sudo $RUNGUARD $RUNGUARD_OPTIONS -C 1.9 ./threads 2 3
 	exec_check_fail sudo $RUNGUARD $RUNGUARD_OPTIONS -C 3.1 -t 1.4 ./threads 2 3
 }
 


### PR DESCRIPTION
`RLIMIT_CPU` counts whole seconds, so runguard rounds the CPU-time limit up to set it: at `-C 2.9` the kernel kills the command once it has spent 3s of CPU. That is exactly what `./threads 2 3` sets out to spend, so whether the test saw it killed came down to which of the two got to 3s first. It survives about one run in five.

Ask for a limit that rounds up to 2s, a second below what the command spends, and say what the number has to stay clear of.

`runguard` returns the exit status of the command, and reports a CPU-time limit it reached in the metadata rather than in that status. Being killed by `RLIMIT_CPU` is the only thing that makes this fail.