### PR TITLE
runguard: Don't close our own stderr with the output files.

### DIFF
--- a/judge/runguard.cc
+++ b/judge/runguard.cc
@@ -1445,10 +1445,20 @@ int main(int argc, char **argv)
 			pump_pipes(&readfds, data_read, data_passed);
 		} while ( data_passed[1] + data_passed[2] > total_data );
 
-		/* Close the output files */
-		for(int i=1; i<=2; i++) {
-			ret = close(child_redirfd[i]);
-			if( ret!=0 ) die(errno,"closing output fd {}", i);
+		/* Always close stdout, also when it is our own without `-o':
+		   its EOF signals the end of the command's output to a
+		   downstream reader such as runpipe, which an interactive
+		   problem's validator relies on. */
+		ret = close(child_redirfd[STDOUT_FILENO]);
+		if ( ret!=0 ) die(errno,"closing output fd {}", STDOUT_FILENO);
+
+		/* Only close stderr when `-e' redirected it to a file. Without
+		   it, child_redirfd[2] aliases our own stderr and closing it
+		   would discard all logmsg()/warning()/die() output for the rest
+		   of our lifetime. */
+		if ( redir_stderr ) {
+			ret = close(child_redirfd[STDERR_FILENO]);
+			if( ret!=0 ) die(errno,"closing output fd {}", STDERR_FILENO);
 		}
 
 		if ( times(&endticks)==(clock_t) -1 ) {

--- a/judge/runguard_test/runguard_test.sh
+++ b/judge/runguard_test/runguard_test.sh
@@ -112,8 +112,11 @@ test_streamsize() {
 test_streamsize_stderr() {
 	exec_check_fail sudo $RUNGUARD $RUNGUARD_OPTIONS -t 1 -s 42 ./fill-stderr.sh
 	expect_stderr "DOMjudge"
-	# Allow 100 bytes extra, for the runguard time limit message.
-	limit=$((42*1024 + 100))
+	# Allow some bytes extra: runguard shares this stderr with the command
+	# and reports the time limit, the signal that killed it and the soft
+	# time limit on it. Those messages are timestamped and carry our pid,
+	# so do not depend on their exact length.
+	limit=$((42*1024 + 512))
 	actual=$(wc -c < "$LOG2")
 	[ $limit -gt $actual ] || fail "stdout not limited to ${limit}B, but wrote ${actual}B"
 }


### PR DESCRIPTION
`child_redirfd[i]` defaults to `i` when no `-o/-e` is given, so the close loop after draining the child's output shut runguard's own stdout and stderr. Every diagnostic goes to `std::cerr`, so from that point on all `logmsg()`, `warning()` and `die()` messages were silently discarded: `total memory used`, `deleted cgroup` and any warning from `output_cgroup_stats()` never reached the user, even under `-v`. Exit codes were still set, so failures were not silent, but their explanations were.

Closing fd 2 also frees the descriptor number for reuse by the next `open()`, e.g. from libcgroup during cgroup teardown.

Keep closing stdout, whose EOF signals the end of the child's output to a downstream reader such as runpipe, and only skip the close when the descriptor is our own stderr.

`test_streamsize_stderr` allowed 100 bytes on top of the stream limit for the messages runguard writes to the shared stderr. Restoring the discarded ones adds the terminating signal and the soft time limit to that, so widen the slack.