### PR TITLE
Remove redundant right hand check

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1074,7 +1074,7 @@ EOF;
             return $text;
         }
         $ret = preg_match_all("/[0-9A-Fa-f]{2}/", $col, $m);
-        if (!($ret && count($m[0]))) {
+        if (!$ret) {
             return $text;
         }
 


### PR DESCRIPTION
In case of failure:
the $ret would be false
-> skipping the if

In case of success:
having 0 matches, the $ret would be 0 which is truthy as false -> skipping the if
having 1+ matches, the $ret would be 1+ which is truthy as true -> passing the if

The extra check on the number of matches is already handled by the returned int.

This was found by the PHPStan upgrade in https://github.com/DOMjudge/domjudge/pull/3693