### PR TITLE
Render every hex notation the color parser accepts.

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1073,26 +1073,10 @@ EOF;
         if (is_null($col)) {
             return $text;
         }
-        $ret = preg_match_all("/[0-9A-Fa-f]{2}/", $col, $m);
-        if (!$ret) {
-            return $text;
-        }
 
-        $m = current($m);
-        switch (count($m)) {
-            case 4:
-                // We also have opacity; load that and use
-                // RGB of case 3
-                $opacity = hexdec(array_pop($m));
-                // no-break
-            case 3:
-                $vals   = array_map(hexdec(...), $m);
-                $vals[] = $opacity;
+        [$red, $green, $blue] = Utils::parseHexColor($col);
 
-                return "rgba(" . implode(",", $vals) . ")";
-        }
-
-        return $text;
+        return sprintf('rgba(%d,%d,%d,%s)', $red, $green, $blue, $opacity);
     }
 
     #[AsTwigFilter('tsvField')]

--- a/webapp/tests/Unit/Twig/TwigExtensionTest.php
+++ b/webapp/tests/Unit/Twig/TwigExtensionTest.php
@@ -9,6 +9,8 @@ use App\Service\EventLogService;
 use App\Service\SubmissionService;
 use App\Twig\TwigExtension;
 use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -63,5 +65,34 @@ class TwigExtensionTest extends TestCase
 
         self::assertStringNotContainsString('<img', $html);
         self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+    /**
+     * Every notation Utils::convertToHex() accepts must render, including the
+     * one and three digits per channel forms.
+     */
+    #[DataProvider('provideHexColorToRGBA')]
+    public function testHexColorToRGBA(string $color, float $opacity, string $expected): void
+    {
+        self::assertSame($expected, $this->twigExtension->hexColorToRGBA($color, $opacity));
+    }
+
+    public static function provideHexColorToRGBA(): Generator
+    {
+        // The same colour in one, two and three hex digits per channel.
+        yield ['#abc', 1, 'rgba(170,187,204,1)'];
+        yield ['#aabbcc', 1, 'rgba(170,187,204,1)'];
+        yield ['#aaabbbccc', 1, 'rgba(170,187,204,1)'];
+
+        // The opacity is the caller's to decide, the colour carries none.
+        yield ['#aabbcc', 0, 'rgba(170,187,204,0)'];
+        yield ['#aabbcc', 0.5, 'rgba(170,187,204,0.5)'];
+
+        // Colour names go through the same path.
+        yield ['firebrick', 1, 'rgba(178,34,34,1)'];
+
+        // Anything convertToHex() rejects is passed through untouched.
+        yield ['doesnotexist', 1, 'doesnotexist'];
+        yield ['#aabbccdd', 1, '#aabbccdd'];
     }
 }


### PR DESCRIPTION
`hexColorToRGBA` pulled the channels out of the hex string by grabbing two digit pairs with `preg_match_all`, which only lines up with one of the three notations `Utils::convertToHex()` returns. That helper accepts one, two or three hex digits per channel (`#abc`, `#aabbcc`, `#aaabbbccc`), so:

*  `#abc`: one pair matched, no case in the switch, the colour was
               returned unchanged and the gradient built from it in
               scoreboard_category_color.css.twig silently did not render
 * `#aaabbbccc`   four pairs matched, so the channels were read as `aa`, `ab`
               and `bb` -- shifted by a digit -- and the leftover `cc` was
               taken for an opacity, as a 0..255 number where CSS wants
               0..1, which then also overrode the opacity the caller asked
               for

Only `#aabbcc` came out right. Use `Utils::parseHexColor()`, which already scales all three notations to 0..255 and is what the rest of the colour handling uses.

This drops the fourth channel as an opacity. Nothing could reach it as one: `convertToHex()` rejects `#RRGGBBAA` -- as its tests assert -- so a fourth pair only ever came from misreading the nine digit form. Supporting CSS alpha notations would mean widening that helper first.