### PR TITLE
Render testcase image thumbnails in memory.

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -666,8 +666,7 @@ class ProblemController extends BaseController
                                     $this->addFlash('danger', sprintf('image: %s', $error));
                                     return $this->redirectToRoute('jury_problem_testcases', ['probId' => $probId]);
                                 }
-                                $thumb = Utils::getImageThumb($content, $thumbnailSize,
-                                                            $this->dj->getDomjudgeTmpDir(), $error);
+                                $thumb = Utils::getImageThumb($content, $thumbnailSize, $error);
                                 if ($thumb === false) {
                                     $this->addFlash('danger', sprintf('image: %s', $error));
                                     return $this->redirectToRoute('jury_problem_testcases', ['probId' => $probId]);
@@ -786,8 +785,7 @@ class ProblemController extends BaseController
                         $this->addFlash('danger', sprintf('image: %s', $error));
                         return $this->redirectToRoute('jury_problem_testcases', ['probId' => $probId]);
                     }
-                    $thumb = Utils::getImageThumb($content, $thumbnailSize,
-                                                  $this->dj->getDomjudgeTmpDir(), $error);
+                    $thumb = Utils::getImageThumb($content, $thumbnailSize, $error);
                     if ($thumb === false) {
                         $this->addFlash('danger', sprintf('image: %s', $error));
                         return $this->redirectToRoute('jury_problem_testcases', ['probId' => $probId]);

--- a/webapp/src/Service/ImportProblemService.php
+++ b/webapp/src/Service/ImportProblemService.php
@@ -450,7 +450,6 @@ readonly class ImportProblemService
                             $thumbnailSize = $this->config->get('thumbnail_size');
                             $imageThumb    = Utils::getImageThumb(
                                 $imageFile, $thumbnailSize,
-                                $this->dj->getDomjudgeTmpDir(),
                                 $errormsg
                             );
                             if ($imageThumb === false) {

--- a/webapp/src/Utils/Utils.php
+++ b/webapp/src/Utils/Utils.php
@@ -703,7 +703,7 @@ class Utils
      * Generate resized thumbnail image and return as string.
      * Return FALSE on errors and stores error message in $error if set.
      */
-    public static function getImageThumb(string $image, int $thumbMaxSize, string $tmpdir, ?string &$error = null): bool|string
+    public static function getImageThumb(string $image, int $thumbMaxSize, ?string &$error = null): bool|string
     {
         if (!function_exists('gd_info')) {
             $error = self::GD_MISSING;
@@ -737,29 +737,26 @@ class Utils
             return false;
         }
 
-        if (!($tmpfname = tempnam($tmpdir, "thumb-"))) {
-            $error = 'Cannot create temporary file in directory ' . $tmpdir . '.';
-            return false;
-        }
-
-        $success = false;
+        // Render into an in-memory buffer rather than a temp file, so this does
+        // not depend on a writable temporary directory and avoids a disk
+        // round-trip.
+        ob_start();
         switch ($type) {
             case 'jpeg':
-                $success = imagejpeg($thumb, $tmpfname);
+                $success = imagejpeg($thumb);
                 break;
             case 'png':
-                $success = imagepng($thumb, $tmpfname);
+                $success = imagepng($thumb);
                 break;
             case 'gif':
-                $success = imagegif($thumb, $tmpfname);
+                $success = imagegif($thumb);
                 break;
+            default:
+                $success = false;
         }
-        if (!$success) {
+        $thumbstr = ob_get_clean();
+        if (!$success || $thumbstr === false || $thumbstr === '') {
             $error = 'Failed to output thumbnail image.';
-            return false;
-        }
-        if (($thumbstr = file_get_contents($tmpfname)) === false) {
-            $error = 'Cannot read image from temporary file \'$tmpfname\'.';
             return false;
         }
 

--- a/webapp/tests/Unit/Utils/UtilsTest.php
+++ b/webapp/tests/Unit/Utils/UtilsTest.php
@@ -728,10 +728,9 @@ class UtilsTest extends TestCase
         $logo = __DIR__ . $imageLocation;
         $image = file_get_contents($logo);
         $error = null;
-        $tmp = sys_get_temp_dir();
         $maxsize = 30;
 
-        $thumb = Utils::getImageThumb($image, $maxsize, $tmp, $error);
+        $thumb = Utils::getImageThumb($image, $maxsize, $error);
         self::assertNull($error);
 
         $data = getimagesizefromstring($thumb);
@@ -753,10 +752,9 @@ class UtilsTest extends TestCase
     {
         $image = 'Not really an image';
         $error = null;
-        $tmp = sys_get_temp_dir();
         $maxsize = 30;
 
-        $thumb = Utils::getImageThumb($image, $maxsize, $tmp, $error);
+        $thumb = Utils::getImageThumb($image, $maxsize, $error);
         self::assertFalse($thumb);
         self::assertEquals('Could not determine image information.', $error);
     }


### PR DESCRIPTION
`Utils::getImageThumb()` wrote the resized thumbnail to a `tempnam()` file and read it back.

Render the thumbnail straight into an in-memory buffer via output buffering instead, saving a disk round-trip.