### PR TITLE
Add another clarification from another team in similar style for unit tests

### DIFF
--- a/webapp/src/Controller/API/ClarificationController.php
+++ b/webapp/src/Controller/API/ClarificationController.php
@@ -154,26 +154,6 @@ class ClarificationController extends AbstractRestController
             $clarification->setProblem($problem->getProblem());
         }
 
-        if ($replyToId = $clarificationPost->replyToId) {
-            // Load the clarification.
-            /** @var Clarification|null $replyTo */
-            $replyTo = $this->em->createQueryBuilder()
-                ->from(Clarification::class, 'c')
-                ->select('c')
-                ->andWhere('c.externalid = :clarification')
-                ->andWhere('c.contest = :contest')
-                ->setParameter('clarification', $replyToId)
-                ->setParameter('contest', $contestId)
-                ->getQuery()
-                ->getOneOrNullResult();
-
-            if ($replyTo === null) {
-                throw new BadRequestHttpException("Clarification '$replyToId' not found.");
-            }
-
-            $clarification->setInReplyTo($replyTo);
-        }
-
         // By default, use the team of the user
         $fromTeam = $this->isGranted('ROLE_API_WRITER') ? null : $this->dj->getUser()->getTeam();
         if ($fromTeamId = $clarificationPost->fromTeamId) {
@@ -206,6 +186,30 @@ class ClarificationController extends AbstractRestController
 
         if ($toTeam && $fromTeam) {
             throw new BadRequestHttpException('Can not send a clarification from and to a team.');
+        }
+
+        if ($replyToId = $clarificationPost->replyToId) {
+            $qb = $this->em->createQueryBuilder()
+                ->from(Clarification::class, 'c')
+                ->select('c')
+                ->andWhere('c.externalid = :clarification')
+                ->andWhere('c.contest = :contest')
+                ->setParameter('clarification', $replyToId)
+                ->setParameter('contest', $contestId);
+            if ($this->dj->checkrole('team')) {
+                $qb
+                    ->andWhere('c.sender = :team OR c.recipient = :team OR (c.sender IS NULL AND c.recipient IS NULL)')
+                    ->setParameter('team', $fromTeam);
+            }
+            // Load the clarification.
+            /** @var Clarification|null $replyTo */
+            $replyTo = $qb->getQuery()->getOneOrNullResult();
+
+            if ($replyTo === null) {
+                throw new BadRequestHttpException("Clarification '$replyToId' not found.");
+            }
+
+            $clarification->setInReplyTo($replyTo);
         }
 
         $time = Utils::now();

--- a/webapp/src/DataFixtures/Test/ClarificationFixture.php
+++ b/webapp/src/DataFixtures/Test/ClarificationFixture.php
@@ -6,9 +6,10 @@ use App\Entity\Contest;
 use App\Entity\Clarification;
 use App\Entity\Problem;
 use App\Entity\Team;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class ClarificationFixture extends AbstractTestDataFixture
+class ClarificationFixture extends AbstractTestDataFixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {
@@ -16,6 +17,8 @@ class ClarificationFixture extends AbstractTestDataFixture
         $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
         /** @var Team $team */
         $team = $manager->getRepository(Team::class)->findOneBy(['name' => 'Example teamname']);
+        /** @var Team $anotherTeam */
+        $anotherTeam = $manager->getRepository(Team::class)->findOneBy(['externalid' => 'nav-alpha']);
         /** @var Problem $problem */
         $problem = $manager->getRepository(Problem::class)->findOneBy(['externalid' => 'hello']);
 
@@ -55,7 +58,16 @@ class ClarificationFixture extends AbstractTestDataFixture
             ->setBody('What is 2+2?')
             ->setAnswered(true);
 
-        foreach ([$unhandledClarification, $juryGeneral, $juryGeneralToTeam, $handledClarification] as $index => $clar) {
+        $unhandledClarificationAnotherTeam = new Clarification();
+        $unhandledClarificationAnotherTeam
+            ->setContest($contest)
+            ->setSubmittime(1518385739.901348000)
+            ->setSender($anotherTeam)
+            ->setProblem($problem)
+            ->setBody('Is it encouraged to read the problem statement carefully?')
+            ->setAnswered(false);
+
+        foreach ([$unhandledClarification, $juryGeneral, $juryGeneralToTeam, $handledClarification, $unhandledClarificationAnotherTeam] as $index => $clar) {
             $manager->persist($clar);
             $manager->flush();
             $this->addReference(sprintf('%s:%d', static::class, $index), $clar);
@@ -77,5 +89,10 @@ class ClarificationFixture extends AbstractTestDataFixture
 //        $handledClarification = $manager->getRepository(Clarification::class)->findOneBy(['body' => 'You have a fast calculator in front of you.']);
         $handledClarification->addReply($answerToExistingClar);
         $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [NavigationTeamsFixture::class];
     }
 }

--- a/webapp/src/DataFixtures/Test/NavigationTeamUsersFixture.php
+++ b/webapp/src/DataFixtures/Test/NavigationTeamUsersFixture.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Role;
+use App\Entity\Team;
+use App\Entity\User;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+class NavigationTeamUsersFixture extends AbstractTestDataFixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        foreach (['nav-alpha', 'nav-beta', 'nav-gamma'] as $id) {
+            $team = $manager->getRepository(Team::class)->findOneBy(['externalid' => $id]);
+            $role = $manager->getRepository(Role::class)->findOneBy(['dj_role' => 'team']);
+            $user = new User();
+            $user
+                ->setExternalid($id . '-user')
+                ->setUsername($id . '-user')
+                ->setPlainPassword($id . '-user')
+                ->setName(ucfirst($id) . ' User')
+                ->setTeam($team)
+                ->addUserRole($role);
+            $manager->persist($user);
+        }
+
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [NavigationTeamsFixture::class];
+    }
+}

