### PR TITLE
Notice when a submission was claimed by another rejudging.

### DIFF
--- a/webapp/src/Service/RejudgingService.php
+++ b/webapp/src/Service/RejudgingService.php
@@ -124,13 +124,21 @@ class RejudgingService
             // So use the direct connection transaction API here.
             $this->em->getConnection()->beginTransaction();
 
-            $this->em->getConnection()->executeStatement(
+            // Claim the submission. The check above ran before this transaction, so another
+            // rejudging may have taken it since; going on regardless would create judge tasks
+            // for a submission somebody else owns.
+            $claimed = $this->em->getConnection()->executeStatement(
                 'UPDATE submission SET rejudgingid = :rejudgingid WHERE submitid = :submitid AND rejudgingid IS NULL',
                 [
                     'rejudgingid' => $rejudging->getRejudgingid(),
                     'submitid' => $judging->getSubmissionId(),
                 ]
             );
+            if (!$claimed) {
+                $this->em->getConnection()->rollBack();
+                $skipped[] = $judging;
+                continue;
+            }
 
             if ($singleJudging) {
                 $teamid = $judging->getSubmission()->getTeamId();

--- a/webapp/tests/Unit/Service/RejudgingServiceTest.php
+++ b/webapp/tests/Unit/Service/RejudgingServiceTest.php
@@ -4,15 +4,19 @@ namespace App\Tests\Unit\Service;
 
 use App\DataFixtures\Test\RejudgingFirstToSolveFixture;
 use App\Entity\Contest;
+use App\Entity\JudgeTask;
 use App\Entity\Judging;
 use App\Entity\Problem;
 use App\Entity\Rejudging;
+use App\Entity\SubmissionSource;
 use App\Entity\Team;
 use App\Service\RejudgingService;
 use App\Service\ScoreboardService;
+use App\Service\SubmissionService;
 use App\Tests\Unit\BaseTestCase;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class RejudgingServiceTest extends BaseTestCase
 {
@@ -78,5 +82,67 @@ class RejudgingServiceTest extends BaseTestCase
         // Now both teams solved the problem, but $team2 solved it first.
         static::assertFalse($scoreboard->solvedFirst($team1, $contestProblem));
         static::assertTrue($scoreboard->solvedFirst($team2, $contestProblem));
+    }
+    /**
+     * A submission can only belong to one rejudging at a time. createRejudging() checks that
+     * before claiming it, but the check reads state from before the claim, so another
+     * rejudging can take the submission in between. The claim itself is guarded; this asserts
+     * that losing it is noticed, because otherwise we would create a judging and judge tasks
+     * for a submission somebody else owns and that work could never be applied.
+     */
+    public function testSubmissionClaimedByAnotherRejudgingIsSkipped(): void
+    {
+        // Deliberately not logged in: createRejudging() records the current user as the
+        // rejudging's start user, and a security token set up outside this entity manager
+        // would be rejected as an unknown entity. A rejudging without a start user is valid.
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+
+        $contest = $em->getRepository(Contest::class)->findOneBy(['shortname' => 'demo']);
+        $team = $em->getRepository(Team::class)->findOneBy(['name' => 'DOMjudge']);
+        $problem = $em->getRepository(Problem::class)->findOneBy(['externalid' => 'hello']);
+
+        $message = null;
+        $submission = $container->get(SubmissionService::class)->submitSolution(
+            $team, null, $problem, $contest, 'c',
+            [new UploadedFile(__FILE__, 'foo.c', null, null, true)],
+            SubmissionSource::UNKNOWN, null, null, null, null, null, $message
+        );
+        $judging = $submission->getJudgings()->first();
+
+        // Stand in for the other rejudging: claim the submission directly, so the entity the
+        // service already holds still says the submission is free. That is precisely the state
+        // the real race leaves behind.
+        $otherRejudging = new Rejudging();
+        $otherRejudging->setStarttime(Utils::now())->setReason('claimed elsewhere');
+        $em->persist($otherRejudging);
+        $em->flush();
+        $em->getConnection()->executeStatement(
+            'UPDATE submission SET rejudgingid = :rejudgingid WHERE submitid = :submitid',
+            ['rejudgingid' => $otherRejudging->getRejudgingid(), 'submitid' => $submission->getSubmitid()]
+        );
+
+        $skipped = [];
+        $rejudging = static::getContainer()->get(RejudgingService::class)->createRejudging(
+            'losing the race',
+            JudgeTask::PRIORITY_DEFAULT,
+            [$judging],
+            false,
+            null,
+            0,
+            null,
+            $skipped
+        );
+
+        static::assertCount(1, $skipped, 'the submission must be reported as skipped');
+        static::assertNull($rejudging, 'a rejudging that skipped everything is cleaned up');
+
+        // The submission still belongs to the other rejudging, and no judging was created for
+        // the one we tried to start.
+        $owner = $em->getConnection()->fetchOne(
+            'SELECT rejudgingid FROM submission WHERE submitid = ?',
+            [$submission->getSubmitid()]
+        );
+        static::assertEquals($otherRejudging->getRejudgingid(), $owner);
     }
 }


### PR DESCRIPTION
The claim was already guarded on rejudgingid IS NULL, but its result was never checked, so losing the race went on to create a judging and judge tasks for a submission owned by another rejudging - work that could never be applied. Roll back and report the submission as skipped instead.