### PR TITLE
Add unit tests for the authenticators and the user state updater

### DIFF
--- a/webapp/tests/Unit/Security/DOMJudgeBasicAuthenticatorTest.php
+++ b/webapp/tests/Unit/Security/DOMJudgeBasicAuthenticatorTest.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Security\DOMJudgeBasicAuthenticator;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+
+/**
+ * HTTP basic authentication is only offered on the stateless firewalls; the interactive
+ * firewall uses the login form instead.
+ */
+class DOMJudgeBasicAuthenticatorTest extends TestCase
+{
+    private const API_FIREWALL = 'security.firewall.map.context.api';
+    private const METRICS_FIREWALL = 'security.firewall.map.context.metrics';
+    private const MAIN_FIREWALL = 'security.firewall.map.context.main';
+
+    private Security&MockObject $security;
+
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+    }
+
+    private function authenticator(): DOMJudgeBasicAuthenticator
+    {
+        return new DOMJudgeBasicAuthenticator($this->security);
+    }
+
+    private static function request(
+        string $firewallContext = self::MAIN_FIREWALL,
+        ?string $authUser = 'teamuser',
+        ?string $authPassword = 'password'
+    ): Request {
+        $request = Request::create('/api/v4/contests');
+        $request->attributes->set('_firewall_context', $firewallContext);
+        if ($authUser !== null) {
+            $request->headers->set('php-auth-user', $authUser);
+        }
+        if ($authPassword !== null) {
+            $request->headers->set('php-auth-pw', $authPassword);
+        }
+
+        return $request;
+    }
+
+    #[DataProvider('provideSupports')]
+    public function testSupports(bool $alreadyAuthenticated, Request $request, bool $expected): void
+    {
+        $this->security
+            ->method('getUser')
+            ->willReturn($alreadyAuthenticated ? new User() : null);
+
+        self::assertSame($expected, $this->authenticator()->supports($request));
+    }
+
+    public static function provideSupports(): Generator
+    {
+        yield 'api firewall with credentials' => [
+            false, self::request(self::API_FIREWALL), true,
+        ];
+        yield 'metrics firewall with credentials' => [
+            false, self::request(self::METRICS_FIREWALL), true,
+        ];
+        yield 'main firewall with credentials' => [
+            false, self::request(), false,
+        ];
+        yield 'api firewall without credentials' => [
+            false, self::request(self::API_FIREWALL, authUser: null), false,
+        ];
+        yield 'already authenticated' => [
+            true, self::request(self::API_FIREWALL), false,
+        ];
+    }
+
+    public function testAuthenticateUsesTheBasicAuthCredentials(): void
+    {
+        $passport = $this->authenticator()->authenticate(self::request(self::API_FIREWALL));
+
+        self::assertSame('teamuser', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        self::assertSame('password', $passport->getBadge(PasswordCredentials::class)->getPassword());
+    }
+
+    public function testOnAuthenticationSuccessLetsTheRequestContinue(): void
+    {
+        self::assertNull(
+            $this->authenticator()->onAuthenticationSuccess(
+                self::request(self::API_FIREWALL),
+                $this->createMock(TokenInterface::class),
+                'api'
+            )
+        );
+    }
+
+    #[DataProvider('provideRejectedExceptions')]
+    public function testOnAuthenticationFailureChallenges(AuthenticationException $exception): void
+    {
+        $response = $this->authenticator()->onAuthenticationFailure(self::request(self::API_FIREWALL), $exception);
+
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        // Command line clients need the challenge to know to send credentials.
+        self::assertSame('Basic realm="Secured Area"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public static function provideRejectedExceptions(): Generator
+    {
+        yield 'bad credentials' => [new BadCredentialsException()];
+        yield 'unknown user' => [new UserNotFoundException()];
+    }
+
+    public function testOnAuthenticationFailureDoesNotChallengeXhrRequests(): void
+    {
+        $request = self::request(self::API_FIREWALL);
+        // Without this the browser stacks its own login dialog on top of ours.
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $response = $this->authenticator()->onAuthenticationFailure($request, new BadCredentialsException());
+
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        self::assertFalse($response->headers->has('WWW-Authenticate'));
+    }
+
+    public function testOnAuthenticationFailurePassesOnOtherExceptions(): void
+    {
+        self::assertNull(
+            $this->authenticator()->onAuthenticationFailure(
+                self::request(self::API_FIREWALL),
+                new AuthenticationException()
+            )
+        );
+    }
+}

--- a/webapp/tests/Unit/Security/DOMJudgeIPAuthenticatorTest.php
+++ b/webapp/tests/Unit/Security/DOMJudgeIPAuthenticatorTest.php
@@ -1,0 +1,406 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Security\DOMJudgeIPAuthenticator;
+use App\Service\ConfigurationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+/**
+ * The IP authenticator logs a user in purely based on the IP address the request came from,
+ * so both the decision to run it at all and the lookup it performs are security relevant.
+ */
+class DOMJudgeIPAuthenticatorTest extends TestCase
+{
+    private const API_FIREWALL = 'security.firewall.map.context.api';
+    private const METRICS_FIREWALL = 'security.firewall.map.context.metrics';
+    private const MAIN_FIREWALL = 'security.firewall.map.context.main';
+
+    private CsrfTokenManagerInterface&MockObject $csrfTokenManager;
+    private Security&MockObject $security;
+    private EntityManagerInterface&MockObject $em;
+    private ConfigurationService&MockObject $config;
+    private RouterInterface&MockObject $router;
+    private RequestStack $requestStack;
+    private UserRepository&MockObject $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $this->security         = $this->createMock(Security::class);
+        $this->em               = $this->createMock(EntityManagerInterface::class);
+        $this->config           = $this->createMock(ConfigurationService::class);
+        $this->router           = $this->createMock(RouterInterface::class);
+        $this->requestStack     = new RequestStack();
+        $this->userRepository   = $this->createMock(UserRepository::class);
+
+        $this->em
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($this->userRepository);
+    }
+
+    private function authenticator(): DOMJudgeIPAuthenticator
+    {
+        return new DOMJudgeIPAuthenticator(
+            $this->csrfTokenManager,
+            $this->security,
+            $this->em,
+            $this->config,
+            $this->router,
+            $this->requestStack
+        );
+    }
+
+    /**
+     * @param string[] $authMethods
+     */
+    private function configReturns(array $authMethods, bool $ipAutologin = false): void
+    {
+        $this->config
+            ->method('get')
+            ->willReturnCallback(fn(string $name) => match ($name) {
+                'auth_methods' => $authMethods,
+                'ip_autologin' => $ipAutologin,
+                default        => null,
+            });
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private static function request(
+        string $method = 'GET',
+        array $parameters = [],
+        ?string $route = null,
+        string $firewallContext = self::MAIN_FIREWALL,
+        string $clientIp = '10.0.0.5'
+    ): Request {
+        $request = Request::create('/', $method, $parameters, [], [], ['REMOTE_ADDR' => $clientIp]);
+        if ($route !== null) {
+            $request->attributes->set('_route', $route);
+        }
+        $request->attributes->set('_firewall_context', $firewallContext);
+
+        return $request;
+    }
+
+    /**
+     * @param string[] $authMethods
+     */
+    #[DataProvider('provideSupports')]
+    public function testSupports(
+        array $authMethods,
+        bool $ipAutologin,
+        bool $alreadyAuthenticated,
+        Request $request,
+        bool $expected
+    ): void {
+        $this->configReturns($authMethods, $ipAutologin);
+        $this->security
+            ->method('getUser')
+            ->willReturn($alreadyAuthenticated ? new User() : null);
+
+        self::assertSame($expected, $this->authenticator()->supports($request));
+    }
+
+    public static function provideSupports(): Generator
+    {
+        // Without 'ipaddress' in auth_methods the authenticator must never run, not even on
+        // the stateless API firewall and not even when IP autologin is switched on.
+        yield 'ipaddress authentication disabled' => [
+            ['password'], false, false,
+            self::request(firewallContext: self::API_FIREWALL),
+            false,
+        ];
+        yield 'ipaddress disabled but autologin on' => [
+            ['password'], true, false,
+            self::request(),
+            false,
+        ];
+
+        // Stateless firewalls authenticate on every request.
+        yield 'api firewall' => [
+            ['ipaddress'], false, false,
+            self::request(firewallContext: self::API_FIREWALL),
+            true,
+        ];
+        yield 'metrics firewall' => [
+            ['ipaddress'], false, false,
+            self::request(firewallContext: self::METRICS_FIREWALL),
+            true,
+        ];
+
+        // On the main firewall the authenticator only runs with autologin enabled...
+        yield 'main firewall without autologin' => [
+            ['ipaddress'], false, false,
+            self::request(),
+            false,
+        ];
+        yield 'main firewall with autologin' => [
+            ['ipaddress'], true, false,
+            self::request(),
+            true,
+        ];
+
+        // ...or when the login form was submitted asking for it.
+        yield 'login form with ipaddress method' => [
+            ['ipaddress'], false, false,
+            self::request('POST', ['loginmethod' => 'ipaddress'], 'login'),
+            true,
+        ];
+        yield 'login form with another method' => [
+            ['ipaddress'], false, false,
+            self::request('POST', ['loginmethod' => 'password'], 'login'),
+            false,
+        ];
+        yield 'login page without submitting' => [
+            ['ipaddress'], false, false,
+            self::request(route: 'login'),
+            false,
+        ];
+
+        // An already authenticated user needs no further authentication, except on the login
+        // page where they may be asking to log in as somebody else.
+        yield 'already authenticated on a normal page' => [
+            ['ipaddress'], true, true,
+            self::request(),
+            false,
+        ];
+        yield 'already authenticated on the api firewall' => [
+            ['ipaddress'], false, true,
+            self::request(firewallContext: self::API_FIREWALL),
+            false,
+        ];
+        yield 'already authenticated on the login page' => [
+            ['ipaddress'], false, true,
+            self::request('POST', ['loginmethod' => 'ipaddress'], 'login'),
+            true,
+        ];
+    }
+
+    public function testAuthenticateOnlyMatchesEnabledUsersOnTheClientIp(): void
+    {
+        $user = (new User())->setUsername('teamuser');
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findBy')
+            // Dropping either filter would turn this into an authentication bypass.
+            ->with(['ipAddress' => '10.0.0.5', 'enabled' => 1])
+            ->willReturn([$user]);
+
+        $request = self::request();
+        $this->requestStack->push($request);
+
+        $passport = $this->authenticator()->authenticate($request);
+
+        self::assertSame('teamuser', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateUsesTheClientIpOfTheMainRequest(): void
+    {
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findBy')
+            ->with(['ipAddress' => '192.0.2.7', 'enabled' => 1])
+            ->willReturn([(new User())->setUsername('teamuser')]);
+
+        $mainRequest = self::request(clientIp: '192.0.2.7');
+        $this->requestStack->push($mainRequest);
+        $subRequest = self::request(clientIp: '10.0.0.5');
+        $this->requestStack->push($subRequest);
+
+        $this->authenticator()->authenticate($subRequest);
+    }
+
+    public function testAuthenticateNarrowsDownByBasicAuthUsername(): void
+    {
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findBy')
+            ->with(['ipAddress' => '10.0.0.5', 'enabled' => 1, 'username' => 'basicuser'])
+            ->willReturn([(new User())->setUsername('basicuser')]);
+
+        $request = self::request();
+        $request->headers->set('php-auth-user', 'basicuser');
+        $this->requestStack->push($request);
+
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testAuthenticateNarrowsDownByPostedUsername(): void
+    {
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findBy')
+            ->with(['ipAddress' => '10.0.0.5', 'enabled' => 1, 'username' => 'formuser'])
+            ->willReturn([(new User())->setUsername('formuser')]);
+
+        $request = self::request('POST', ['_username' => 'formuser']);
+        $this->requestStack->push($request);
+
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testPostedUsernameOverridesBasicAuthUsername(): void
+    {
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findBy')
+            ->with(['ipAddress' => '10.0.0.5', 'enabled' => 1, 'username' => 'formuser'])
+            ->willReturn([(new User())->setUsername('formuser')]);
+
+        $request = self::request('POST', ['_username' => 'formuser']);
+        $request->headers->set('php-auth-user', 'basicuser');
+        $this->requestStack->push($request);
+
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testAuthenticateFailsWithoutAMatchingUser(): void
+    {
+        $this->userRepository->method('findBy')->willReturn([]);
+
+        $request = self::request();
+        $this->requestStack->push($request);
+
+        $this->expectException(UserNotFoundException::class);
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testAuthenticateFailsWhenTheIpMatchesMoreThanOneUser(): void
+    {
+        $this->userRepository->method('findBy')->willReturn([
+            (new User())->setUsername('one'),
+            (new User())->setUsername('two'),
+        ]);
+
+        $request = self::request();
+        $this->requestStack->push($request);
+
+        $this->expectException(UserNotFoundException::class);
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsAnInvalidCsrfTokenOnTheLoginForm(): void
+    {
+        $this->csrfTokenManager->method('isTokenValid')->willReturn(false);
+        $this->userRepository->expects(self::never())->method('findBy');
+
+        $request = self::request('POST', ['_csrf_token' => 'wrong'], 'login');
+        $this->requestStack->push($request);
+
+        $this->expectException(InvalidCsrfTokenException::class);
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testAuthenticateAcceptsAValidCsrfTokenOnTheLoginForm(): void
+    {
+        $this->csrfTokenManager->method('isTokenValid')->willReturn(true);
+        $this->userRepository
+            ->method('findBy')
+            ->willReturn([(new User())->setUsername('teamuser')]);
+
+        $request = self::request('POST', ['_csrf_token' => 'right'], 'login');
+        $this->requestStack->push($request);
+
+        $passport = $this->authenticator()->authenticate($request);
+
+        self::assertSame('teamuser', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateDoesNotCheckCsrfOutsideTheLoginForm(): void
+    {
+        // Only a login form submission carries a CSRF token.
+        $this->csrfTokenManager->expects(self::never())->method('isTokenValid');
+        $this->userRepository
+            ->method('findBy')
+            ->willReturn([(new User())->setUsername('teamuser')]);
+
+        $request = self::request(firewallContext: self::API_FIREWALL);
+        $this->requestStack->push($request);
+
+        $this->authenticator()->authenticate($request);
+    }
+
+    public function testOnAuthenticationSuccessRedirectsToTheTargetPathAfterLogin(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.main.target_path', '/jury/problems');
+
+        $request = self::request('POST', ['loginmethod' => 'ipaddress'], 'login');
+        $request->setSession($session);
+
+        $response = $this->authenticator()->onAuthenticationSuccess(
+            $request,
+            $this->createMock(TokenInterface::class),
+            'main'
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/jury/problems', $response->getTargetUrl());
+        self::assertFalse($session->has('_security.main.target_path'));
+    }
+
+    public function testOnAuthenticationSuccessRedirectsToTheRootWithoutATargetPath(): void
+    {
+        $this->router->method('generate')->with('root')->willReturn('/');
+
+        $request = self::request('POST', ['loginmethod' => 'ipaddress'], 'login');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $response = $this->authenticator()->onAuthenticationSuccess(
+            $request,
+            $this->createMock(TokenInterface::class),
+            'main'
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/', $response->getTargetUrl());
+    }
+
+    public function testOnAuthenticationSuccessDoesNotRedirectOutsideTheLoginForm(): void
+    {
+        $response = $this->authenticator()->onAuthenticationSuccess(
+            self::request(),
+            $this->createMock(TokenInterface::class),
+            'main'
+        );
+
+        self::assertNull($response);
+    }
+
+    public function testOnAuthenticationFailureLetsOtherAuthenticatorsTry(): void
+    {
+        self::assertNull(
+            $this->authenticator()->onAuthenticationFailure(self::request(), new UserNotFoundException())
+        );
+    }
+
+    public function testStartAsksForBasicAuthentication(): void
+    {
+        $response = $this->authenticator()->start(self::request());
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        self::assertSame('Basic realm="Secured Area"', $response->headers->get('WWW-Authenticate'));
+    }
+}

--- a/webapp/tests/Unit/Security/DOMJudgeXHeadersAuthenticatorTest.php
+++ b/webapp/tests/Unit/Security/DOMJudgeXHeadersAuthenticatorTest.php
@@ -1,0 +1,215 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Security\DOMJudgeXHeadersAuthenticator;
+use App\Service\ConfigurationService;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+
+/**
+ * The X-headers authenticator takes a username and a base64 encoded password out of request
+ * headers, so it must only ever run when that method is enabled and explicitly asked for.
+ */
+class DOMJudgeXHeadersAuthenticatorTest extends TestCase
+{
+    private const BOTH_HEADERS = [
+        'X-DOMjudge-Login' => 'teamuser',
+        'X-DOMjudge-Pass'  => 'cGFzc3dvcmQ=',
+    ];
+
+    private Security&MockObject $security;
+    private ConfigurationService&MockObject $config;
+    private RouterInterface&MockObject $router;
+
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->config   = $this->createMock(ConfigurationService::class);
+        $this->router   = $this->createMock(RouterInterface::class);
+    }
+
+    private function authenticator(): DOMJudgeXHeadersAuthenticator
+    {
+        return new DOMJudgeXHeadersAuthenticator($this->security, $this->config, $this->router);
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @param array<string, string> $headers
+     */
+    private static function request(
+        string $method = 'GET',
+        array $parameters = [],
+        ?string $route = null,
+        array $headers = []
+    ): Request {
+        $request = Request::create('/', $method, $parameters);
+        if ($route !== null) {
+            $request->attributes->set('_route', $route);
+        }
+        foreach ($headers as $name => $value) {
+            $request->headers->set($name, $value);
+        }
+
+        return $request;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private static function loginRequest(array $headers, string $loginMethod = 'xheaders'): Request
+    {
+        return self::request('POST', ['loginmethod' => $loginMethod], 'login', $headers);
+    }
+
+    /**
+     * @param string[] $authMethods
+     */
+    #[DataProvider('provideSupports')]
+    public function testSupports(
+        array $authMethods,
+        bool $alreadyAuthenticated,
+        Request $request,
+        bool $expected
+    ): void {
+        $this->config->method('get')->willReturnCallback(
+            fn(string $name) => $name === 'auth_methods' ? $authMethods : null
+        );
+        $this->security
+            ->method('getUser')
+            ->willReturn($alreadyAuthenticated ? new User() : null);
+
+        self::assertSame($expected, $this->authenticator()->supports($request));
+    }
+
+    public static function provideSupports(): Generator
+    {
+        yield 'xheaders authentication disabled' => [
+            ['password'], false, self::loginRequest(self::BOTH_HEADERS), false,
+        ];
+        yield 'already authenticated' => [
+            ['xheaders'], true, self::loginRequest(self::BOTH_HEADERS), false,
+        ];
+        yield 'both headers on a login submit' => [
+            ['xheaders'], false, self::loginRequest(self::BOTH_HEADERS), true,
+        ];
+        yield 'login header missing' => [
+            ['xheaders'], false, self::loginRequest(['X-DOMjudge-Pass' => 'cGFzc3dvcmQ=']), false,
+        ];
+        yield 'password header missing' => [
+            ['xheaders'], false, self::loginRequest(['X-DOMjudge-Login' => 'teamuser']), false,
+        ];
+        yield 'another login method requested' => [
+            ['xheaders'], false, self::loginRequest(self::BOTH_HEADERS, 'password'), false,
+        ];
+
+        // Unlike the IP authenticator this one never authenticates outside the login form,
+        // so the headers on their own are not enough on any route.
+        yield 'headers without a login submit' => [
+            ['xheaders'], false, self::request(headers: self::BOTH_HEADERS), false,
+        ];
+        yield 'headers on a GET of the login page' => [
+            ['xheaders'], false, self::request(route: 'login', headers: self::BOTH_HEADERS), false,
+        ];
+    }
+
+    public function testAuthenticateDecodesTheCredentials(): void
+    {
+        $request  = self::loginRequest(self::BOTH_HEADERS);
+        $passport = $this->authenticator()->authenticate($request);
+
+        self::assertSame('teamuser', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        self::assertSame('password', $passport->getBadge(PasswordCredentials::class)->getPassword());
+    }
+
+    public function testAuthenticateTrimsTheHeaders(): void
+    {
+        $request = self::loginRequest([
+            'X-DOMjudge-Login' => '  teamuser  ',
+            'X-DOMjudge-Pass'  => '  cGFzc3dvcmQ=  ',
+        ]);
+
+        $passport = $this->authenticator()->authenticate($request);
+
+        self::assertSame('teamuser', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        self::assertSame('password', $passport->getBadge(PasswordCredentials::class)->getPassword());
+    }
+
+    public function testOnAuthenticationSuccessRedirectsToTheTargetPath(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.main.target_path', '/team');
+
+        $request = self::loginRequest(self::BOTH_HEADERS);
+        $request->setSession($session);
+
+        $response = $this->authenticator()->onAuthenticationSuccess(
+            $request,
+            $this->createMock(TokenInterface::class),
+            'main'
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/team', $response->getTargetUrl());
+        self::assertFalse($session->has('_security.main.target_path'));
+    }
+
+    public function testOnAuthenticationSuccessRedirectsToTheRootWithoutATargetPath(): void
+    {
+        $this->router->method('generate')->with('root')->willReturn('/');
+
+        $request = self::loginRequest(self::BOTH_HEADERS);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $response = $this->authenticator()->onAuthenticationSuccess(
+            $request,
+            $this->createMock(TokenInterface::class),
+            'main'
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/', $response->getTargetUrl());
+    }
+
+    public function testOnAuthenticationSuccessDoesNotRedirectOutsideTheLoginForm(): void
+    {
+        self::assertNull(
+            $this->authenticator()->onAuthenticationSuccess(
+                self::request(headers: self::BOTH_HEADERS),
+                $this->createMock(TokenInterface::class),
+                'main'
+            )
+        );
+    }
+
+    public function testOnAuthenticationFailureLetsOtherAuthenticatorsTry(): void
+    {
+        self::assertNull(
+            $this->authenticator()->onAuthenticationFailure(self::request(), new BadCredentialsException())
+        );
+    }
+
+    public function testStartRedirectsToTheLoginPage(): void
+    {
+        $this->router->method('generate')->willReturn('https://example.org/login');
+
+        $response = $this->authenticator()->start(self::request());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('https://example.org/login', $response->getTargetUrl());
+    }
+}

--- a/webapp/tests/Unit/Security/UserCheckerTest.php
+++ b/webapp/tests/Unit/Security/UserCheckerTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Security\UserChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * The user checker is the last line that keeps a disabled account from being logged in,
+ * whichever authenticator handled the request.
+ */
+class UserCheckerTest extends TestCase
+{
+    private UserChecker $userChecker;
+
+    protected function setUp(): void
+    {
+        $this->userChecker = new UserChecker();
+    }
+
+    public function testDisabledUserIsRejected(): void
+    {
+        $user = (new User())->setEnabled(false);
+
+        $this->expectException(DisabledException::class);
+        $this->userChecker->checkPostAuth($user);
+    }
+
+    public function testEnabledUserIsAccepted(): void
+    {
+        $user = (new User())->setEnabled(true);
+
+        $this->userChecker->checkPostAuth($user);
+
+        // checkPostAuth() throws for a disabled user; reaching this point is the assertion.
+        self::assertTrue($user->getEnabled());
+    }
+
+
+    public function testOtherUserImplementationsAreLeftAlone(): void
+    {
+        // checkPostAuth() throws for a disabled user of ours; returning at all is the assertion.
+        $this->expectNotToPerformAssertions();
+
+        $this->userChecker->checkPostAuth($this->createMock(UserInterface::class));
+    }
+
+    public function testCheckPreAuthDoesNothing(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->userChecker->checkPreAuth((new User())->setEnabled(false));
+    }
+}

--- a/webapp/tests/Unit/Security/UserStateUpdaterTest.php
+++ b/webapp/tests/Unit/Security/UserStateUpdaterTest.php
@@ -1,0 +1,159 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Entity\User;
+use App\Security\UserStateUpdater;
+use App\Service\DOMJudgeService;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+
+/**
+ * Which timestamp a successful authentication updates depends on the firewall it happened on:
+ * the API is called constantly, so it must not touch the interactive login time or write an
+ * audit log entry for every request.
+ */
+class UserStateUpdaterTest extends TestCase
+{
+    private DOMJudgeService&MockObject $dj;
+    private EntityManagerInterface&MockObject $em;
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $this->dj           = $this->createMock(DOMJudgeService::class);
+        $this->em           = $this->createMock(EntityManagerInterface::class);
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push(Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '192.0.2.7']));
+    }
+
+    private function updater(): UserStateUpdater
+    {
+        return new UserStateUpdater($this->dj, $this->em, $this->requestStack);
+    }
+
+    private function update(User $user, string $firewallName): void
+    {
+        $this->updater()->updateUserState(
+            new AuthenticationSuccessEvent(new PostAuthenticationToken($user, $firewallName, ['ROLE_USER']))
+        );
+    }
+
+    public function testItSubscribesToSuccessfulAuthentication(): void
+    {
+        self::assertSame(
+            [AuthenticationSuccessEvent::class => 'updateUserState'],
+            UserStateUpdater::getSubscribedEvents()
+        );
+    }
+
+    public function testMainFirewallUpdatesTheInteractiveLoginTime(): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+        $this->em->expects(self::once())->method('flush');
+
+        $user = (new User())->setUsername('teamuser');
+        $this->update($user, 'main');
+
+        self::assertNotNull($user->getLastLogin());
+        self::assertNull($user->getLastApiLogin());
+        self::assertSame('10.0.0.5', $user->getLastIpAddress());
+    }
+
+    #[DataProvider('provideStatelessFirewalls')]
+    public function testStatelessFirewallsUpdateTheApiLoginTime(string $firewallName): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+        // The API is polled constantly, so it gets its own timestamp and no audit entry.
+        $this->dj->expects(self::never())->method('auditlog');
+
+        $user = (new User())->setUsername('teamuser');
+        $this->update($user, $firewallName);
+
+        self::assertNotNull($user->getLastApiLogin());
+        self::assertNull($user->getLastLogin());
+        self::assertSame('10.0.0.5', $user->getLastIpAddress());
+    }
+
+    public static function provideStatelessFirewalls(): Generator
+    {
+        yield ['api'];
+        yield ['metrics'];
+    }
+
+    public function testOtherFirewallsUpdateNeitherLoginTime(): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+
+        $user = (new User())->setUsername('teamuser');
+        $this->update($user, 'somethingelse');
+
+        self::assertNull($user->getLastLogin());
+        self::assertNull($user->getLastApiLogin());
+        self::assertSame('10.0.0.5', $user->getLastIpAddress());
+    }
+
+    public function testMainFirewallWritesAnAuditLogEntry(): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+        $this->dj
+            ->expects(self::once())
+            ->method('auditlog')
+            // The audit log uses the main request's IP, not the one the service reports.
+            ->with('user', 'teamuser', 'logged on on 192.0.2.7', null, 'teamuser');
+
+        $user = (new User())->setUsername('teamuser');
+        $user->setExternalid('teamuser');
+
+        $this->update($user, 'main');
+    }
+
+    public function testFirstLoginIsRecordedOnlyOnce(): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+
+        $user = (new User())->setUsername('teamuser');
+        $this->update($user, 'main');
+
+        $firstLogin = $user->getFirstLogin();
+        self::assertNotNull($firstLogin);
+
+        $this->update($user, 'main');
+
+        self::assertSame($firstLogin, $user->getFirstLogin());
+    }
+
+    public function testUsersFromAnotherProviderAreIgnored(): void
+    {
+        $this->em->expects(self::never())->method('flush');
+        $this->dj->expects(self::never())->method('auditlog');
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn(null);
+
+        $this->updater()->updateUserState(new AuthenticationSuccessEvent($token));
+    }
+
+    public function testTokensWithoutAFirewallNameCountAsMain(): void
+    {
+        $this->dj->method('getClientIp')->willReturn('10.0.0.5');
+        $this->dj->expects(self::once())->method('auditlog');
+
+        $user  = (new User())->setUsername('teamuser');
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $this->updater()->updateUserState(new AuthenticationSuccessEvent($token));
+
+        self::assertNotNull($user->getLastLogin());
+        self::assertNull($user->getLastApiLogin());
+    }
+}


### PR DESCRIPTION
No test referenced auth_methods, ip_autologin or ipaddress, so nothing covered how a request becomes authenticated. The E2E crawl checks what each role may reach, which is a different question.