### PR TITLE
Do not automatically mark the replacement of an internal error judgin…

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -886,13 +886,18 @@ class JudgehostController extends AbstractFOSRestController
             });
 
             if ($judgehost === null) {
-                // Invalidate old judging and create a new one - but without judgetasks yet since this was triggered by
-                // an internal error.
+                // Invalidate old judging and create a new one - but without
+                // judgetasks yet since this was triggered by an internal
+                // error.
+                // The new judging takes the place of the old one, so it is
+                // only valid if the old one was; this is particularly
+                // important in case of rejudgings.
+                $wasValid = $judging->getValid();
                 $judging->setValid(false);
                 $newJudging = new Judging();
                 $newJudging
                     ->setContest($judging->getContest())
-                    ->setValid(true)
+                    ->setValid($wasValid)
                     ->setSubmission($judging->getSubmission())
                     ->setOriginalJudging($judging);
                 $this->em->persist($newJudging);


### PR DESCRIPTION
…g valid.

Part of #2163 where Jaap reported multiple such cases. Luckily there is enough traces in the audit log to figure out what happened.

When a judging hits an internal error, `giveBackJudging()` invalidates it and creates a replacement judging that takes its place. That replacement was always created with `valid = 1`, but the judging it replaces is not necessarily valid: a judging that is part of a rejudging only becomes valid once that rejudging is applied.

So an internal error during a rejudging may have left the submission with two valid judgings: the one from an earlier, applied rejudging, and the replacement, which is not associated with any rejudging (`giveBackJudging()` does not carry the rejudging over).

That breaks the invariant that a submission has exactly one valid judging, and everything downstream that relies on it: rejudging a submission in that state selects both judgings (`j.valid = 1`), which then yields several judgings for the same (rejudging, submission) pair.

Now, we let the replacement inherit the validity of the judging it replaces. It stays detached from the rejudging, as before: an abandoned judging keeps endtime `NULL`, so re-attaching it would make the rejudging's todo count never reach 0.