### PR TITLE
Restore clarification visibility lost in the QueryBuilder extraction

### DIFF
--- a/webapp/src/Controller/Jury/ClarificationController.php
+++ b/webapp/src/Controller/Jury/ClarificationController.php
@@ -14,7 +14,6 @@ use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -167,7 +166,7 @@ class ClarificationController extends BaseController
         $lastClarification = end($clarificationList);
         $formData['message'] = "> " . str_replace("\n", "\n> ", Utils::wrapUnquoted($lastClarification->getBody())) . "\n\n";
 
-        $form = $this->createForm(JuryClarificationType::class, $formData, ['limit_to_team' => $clarification->getSender(), 'clarid' => $id]);
+        $form = $this->createForm(JuryClarificationType::class, $formData, ['limit_to_team' => $clarification->getSender(), 'clarid' => $id, 'contestId' => $contestId]);
 
         $form->handleRequest($request);
 
@@ -245,7 +244,7 @@ class ClarificationController extends BaseController
 
         $parameters['queues'] = $queues;
         $parameters['answers'] = $clarificationAnswers;
-        $parameters['jurymember'] = $this->clarificationService->getQueryBuilder(externalClarificationId: $clarification->getExternalid())
+        $parameters['jurymember'] = $this->clarificationService->getQueryBuilder(externalContestId: $contestId, externalClarificationId: $clarification->getExternalid())
             ->select('clar.jury_member')
             ->getQuery()
             ->getSingleResult()['jury_member'];
@@ -274,7 +273,7 @@ class ClarificationController extends BaseController
             $formData['recipient'] = $teamto;
         }
 
-        $form = $this->createForm(JuryClarificationType::class, $formData);
+        $form = $this->createForm(JuryClarificationType::class, $formData, ['contestId' => $contestId]);
 
         $form->handleRequest($request);
 

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -18,7 +18,6 @@ use App\Service\SubmissionService;
 use App\Twig\TwigExtension;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -16,7 +16,6 @@ use App\Service\EventLogService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -77,7 +76,11 @@ class ClarificationController extends BaseController
         }
 
         /** @var Clarification[] $clarifications */
-        $clarifications = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid(), problem: strval($problem->getProbid()))
+        $clarifications = $this->clarificationService->getQueryBuilder(
+            externalContestId: $contest->getExternalid(),
+            problem: strval($problem->getProbid()),
+            onlyForRecipientTeam: true,
+            recipientTeamId: $teamId)
             ->select('clar', 'p')
             // Needed to filter out team clarification requests.
             ->andWhere('clar.sender IS NULL')

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -95,7 +95,10 @@ class MiscController extends BaseController
                 paginated: false
             )[0];
 
-            $qb = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+            $qb = $this->clarificationService->getQueryBuilder(
+                externalContestId: $contest->getExternalid(),
+                onlyForRecipientTeam: true,
+                recipientTeamId: $teamId)
                 ->select('clar', 'p')
                 // Needed to filter out team clarification requests.
                 ->andWhere('clar.sender IS NULL')

