### PR TITLE
judgedaemon: Execute commands without a shell in runCommandSafe.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1155,12 +1155,14 @@ class JudgeDaemon
             self::FD_STDERR => ['file', $stderr_target ?: '/dev/null', 'w'],
         ];
 
-        // For proc_open, we need to pass the command as a string for security
         $command_string = implode(' ', array_map(dj_escapeshellarg(...), $command_parts));
-
         logmsg(LOG_DEBUG, "Executing command: $command_string");
 
-        $process = proc_open($command_string, $descriptorspec, $pipes);
+        // Pass the command as an array so proc_open() execvp()'s it directly
+        // instead of running it through `/bin/sh -c`. This avoids one shell
+        // process per call and is safer, as no shell command line (that would
+        // need escaping) is ever constructed.
+        $process = proc_open($command_parts, $descriptorspec, $pipes);
         if (!is_resource($process)) {
             logmsg(LOG_ERR, "Failed to start process: $command_string");
             if ($stderr_temp !== null) {


### PR DESCRIPTION
`runCommandSafe()` built an escaped shell command line and handed the string to `proc_open()`, which runs it via `/bin/sh -c`. Every command therefore forked a shell in addition to the target process.

Pass the command as an array instead, so `proc_open()` `execvp()`'s the program directly without a shell subprocess per call.

This is also safer: no shell command line that needs escaping is ever constructed. The escaped string is still built for the debug/error log (we will investigate this separately).

See https://www.php.net/manual/en/function.proc-open.php:

> As of PHP 7.4.0, command may be passed as array of command parameters.
> In this case the process will be opened directly (without going through
> a shell) and PHP will take care of any necessary argument escaping.

For a submission with 277 test cases and trivial run time, this results in an almost ~3s end to end time reduction, speeding it up by ~14%.