### PR TITLE
Allow setting webserver alias in configure step

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,19 @@ else
 fi
 AC_MSG_RESULT($BASEURL)
 
+AC_MSG_CHECKING([alias])
+AC_ARG_WITH([alias], [AS_HELP_STRING([--with-alias=alias],
+[Base path of the DOMjudge web interfaces. Example default:
+ "https://<URL>/domjudge/".])], [], [])
+AX_WITH_COMMENT(8,[       ])
+
+if test "x$with_alias" != x; then
+	AC_SUBST(domserver_webroot, $with_alias)
+else
+	AC_SUBST(domserver_webroot, "/domjudge")
+fi
+AC_MSG_RESULT($domserver_webroot)
+
 # Checks for programs.
 if test "x$JUDGEHOST_BUILD_ENABLED" = xyes; then
 AC_PROG_CXX
@@ -356,6 +369,7 @@ echo " * webserver group.....: $WEBSERVER_GROUP"
 fi
 echo ""
 echo " * website base URL....: $BASEURL"
+echo " * website alias.......: $domserver_webroot"
 echo ""
 echo -n " * documentation.......: AX_VAR_EXPAND($domjudge_docdir)"
 if test "x$DOC_BUILD_ENABLED" != xyes ; then

--- a/etc/apache.conf.in
+++ b/etc/apache.conf.in
@@ -57,8 +57,8 @@
 #
 # Alternatively, use this instead of the VirtualHost above when you don't
 # want DOMjudge in the root, but only occupy a subdir, like this:
-# www.example.com/domjudge
-Alias /domjudge @domserver_webappdir@/public
+# www.example.com@domserver_webroot@
+Alias @domserver_webroot@ @domserver_webappdir@/public
 
 ### General options ###
 #

--- a/etc/nginx-conf-inner.in
+++ b/etc/nginx-conf-inner.in
@@ -13,8 +13,8 @@ add_header X-Robots-Tag "none" always;
 
 # Variables used in the nginx configuration
 set $domjudgeRoot @domserver_webappdir@/public;
-# Set this to '' instead of /domjudge when running in the root of your system
-set $prefix /domjudge;
+# Set this to '' instead of @domserver_webroot@ when running in the root of your system
+set $prefix @domserver_webroot@;
 
 # Uncomment to run it out of the root of your system
 # # Disallow opening .php files directly
@@ -32,17 +32,17 @@ set $prefix /domjudge;
 # }
 
 # Or you can install it with a prefix
-location /domjudge { return 301 /domjudge/; }
+location @domserver_webroot@ { return 301 @domserver_webroot@/; }
 # Disallow opening .php files directly
-location ~ ^/domjudge/+[^/]+\.php$ { return 404; }
-location /domjudge/ {
+location ~ ^@domserver_webroot@/+[^/]+\.php$ { return 404; }
+location @domserver_webroot@/ {
 	root $domjudgeRoot;
-	rewrite ^/domjudge/(.*)$ /$1 break;
+	rewrite ^@domserver_webroot@/(.*)$ /$1 break;
 	try_files $uri @domjudgeFront;
 
 	# Handle API requests separately to be able to split the log
-	location /domjudge/api/ {
-		rewrite ^/domjudge/(.*)$ /$1 break;
+	location @domserver_webroot@/api/ {
+		rewrite ^@domserver_webroot@/(.*)$ /$1 break;
 		try_files $uri @domjudgeFrontApi;
 	}
 }

--- a/paths.mk.in
+++ b/paths.mk.in
@@ -93,6 +93,7 @@ domserver_tmpdir                 = @domserver_tmpdir@
 domserver_exampleprobdir         = @domserver_exampleprobdir@
 domserver_scoringexampleprobdir  = @domserver_scoringexampleprobdir@
 domserver_databasedumpdir        = @domserver_databasedumpdir@
+domserver_webroot                = @domserver_webroot@
 PHPVERSION                       = @PHPVERSION@
 
 judgehost_bindir          = @judgehost_bindir@
@@ -142,6 +143,7 @@ define substconfigvars
 	-e 's,@domserver_exampleprobdir[@],@domserver_exampleprobdir@,g' \
 	-e 's,@domserver_scoringexampleprobdir[@],@domserver_scoringexampleprobdir@,g' \
 	-e 's,@domserver_databasedumpdir[@],@domserver_databasedumpdir@,g' \
+	-e 's,@domserver_webroot[@],@domserver_webroot@,g' \
 	-e 's,@judgehost_bindir[@],@judgehost_bindir@,g' \
 	-e 's,@judgehost_etcdir[@],@judgehost_etcdir@,g' \
 	-e 's,@judgehost_libdir[@],@judgehost_libdir@,g' \


### PR DESCRIPTION
This makes it easier to configure an installation from scripts without copying the webserver config files.

I needed this for a side-project, as it's trivial enough I think it makes sense to merge this and make scripted installs easier.