### PR TITLE
runpipe_test: Fix signature for SIGTERM handlers.

### DIFF
--- a/judge/runpipe_test/sigterm/judge.c
+++ b/judge/runpipe_test/sigterm/judge.c
@@ -4,7 +4,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-void sigterm() {
+void sigterm(int sig) {
   assert(open("judge.txt", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR) != -1);
   _exit(42);
 }

--- a/judge/runpipe_test/sigterm/solution.c
+++ b/judge/runpipe_test/sigterm/solution.c
@@ -4,7 +4,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-void sigterm() {
+void sigterm(int sig) {
   assert(open("solution.txt", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR) != -1);
   _exit(42);
 }


### PR DESCRIPTION
Previous code started breaking with GCC.