### PR TITLE
Join judging runs on the judgetask when determining the verdict.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -1038,11 +1038,10 @@ class JudgehostController extends AbstractFOSRestController
         /** @var JudgingRun[] $runs */
         $runs = $this->em->createQueryBuilder()
             ->from(JudgeTask::class, 'jt')
-            ->leftJoin(JudgingRun::class, 'jr', Join::WITH, 'jt.testcase_id = jr.testcase AND jr.judging = :judgingid')
+            ->leftJoin(JudgingRun::class, 'jr', Join::WITH, 'jt.judgetaskid = jr.judgetask AND jr.judging = :judgingid')
             ->select('jr.runresult')
             ->andWhere('jt.jobid = :judgingid')
             ->andWhere('jr.judging = :judgingid')
-            ->andWhere('jt.testcase_id = jr.testcase')
             ->orderBy('jt.judgetaskid')
             ->setParameter('judgingid', $judging->getJudgingid())
             ->getQuery()


### PR DESCRIPTION
Previously, we joined the judgetasks of a judging to their runs on the testcase instead of on the judgetask.

However, requesting the output of a run (e.g. from the jury interface) creates a `debug_info` judgetask with the same job ID and testcase, and the query didn't filter on the type, so from then on that testcase's result was counted twice when determining the final verdict.

This is ~harmless today because both rows carry the same result, but it stops being harmless as soon as there can be more than one run per testcase, which is what multi-pass problems will need.

Joining on the judgetask also drops the `debug_info` judgetasks, which have no run at all, so the extra condition on the testcase is no longer needed.