### PR TITLE
Log database conflicts under a name that can be grepped for.

### DIFF
--- a/webapp/src/EventListener/LogDatabaseConflictListener.php
+++ b/webapp/src/EventListener/LogDatabaseConflictListener.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Throwable;
+
+/**
+ * Log requests that failed on a database conflict under a fixed, greppable marker.
+ *
+ * Deadlocks, lock wait timeouts and MariaDB's "record has changed since last read" used to be
+ * indistinguishable from any other 500, so nobody could tell how often they happened. This
+ * listener only logs them: a conflict that gets this far is a code path that still needs
+ * fixing, and a friendlier response would hide that. Judgedaemons retry failed requests anyway.
+ *
+ * See https://github.com/DOMjudge/domjudge/issues/2848
+ */
+#[AsEventListener]
+readonly class LogDatabaseConflictListener
+{
+    /**
+     * Raised by MariaDB under innodb_snapshot_isolation; Doctrine has no exception class for it.
+     */
+    private const ERROR_RECORD_HAS_CHANGED = 1020;
+
+    public function __construct(protected LoggerInterface $logger) {}
+
+    public function __invoke(ExceptionEvent $event): void
+    {
+        // The conflict is usually wrapped, by Doctrine and then by the controller, so walk the chain.
+        for ($throwable = $event->getThrowable(); $throwable !== null; $throwable = $throwable->getPrevious()) {
+            $kind = self::conflictKind($throwable);
+            if ($kind === null) {
+                continue;
+            }
+
+            $this->logger->warning('db-conflict: {kind} on {method} {path}: {message}', [
+                'kind' => $kind,
+                'method' => $event->getRequest()->getMethod(),
+                'path' => $event->getRequest()->getPathInfo(),
+                'message' => $throwable->getMessage(),
+            ]);
+            return;
+        }
+    }
+
+    private static function conflictKind(Throwable $throwable): ?string
+    {
+        return match (true) {
+            $throwable instanceof DeadlockException => 'deadlock',
+            $throwable instanceof LockWaitTimeoutException => 'lock wait timeout',
+            $throwable instanceof DriverException
+                && $throwable->getCode() === self::ERROR_RECORD_HAS_CHANGED => 'record changed since last read',
+            default => null,
+        };
+    }
+}

--- a/webapp/tests/Unit/EventListener/LogDatabaseConflictListenerTest.php
+++ b/webapp/tests/Unit/EventListener/LogDatabaseConflictListenerTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener;
+
+use App\EventListener\LogDatabaseConflictListener;
+use Doctrine\DBAL\Driver\Exception as DriverExceptionInterface;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Doctrine\DBAL\Query;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use RuntimeException;
+use Stringable;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Throwable;
+
+class LogDatabaseConflictListenerTest extends TestCase
+{
+    /**
+     * Feed the throwable to the listener and return what it logged.
+     *
+     * @return list<array{level: mixed, message: string, context: array<string, mixed>}>
+     */
+    private function handle(Throwable $throwable): array
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string)$message, 'context' => $context];
+            }
+        };
+
+        $listener = new LogDatabaseConflictListener($logger);
+        $listener(new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/jury/submissions/1/verify', 'POST'),
+            HttpKernelInterface::MAIN_REQUEST,
+            $throwable
+        ));
+
+        return $logger->records;
+    }
+
+    private static function driverException(int $code): DriverExceptionInterface
+    {
+        return new class($code) extends RuntimeException implements DriverExceptionInterface {
+            public function __construct(int $errorCode)
+            {
+                parent::__construct('driver failure', $errorCode);
+            }
+
+            public function getSQLState(): string
+            {
+                return 'HY000';
+            }
+        };
+    }
+
+    #[DataProvider('provideConflicts')]
+    public function testConflictsAreLogged(Throwable $throwable, string $expectedKind): void
+    {
+        $records = $this->handle($throwable);
+
+        self::assertCount(1, $records, 'the conflict should have been logged exactly once');
+        $record = $records[0];
+        self::assertSame('warning', $record['level']);
+        self::assertStringStartsWith('db-conflict: ', $record['message']);
+        self::assertSame($expectedKind, $record['context']['kind']);
+        self::assertSame('POST', $record['context']['method']);
+        self::assertSame('/jury/submissions/1/verify', $record['context']['path']);
+    }
+
+    /**
+     * @return iterable<string, array{Throwable, string}>
+     */
+    public static function provideConflicts(): iterable
+    {
+        $query = new Query('UPDATE judging SET verified = 1', [], []);
+
+        yield 'deadlock' => [
+            new DeadlockException(self::driverException(1213), $query),
+            'deadlock',
+        ];
+        yield 'lock wait timeout' => [
+            new LockWaitTimeoutException(self::driverException(1205), $query),
+            'lock wait timeout',
+        ];
+        // Doctrine has no dedicated class for 1020, so it arrives as a plain DriverException.
+        yield 'record changed since last read' => [
+            new DriverException(self::driverException(1020), $query),
+            'record changed since last read',
+        ];
+        yield 'wrapped by the controller' => [
+            new RuntimeException('failed to verify', 0, new DeadlockException(self::driverException(1213), $query)),
+            'deadlock',
+        ];
+    }
+
+    public function testUnrelatedDriverErrorsAreIgnored(): void
+    {
+        // 1062 is a duplicate key: a bug, but not a conflict this is about.
+        $records = $this->handle(new DriverException(self::driverException(1062), new Query('INSERT INTO balloon', [], [])));
+
+        self::assertSame([], $records);
+    }
+
+    public function testUnrelatedExceptionsAreIgnored(): void
+    {
+        $records = $this->handle(new RuntimeException('something else entirely'));
+
+        self::assertSame([], $records);
+    }
+}


### PR DESCRIPTION
Deadlocks, lock wait timeouts and "record has changed since last read" were indistinguishable from any other 500, which is why #2848 was hard to quantify. Log them at warning level under a fixed marker. Only log: a conflict that gets this far is a code path that still needs fixing, so a friendlier response would hide it, and judgedaemons already retry.