### PR TITLE
Escape interpolated values in HTML-safe Twig filters

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -269,10 +269,10 @@ class TwigExtension
                 $icon = 'check';
                 break;
             default:
-                return $status;
+                return htmlspecialchars($status);
         }
         return sprintf('<i class="fas fa-%s-circle" aria-hidden="true"></i><span class="sr-only">%s</span>', $icon,
-                       $status);
+                       htmlspecialchars($status));
     }
 
     #[AsTwigFilter('countryFlag', isSafe: ['html'])]
@@ -469,7 +469,7 @@ class TwigExtension
             }
             $icon    = sprintf('<span class="badge text-bg-%s badge-testcase">%s</span>', $class, $text);
             $results .= sprintf('<a title="%s" href="#run-%d" %s>%s</a>',
-                join(', ', $titleElements), $testcase->getRank(),
+                htmlspecialchars(join(', ', $titleElements)), $testcase->getRank(),
                                 $isCorrect ? 'onclick="display_correctruns(true);"' : '', $icon);
         }
 
@@ -540,7 +540,8 @@ class TwigExtension
                 }
         }
 
-        return sprintf('<span class="sol %s">%s</span>', $valid ? $style : 'disabled', $result);
+        return sprintf('<span class="sol %s">%s</span>', $valid ? $style : 'disabled',
+                       htmlspecialchars($result));
     }
 
     #[AsTwigFilter('printValidJuryResult', isSafe: ['html'])]
@@ -786,6 +787,7 @@ class TwigExtension
             }
             $team      = $is_validator ? '<td></td>' : $content;
             $validator = $is_validator ? $content : '<td></td>';
+            $time      = htmlspecialchars($time);
             $body      .= "<tr>" . ($forTeam ? "" : "<td>$time</td>")
                           . $validator
                           . $team