--- a/webapp/src/DataFixtures/Test/NavigationTeamsFixture.php
+++ b/webapp/src/DataFixtures/Test/NavigationTeamsFixture.php
@@ -18,6 +18,7 @@ class NavigationTeamsFixture extends AbstractTestDataFixture implements Dependen
             $team = new Team();
             $team
                 ->setExternalid($id)
+                ->setIcpcId($id)
                 ->setName(ucfirst($id) . ' Team')
                 ->addCategory($category);
             $manager->persist($team);

--- a/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/ClarificationControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Controller\API;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use App\DataFixtures\Test\ClarificationFixture;
+use App\DataFixtures\Test\NavigationTeamUsersFixture;
 use App\DataFixtures\Test\RemoveTeamFromDemoUserFixture;
 use App\Entity\Clarification;
 use App\Entity\Problem;
@@ -16,7 +17,7 @@ class ClarificationControllerTest extends BaseTestCase
 
     protected ?string $apiUser = 'admin';
 
-    protected static array $fixtures = [ClarificationFixture::class];
+    protected static array $fixtures = [ClarificationFixture::class, NavigationTeamUsersFixture::class];
 
     protected ?string $entityClass = Clarification::class;
 
@@ -47,6 +48,15 @@ class ClarificationControllerTest extends BaseTestCase
             "time"         => "2018-02-11T21:47:43.689+00:00",
             "text"         => "There was a mistake in judging this problem. Please try again",
             "answered"     => true,
+        ],
+        ClarificationFixture::class . ':4' => [
+            "problem_id"   => "hello",
+            "from_team_id" => "nav-alpha",
+            "to_team_id"   => null,
+            "reply_to_id"  => null,
+            "time"         => "2018-02-11T21:48:59.901+00:00",
+            "text"         => "Is it encouraged to read the problem statement carefully?",
+            "answered"     => false,
         ],
     ];
 
@@ -103,6 +113,19 @@ class ClarificationControllerTest extends BaseTestCase
             static::assertEquals("exteam", $clarificationFromApi[$mistakJudgingId]['to_team_id']);
             static::assertEquals("There was a mistake in judging this problem. Please try again", $clarificationFromApi[$mistakJudgingId]['text']);
             static::assertArrayNotHasKey('answered', $clarificationFromApi[$mistakJudgingId]);
