### PR TITLE
Retrieve the externalId from the select statement for submissions too

### DIFF
--- a/webapp/src/Controller/Jury/ContestController.php
+++ b/webapp/src/Controller/Jury/ContestController.php
@@ -777,8 +777,8 @@ class ContestController extends BaseController
                                   Utils::printtime($contest->getEndtime(), 'Y-m-d H:i:s (T)'));
         }
 
-        /** @var int[] $submissionIds */
-        $submissionIds = array_map(fn(array $data) => $data['submitid'], $this->em->createQueryBuilder()
+        /** @var string[] $submissionIds */
+        $submissionIds = array_map(fn(array $data) => $data['externalid'], $this->em->createQueryBuilder()
             ->from(Submission::class, 's')
             ->join('s.judgings', 'j', Join::WITH, 'j.valid = 1')
             ->select('s.externalid')
@@ -795,7 +795,7 @@ class ContestController extends BaseController
             $blockers[] = 'Unjudged submissions found: ' . implode(', ', $submissionIds);
         }
 
-        /** @var int[] $clarificationIds */
+        /** @var string[] $clarificationIds */
         $clarificationIds = array_map(fn(array $data) => $data['externalid'], $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
             ->select('clar.externalid')
             ->andWhere('clar.answered = false')

--- a/webapp/src/DataFixtures/Test/UnjudgedSubmissionFixture.php
+++ b/webapp/src/DataFixtures/Test/UnjudgedSubmissionFixture.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace App\DataFixtures\Test;
+
+use App\Entity\Contest;
+use App\Entity\ContestProblem;
+use App\Entity\Judging;
+use App\Entity\Language;
+use App\Entity\Submission;
+use App\Entity\Team;
+use App\Utils\Utils;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * A valid submission whose valid judging has no result yet, i.e. one that
+ * blocks finalizing the contest.
+ */
+class UnjudgedSubmissionFixture extends AbstractTestDataFixture
+{
+    final public const EXTERNAL_ID = 'unjudged-1';
+
+    public function load(ObjectManager $manager): void
+    {
+        /** @var Contest $contest */
+        $contest = $manager->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        /** @var ContestProblem $problem */
+        $problem = $contest->getProblems()->filter(
+            fn(ContestProblem $problem) => $problem->getShortname() === 'A'
+        )->first();
+
+        $submission = (new Submission())
+            ->setExternalid(static::EXTERNAL_ID)
+            ->setContest($contest)
+            ->setTeam($manager->getRepository(Team::class)->findOneBy(['name' => 'Example teamname']))
+            ->setContestProblem($problem)
+            ->setLanguage($manager->getRepository(Language::class)->findByExternalId('cpp'))
+            ->setSubmittime(Utils::toEpochFloat('2021-01-01 12:34:56'));
+        $judging = (new Judging())
+            ->setContest($contest)
+            ->setSubmission($submission)
+            ->setStarttime(Utils::toEpochFloat('2021-01-01 12:34:56'));
+        $submission->addJudging($judging);
+
+        $manager->persist($submission);
+        $manager->persist($judging);
+        $manager->flush();
+
+        $this->addReference(sprintf('%s:0', static::class), $submission);
+    }
+}

--- a/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ContestControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Controller\Jury;
 
+use App\DataFixtures\Test\UnjudgedSubmissionFixture;
 use App\Entity\Contest;
 use App\Entity\ContestProblemsetContent;
 use App\Entity\JudgeTask;
@@ -740,5 +741,28 @@ class ContestControllerTest extends JuryControllerTestCase
         $this->verifyPageResponse('GET', $deleteUrl, 200);
         $crawler = $this->getCurrentCrawler();
         self::assertStringStartsWith('Delete contest ', $crawler->filter('h1')->text());
+    }
+
+    public function testFinalizeBlockerShowsUnjudgedSubmissionExternalId(): void
+    {
+        $this->roles = ['admin'];
+        $this->logOut();
+        $this->logIn();
+        $this->loadFixture(UnjudgedSubmissionFixture::class);
+
+        $this->verifyPageResponse('GET', '/jury/contests/demo/finalize', 200);
+        $blockers = $this->getCurrentCrawler()
+            ->filter('.alert-danger li')
+            ->each(fn(Crawler $node) => $node->text());
+
+        $unjudgedBlockers = array_values(array_filter(
+            $blockers,
+            fn(string $blocker) => str_starts_with($blocker, 'Unjudged submissions found:')
+        ));
+        self::assertCount(1, $unjudgedBlockers, implode("\n", $blockers));
+        self::assertSame(
+            'Unjudged submissions found: ' . UnjudgedSubmissionFixture::EXTERNAL_ID,
+            $unjudgedBlockers[0]
+        );
     }
 }


### PR DESCRIPTION
Commit 909f5491 fixed this for clarifications, but the identical bug sits 15 lines above it in the same method: the query selects `s.externalid`, so Doctrine returns rows keyed `externalid`, while the mapper still read `$data['submitid']`.

The result was an undefined array key warning per unjudged submission and a `null` for each id, so the finalize page showed:

```
    Unjudged submissions found: , ,
```

Both were introduced by cf86a1849 when the UI moved to external IDs.