@@ -932,7 +934,7 @@ JS;
 $(function() {
     const editorId = '%s';
     const diffId = '%s';
-    const submissionId = '%s';
+    const submissionId = %s;
     const models = %s;
     require(['vs/editor/editor.main'], () => {
         initDiffEditorTab(editorId, diffId, submissionId, models);
@@ -945,7 +947,7 @@ HTML;
             $editor,
             $editorId,
             $diffId,
-            $submissionId,
+            $this->serializer->serialize($submissionId, 'json'),
             $this->serializer->serialize($files, 'json'),
         );
     }
@@ -1039,7 +1041,11 @@ HTML;
         if ($description == null) {
             return '';
         }
-        $descriptionLines = explode("\n", $description);
+        // Escape every line on its own: the newlines are deliberately turned into <br>,
+        // but nothing else in the description may end up as markup. The data-attributes
+        // below are assigned to innerHTML by toggleExpand(), so they carry the same
+        // already-escaped content.
+        $descriptionLines = array_map(htmlspecialchars(...), explode("\n", $description));
         if (count($descriptionLines) <= 3) {
             return implode('<br>', $descriptionLines);
         } else {
@@ -1120,7 +1126,7 @@ EOF;
             $rgb,
             $border,
             $foreground,
-            $problem?->getShortname() ?? '?'
+            htmlspecialchars($problem?->getShortname() ?? '?')
         );
     }
 
@@ -1162,10 +1168,10 @@ EOF;
             $rgb,
             $border,
             $submissionsUrl,
-            $score->team->getExternalid(),
-            $problem->getExternalId(),
+            htmlspecialchars((string)$score->team->getExternalid()),
+            htmlspecialchars((string)$problem->getExternalId()),
             $foreground,
-            $problem->getShortname()
+            htmlspecialchars($problem->getShortname())
         );
         if (!$matrixItem->isCorrect) {
             if ($matrixItem->numSubmissionsPending > 0) {
@@ -1224,20 +1230,21 @@ EOF;
     {
         switch ($warning->getType()) {
             case ExternalSourceWarning::TYPE_UNSUPORTED_ACTION:
-                $action = $warning->getContent()['action'];
+                $action = htmlspecialchars((string)$warning->getContent()['action']);
                 return "Action $action not supported for this entity type";
             case ExternalSourceWarning::TYPE_DATA_MISMATCH:
                 $rows = [];
                 $null = '&lt;null&gt;';
                 foreach ($warning->getContent()['diff'] as $field => $diff) {
-                    $tdField    = "<td><code>$field</code></td>";
+                    $fieldEscaped = htmlspecialchars((string)$field);
+                    $tdField    = "<td><code>$fieldEscaped</code></td>";
                     $tdUs       = sprintf(
                         '<td><code>%s</code></td>',
-                        $diff['us'] ?? $null
+                        isset($diff['us']) ? htmlspecialchars((string)$diff['us']) : $null
                     );
                     $tdExternal = sprintf(
                         '<td><code>%s</code></td>',
-                        $diff['external'] ?? $null
+                        isset($diff['external']) ? htmlspecialchars((string)$diff['external']) : $null
                     );
                     $rows[]     = "<tr>{$tdField}{$tdUs}{$tdExternal}</tr>";
                 }
@@ -1257,8 +1264,8 @@ EOF;
             case ExternalSourceWarning::TYPE_DEPENDENCY_MISSING:
                 $rows = [];
                 foreach ($warning->getContent()['dependencies'] as $dependency) {
-                    $type   = $dependency['type'];
-                    $id     = $dependency['id'];
+                    $type   = htmlspecialchars((string)$dependency['type']);
+                    $id     = htmlspecialchars((string)$dependency['id']);
                     $rows[] = "<tr><td>$type</td><td>$id</td></tr>";
                 }
                 $header  = <<<'EOF'
@@ -1276,7 +1283,7 @@ EOF;
             case ExternalSourceWarning::TYPE_ENTITY_SHOULD_NOT_EXIST:
                 return '';
             case ExternalSourceWarning::TYPE_SUBMISSION_ERROR:
-                return $warning->getContent()['message'];
+                return htmlspecialchars((string)$warning->getContent()['message']);
         }
 
         return '';

--- a/webapp/tests/Unit/Twig/TwigExtensionTest.php
+++ b/webapp/tests/Unit/Twig/TwigExtensionTest.php
@@ -2,15 +2,22 @@
 
 namespace App\Tests\Unit\Twig;
 
+use App\Entity\ContestProblem;
+use App\Entity\ExternalSourceWarning;
+use App\Entity\Team;
+use App\Entity\Testcase as TestcaseEntity;
 use App\Service\AwardService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\SubmissionService;
 use App\Twig\TwigExtension;
+use App\Utils\Scoreboard\ScoreboardMatrixItem;
+use App\Utils\Scoreboard\TeamScore;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -18,12 +25,36 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Twig\Environment;
 
+/**
+ * Filters marked `isSafe: ['html']` are put into the page as raw markup, so each has to escape
+ * whatever it interpolates itself. The ones covered here render values we do not control:
+ * testcase descriptions and filenames from imported problem archives, and warnings and
+ * external ids the shadow importer writes straight from the remote CCS.
+ *
+ * `AppAssert\Identifier` looks like it makes those external ids safe, but it only applies when
+ * the validator runs and `ExternalContestSourceService` never runs it.
+ *
+ * Not covered here, because they interpolate nothing we do not already constrain: `button` is
+ * called with literals from our own templates, `codeEditor` with a language id that only an
+ * admin can set through a validated form, and `countryFlag` with a code that has been resolved
+ * against the ICU country list by the time it is used.
+ */
 class TwigExtensionTest extends TestCase
 {
+    /**
+     * A payload that renders harmlessly as text but executes if it reaches the page as markup.
+     */
+    private const XSS_PAYLOAD = '<img src=x onerror="alert(1)">';
+
     private TwigExtension $twigExtension;
+    private RouterInterface&MockObject $router;
+    private SerializerInterface&MockObject $serializer;
 
     protected function setUp(): void
     {
+        $this->router     = $this->createMock(RouterInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+
         $this->twigExtension = new TwigExtension(
             $this->createMock(DOMJudgeService::class),
             $this->createMock(ConfigurationService::class),
@@ -34,11 +65,13 @@ class TwigExtensionTest extends TestCase
             $this->createMock(AwardService::class),
             $this->createMock(TokenStorageInterface::class),
             $this->createMock(AuthorizationCheckerInterface::class),
-            $this->createMock(RouterInterface::class),
-            $this->createMock(SerializerInterface::class),
+            $this->router,
+            $this->serializer,
             '/tmp'
         );
     }
+
+
 
     public function testPrintMetadataNull(): void
     {
@@ -59,9 +92,9 @@ class TwigExtensionTest extends TestCase
 
     public function testPrintMetadataEscapesHtmlPayload(): void
     {
-        $payload = '<img src=x onerror="alert(1)">';
+        $payload  = self::XSS_PAYLOAD;
         $metadata = "cpu-time: {$payload}\nwall-time: {$payload}\nexitcode: {$payload}\nsignal: {$payload}";
-        $html = $this->twigExtension->printMetadata($metadata);
+        $html     = $this->twigExtension->printMetadata($metadata);
 
         self::assertStringNotContainsString('<img', $html);
         self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
@@ -186,4 +219,413 @@ class TwigExtensionTest extends TestCase
         yield ['doesnotexist', 1, 'doesnotexist'];
         yield ['#aabbccdd', 1, '#aabbccdd'];
     }
+    public function testDescriptionExpandNull(): void
+    {
+        self::assertSame('', $this->twigExtension->descriptionExpand(null));
+    }
+
+    public function testDescriptionExpandTurnsNewlinesIntoLineBreaks(): void
+    {
+        self::assertSame(
+            'first<br>second<br>third',
+            $this->twigExtension->descriptionExpand("first\nsecond\nthird")
+        );
+    }
+
+    /**
+     * Testcase and run descriptions come out of imported problem archives, so a short
+     * description must not be able to smuggle markup into the jury interface.
+     */
+    public function testDescriptionExpandEscapesShortDescription(): void
+    {
+        $html = $this->twigExtension->descriptionExpand(self::XSS_PAYLOAD);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertSame('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+    /**
+     * Descriptions longer than three lines are collapsed. The visible part is written into
+     * the document directly and both parts are stashed in data-attributes that
+     * toggleExpand() assigns to innerHTML, so all three places need escaping.
+     */
+    public function testDescriptionExpandEscapesLongDescription(): void
+    {
+        $description = implode("\n", [self::XSS_PAYLOAD, 'two', 'three', 'four']);
+        $html        = $this->twigExtension->descriptionExpand($description);
+
+        self::assertStringNotContainsString('<img', $html);
+
+        // The collapsed part shows the first three lines, the expanded part shows all four.
+        self::assertMatchesRegularExpression('/data-collapsed="[^"]*two&lt;br&gt;three"/', $html);
+        self::assertMatchesRegularExpression('/data-expanded="[^"]*three&lt;br&gt;four"/', $html);
+
+        // The data-attributes end up as innerHTML, so they carry the payload escaped twice:
+        // once so it survives as attribute text and once so innerHTML renders it as text.
+        self::assertStringContainsString('&amp;lt;img src=x onerror=&amp;quot;alert(1)&amp;quot;&amp;gt;', $html);
+    }
+
+    public function testDescriptionExpandKeepsLongDescriptionReadable(): void
+    {
+        $html = $this->twigExtension->descriptionExpand("one\ntwo\nthree\nfour");
+
+        self::assertStringContainsString('one<br>two<br>three', $html);
+        self::assertStringContainsString('[expand]', $html);
+    }
+
+    /**
+     * External source warnings are rendered from data supplied by the remote contest system,
+     * including ZIP entry names taken from downloaded submissions.
+     *
+     * @param array<string, mixed> $content
+     */
+    #[DataProvider('provideWarningsWithPayload')]
+    public function testPrintWarningContentEscapesContent(string $type, array $content): void
+    {
+        $warning = (new ExternalSourceWarning())
+            ->setType($type)
+            ->setContent($content);
+
+        $html = $this->twigExtension->printWarningContent($warning);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+    public static function provideWarningsWithPayload(): Generator
+    {
+        yield 'unsupported action' => [
+            ExternalSourceWarning::TYPE_UNSUPORTED_ACTION,
+            ['action' => self::XSS_PAYLOAD],
+        ];
+        yield 'data mismatch in field name' => [
+            ExternalSourceWarning::TYPE_DATA_MISMATCH,
+            ['diff' => [self::XSS_PAYLOAD => ['us' => 'a', 'external' => 'b']]],
+        ];
+        yield 'data mismatch in our value' => [
+            ExternalSourceWarning::TYPE_DATA_MISMATCH,
+            ['diff' => ['name' => ['us' => self::XSS_PAYLOAD, 'external' => 'b']]],
+        ];
+        yield 'data mismatch in external value' => [
+            ExternalSourceWarning::TYPE_DATA_MISMATCH,
+            ['diff' => ['name' => ['us' => 'a', 'external' => self::XSS_PAYLOAD]]],
+        ];
+        yield 'missing dependency type' => [
+            ExternalSourceWarning::TYPE_DEPENDENCY_MISSING,
+            ['dependencies' => [['type' => self::XSS_PAYLOAD, 'id' => '1']]],
+        ];
+        yield 'missing dependency id' => [
+            ExternalSourceWarning::TYPE_DEPENDENCY_MISSING,
+            ['dependencies' => [['type' => 'team', 'id' => self::XSS_PAYLOAD]]],
+        ];
+        yield 'submission error' => [
+            ExternalSourceWarning::TYPE_SUBMISSION_ERROR,
+            ['message' => 'Cannot create temporary file for ' . self::XSS_PAYLOAD],
+        ];
+    }
+
+    /**
+     * A missing value keeps its placeholder, which is pre-escaped and must not be escaped again.
+     */
+    public function testPrintWarningContentKeepsNullPlaceholder(): void
+    {
+        $warning = (new ExternalSourceWarning())
+            ->setType(ExternalSourceWarning::TYPE_DATA_MISMATCH)
+            ->setContent(['diff' => ['name' => ['us' => null, 'external' => 'other']]]);
+
+        $html = $this->twigExtension->printWarningContent($warning);
+
+        self::assertStringContainsString('<code>&lt;null&gt;</code>', $html);
+        self::assertStringNotContainsString('&amp;lt;null&amp;gt;', $html);
+        self::assertStringContainsString('<code>other</code>', $html);
+    }
+
+
+    public function testInteractiveLogRendersRows(): void
+    {
+        $html = $this->twigExtension->interactiveLog('[1.234/5]>: hello');
+
+        self::assertStringContainsString('<td>1.234</td>', $html);
+        self::assertStringContainsString('hello', $html);
+    }
+
+    /**
+     * The log is parsed positionally, so a desynchronised parse can put arbitrary bytes from
+     * the log into the time column.
+     */
+    public function testInteractiveLogEscapesTimeColumn(): void
+    {
+        $html = $this->twigExtension->interactiveLog('[' . self::XSS_PAYLOAD . '/5]>: hello');
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+    public function testInteractiveLogEscapesContent(): void
+    {
+        $payload = self::XSS_PAYLOAD;
+        $html    = $this->twigExtension->interactiveLog(sprintf('[1.234/%d]>: %s', strlen($payload), $payload));
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+
+    #[DataProvider('provideResults')]
+    public function testPrintResultUsesExpectedStyle(string $result, bool $jury, string $expected): void
+    {
+        self::assertSame($expected, $this->twigExtension->printResult($result, true, $jury));
+    }
+
+    public static function provideResults(): Generator
+    {
+        yield 'correct' => ['correct', false, '<span class="sol sol_correct">correct</span>'];
+        yield 'wrong answer' => ['wrong-answer', false, '<span class="sol sol_incorrect">wrong-answer</span>'];
+        yield 'queued for a team' => ['queued', false, '<span class="sol sol_queued">pending</span>'];
+        yield 'queued for the jury' => ['queued', true, '<span class="sol sol_queued">queued</span>'];
+        yield 'internal error hidden from teams' => ['internal', false, '<span class="sol sol_queued">pending</span>'];
+        yield 'internal error for the jury' => ['internal', true, '<span class="sol sol_internal">internal</span>'];
+    }
+
+    public function testPrintResultShowsPendingForEmptyResult(): void
+    {
+        self::assertSame('<span class="sol sol_queued">pending</span>', $this->twigExtension->printResult(null));
+        self::assertSame(
+            '<span class="sol sol_queued">judging</span>',
+            $this->twigExtension->printResult(null, true, true)
+        );
+    }
+
+    public function testPrintResultMarksInvalidJudgingsAsDisabled(): void
+    {
+        self::assertSame(
+            '<span class="sol disabled">correct</span>',
+            $this->twigExtension->printResult('correct', false)
+        );
+    }
+
+    /**
+     * Unknown results fall through to the default branch, which used to echo them verbatim.
+     */
+    public function testPrintResultEscapesUnknownResult(): void
+    {
+        $html = $this->twigExtension->printResult(self::XSS_PAYLOAD);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+    public function testPrintValidJuryResultShowsJuryResult(): void
+    {
+        self::assertSame(
+            '<span class="sol sol_internal">internal</span>',
+            $this->twigExtension->printValidJuryResult('internal')
+        );
+    }
+
+    #[DataProvider('provideStatuses')]
+    public function testStatusIcon(string $status, string $expectedIcon): void
+    {
+        $html = TwigExtension::statusIcon($status);
+
+        self::assertStringContainsString(sprintf('fa-%s-circle', $expectedIcon), $html);
+        self::assertStringContainsString(sprintf('<span class="sr-only">%s</span>', $status), $html);
+    }
+
+    public static function provideStatuses(): Generator
+    {
+        yield ['noconn', 'question'];
+        yield ['crit', 'times'];
+        yield ['warn', 'exclamation'];
+        yield ['ok', 'check'];
+    }
+
+    public function testStatusIconEscapesUnknownStatus(): void
+    {
+        $html = TwigExtension::statusIcon(self::XSS_PAYLOAD);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertSame('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+
+
+    public function testPrintHostEscapes(): void
+    {
+        $html = $this->twigExtension->printHost(self::XSS_PAYLOAD, true);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+
+    public function testPrintHostsEscapes(): void
+    {
+        $html = $this->twigExtension->printHosts([self::XSS_PAYLOAD, 'judgehost']);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img', $html);
+    }
+
+    /**
+     * The testcase title lists the original input filename and the description, both of which
+     * come out of the imported problem archive, and it is built into a title attribute. Its
+     * sibling `testcaseResults` escapes the same description.
+     */
+    public function testDisplayTestcaseResultsEscapesTheTitle(): void
+    {
+        $html = $this->twigExtension->displayTestcaseResults(
+            [$this->testcase(description: '" onmouseover="alert(1)')],
+            false
+        );
+
+        self::assertStringNotContainsString('onmouseover', strip_tags($html));
+        self::assertStringContainsString('&quot; onmouseover=&quot;alert(1)', $html);
+    }
+
+    public function testDisplayTestcaseResultsEscapesTheOriginalFilename(): void
+    {
+        $html = $this->twigExtension->displayTestcaseResults(
+            [$this->testcase(filename: '" onmouseover="alert(1)')],
+            false
+        );
+
+        self::assertStringContainsString('&quot; onmouseover=&quot;alert(1)', $html);
+    }
+
+    public function testDisplayTestcaseResultsShowsRankAndPendingState(): void
+    {
+        $html = $this->twigExtension->displayTestcaseResults(
+            [$this->testcase(description: 'the description', filename: 'first.in')],
+            false
+        );
+
+        self::assertStringContainsString('title="#1, name: first.in, desc: the description"', $html);
+        self::assertStringContainsString('href="#run-1"', $html);
+        self::assertStringContainsString('badge-testcase', $html);
+    }
+
+    private function testcase(string $description = '', string $filename = '', int $rank = 1): TestcaseEntity
+    {
+        $testcase = $this->createMock(TestcaseEntity::class);
+        $testcase->method('getSample')->willReturn(true);
+        $testcase->method('getFirstJudgingRun')->willReturn(null);
+        $testcase->method('getRank')->willReturn($rank);
+        $testcase->method('getOrigInputFilename')->willReturn($filename);
+        $testcase->method('getDescription')->willReturn($description);
+
+        return $testcase;
+    }
+
+    /**
+     * Problem labels are only validated to be non-blank, and the badge is shown on the public
+     * scoreboard.
+     */
+    public function testProblemBadgeEscapesTheShortname(): void
+    {
+        $problem = $this->createMock(ContestProblem::class);
+        $problem->method('getColor')->willReturn('#ff0000');
+        $problem->method('getShortname')->willReturn(self::XSS_PAYLOAD);
+
+        $html = $this->twigExtension->problemBadge($problem);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+    }
+
+
+    /**
+     * An unknown colour falls back to a fixed one rather than reaching the style attribute.
+     */
+    public function testProblemBadgeIgnoresAnUnparseableColour(): void
+    {
+        $problem = $this->createMock(ContestProblem::class);
+        $problem->method('getColor')->willReturn('"><script>alert(1)</script>');
+        $problem->method('getShortname')->willReturn('A');
+
+        $html = $this->twigExtension->problemBadge($problem);
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('background-color: #F5F5F5', $html);
+    }
+
+    /**
+     * The scoreboard variant of the badge escapes the same label, and additionally puts the
+     * team and problem external ids into data-attributes.
+     */
+    public function testProblemBadgeMaybeEscapesTheShortnameAndIds(): void
+    {
+        $html = $this->problemBadgeMaybe(
+            shortname: self::XSS_PAYLOAD,
+            teamExternalId: '" onmouseover="alert(1)',
+            problemExternalId: '" onfocus="alert(2)'
+        );
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;', $html);
+        self::assertStringContainsString('data-team-id="&quot; onmouseover=&quot;alert(1)"', $html);
+        self::assertStringContainsString('data-problem-id="&quot; onfocus=&quot;alert(2)"', $html);
+    }
+
+
+
+    private function problemBadgeMaybe(
+        string $shortname,
+        string $teamExternalId = 'team1',
+        string $problemExternalId = 'problem1',
+        bool $isCorrect = true,
+        int $numSubmissions = 1,
+        int $numPending = 0
+    ): string {
+        $this->router->method('generate')->willReturn('/submissions');
+
+        $problem = $this->createMock(ContestProblem::class);
+        $problem->method('getColor')->willReturn('#ff0000');
+        $problem->method('getShortname')->willReturn($shortname);
+        $problem->method('getExternalId')->willReturn($problemExternalId);
+
+        $team = $this->createMock(Team::class);
+        $team->method('getPenalty')->willReturn(0);
+        $team->method('getExternalid')->willReturn($teamExternalId);
+
+        return $this->twigExtension->problemBadgeMaybe(
+            $problem,
+            new ScoreboardMatrixItem($isCorrect, false, $numSubmissions, $numPending, 0, 0, 0),
+            new TeamScore($team, null, true)
+        );
+    }
+
+
+
+    /**
+     * The submission's external id lands in a script block, and in shadow mode it comes from
+     * the remote CCS without ever passing the validator.
+     */
+    public function testShowDiffEncodesTheSubmissionId(): void
+    {
+        $this->serializer
+            ->method('serialize')
+            ->willReturnCallback(fn(mixed $data): string => json_encode($data));
+
+        $html = $this->twigExtension->showDiff('editor1', 'diff-main.c', "');alert(1);//", 'main.c', []);
+
+        // json_encode also escapes the slashes, which is what keeps a </script> out of it.
+        self::assertStringContainsString('const submissionId = "\');alert(1);\\/\\/";', $html);
+        self::assertStringNotContainsString("const submissionId = '", $html);
+    }
+
+    /**
+     * runDiff renders the output a contestant's program produced next to the reference output.
+     */
+    public function testRunDiffEscapesBothSides(): void
+    {
+        $html = $this->twigExtension->runDiff([
+            'output_run'       => self::XSS_PAYLOAD,
+            'output_reference' => 'expected',
+        ]);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringContainsString('&lt;img', $html);
+    }
+
 }


### PR DESCRIPTION
Filters marked `isSafe: ['html']` bypass Twig's escaping, so each has to escape what it interpolates itself. Only `printMetadata` did (since recently), while others render testcase descriptions from imported problem archives and entity fields the shadow importer writes straight from the remote CCS.

`AppAssert\Identifier` is no help there: it only applies when the validator runs, and `ExternalContestSourceService` never runs it.