### PR TITLE
multipass: Report internal error for `nextpass.in` without exit code 42.

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -2601,10 +2601,31 @@ class JudgeDaemon
                     . '  ...done in ' . $metadata['wall-time'] . 's (CPU: ' . $runtime . 's), result: ' . $result);
             }
 
+            $hasNextPass = file_exists($passdir . '/feedback/nextpass.in');
+
+            // The spec states we have to treat it is a judge error if
+            // `nextpass.in` is produced when exiting with any other code
+            // than 42.
+            if ($hasNextPass) {
+                $compareMeta = $this->readMetadata($passdir . '/compare.meta');
+                /** @var MetaData_Compare $compareMeta */
+                if ((int)$compareMeta['exitcode'] !== self::COMPARE_EXITCODE_CORRECT) {
+                    $description = sprintf(
+                        "compare script %s created 'nextpass.in' but exited with code %s, expected %d",
+                        $judgeTask['compare_script_id'],
+                        $compareMeta['exitcode'],
+                        self::COMPARE_EXITCODE_CORRECT
+                    );
+                    logmsg(LOG_ERR, $description);
+                    $this->disable('compare_script', 'compare_script_id', $judgeTask['compare_script_id'], $description, $judgeTask['judgetaskid']);
+                    return false;
+                }
+            }
+
             if ($result !== 'correct') {
                 break;
             }
-            if (file_exists($passdir . '/feedback/nextpass.in')) {
+            if ($hasNextPass) {
                 $input = $passdir . '/feedback/nextpass.in';
                 $nextPass = true;
             } else {


### PR DESCRIPTION
The problem package format states that it is a judge error to create the `nextpass.in` file and exit with any other code than 42. We only looked at `nextpass.in` for a correct verdict, so a validator that created it and exited with 43 silently resulted in a wrong answer instead.

Check this independently of the verdict: the validator may legitimately exit with 42 and ask for another pass while the run itself failed with for example a timelimit, in which case judging simply stops.

See https://icpc.io/problem-package-format/spec/2025-09.html?highlight=nextpass#multi-pass-validation