### PR TITLE
Document 204 instead of 200 for API actions that return void.

### DIFF
--- a/webapp/src/Controller/API/JudgehostController.php
+++ b/webapp/src/Controller/API/JudgehostController.php
@@ -247,7 +247,7 @@ class JudgehostController extends AbstractFOSRestController
     #[IsGranted('ROLE_JUDGEHOST')]
     #[Rest\Put(path: '/update-judging/{hostname}/{judgetaskid<\d+>}')]
     #[OA\Response(
-        response: 200,
+        response: 204,
         description: 'When the judging has been updated'
     )]
     #[OA\RequestBody(
@@ -469,7 +469,7 @@ class JudgehostController extends AbstractFOSRestController
      */
     #[IsGranted('ROLE_JUDGEHOST')]
     #[Rest\Post(path: '/add-debug-info/{hostname}/{judgeTaskId<\d+>}')]
-    #[OA\Response(response: 200, description: 'When the debug info has been added')]
+    #[OA\Response(response: 204, description: 'When the debug info has been added')]
     public function addDebugInfo(
         Request $request,
         #[OA\PathParameter(description: 'The hostname of the judgehost that wants to add the debug info')]

--- a/webapp/src/Controller/API/LanguageController.php
+++ b/webapp/src/Controller/API/LanguageController.php
@@ -76,7 +76,7 @@ class LanguageController extends AbstractRestController
     #[IsGranted('ROLE_ADMIN')]
     #[Rest\Post(path: 'languages/{id}/executable')]
     #[OA\Response(
-        response: 200,
+        response: 204,
         description: 'Update the executable for a given language.',
     )]
     #[OA\Parameter(ref: '#/components/parameters/id')]

--- a/webapp/tests/Unit/Controller/API/ResponseStatusDocumentationTest.php
+++ b/webapp/tests/Unit/Controller/API/ResponseStatusDocumentationTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller\API;
+
+use App\Controller\API\JudgehostController;
+use OpenApi\Attributes as OA;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+/**
+ * An API action that returns void sends no body, so Symfony answers 204 No Content. Several
+ * such actions documented a 200 instead, which publishes a response code the API never
+ * actually returns.
+ *
+ * This works by reflection rather than by reading the generated OpenAPI document, so it needs
+ * no kernel and covers every controller in the namespace, including ones added later.
+ */
+class ResponseStatusDocumentationTest extends TestCase
+{
+    private const CONTROLLER_NAMESPACE = 'App\\Controller\\API\\';
+
+    public function testVoidActionsDocumentNoContent(): void
+    {
+        $checked = 0;
+        $wrong = [];
+
+        foreach ($this->apiControllers() as $class) {
+            foreach ((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() !== $class) {
+                    continue;
+                }
+
+                $returnType = $method->getReturnType();
+                if (!$returnType instanceof ReflectionNamedType || $returnType->getName() !== 'void') {
+                    continue;
+                }
+
+                foreach ($method->getAttributes(OA\Response::class) as $attribute) {
+                    $arguments = $attribute->getArguments();
+                    $code = $arguments['response'] ?? $arguments[0] ?? null;
+                    if (!is_int($code) || $code < 200 || $code >= 300) {
+                        // Only the success response is interesting; error codes are unaffected.
+                        continue;
+                    }
+
+                    $checked++;
+                    if ($code !== 204) {
+                        // Collect rather than assert immediately, so a maintainer sees every
+                        // offender at once instead of one per run.
+                        $wrong[] = sprintf('%s::%s() documents %d', $class, $method->getName(), $code);
+                    }
+                }
+            }
+        }
+
+        self::assertGreaterThan(
+            0,
+            $checked,
+            'found no documented void API actions at all, so this test is not checking anything'
+        );
+        self::assertSame(
+            [],
+            $wrong,
+            "These actions return void, so they answer 204 No Content:\n  " . implode("\n  ", $wrong)
+        );
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function apiControllers(): array
+    {
+        // Locate the controller directory through a known class rather than by counting
+        // parent directories, so moving this test does not silently make it check nothing.
+        $directory = dirname((new ReflectionClass(JudgehostController::class))->getFileName());
+
+        $classes = [];
+        foreach (glob($directory . '/*.php') ?: [] as $file) {
+            $class = self::CONTROLLER_NAMESPACE . basename($file, '.php');
+            if (class_exists($class)) {
+                $classes[] = $class;
+            }
+        }
+
+        self::assertNotEmpty($classes, 'no API controllers found');
+
+        return $classes;
+    }
+}


### PR DESCRIPTION
An action with a void return type sends no body, so Symfony answers 204 No Content. Three of them advertised a 200 in their OA\Response attribute, so the published OpenAPI document named a status code the API never returns:

  JudgehostController::updateJudgingAction
  JudgehostController::addDebugInfo
  LanguageController::updateExecutableActions

BalloonController::markDoneAction already documented 204, which is the convention this follows. Only the documentation changes; the responses themselves were and stay 204.

Guard it with a reflection-based test over the whole API controller namespace, so an action added later cannot reintroduce the mismatch. It needs no kernel or database and reports every offender in one run.