### PR TITLE
Make `JudgeTask::getPass()` nullable.

### DIFF
--- a/webapp/src/Entity/JudgeTask.php
+++ b/webapp/src/Entity/JudgeTask.php
@@ -287,13 +287,13 @@ class JudgeTask
         return $this->compare_script_id;
     }
 
-    public function setPass(int $pass): JudgeTask
+    public function setPass(?int $pass): JudgeTask
     {
         $this->pass = $pass;
         return $this;
     }
 
-    public function getPass(): int
+    public function getPass(): ?int
     {
         return $this->pass;
     }


### PR DESCRIPTION
The column is nullable and is only set for multipass problems, so the non-nullable return type would have been a type error for every other judge task.

`JudgingRun` already declares this correctly.