### PR TITLE
Make testcase retries safe and reclaim testcase cache under disk pressure

### DIFF
--- a/judge/judgedaemon.main.php
+++ b/judge/judgedaemon.main.php
@@ -1127,6 +1127,22 @@ class JudgeDaemon
     }
 
     /**
+     * Recreate the result directory for a testcase attempt.
+     *
+     * A task can be returned and fetched again by the same judgedaemon. Never
+     * reuse output, feedback, or hardlinks from an earlier attempt.
+     */
+    private function resetTestcaseDirectory(string $testcasedir): bool
+    {
+        if ((file_exists($testcasedir) || is_link($testcasedir)) &&
+            !$this->runCommandSafe(['rm', '-rf', '--', $testcasedir])) {
+            return false;
+        }
+
+        return mkdir($testcasedir, 0755, true);
+    }
+
+    /**
      * Recursively adjust permission bits of $path and everything below it,
      * like `chmod -R`: the bits in $add are turned on, the bits in $remove are
      * turned off, all other bits (including setuid/setgid/sticky) are left
@@ -2435,6 +2451,10 @@ class JudgeDaemon
         $input = $tcfile['input'];
         $output = $tcfile['output'];
         $passLimit = $run_config['pass_limit'];
+        if (!$this->resetTestcaseDirectory($testcasedir)) {
+            error("Could not reset testcase result directory '$testcasedir'.");
+        }
+
         // All of those are to help PHPStan, it seems to not see that they are defined in the loop
         // and the loop always runs as tpassLimit >= $passCnt.
         $score = "";

--- a/judge/tests/Unit/TestcaseDirectoryResetTest.php
+++ b/judge/tests/Unit/TestcaseDirectoryResetTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace DOMjudge\Tests\Unit;
+
+use DOMjudge\JudgeDaemon;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+class TestcaseDirectoryResetTest extends TestCase
+{
+    private ?JudgeDaemon $daemon = null;
+    private ?ReflectionMethod $resetMethod = null;
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $reflection = new ReflectionClass(JudgeDaemon::class);
+        $this->daemon = $reflection->newInstanceWithoutConstructor();
+        $this->resetMethod = $reflection->getMethod('resetTestcaseDirectory');
+
+        $this->tempDir = sys_get_temp_dir() . '/domjudge-test-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            exec('rm -rf ' . escapeshellarg($this->tempDir));
+        }
+    }
+
+    private function resetTestcaseDirectory(string $path): bool
+    {
+        return $this->resetMethod->invoke($this->daemon, $path);
+    }
+
+    public function testRepeatedSetupRemovesPreviousHardlinksAndOutput(): void
+    {
+        $compileDir = $this->tempDir . '/compile';
+        mkdir($compileDir, 0755, true);
+        file_put_contents($compileDir . '/program', 'compiled program');
+
+        $testcaseDir = $this->tempDir . '/testcase00001';
+        $programDir = $testcaseDir . '/1/execdir';
+        mkdir($programDir, 0755, true);
+        link($compileDir . '/program', $programDir . '/program');
+        file_put_contents($testcaseDir . '/1/program.out', 'stale output');
+        mkdir($testcaseDir . '/1/feedback', 0755, true);
+        file_put_contents(
+            $testcaseDir . '/1/feedback/judgemessage.txt',
+            'stale feedback'
+        );
+
+        $this->assertSame(
+            fileinode($compileDir . '/program'),
+            fileinode($programDir . '/program')
+        );
+
+        $this->assertTrue($this->resetTestcaseDirectory($testcaseDir));
+        $this->assertDirectoryExists($testcaseDir);
+        $this->assertFileDoesNotExist($testcaseDir . '/1/program.out');
+        $this->assertFileDoesNotExist(
+            $testcaseDir . '/1/feedback/judgemessage.txt'
+        );
+
+        $programDir = $testcaseDir . '/1/execdir';
+        mkdir($programDir, 0755, true);
+        link($compileDir . '/program', $programDir . '/program');
+        $this->assertFileExists($programDir . '/program');
+        $this->assertSame(
+            fileinode($compileDir . '/program'),
+            fileinode($programDir . '/program')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes judgedaemon testcase retries safe after interrupted attempts and allows the low-disk cleanup path to reclaim the derived testcase cache before disabling the judgehost.

## Problem

### Testcase data accumulates across contests

Each judgehost stores fetched testcase input and answer files under:

```text
<endpoint workdir>/testcase/
```

Long-running DOMjudge installations may reuse the same deployment and judgehost work directories across multiple contests. A judgehost keeps every testcase it has fetched, so this directory becomes an aggregate cache of testdata from all contests served by that judgehost.

The existing automatic low-disk cleanup removes numeric submission and judging directories. Historical testdata under `<endpoint workdir>/testcase/` remains on disk and can become the dominant disk consumer while the cleanup path reclaims little space.

### Disk pressure can leave a partial testcase attempt

Running a testcase creates a result directory containing pass directories, feedback, output, and hardlinks to the compiled submission. If a later operation fails with `ENOSPC`, or another non-fatal filesystem error, the current attempt can fail after some of those paths have already been created.

The judging task can then remain unfinished and be returned to the queue. The judgedaemon process stays alive, while its partial testcase result directory remains in the judging work directory.

### Retrying the task reuses the partial directory

The same judgedaemon process can subsequently receive the unfinished task and reuse its work directory, testcase path, and pass path. Files created by the previous attempt remain in place.

Setup operations such as `mkdir()` and hardlink creation then encounter paths left by the previous attempt. Some of these collisions call `error()`, turning a recoverable testcase failure into termination of the entire judgedaemon.

The resulting sequence is:

```text
testdata accumulates across contests
    -> disk pressure causes a partial testcase attempt
    -> the unfinished task is returned and assigned again
    -> the retry collides with files from the previous attempt
    -> judgedaemon exits
```

## Reproduction

The issue was reproduced using a stock `main` judgedaemon in Docker with a 160 MiB tmpfs mounted as its judging directory.

Three testcase answer files of approximately 50, 40, and 40 MiB were used:

1. The first two testcases completed successfully and remained in the testcase cache.
2. The third testcase was downloaded successfully.
3. Copying its answer file into the testcase result directory failed with `ENOSPC`.

The judgedaemon process remained alive:

```text
judgedaemon[51]: Running testcase 70...
judgedaemon[51]: Fetched new testcase 70.
copy(): Write of 8192 bytes failed with errno=28 No space left on device
judgedaemon[51]: Could not copy .../testcase/70/...out
    to .../5/5/testcase00070/1/testdata.out
```

The unfinished testcase was then returned to the queue without restarting the container or modifying the work directory.

The same judgedaemon PID received it again:

```text
judgedaemon[51]: Received 1 'judging_run' judge tasks
judgedaemon[51]: Working directory: .../5/5
judgedaemon[51]: Running testcase 70...
mkdir(): File exists
judgedaemon[51]: error: Could not create directory
    '.../5/5/testcase00070/1/execdir'
```

The judgedaemon then exited with status 1.

## Changes

### Recreate testcase result directories

Before executing a testcase, its result directory is removed and recreated.

The reset removes derived data left by an earlier attempt, including:

- pass directories;
- program output and metadata;
- validator feedback;
- hardlinks to compiled files.

Failure to remove or recreate the directory remains fatal. The existing testcase setup failure handling is otherwise unchanged.

This per-attempt reset does not clear fetched testcase data, executable caches, or compilation caches.

### Reclaim testcase cache on low disk space

The low-disk cleanup order is now:

1. Remove eligible numeric judging directories.
2. Log the judging-directory cleanup result and check available space again.
3. If space is still below `diskspace_error`, clear the endpoint testcase cache.
4. Recreate the testcase cache root as a real directory with `0700` permissions.
5. Check available space again.
6. If space is still insufficient, use the existing internal-error and judgehost-disable behavior.

The testcase cache contains derived data and is rebuilt automatically by `fetchTestcase()` when needed.

Normal operation retains the testcase cache. Under disk pressure, cleanup can reclaim stale testdata accumulated across previous contests.

Automatic cleanup remains disabled in `--diskspace-error` mode.

Cache removal or recreation failures are reported to the existing warning path. The final low-disk check still determines whether the judgehost is disabled.

## Tests

The following cases are covered by unit tests:

- stale output, feedback, and hardlinks are removed before retrying a testcase;
- a testcase directory can be prepared again after an earlier attempt;
- clearing the testcase cache leaves numeric judging directories intact;
- the cache root is recreated with `0700` permissions;
- a missing cache is created with `0700` permissions;
- replacing a cache symlink leaves its target intact and creates a real cache directory.

Static validation performed:

```shell
php -l judge/judgedaemon.main.php
php -l judge/tests/Unit/TestcaseCacheCleanupTest.php
git diff --check
```

## Compatibility

- No DOMserver changes.
- No REST API changes.
- No task identity or deduplication changes.
- No change to normal successful testcase cleanup.
- Testcase cache misses continue to use the existing download path.