### PR TITLE
Fix Yarn dependency installation recipes

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -63,14 +63,14 @@ fi
 endef
 
 node-dependencies:
-	${ \
+	@{ \
 		$(detect_yarn); \
 		$$YARN_CMD install; \
 		$(yarn_licenses_warn); \
 	}
 
 node-dependencies-dist:
-	${ \
+	@{ \
 		$(detect_yarn); \
 		$$YARN_CMD install; \
 		$(yarn_licenses_strict); \


### PR DESCRIPTION
The node dependency recipes used `${ ... }` to group their shell commands. GNU Make treats `${foo}` as a variable reference [1].

It therefore parsed the whole block as an undefined variable and expanded it to an empty command, so both dependency targets returned successfully without running Yarn.

This left `node_modules` absent and caused symlinked frontend assets such as Monaco and jQuery to return 404 responses.

Use `@{ ... }` to execute the commands as a shell group. GNU Make uses the leading `@` to suppress echoing and discards it before passing the recipe to the shell [2]. This ensures that development and distribution dependency installs run Yarn and perform their respective license checks.

[1]: https://www.gnu.org/software/make/manual/html_node/Reference.html
[2]: https://www.gnu.org/software/make/manual/html_node/Echoing.html