### PR TITLE
runguard: Do not leave SIGCHLD blocked for the command.

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -1292,6 +1292,13 @@ int main(int argc, char **argv)
 			logmsg(LOG_DEBUG, "metafile closed in child");
 		}
 
+		/* Restore the signal mask before we hand over: we inherit the
+		   one of runguard, which blocks SIGCHLD for its own bookkeeping,
+		   and execve() leaves it in place. */
+		if ( sigprocmask(SIG_SETMASK, &emptymask, nullptr)!=0 ) {
+			die(errno,"unblocking signals for command");
+		}
+
 		/* And execute child command. */
 		execvp(cmdname,cmdargs);
 		die(errno,"cannot start `{}' as user `{}'", cmdname, username());

--- a/judge/runguard_test/runguard_test.sh
+++ b/judge/runguard_test/runguard_test.sh
@@ -202,6 +202,13 @@ test_memsize() {
 	expect_stdout "mem = 1073741824"
 }
 
+test_signal_mask() {
+	# runguard blocks SIGCHLD for its own bookkeeping, and a signal mask
+	# survives the execve(), so the command must not inherit ours.
+	exec_check_success sudo $RUNGUARD $RUNGUARD_OPTIONS grep SigBlk /proc/self/status
+	expect_stdout "SigBlk:.*0000000000000000"
+}
+
 test_envvars() {
 	exec_check_success sudo $RUNGUARD $RUNGUARD_OPTIONS ./print_envvars.py
 	expect_stdout "COUNT: 2."


### PR DESCRIPTION
We block SIGCHLD before forking, to keep it from arriving outside the `pselect()` that waits for it. The command inherits that signal mask, and `execve()` keeps it, so every command we run so far starts with SIGCHLD blocked. That is state of ours leaking into the sandbox, and it changes how a command that waits for children of its own behaves.

Restore the signal mask in the child before executing the command.