### PR TITLE
Fix balloon notifications.

### DIFF
--- a/webapp/public/js/domjudge.js
+++ b/webapp/public/js/domjudge.js
@@ -824,7 +824,7 @@ function updateMenuBalloons(data)
             var text = (data[i].location !== null) ? data[i].location+': ' : '';
             text += data[i].pname + ' ' + data[i].name;
             sendNotification('New balloon:',
-                 {'tag': 'ball_' + data[i].baloonid,
+                 {'tag': 'ball_' + data[i].balloonid,
                         'link': domjudge_base_url + '/jury/balloons',
                         'body': text});
         }


### PR DESCRIPTION
The notification tag was built from `data[i].baloonid` (notice the typo!), but `getUpdates()` serves the key as `balloonid`. Every balloon therefore got the tag `ball_undefined`.

Since `sendNotification()` records sent tags in `localStorage` and returns early on a match, the first balloon notification a user saw suppressed every balloon notification afterwards.