### PR TITLE
Allow verification of submissions on (contest)problem level

### DIFF
--- a/webapp/src/Controller/Jury/ProblemController.php
+++ b/webapp/src/Controller/Jury/ProblemController.php
@@ -1274,7 +1274,7 @@ class ProblemController extends BaseController
     }
 
     #[IsGranted('ROLE_ADMIN')]
-    #[Route(path: '/{contestId}/{probId}/toggle/{type<judge|submit>}', name: 'jury_problem_toggle')]
+    #[Route(path: '/{contestId}/{probId}/toggle/{type<judge|submit|verification>}', name: 'jury_problem_toggle')]
     public function toggleSubmitAction(
         RouterInterface $router,
         Request $request,
@@ -1297,6 +1297,10 @@ class ProblemController extends BaseController
             case 'submit':
                 $contestProblem->setAllowSubmit($value);
                 $label = 'set allow submit';
+                break;
+            case 'verification':
+                $contestProblem->setVerificationRequired($value);
+                $label = 'set verification required';
                 break;
             default:
                 throw new BadRequestHttpException('Unknown toggle type');

--- a/webapp/src/Controller/Team/SubmissionController.php
+++ b/webapp/src/Controller/Team/SubmissionController.php
@@ -210,13 +210,29 @@ class SubmissionController extends BaseController
         return [[$uploadedFile], $tmpFile];
     }
 
+    private function helperCheckVerificationRequired(int $submitId): bool
+    {
+        $globalRequired = (bool)$this->config->get('verification_required');
+        if ($globalRequired) {
+            return true;
+        }
+        return $this->em->createQueryBuilder()
+            ->from(Submission::class, 's')
+            ->join('s.contest_problem', 'cp')
+            ->select('cp.verification_required')
+            ->where('s.submission = :submitId')
+            ->setParameter('submitId', $submitId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     /**
      * @throws NonUniqueResultException
      */
     #[Route(path: '/submission/{submitId<\d+>}', name: 'team_submission')]
     public function viewAction(Request $request, int $submitId): Response
     {
-        $verificationRequired = (bool)$this->config->get('verification_required');
+        $verificationRequired = $this->helperCheckVerificationRequired($submitId);
         $showCompile          = $this->config->get('show_compile');
         $showSampleOutput     = $this->config->get('show_sample_output');
         $allowDownload        = (bool)$this->config->get('allow_team_submission_download');

--- a/webapp/src/Entity/ContestProblem.php
+++ b/webapp/src/Entity/ContestProblem.php
@@ -59,6 +59,10 @@ class ContestProblem extends BaseApiEntity
     #[Serializer\Exclude]
     private bool $allowJudge = true;
 
+    #[ORM\Column(options: ['comment' => 'Is manual verification of judgings by jury required before publication?', 'default' => 0])]
+    #[Serializer\Exclude]
+    private bool $verificationRequired = false;
+
     #[ORM\Column(
         length: 32,
         nullable: true,
@@ -155,6 +159,17 @@ class ContestProblem extends BaseApiEntity
     public function getAllowJudge(): bool
     {
         return $this->allowJudge;
+    }
+
+    public function setVerificationRequired(bool $verificationRequired): ContestProblem
+    {
+        $this->verificationRequired = $verificationRequired;
+        return $this;
+    }
+
+    public function getVerificationRequired(): bool
+    {
+        return $this->verificationRequired;
     }
 
     public function setColor(?string $color): ContestProblem

--- a/webapp/src/Form/Type/ContestProblemType.php
+++ b/webapp/src/Form/Type/ContestProblemType.php
@@ -53,7 +53,7 @@ class ContestProblemType extends AbstractType
             'label' => 'Colour',
             'attr' => [
                 'data-color-picker' => '',
-                'size' => 6,
+                'size' => 8,
             ],
         ]);
         $builder->add('lazyEvalResults', ChoiceType::class, [

--- a/webapp/src/Form/Type/ContestProblemType.php
+++ b/webapp/src/Form/Type/ContestProblemType.php
@@ -48,6 +48,11 @@ class ContestProblemType extends AbstractType
             'required' => false,
             'attr' => ContestType::TOGGLE_ATTRS,
         ]);
+        $builder->add('verificationRequired', CheckboxType::class, [
+            'label' => 'Manual verification',
+            'required' => false,
+            'attr' => ContestType::TOGGLE_ATTRS,
+        ]);
         $builder->add('color', TextType::class, [
             'required' => false,
             'label' => 'Colour',

--- a/webapp/templates/jury/contest.html.twig
+++ b/webapp/templates/jury/contest.html.twig
@@ -445,6 +445,7 @@
                             <th>Points</th>
                             <th>Allow<br>submit</th>
                             <th>Allow<br>judge</th>
+                            <th>Manual<br>verification</th>
                             <th>Color</th>
                             <th>Lazy eval</th>
                             <th></th>
@@ -465,6 +466,9 @@
                                 </td>
                                 <td>
                                     {% include 'jury/partials/problem_toggle.html.twig' with {contestProblem: problem, type: 'judge', enabled: problem.allowJudge} %}
+                                </td>
+                                <td>
+                                    {% include 'jury/partials/problem_toggle.html.twig' with {contestProblem: problem, type: 'verification', enabled: problem.verificationRequired} %}
                                 </td>
                                 {% if problem.color is empty %}
                                     <td><a href="{{ link }}">&nbsp;</a></td>

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -145,6 +145,7 @@
         <th>{{ form.problems.vars.prototype.points.vars.label }}</th>
         <th>{{ form.problems.vars.prototype.allowSubmit.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.allowJudge.vars.label | replace({" ":"<br>"}) | raw }}</th>
+        <th>{{ form.problems.vars.prototype.verificationRequired.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.color.vars.label }}</th>
         <th class="text-nowrap">{{ form.problems.vars.prototype.lazyEvalResults.vars.label }}</th>
         <th></th>
@@ -172,6 +173,10 @@
             <td>
                 {{ form_errors(problem.allowJudge) }}
                 {{ form_widget(problem.allowJudge, {label: false}) }}
+            </td>
+            <td>
+                {{ form_errors(problem.verificationRequired) }}
+                {{ form_widget(problem.verificationRequired, {label: false}) }}
             </td>
             <td>
                 {{ form_errors(problem.color) }}

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -141,10 +141,10 @@
     <thead>
     <tr>
         <th>{{ form.problems.vars.prototype.problem.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.shortname.vars.label }}</th>
+        <th>{{ form.problems.vars.prototype.shortname.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.points.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.allowSubmit.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.allowJudge.vars.label }}</th>
+        <th>{{ form.problems.vars.prototype.allowSubmit.vars.label | replace({" ":"<br>"}) | raw }}</th>
+        <th>{{ form.problems.vars.prototype.allowJudge.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.color.vars.label }}</th>
         <th class="text-nowrap">{{ form.problems.vars.prototype.lazyEvalResults.vars.label }}</th>
         <th></th>


### PR DESCRIPTION
This allows for checking of the results and already allowing for some problems when enough submissions have come in.

As suggested by @mkfuron in https://domjudge-org.slack.com/archives/CHHURFUM7/p1779496255283309

That discussion also had other options by @mpsijm which I think are different ways of looking at the problem so I suspect we should support both (or neither?).

Also added some minor fixes:
<img width="1936" height="279" alt="image" src="https://github.com/user-attachments/assets/13c53d0c-79d9-4bd4-aafe-5bebf80b40f3" />
