### PR TITLE
Prevent stored XSS when rendering execution metadata

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,3 +73,4 @@ Special thanks go to the following people for researching and
 responsibly disclosing a security vulnerability in DOMjudge:
 * Atsutoshi Kikuchi
 * Aidan Stephenson
+* teddyctf

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -1108,13 +1108,13 @@ EOF;
         $metadata = $this->dj->parseMetadata($metadata);
         return '<span style="display:inline; margin-left: 5px;">'
             . '<i class="fas fa-stopwatch" title="runtime"></i> '
-            . $metadata['cpu-time'] . 's CPU, '
-            . $metadata['wall-time'] . 's wall, '
+            . htmlspecialchars($metadata['cpu-time']) . 's CPU, '
+            . htmlspecialchars($metadata['wall-time']) . 's wall, '
             . '<i class="fas fa-memory" title="RAM"></i> '
             . Utils::printsize((int)($metadata['memory-bytes'])) . ', '
             . '<i class="far fa-question-circle" title="exit-status"></i> '
-            . 'exit-code: ' . $metadata['exitcode']
-            . (($metadata['signal'] ?? -1) > 0 ? ' signal: ' . $metadata['signal'] : '');
+            . 'exit-code: ' . htmlspecialchars($metadata['exitcode'])
+            . (($metadata['signal'] ?? -1) > 0 ? ' signal: ' . htmlspecialchars($metadata['signal']) : '');
     }
 
     public function printWarningContent(ExternalSourceWarning $warning): string

--- a/webapp/tests/Unit/Twig/TwigExtensionTest.php
+++ b/webapp/tests/Unit/Twig/TwigExtensionTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Twig;
+
+use App\Service\AwardService;
+use App\Service\ConfigurationService;
+use App\Service\DOMJudgeService;
+use App\Service\EventLogService;
+use App\Service\SubmissionService;
+use App\Twig\TwigExtension;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Twig\Environment;
+
+class TwigExtensionTest extends TestCase
+{
+    private TwigExtension $twigExtension;
+
+    protected function setUp(): void
+    {
+        $this->twigExtension = new TwigExtension(
+            $this->createMock(DOMJudgeService::class),
+            $this->createMock(ConfigurationService::class),
+            $this->createMock(Environment::class),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(SubmissionService::class),
+            $this->createMock(EventLogService::class),
+            $this->createMock(AwardService::class),
+            $this->createMock(TokenStorageInterface::class),
+            $this->createMock(AuthorizationCheckerInterface::class),
+            '/tmp'
+        );
+    }
+
+    public function testPrintMetadataNull(): void
+    {
+        self::assertSame('', $this->twigExtension->printMetadata(null));
+    }
+
+    public function testPrintMetadataValid(): void
+    {
+        $metadata = "cpu-time: 0.123\nwall-time: 0.456\nmemory-bytes: 1048576\nexitcode: 0\nsignal: 1";
+        $html = $this->twigExtension->printMetadata($metadata);
+
+        self::assertStringContainsString('0.123s CPU', $html);
+        self::assertStringContainsString('0.456s wall', $html);
+        self::assertStringContainsString('1 MB', $html);
+        self::assertStringContainsString('exit-code: 0', $html);
+        self::assertStringContainsString('signal: 1', $html);
+    }
+
+    public function testPrintMetadataEscapesHtmlPayload(): void
+    {
+        $payload = '<img src=x onerror="alert(1)">';
+        $metadata = "cpu-time: {$payload}\nwall-time: {$payload}\nmemory-bytes: 1048576\nexitcode: {$payload}";
+        $html = $this->twigExtension->printMetadata($metadata);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+}


### PR DESCRIPTION
Execution and compilation metadata fields can be influenced by untrusted compiler or execution outputs. Because the printMetadata Twig filter is marked safe for HTML, unescaped values allowed contestant submissions to trigger stored XSS in the jury interface.

Thanks to teddyctf for finding and reporting this issue.

(cherry picked from commit 439cfdd6e7ef68f9a38bf5268a87ac7bd0391351)