--- a/webapp/src/Form/Type/JuryClarificationType.php
+++ b/webapp/src/Form/Type/JuryClarificationType.php
@@ -24,9 +24,6 @@ class JuryClarificationType extends AbstractType
 {
     public const RECIPIENT_MUST_SELECT = 'domjudge-must-select';
 
-    /** @var string The clarification entity id if the entity exists in the database */
-    private $clarid;
-
     public function __construct(
         private readonly AuthorizedUserService $authService,
         private readonly EntityManagerInterface $em,
@@ -36,7 +33,11 @@ class JuryClarificationType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $this->clarid = $options['clarid'];
+        // Form types are shared services, so keep the per-form options in local
+        // variables and hand them to the validation callback below instead of
+        // storing them on `$this`.
+        $clarid = $options['clarid'];
+        $contestId = $options['contestId'];
         $recipientOptions = [
             '(select...)' => static::RECIPIENT_MUST_SELECT,
             'ALL' => '',
@@ -124,7 +125,11 @@ class JuryClarificationType extends AbstractType
 
         $builder->add('jurymember', HiddenType::class, [
             'constraints' => [
-                new Callback($this->checkJuryMember(...))
+                new Callback(
+                    function (mixed $value, ExecutionContextInterface $context) use ($clarid, $contestId): void {
+                        $this->checkJuryMember($value, $context, $clarid, $contestId);
+                    }
+                )
             ]
         ]);
     }
@@ -133,6 +138,7 @@ class JuryClarificationType extends AbstractType
     {
         $resolver->setDefault('limit_to_team', null);
         $resolver->setDefault('clarid', null);
+        $resolver->setDefault('contestId', null);
     }
 
     private function getTeamLabel(Team $team): string
@@ -144,10 +150,14 @@ class JuryClarificationType extends AbstractType
         return sprintf('%s (%s)', $team->getEffectiveName(), $team->getExternalId());
     }
 
-    public function checkJuryMember(mixed $value, ExecutionContextInterface $context, mixed $payload): void
-    {
-        if ($this->clarid) {
-            $juryMember = $this->clarificationService->getQueryBuilder(externalClarificationId: $this->clarid)
+    public function checkJuryMember(
+        mixed $value,
+        ExecutionContextInterface $context,
+        ?string $clarid,
+        ?string $contestId
+    ): void {
+        if ($clarid) {
+            $juryMember = $this->clarificationService->getQueryBuilder(externalContestId: $contestId, externalClarificationId: $clarid)
                 ->select('clar.jury_member')
                 ->getQuery()
                 ->getSingleResult()['jury_member'];

--- a/webapp/src/Service/ClarificationService.php
+++ b/webapp/src/Service/ClarificationService.php
@@ -76,9 +76,21 @@ readonly class ClarificationService
             ->getResult();
     }
 
+    /**
+     * Build a query for the clarifications the current user is allowed to see.
+     *
+     * Team facing pages should pass `onlyForRecipientTeam` so that they keep
+     * showing what the team sees: jury and admin users are exempt from the
+     * visibility restriction below, and would otherwise see the clarifications
+     * addressed to every other team on their own team pages. A null
+     * `recipientTeamId` then limits the result to clarifications sent to
+     * everyone.
+     */
     public function getQueryBuilder(?string $externalContestId = null, ?int $internalContestId = null,
                                     ?string $externalClarificationId = null,
-                                    ?string $problem = null
+                                    ?string $problem = null,
+                                    bool $onlyForRecipientTeam = false,
+                                    ?int $recipientTeamId = null
     ): QueryBuilder {
         $queryBuilder = $this->em->createQueryBuilder()
             ->from(Clarification::class, 'clar')
@@ -106,7 +118,14 @@ readonly class ClarificationService
                 ->setParameter('clarification', $externalClarificationId);
         }
 
-        if (!$this->authService->checkRole('api_reader') &&
+        // Staff handling clarifications sees every clarification. Note that
+        // `clarification_rw` is implied by `jury` (and therefore by `api_reader`),
+        // but can also be granted on its own to someone who only answers
+        // clarifications and has no other jury permissions.
+        $isClarificationStaff = $this->authService->checkRole('api_reader') ||
+            $this->authService->checkRole('clarification_rw');
+
+        if (!$isClarificationStaff &&
             !$this->authService->checkRole('judgehost')) {
             if ($this->authService->checkRole('team')) {
                 $queryBuilder
@@ -119,15 +138,21 @@ readonly class ClarificationService
             }
         }
 
-        if (!$this->authService->checkRole('api_reader')) {
+        if (!$isClarificationStaff) {
             $queryBuilder
-                // For non-API-reader users, only expose the problems after the contest has started.
+                // For non-staff users, only expose the problems after the contest has started.
                 // `WF Access Policy` allows for clarifications before the contest, but not to disclose the problem
                 // so referencing them in clarifications would violate referential integrity.
                 ->andWhere('c.starttime < :now OR clar.problem IS NULL')
                 ->setParameter('now', Utils::now())
                 // Don't display future clarifications to non-jury users.
                 ->andWhere('clar.submittime <= :now');
+        }
+
+        if ($onlyForRecipientTeam) {
+            $queryBuilder
+                ->andWhere('clar.recipient IS NULL OR clar.recipient = :recipientTeam')
+                ->setParameter('recipientTeam', $recipientTeamId);
         }
 
         if (!is_null($problem)) {

--- a/webapp/src/Service/DOMJudgeService.php
+++ b/webapp/src/Service/DOMJudgeService.php
@@ -6,7 +6,6 @@ use App\DataTransferObject\ContestStatus;
 use App\Doctrine\DBAL\Types\JudgeTaskType;
 use App\Entity\AssetEntityInterface;
 use App\Entity\AuditLog;
-use App\Entity\Clarification;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Executable;
@@ -1154,16 +1153,17 @@ class DOMJudgeService
                 $samples[$sample['probid']] = $sample['numsamples'];
             }
 
-            $raw_clars = $this->clarificationService->getQueryBuilder(externalContestId: $contest->getExternalid())
+            $raw_clars = $this->clarificationService->getQueryBuilder(
+                externalContestId: $contest->getExternalid(),
+                // Only clars send to all teams or just this team.
+                // Even for jury/admin we don't want to show all clarifications to all teams.
+                onlyForRecipientTeam: true,
+                recipientTeamId: $teamId)
                 ->select('clar')
                 // Only clars associated with a problem.
                 ->andWhere('clar.problem IS NOT NULL')
                 // Only clars send from the jury.
                 ->andWhere('clar.sender IS NULL')
-                // Only clars send to all teams or just this team.
-                // Even for jury/admin we don't want to show all clarifications to all teams
-                ->andWhere('clar.recipient IS NULL OR clar.recipient = :teamid')
-                ->setParameter('teamid', $teamId)
                 ->orderBy('clar.submittime', 'DESC')
                 ->getQuery()
                 ->getResult();

--- a/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
+++ b/webapp/tests/Unit/Controller/Jury/ClarificationControllerTest.php
@@ -4,7 +4,9 @@ namespace App\Tests\Unit\Controller\Jury;
 
 use App\DataFixtures\Test\ClarificationFixture;
 use App\Entity\Clarification;
+use App\Entity\Contest;
 use App\Tests\Unit\BaseTestCase;
+use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 
 class ClarificationControllerTest extends BaseTestCase
@@ -119,5 +121,67 @@ class ClarificationControllerTest extends BaseTestCase
                                          'Technical issue');
         self::assertSelectorTextContains('div.card-text',
                                          'This is a clarification');
+    }
+
+    /**
+     * Test that a user with only the clarification_rw role sees the team
+     * clarifications, and not just the general ones.
+     */
+    public function testClarificationHandlerSeesTeamClarifications(): void
+    {
+        $this->roles = ['clarification_rw'];
+        $this->logOut();
+        $this->logIn();
+        $this->loadFixture(ClarificationFixture::class);
+
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications', 200);
+        self::assertSelectorTextContains('h2#newrequests ~ div.table-wrapper', 'Is it necessary to');
+        self::assertSelectorTextContains('h2#oldrequests ~ div.table-wrapper', 'What is 2+2?');
+
+        /** @var Clarification $clar */
+        $clar = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(Clarification::class)->findOneBy(['body' => 'What is 2+2?']);
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications/' . $clar->getExternalid(), 200);
+        self::assertSelectorTextContains('div.card-text', 'What is 2+2?');
+    }
+
+    /**
+     * External clarification ids are only unique per contest, so a second
+     * contest may reuse one. Looking one up must stay scoped to its contest.
+     */
+    public function testClarificationRequestViewWithExternalIdReusedByOtherContest(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $demo = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+
+        // External ids are assigned from the internal id unless they are set
+        // explicitly, which is what an external CCS or the API does.
+        $em->persist((new Clarification())
+            ->setExternalid('shared-id')
+            ->setContest($demo)
+            ->setSubmittime(Utils::now())
+            ->setJuryMember('admin')
+            ->setBody('This one belongs to the demo contest')
+            ->setAnswered(true));
+
+        $otherContest = (new Contest())
+            ->setExternalid('other')
+            ->setName('Other contest')
+            ->setShortname('other')
+            ->setStarttimeString('2021-07-17 16:09:00 Europe/Amsterdam')
+            ->setEndtimeString('2021-07-17 16:11:00 Europe/Amsterdam');
+        $em->persist($otherContest);
+        $em->persist((new Clarification())
+            ->setExternalid('shared-id')
+            ->setContest($otherContest)
+            ->setSubmittime(Utils::now())
+            ->setJuryMember('admin')
+            ->setBody('This one belongs to the other contest')
+            ->setAnswered(true));
+        $em->flush();
+
+        $this->verifyPageResponse('GET', '/jury/contests/demo/clarifications/shared-id', 200);
+        self::assertSelectorTextContains('div.card-text', 'This one belongs to the demo contest');
     }
 }

--- a/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
+++ b/webapp/tests/Unit/Controller/Team/MiscControllerTest.php
@@ -3,8 +3,12 @@
 namespace App\Tests\Unit\Controller\Team;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use App\Entity\Clarification;
 use App\Entity\Contest;
+use App\Entity\Problem;
+use App\Entity\Team;
 use App\Tests\Unit\BaseTestCase;
+use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -193,5 +197,41 @@ class MiscControllerTest extends BaseTestCase
         $this->verifyPageResponse('GET', '/team', 200);
 
         self::assertSelectorNotExists('a:contains("Docs")');
+    }
+
+    /**
+     * Jury and admin users are not restricted by the clarification query
+     * builder, but their own team page should still only show the
+     * clarifications their team is allowed to see.
+     */
+    public function testTeamOverviewHidesClarificationsForOtherTeams(): void
+    {
+        // `team` is needed to reach /team at all, `admin` to be exempt from the
+        // restriction the clarification query builder applies to teams: that
+        // exemption is exactly what this page has to compensate for.
+        $this->roles = ['admin', 'team'];
+        $this->logOut();
+        $this->logIn();
+
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $otherTeam = $em->getRepository(Team::class)->findOneBy(['name' => 'DOMjudge']);
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => 'hello']);
+
+        $clarification = (new Clarification())
+            ->setExternalid('for-the-other-team')
+            ->setContest($contest)
+            ->setSubmittime(Utils::now())
+            ->setRecipient($otherTeam)
+            ->setJuryMember('admin')
+            ->setProblem($problem)
+            ->setBody('This message is only meant for the other team')
+            ->setAnswered(true);
+        $em->persist($clarification);
+        $em->flush();
+
+        $this->verifyPageResponse('GET', '/team', 200);
+        self::assertSelectorTextNotContains('body', 'This message is only meant for the other team');
     }
 }


