### PR TITLE
Contest overview small improvements

### DIFF
--- a/webapp/src/Form/Type/ContestProblemType.php
+++ b/webapp/src/Form/Type/ContestProblemType.php
@@ -53,7 +53,7 @@ class ContestProblemType extends AbstractType
             'label' => 'Colour',
             'attr' => [
                 'data-color-picker' => '',
-                'size' => 6,
+                'size' => 8,
             ],
         ]);
         $builder->add('lazyEvalResults', ChoiceType::class, [

--- a/webapp/templates/jury/partials/contest_form.html.twig
+++ b/webapp/templates/jury/partials/contest_form.html.twig
@@ -141,10 +141,10 @@
     <thead>
     <tr>
         <th>{{ form.problems.vars.prototype.problem.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.shortname.vars.label }}</th>
+        <th>{{ form.problems.vars.prototype.shortname.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.points.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.allowSubmit.vars.label }}</th>
-        <th>{{ form.problems.vars.prototype.allowJudge.vars.label }}</th>
+        <th>{{ form.problems.vars.prototype.allowSubmit.vars.label | replace({" ":"<br>"}) | raw }}</th>
+        <th>{{ form.problems.vars.prototype.allowJudge.vars.label | replace({" ":"<br>"}) | raw }}</th>
         <th>{{ form.problems.vars.prototype.color.vars.label }}</th>
         <th class="text-nowrap">{{ form.problems.vars.prototype.lazyEvalResults.vars.label }}</th>
         <th></th>


### PR DESCRIPTION
When working on https://github.com/DOMjudge/domjudge/pull/3695 I found some small fixes, as that PR will need a bit of extra work it made sense to PR the unrelated changes independently. 

After:
<img width="1936" height="279" alt="image" src="https://github.com/user-attachments/assets/13c53d0c-79d9-4bd4-aafe-5bebf80b40f3" />

Before:
<img width="1774" height="1059" alt="image" src="https://github.com/user-attachments/assets/75470725-ea72-4706-b971-1f026ec0de8c" />