+
+            // Different team with different clarifications
+            if ($problemId) {
+                $expectedNumber = 1;
+            } else {
+                $expectedNumber = 2;
+            }
+            $clarificationFromApi = $this->verifyApiJsonResponse('GET', $clarificationApi.$postfix, 200, 'nav-alpha-user');
+            static::assertCount($expectedNumber, $clarificationFromApi);
+
+            static::assertEquals("nav-alpha", $clarificationFromApi[$expectedNumber-1]['from_team_id']);
+            static::assertEquals("Is it encouraged to read the problem statement carefully?", $clarificationFromApi[$expectedNumber-1]['text']);
+            static::assertArrayNotHasKey('answered', $clarificationFromApi[$expectedNumber-1]);
         }
         $clarificationFromApi = $this->verifyApiJsonResponse('GET', $clarificationApi."?problem=9999", 200, 'demo');
         static::assertCount(0, $clarificationFromApi);
@@ -122,8 +145,18 @@ class ClarificationControllerTest extends BaseTestCase
      * Test that if invalid data is supplied, the correct message is returned.
      */
     #[DataProvider('provideAddInvalidData')]
-    public function testAddInvalidData(string $user, array $dataToSend, string $expectedMessage): void
+    public function testAddInvalidData(string $user, array $dataToSend, string $expectedMessage, ?string $id = null): void
     {
+        if (!is_null($id)) {
+            $referencedId = strval($this->resolveReference(ClarificationFixture::class . ':' .$id));
+            $expectedMessage = str_replace('%s', $referencedId, $expectedMessage);
+            foreach ($dataToSend as $key => $value) {
+                if (is_string($value)) {
+                    $dataToSend[$key] = str_replace('%s', $referencedId, $value);
+                }
+            }
+        }
+
         $contestId = $this->getDemoContestId();
         $apiEndpoint = $this->apiEndpoint;
         $method = isset($dataToSend['id']) ? 'PUT' : 'POST';
@@ -153,6 +186,7 @@ class ClarificationControllerTest extends BaseTestCase
         yield ['admin', ['text' => 'This is a clarification', 'from_team_id' => 'noteam'], "Team with ID 'noteam' not found in contest or not enabled."];
         yield ['admin', ['text' => 'This is a clarification', 'to_team_id' => 'noteam'], "Team with ID 'noteam' not found in contest or not enabled."];
         yield ['admin', ['text' => 'This is a clarification', 'time' => 'this is not a time'], "Can not parse time 'this is not a time'."];
+        yield ['nav-alpha-user', ['text' => 'This is a response to a clarification of another team', 'reply_to_id' => '%s'], "Clarification '%s' not found.", '0'];
     }
 
     /**

--- a/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ImportExportControllerTest.php
@@ -244,11 +244,11 @@ observers	Observers
 
     public static function provideResultsTsvExport(): Generator
     {
-        yield [0, true, true, "results	1\nexteam		Honorable	0	0	0	\n"];
-        yield [0, true, false, "results	1\nexteam		Honorable	0	0	0	\n"];
-        yield [0, false, true, "results	1\nexteam		Honorable	0	0	0	\n"];
-        yield [0, false, true, "results	1\nexteam		Honorable	0	0	0	\n"];
-        yield [1, true, true, "results	1\n"];
+        yield [0, true, true,  "results	1\nexteam		Honorable	0	0	0	\nnav-alpha		Honorable	0	0	0	\nnav-beta		Honorable	0	0	0	\nnav-gamma		Honorable	0	0	0	\n"];
+        yield [0, true, false, "results	1\nexteam		Honorable	0	0	0	\nnav-alpha		Honorable	0	0	0	\nnav-beta		Honorable	0	0	0	\nnav-gamma		Honorable	0	0	0	\n"];
+        yield [0, false, true, "results	1\nexteam		Honorable	0	0	0	\nnav-alpha		Honorable	0	0	0	\nnav-beta		Honorable	0	0	0	\nnav-gamma		Honorable	0	0	0	\n"];
+        yield [0, false, true, "results	1\nexteam		Honorable	0	0	0	\nnav-alpha		Honorable	0	0	0	\nnav-beta		Honorable	0	0	0	\nnav-gamma		Honorable	0	0	0	\n"];
+        yield [1, true, true,  "results	1\n"];
         yield [1, true, false, "results	1\n"];
         yield [1, false, true, "results	1\n"];
         yield [1, false, true, "results	1\n"];


### PR DESCRIPTION
We check if we can react to our own (that was there before) and that an user can not react to the clarification of others but also can't guess that it exists.

This reuses some other fixtures to prevent the duplication of creation of teams. This way we can now easily reuse the teams from other fixtures with associated users each time extending those more and more to almost real-world usecases.