### PR TITLE
Report missing start_time/end_time in add-judging-run as a bad request.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -625,7 +625,9 @@ class JudgehostController extends AbstractFOSRestController
             'output_run',
             'output_diff',
             'output_error',
-            'output_system'
+            'output_system',
+            'start_time',
+            'end_time'
         ];
 
         foreach ($required as $argument) {

--- a/webapp/tests/Unit/Controller/API/JudgehostControllerTest.php
+++ b/webapp/tests/Unit/Controller/API/JudgehostControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Controller\API;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Generator;
+use Symfony\Component\HttpFoundation\Response;
 
 class JudgehostControllerTest extends BaseTestCase
 {
@@ -62,5 +63,87 @@ class JudgehostControllerTest extends BaseTestCase
         $url = $this->helperGetEndpointURL($this->apiEndpoint, $id);
         $object = $this->verifyApiJsonResponse('GET', $url, 200, $this->apiUser);
         static::assertEquals([], $object);
+    }
+
+    /**
+     * The judgehost endpoints take form-encoded parameters rather than JSON, so they can not
+     * use the JSON helpers from the base class.
+     *
+     * @param array<string, string> $parameters
+     */
+    private function postForm(string $apiUri, array $parameters): Response
+    {
+        $adminPasswordFile = sprintf(
+            '%s/%s',
+            static::getContainer()->getParameter('domjudge.etcdir'),
+            'initial_admin_password.secret'
+        );
+        // ROLE_ADMIN includes ROLE_JUDGEHOST through the role hierarchy.
+        $this->client->request('POST', '/api' . $apiUri, $parameters, [], [
+            'PHP_AUTH_USER' => 'admin',
+            'PHP_AUTH_PW' => trim(file_get_contents($adminPasswordFile)),
+        ]);
+
+        return $this->client->getResponse();
+    }
+
+    /**
+     * A judgehost must exist before add-judging-run gets as far as looking at its arguments'
+     * types, otherwise the endpoint rejects the caller first and the test would pass for the
+     * wrong reason.
+     */
+    private function registerJudgehost(string $hostname): void
+    {
+        $response = $this->postForm('/judgehosts', ['hostname' => $hostname]);
+        static::assertEquals(200, $response->getStatusCode(), (string)$response->getContent());
+    }
+
+    /**
+     * Every mandatory argument of add-judging-run must be reported as such.
+     *
+     * `start_time` and `end_time` used to be missing from the check while being typed as
+     * non-nullable strings further down, so leaving them out produced a 500 TypeError instead
+     * of a 400.
+     */
+    #[DataProvider('provideMandatoryJudgingRunArgument')]
+    public function testAddJudgingRunRequiresArgument(string $missing): void
+    {
+        $hostname = 'test-judgehost';
+        $this->registerJudgehost($hostname);
+
+        $parameters = [
+            'runresult' => 'correct',
+            'runtime' => '0.01',
+            'start_time' => '1000.0',
+            'end_time' => '1001.0',
+            'output_run' => '',
+            'output_diff' => '',
+            'output_error' => '',
+            'output_system' => '',
+        ];
+        unset($parameters[$missing]);
+
+        $response = $this->postForm(
+            sprintf('/judgehosts/add-judging-run/%s/1', $hostname),
+            $parameters
+        );
+
+        static::assertEquals(400, $response->getStatusCode(), (string)$response->getContent());
+        static::assertStringContainsString(
+            sprintf("Argument '%s' is mandatory", $missing),
+            (string)$response->getContent()
+        );
+    }
+
+    public static function provideMandatoryJudgingRunArgument(): Generator
+    {
+        yield ['runresult'];
+        yield ['runtime'];
+        yield ['start_time'];
+        yield ['end_time'];
+        yield ['output_run'];
+        yield ['output_diff'];
+        yield ['output_error'];
+        yield ['output_system'];
     }
 }


### PR DESCRIPTION
The endpoint verifies that runresult, runtime and the four output_* arguments are present, but start_time and end_time were missing from that list while addSingleJudgingRun() types them as non-nullable strings. A request without them therefore died with a TypeError and returned a 500 instead of a 400.

The judgedaemon always sends both (see the key list in judgedaemon.main.php), so this only affects malformed or third-party clients. For those a 500 is actively unhelpful: request() treats it as a transient failure and burns its retry backoff instead of reporting what is wrong.

Add both to the mandatory argument list, and cover every mandatory argument of the endpoint with a test.