### PR TITLE
Do not let a duplicate balloon close the entity manager.

### DIFF
--- a/webapp/src/Service/BalloonService.php
+++ b/webapp/src/Service/BalloonService.php
@@ -6,11 +6,9 @@ use App\Entity\Balloon;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Entity\Judging;
-use App\Entity\Problem;
 use App\Entity\Submission;
 use App\Entity\Team;
 use App\Entity\TeamCategory;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\NonUniqueResultException;
@@ -55,32 +53,19 @@ readonly class BalloonService
             return;
         }
 
-        // Prevent duplicate balloons in case of multiple correct submissions.
-        $numCorrect = $this->em->createQueryBuilder()
-            ->from(Balloon::class, 'b')
-            ->select('COUNT(b.submission) AS numBalloons')
-            ->andWhere('b.problem = :probid')
-            ->andWhere('b.team = :teamid')
-            ->andWhere('b.contest = :cid')
-            ->setParameter('probid', $submission->getProblem())
-            ->setParameter('teamid', $submission->getTeam())
-            ->setParameter('cid', $submission->getContest())
-            ->getQuery()
-            ->getSingleScalarResult();
-
-        if ($numCorrect == 0) {
-            $balloon = new Balloon();
-            $balloon->setSubmission($this->em->getReference(Submission::class, $submission->getSubmitid()));
-            $balloon->setTeam($this->em->getReference(Team::class, $submission->getTeamId()));
-            $balloon->setContest(
-                $this->em->getReference(Contest::class, $submission->getContest()->getCid()));
-            $balloon->setProblem($this->em->getReference(Problem::class, $submission->getProblemId()));
-            $this->em->persist($balloon);
-            try {
-                $this->em->flush();
-            } catch (UniqueConstraintViolationException) {
-            }
-        }
+        // Prevent duplicate balloons in case of multiple correct submissions. The unique key on
+        // (cid, teamid, probid) decides: checking first races with other judgehosts, and
+        // catching the violation instead would leave the entity manager closed for callers
+        // that are mid-transaction, such as RejudgingService::finishRejudging().
+        $this->em->getConnection()->executeStatement(
+            'INSERT IGNORE INTO balloon (submitid, teamid, probid, cid) VALUES (:submitid, :teamid, :probid, :cid)',
+            [
+                'submitid' => $submission->getSubmitid(),
+                'teamid' => $submission->getTeamId(),
+                'probid' => $submission->getProblemId(),
+                'cid' => $submission->getContest()->getCid(),
+            ]
+        );
     }
 
     /**

--- a/webapp/tests/Unit/Service/BalloonServiceTest.php
+++ b/webapp/tests/Unit/Service/BalloonServiceTest.php
@@ -5,16 +5,21 @@ namespace App\Tests\Unit\Service;
 use App\DataFixtures\Test\BalloonNotificationsSettingsFixture;
 use App\DataFixtures\Test\ContestTimeFixture;
 use App\Entity\Contest;
+use App\Entity\Judging;
+use App\Entity\Problem;
+use App\Entity\SubmissionSource;
 use App\Entity\Team;
 use App\Service\BalloonService;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
 use App\Service\EventLogService;
 use App\Service\ScoreboardService;
+use App\Service\SubmissionService;
 use App\Tests\Unit\BaseTestCase;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class BalloonServiceTest extends BaseTestCase
 {
@@ -134,5 +139,72 @@ class BalloonServiceTest extends BaseTestCase
             'At most 4, including post-freeze submissions' => [4, true, $everyoneSolvedEverything],
             'At most 5, including post-freeze submissions' => [5, true, $everyoneSolvedEverything],
         ];
+    }
+
+    /**
+     * A team can have several correct submissions for the same problem, and several
+     * judgehosts can report them at the same time, so updateBalloons() must be safe to call
+     * more than once. It must in particular leave the entity manager usable: it is called
+     * from inside RejudgingService::finishRejudging()'s transaction, which cannot continue
+     * with a closed one.
+     */
+    #[Test]
+    public function testUpdateBalloonsCreatesAtMostOneBalloonPerTeamAndProblem(): void
+    {
+        $this->logIn();
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        $balloonService = $container->get(BalloonService::class);
+
+        [$contest, $team, $problem, $submission, $judging] = $this->correctSubmission();
+
+        $balloonService->updateBalloons($contest, $submission, $judging);
+        $balloonService->updateBalloons($contest, $submission, $judging);
+
+        self::assertTrue($em->isOpen(), 'a repeated balloon must not close the entity manager');
+        self::assertSame(1, $this->countBalloons($contest, $team, $problem));
+    }
+
+    /**
+     * Submit a solution to the demo contest and mark its judging correct.
+     *
+     * @return array{Contest, Team, Problem, \App\Entity\Submission, Judging}
+     */
+    private function correctSubmission(): array
+    {
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $contest->setProcessBalloons(true);
+        $team = $em->getRepository(Team::class)->findOneBy(['name' => 'DOMjudge']);
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => 'hello']);
+
+        // The demo data may already contain balloons for this pair.
+        $em->getConnection()->executeStatement(
+            'DELETE FROM balloon WHERE cid = :cid AND teamid = :teamid AND probid = :probid',
+            ['cid' => $contest->getCid(), 'teamid' => $team->getTeamid(), 'probid' => $problem->getProbid()]
+        );
+
+        $message = null;
+        $submission = $container->get(SubmissionService::class)->submitSolution(
+            $team, null, $problem, $contest, 'c',
+            [new UploadedFile(__FILE__, 'foo.c', null, null, true)],
+            SubmissionSource::UNKNOWN, null, null, null, null, null, $message
+        );
+
+        $judging = $submission->getJudgings()->first();
+        $judging->setResult(Judging::RESULT_CORRECT);
+        $em->flush();
+
+        return [$contest, $team, $problem, $submission, $judging];
+    }
+
+    private function countBalloons(Contest $contest, Team $team, Problem $problem): int
+    {
+        return (int)static::getContainer()->get(EntityManagerInterface::class)->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM balloon WHERE cid = :cid AND teamid = :teamid AND probid = :probid',
+            ['cid' => $contest->getCid(), 'teamid' => $team->getTeamid(), 'probid' => $problem->getProbid()]
+        );
     }
 }


### PR DESCRIPTION
Catching the constraint violation after a failed flush does not recover from it: the entity manager is closed, and RejudgingService::finishRejudging() keeps using it inside its own transaction. Let the unique key deduplicate in a single INSERT IGNORE instead, which also removes the check-then-insert race.