### PR TITLE
Add each submission at most once to a rejudging.

### DIFF
--- a/webapp/src/Service/RejudgingService.php
+++ b/webapp/src/Service/RejudgingService.php
@@ -95,6 +95,10 @@ class RejudgingService
         $singleJudging = (count($judgings) == 1);
         $index = 0;
         $first = true;
+        // We can be handed more than one judging of the same submission, for
+        // example when a submission ended up with several valid judgings. Only
+        // rejudge each submission once by tracking them as seen.
+        $seenSubmissions = [];
         foreach ($judgings as $judging) {
             $submission = $judging->getSubmission();
             $contestProblem = $submission->getContestProblem();
@@ -102,15 +106,17 @@ class RejudgingService
 
             $index++;
             if (
-                // Record and skip submission/judging if it is already part of another judging or is not allowed
-                // to be judged.
+                // Record and skip submission/judging if it is already part of
+                // another judging or is not allowed to be judged.
                 $submission->getRejudging() !== null
+                || isset($seenSubmissions[$submission->getSubmitid()])
                 || !$contestProblem->getAllowJudge()
                 || !$language->getAllowJudge()
             ) {
                 $skipped[] = $judging;
                 continue;
             }
+            $seenSubmissions[$submission->getSubmitid()] = true;
 
 
             // $this->>em->wrapInTransaction flushes the entity manager, which is pretty slow.


### PR DESCRIPTION
Fixes #2163.

`createRejudging()` is handed a list of judgings and creates a new judging for each of them. It does guard against rejudging a submission that is already part of a rejudging, but that guard cannot fire when the same submission is passed twice (i.e. through multiple judgings of the same submission).

Fix by keeping track of the submissions we have already handled in this loop, so that this does not depend on the state of the entity manager.

This is also what #2163 has been running into: the duplicate judgings reported there make done/todo inconsistent, so the apply button never shows up. It explains why repeating the rejudging on current main did not help either - the repeat recreates the duplicates through this same path.

See also the other PRs that mention #2163 that help making this more robust.