### PR TITLE
Handle multiple judgings per rejudging on the jury submission page.

### DIFF
--- a/webapp/src/Controller/Jury/SubmissionController.php
+++ b/webapp/src/Controller/Jury/SubmissionController.php
@@ -301,6 +301,12 @@ class SubmissionController extends BaseController
                 ->setParameter('rejudgingId', $rejudgingId)
                 ->setParameter('submitId', $submitId)
                 ->setParameter('contest', $contest)
+                // A submission can have more than one judging within the same
+                // rejudging, for example when a judging was aborted or
+                // requeued after an internal error. Make this more robust by
+                // picking the most recent one.
+                ->orderBy('j.judgingid', 'DESC')
+                ->setMaxResults(1)
                 ->getQuery()
                 ->getOneOrNullResult();
             if ($judging) {


### PR DESCRIPTION
Found and verified when debugging #2163.

Visiting a submission with `?rejudgingid=<id>` deduced the judging to show with `getOneOrNullResult()`, which assumes a submission has at most one judging within a given rejudging.

That does not always hold true: when a judging is aborted or requeued after an internal error, a second judging is created for the same (rejudging, submission) pair, resulting in

```
Doctrine\ORM\NonUniqueResultException: More than one result was found
for query although one row or none was expected.
```

Now we pick and show the most recent judging of the rejudging instead. The older ones stay reachable, as the page links to every judging of the submission anyway.