### PR TITLE
Prevent metadata injection through compiler output

### DIFF
--- a/example_problems/hello/submissions/accepted/test-metadata-injection.c
+++ b/example_problems/hello/submissions/accepted/test-metadata-injection.c
@@ -1,0 +1,25 @@
+/*
+ * This should give CORRECT on the default problem 'hello'.
+ *
+ * The compiler warning below repeats the entry point detection message that
+ * compile scripts use. judge/compile.sh must not pick this up: it only looks
+ * at lines starting with the detection message and only copies the detected
+ * value. Without that, the greedy match would append the second half of the
+ * warning to compile.meta, here faking a compilation timeout and thus
+ * turning this submission into a COMPILER-ERROR.
+ *
+ * Keep this in sync with the entry point detection in judge/compile.sh.
+ *
+ * @EXPECTED_RESULTS@: CORRECT
+ */
+
+#warning detected entry_point: x detected time-result: timelimit
+
+#include <stdio.h>
+
+int main()
+{
+	char hello[20] = "Hello world!";
+	printf("%s\n",hello);
+	return 0;
+}

--- a/judge/compile.sh
+++ b/judge/compile.sh
@@ -181,8 +181,15 @@ fi
 
 # Check if the compile script auto-detected the entry point, and if
 # so, store it in the compile.meta for later reuse, e.g. in a replay.
-ENTRY_POINT_REGEX='[Dd]etected entry_point: '
-grep "$ENTRY_POINT_REGEX" compile.tmp | sed 's/^.*etected //' >>compile.meta
+# Only lines that start with the detection message are considered and only
+# the detected value is copied over, prefixed with the 'entry_point' key.
+# This prevents compiler output, which is under control of the submitter,
+# from injecting arbitrary keys into the metadata. When changing the regex
+# below, also update example_problems/hello/submissions/accepted/test-metadata-injection.c
+# which checks that such injections are rejected.
+ENTRY_POINT_REGEX='^(Info: )?[Dd]etected entry_point: '
+grep -E "$ENTRY_POINT_REGEX" compile.tmp | \
+	sed -E "s@$ENTRY_POINT_REGEX@entry_point: @" >>compile.meta
 
 logmsg $LOG_DEBUG "checking compilation exit-status"
 if grep '^time-result: .*timelimit' compile.meta >/dev/null 2>&1 ; then
@@ -204,7 +211,7 @@ fi
 # Remove any entry point detection message when compilation succeeded,
 # since we already stored it above and it only confuses contestants.
 # Ignore the exit code, since grep returns 1 when no line matched.
-grep -v "$ENTRY_POINT_REGEX" compile.tmp >>compile.out || true
+grep -vE "$ENTRY_POINT_REGEX" compile.tmp >>compile.out || true
 
 logmsg $LOG_INFO "Compilation successful"
 cleanexit 0


### PR DESCRIPTION
Entry point detection matched the detection message anywhere in a line and stripped everything up to the last "etected ". Since compiler output is under submitter control, a crafted line could write an arbitrary key/value pair into compile.meta, e.g. an 'internal-error' that disables the judgehost.

Anchor the match at the start of the line and only copy the detected value, always under the 'entry_point' key. The added submission fakes a compile timeout this way and was judged as COMPILER-ERROR before.

Thanks to teddyctf for finding and reporting this issue.