### PR TITLE
Don't print a hostname twice in printHosts

### DIFF
--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -682,14 +682,9 @@ class TwigExtension
     #[AsTwigFilter('printHosts', isSafe: ['html'])]
     public function printHosts(array $hostnames): string
     {
-        $hostnames = array_values($hostnames);
         if (empty($hostnames)) {
             return "";
         }
-        if (count($hostnames) == 1) {
-            return $this->printHost($hostnames[0]);
-        }
-        $hostnames = array_unique($hostnames);
 
         $local_parts = [];
         foreach ($hostnames as $hostname) {
@@ -700,25 +695,35 @@ class TwigExtension
             }
             $local_parts[] = $hostname;
         }
+        // Hostnames in different domains can share their first label, so only deduplicate
+        // after shortening: duplicates here would be printed twice below.
+        $local_parts = array_values(array_unique($local_parts));
+
+        if (count($local_parts) == 1) {
+            return $this->printHost($local_parts[0]);
+        }
 
         // Extract the longest common prefix.
         $common_prefix = $this->getCommonPrefix($local_parts);
         $prefix_len = strlen($common_prefix);
 
-        // Extract the longest common suffix.
+        // Extract the longest common suffix, clipped so it cannot overlap the common prefix:
+        // for e.g. ["abab", "ab"] both would otherwise be the entire shortest string, which
+        // would print that string twice and lose the parts in between.
         $reversed = array_map(strrev(...), $local_parts);
         $common_suffix = strrev($this->getCommonPrefix($reversed));
-        $suffix_len = strlen($common_suffix);
+        $shortest_len = min(array_map(strlen(...), $local_parts));
+        $suffix_len = min(strlen($common_suffix), $shortest_len - $prefix_len);
+        $common_suffix = $suffix_len > 0 ? substr($common_suffix, -$suffix_len) : "";
 
-        // Extract the list of remaining parts. This list may contain empty values. If $common_prefix overlaps
-        // $common_suffix, then $common_prefix = $common_suffix = the entire string.
+        // Extract the list of remaining parts. This list may contain empty values.
         $middle_parts = array_map(fn($host) => substr($host, $prefix_len, strlen($host) - $prefix_len - $suffix_len), $local_parts);
         // Usually the middle parts contain numbers, so use natural sort for them.
         usort($middle_parts, strnatcmp(...));
 
         if (empty($common_prefix) && empty($common_suffix)) {
             // No common prefix nor suffix: list all the names without "{}".
-            return implode(", ", array_map($this->printHost(...), $hostnames));
+            return implode(", ", array_map($this->printHost(...), $local_parts));
         } else {
             $hosts = $common_prefix . "{" . implode(",", $middle_parts) . "}" . $common_suffix;
             return $this->printHost($hosts, true);

--- a/webapp/tests/Unit/Twig/TwigExtensionTest.php
+++ b/webapp/tests/Unit/Twig/TwigExtensionTest.php
@@ -159,6 +159,44 @@ class TwigExtensionTest extends TestCase
     }
 
     /**
+     * @param string[] $hostnames
+     */
+    #[DataProvider('providePrintHosts')]
+    public function testPrintHosts(array $hostnames, string $expected): void
+    {
+        self::assertSame($expected, strip_tags($this->twigExtension->printHosts($hostnames)));
+    }
+
+    public static function providePrintHosts(): Generator
+    {
+        yield 'no hosts' => [[], ''];
+        yield 'single host is shortened' => [['judgehost-1.example.com'], 'judgehost-1'];
+
+        // The common prefix and suffix are factored out, the rest is sorted naturally.
+        yield 'common prefix' => [['judgehost-1', 'judgehost-2', 'judgehost-10'], 'judgehost-{1,2,10}'];
+        yield 'common suffix' => [['a-judgehost', 'b-judgehost'], '{a,b}-judgehost'];
+        yield 'both' => [['judge-1-host', 'judge-2-host'], 'judge-{1,2}-host'];
+
+        // Nothing in common: list the names in full.
+        yield 'nothing in common' => [['foo', 'bar'], 'foo, bar'];
+
+        // Hosts in different domains share their first label: only one name is left after
+        // shortening, so it must be printed once instead of as "judgehost{,}judgehost".
+        yield 'same label, other domain' => [
+            ['judgehost.example.com', 'judgehost.example.org'],
+            'judgehost',
+        ];
+        yield 'duplicate hostnames' => [['judgehost-1', 'judgehost-1'], 'judgehost-1'];
+
+        // The common prefix and suffix would overlap: the suffix is clipped so that no part
+        // of a hostname is printed twice, and "abab" is still recoverable from the output.
+        yield 'overlapping prefix and suffix' => [['abab', 'ab'], 'ab{,ab}'];
+
+        // IP addresses are not shortened.
+        yield 'ip addresses' => [['127.0.0.1', '127.0.0.2'], '127.0.0.{1,2}'];
+    }
+
+    /**
      * Every notation Utils::convertToHex() accepts must render, including the
      * one and three digits per channel forms.
      */


### PR DESCRIPTION
Deduplicate hostnames after shortening them to their first label, and clip the common suffix so it cannot overlap the common prefix.