### PR DESCRIPTION
Extracting the clarification QueryBuilder into ClarificationService moved three decisions into one place, and each of them regressed a caller.

The role check only exempted `api_reader` and `judgehost`. But the jury clarification pages are guarded by `ROLE_CLARIFICATION_RW`, which is a role of its own ("Clarification handler"): it is implied by `jury`, yet it can also be granted on its own, and then it implies neither `jury` nor `api_reader`. Such a user fell through to the public-only branch, so `/jury/clarifications` showed no team requests at all -- the one thing the role exists for -- and the `jury_member` lookup, which uses `getSingleResult()`, threw a NoResultException on the detail page.

The `jury_member` lookup in the jury controller used to select on `clar.clarid`, which is globally unique. It now selects on the external id, which is only unique per `(cid, externalid)`, without passing a contest, so a second contest reusing an external id turns it into a NonUniqueResultException. External ids are derived from the internal id unless they are set explicitly, so this needs an external CCS or the API to trigger, but both do exactly that. Pass the contest at both call sites; the form type gets a `contestId` option for this, which the compose action passes as well even though it has no clarification to look up.

The two team pages dropped `recipient = :team OR recipient IS NULL` and relied on the query builder instead. That works for teams, but jury and admin users are exempt from the restriction, so a jury member with a team saw the clarifications addressed to every other team on their own team page. Rather than repeat the condition on every team facing page, the query builder grows an `onlyForRecipientTeam` argument, which is what getTwigDataForProblemsAction() was open coding already.

While here, take the clarification id and the contest id out of the form type's instance state. Form types are shared services, so options belonging to one form must not be stashed on `$this`; hand them to the validation callback through the closure instead.

Also drop the Expr\Join and Clarification imports that the extraction left unused.