### PR TITLE
runpipe: Properly pass -U to runguard.

### DIFF
--- a/judge/runpipe.cc
+++ b/judge/runpipe.cc
@@ -236,11 +236,22 @@ struct process_t {
     std::array<int, 3> stdio = {stdin_fd, stdout_fd, FDREDIR_NONE};
 
     auto exec_args = args;
-    if (cmd == "sudo" && exec_args.size() > 1 && exec_args[1].find("/runguard") != string::npos) {
-        // This is a hack, and can be improved significantly after implementing
-        // https://docs.google.com/document/d/1WZRwdvJUamsczYC7CpP3ZIBU8xG6wNqYqrNJf7osxYs/edit#heading=h.i7kgdnmw8qd7
-        exec_args.push_back("-U");
-        exec_args.push_back(std::to_string(getpid()));
+    if (cmd == "sudo") {
+      // Tell runguard our pid, so that it can signal us when the command hits
+      // its time limit. The option must be inserted directly behind the
+      // runguard path: the caller ends runguard's option list with a `--`, so
+      // appending would place it behind that separator, where runguard would
+      // pass it on to the command instead of parsing it.
+      // This is a hack, and can be improved significantly after implementing
+      // https://docs.google.com/document/d/1WZRwdvJUamsczYC7CpP3ZIBU8xG6wNqYqrNJf7osxYs/edit#heading=h.i7kgdnmw8qd7
+      auto runguard = std::find_if(exec_args.begin(), exec_args.end(), [](const string &arg) {
+        return arg.find("/runguard") != string::npos;
+      });
+      if (runguard == exec_args.end()) {
+        logmsg(LOG_DEBUG, "no runguard found in the arguments of #{}, not passing -U", index);
+      } else {
+        exec_args.insert(runguard + 1, {"-U", std::to_string(getpid())});
+      }
     }
 
     pid = execute(cmd, exec_args, stdio, false);

--- a/judge/runpipe_test/Makefile
+++ b/judge/runpipe_test/Makefile
@@ -3,7 +3,7 @@ TOPDIR=../..
 endif
 include $(TOPDIR)/Makefile.global
 
-TESTCASES = J_closes_stdout J_returns_42 J_returns_43 S_exits_early J_exits_early J_exits_early_S_loops S_closes_stdin S_doesnt_write J_doesnt_write sigterm timeout_with_traffic
+TESTCASES = J_closes_stdout J_returns_42 J_returns_43 S_exits_early J_exits_early J_exits_early_S_loops S_closes_stdin S_doesnt_write J_doesnt_write sigterm timeout_with_traffic runguard_pid
 RUNPIPES = runpipe
 
 TESTCASES_JUDGE = $(TESTCASES:=/judge)

--- a/judge/runpipe_test/runguard_pid/judge.c
+++ b/judge/runpipe_test/runguard_pid/judge.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+int main() {
+  signal(SIGPIPE, SIG_IGN);
+  assert(4 == printf("123\n"));
+  fflush(stdout);
+
+  int x;
+  assert(1 == scanf("%d", &x));
+  if (x == 123)
+    return 42;
+  return 43;
+}

--- a/judge/runpipe_test/runguard_pid/run.sh
+++ b/judge/runpipe_test/runguard_pid/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# When the solution is wrapped in `sudo ... runguard ... -- <program>`, runpipe
+# passes its own pid to runguard with -U, so that runguard can report a time
+# limit back. That option only reaches runguard if it is placed before the `--`
+# that ends runguard's option list; appended after it, runguard would hand it to
+# the contestant program instead and never learn the pid.
+#
+# Stand-ins for sudo and runguard record the arguments they are called with, so
+# that this can be checked without needing root.
+
+[[ $# != 1 ]] && echo "Usage: $0 runpipe" && exit 2
+
+RUNPIPE="$(realpath "$1")"
+STUBS="$(mktemp -d)"
+trap 'rm -rf "$STUBS"' EXIT
+
+cat > "$STUBS/sudo" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "-n" ]] && shift
+exec "$@"
+EOF
+
+cat > "$STUBS/runguard" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$RUNGUARD_ARGV"
+# Drop our own options and run whatever follows the separator.
+while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+shift
+exec "$@"
+EOF
+
+chmod +x "$STUBS/sudo" "$STUBS/runguard"
+
+export RUNGUARD_ARGV="$STUBS/argv.txt"
+PATH="$STUBS:$PATH" "$RUNPIPE" -o output.txt \
+	./judge 42 = sudo -n "$STUBS/runguard" --walltime=5 -- ./solution 42
+ret=$?
+
+if [[ $ret != 42 ]]; then
+	printf "\033[31;1mExpecting code 42, got %s\033[0m\n" "$ret"
+	exit 1
+fi
+
+if [[ ! -f "$RUNGUARD_ARGV" ]]; then
+	printf "\033[31;1mrunguard was never invoked\033[0m\n"
+	exit 1
+fi
+
+mapfile -t argv < "$RUNGUARD_ARGV"
+
+# Locate the -U option and the separator that ends runguard's options.
+u_index=-1
+sep_index=-1
+for i in "${!argv[@]}"; do
+	[[ "${argv[$i]}" == "-U" && $u_index == -1 ]] && u_index=$i
+	[[ "${argv[$i]}" == "--" && $sep_index == -1 ]] && sep_index=$i
+done
+
+if [[ $u_index == -1 ]]; then
+	printf "\033[31;1mrunguard was not passed -U at all: %s\033[0m\n" "${argv[*]}"
+	exit 1
+fi
+
+if [[ $sep_index != -1 && $u_index -gt $sep_index ]]; then
+	printf "\033[31;1m-U is behind the '--' separator, so runguard never sees it: %s\033[0m\n" "${argv[*]}"
+	exit 1
+fi
+
+if ! [[ "${argv[$((u_index + 1))]}" =~ ^[0-9]+$ ]]; then
+	printf "\033[31;1m-U is not followed by a pid: %s\033[0m\n" "${argv[*]}"
+	exit 1
+fi
+
+# Everything after the separator is the command, which must be untouched.
+command=( "${argv[@]:$((sep_index + 1))}" )
+if [[ "${command[*]}" != "./solution 42" ]]; then
+	printf "\033[31;1mthe command was altered, expected './solution 42', got '%s'\033[0m\n" "${command[*]}"
+	exit 1
+fi
+
+printf "\033[32;1mok\033[0m\n"

--- a/judge/runpipe_test/runguard_pid/solution.c
+++ b/judge/runpipe_test/runguard_pid/solution.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+  int x;
+  assert(1 == scanf("%d", &x));
+  assert(x == 123);
+
+  assert(4 == printf("123\n"));
+  fflush(stdout);
+}


### PR DESCRIPTION
runpipe tells runguard its pid with `-U`, so that runguard can raise `SIGUSR1` when the command hits its hard wall-time limit. However, this broke in a previous refactoring.

The option was appended to the argument list, but the judgedaemon already ends runguard's options with a `--` before the program path. The option therefore landed behind that separator, so runguard never received it, and `-U <pid>` were appended to the contestant's program as two stray arguments.

Consequently `runpipe_pid` stayed unset and the `SIGUSR1` was never sent, so runpipe could not distinguish a timed-out command from a normal exit. It then recorded `validator-exited-first` based on whichever process `waitpid()` happened to reap first, which feeds into verdict determination.