### PR TITLE
runpipe_test: Actually run the J_exits_early_S_loops testcase.

### DIFF
--- a/judge/runpipe_test/Makefile
+++ b/judge/runpipe_test/Makefile
@@ -3,7 +3,7 @@ TOPDIR=../..
 endif
 include $(TOPDIR)/Makefile.global
 
-TESTCASES = J_closes_stdout J_returns_42 J_returns_43 S_exits_early J_exits_early S_closes_stdin S_doesnt_write J_doesnt_write sigterm timeout_with_traffic
+TESTCASES = J_closes_stdout J_returns_42 J_returns_43 S_exits_early J_exits_early J_exits_early_S_loops S_closes_stdin S_doesnt_write J_doesnt_write sigterm timeout_with_traffic
 RUNPIPES = runpipe
 
 TESTCASES_JUDGE = $(TESTCASES:=/judge)


### PR DESCRIPTION
The testcase has been present, with a judge, a solution and a run script, but was never listed in `TESTCASES`, so it never ran.