### PR TITLE
Fetch testcase results for a submission list in one go.

### DIFF
--- a/webapp/src/Service/SubmissionService.php
+++ b/webapp/src/Service/SubmissionService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\DataTransferObject\SubmissionRestriction;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
+use App\Entity\ExternalJudgement;
 use App\Entity\JudgeTask;
 use App\Entity\Judging;
 use App\Entity\JudgingRun;
@@ -19,6 +20,7 @@ use App\Entity\TestcaseGroup;
 use App\Entity\User;
 use App\Utils\FreezeData;
 use App\Utils\Utils;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
@@ -311,6 +313,104 @@ class SubmissionService
         }
 
         return $hierarchy;
+    }
+
+    /**
+     * Get the per-testcase results to show for the given submissions, keyed by submission ID.
+     *
+     * The results are those of the first judging (or external judgement when $external is set)
+     * of each submission, which is the one the submission list query joined. Testcases without
+     * a run yet are included with a null result.
+     *
+     * @param iterable<Submission> $submissions
+     * @return array<int, list<array<string, mixed>>>
+     */
+    public function getTestcaseResults(iterable $submissions, bool $external = false): array
+    {
+        $judgingIds = [];
+        $probIds    = [];
+        foreach ($submissions as $submission) {
+            $judgingIds[$submission->getSubmitid()] = $this->getTestcaseResultsJudgingId($submission, $external);
+            $probIds[$submission->getSubmitid()]    = $submission->getProblem()->getProbid();
+        }
+        if (empty($probIds)) {
+            return [];
+        }
+
+        $connection = $this->em->getConnection();
+
+        $testcasesByProblem = [];
+        $rows = $connection->fetchAllAssociative(
+            'SELECT probid, testcaseid, ranknumber, description, sample
+               FROM testcase
+              WHERE probid IN (:probids)
+              ORDER BY probid, ranknumber',
+            ['probids' => array_values(array_unique($probIds))],
+            ['probids' => ArrayParameterType::INTEGER]
+        );
+        foreach ($rows as $row) {
+            $testcasesByProblem[$row['probid']][] = $row;
+        }
+
+        $runs = [];
+        if ($usedJudgingIds = array_values(array_unique(array_filter($judgingIds)))) {
+            if ($external) {
+                $rows = $connection->fetchAllAssociative(
+                    'SELECT er.extjudgementid AS judgingid, er.testcaseid, er.result AS runresult
+                       FROM external_run er
+                      WHERE er.extjudgementid IN (:judgingids)',
+                    ['judgingids' => $usedJudgingIds],
+                    ['judgingids' => ArrayParameterType::INTEGER]
+                );
+            } else {
+                $rows = $connection->fetchAllAssociative(
+                    'SELECT r.judgingid, r.testcaseid, r.runresult, jh.hostname, jt.valid
+                       FROM judging_run r
+                       LEFT JOIN judgetask jt ON (r.judgetaskid = jt.judgetaskid)
+                       LEFT JOIN judgehost jh ON (jt.judgehostid = jh.judgehostid)
+                      WHERE r.judgingid IN (:judgingids)',
+                    ['judgingids' => $usedJudgingIds],
+                    ['judgingids' => ArrayParameterType::INTEGER]
+                );
+            }
+            foreach ($rows as $row) {
+                $runs[$row['judgingid']][$row['testcaseid']] = $row;
+            }
+        }
+
+        $results = [];
+        foreach ($probIds as $submitId => $probId) {
+            $results[$submitId] = [];
+            foreach ($testcasesByProblem[$probId] ?? [] as $testcase) {
+                $run    = $runs[$judgingIds[$submitId]][$testcase['testcaseid']] ?? null;
+                $result = [
+                    'runresult'   => $run['runresult'] ?? null,
+                    'ranknumber'  => $testcase['ranknumber'],
+                    'description' => $testcase['description'],
+                    'sample'      => $testcase['sample'],
+                ];
+                if (!$external) {
+                    $result['hostname'] = $run['hostname'] ?? null;
+                    $result['valid']    = $run['valid'] ?? null;
+                }
+                $results[$submitId][] = $result;
+            }
+        }
+
+        return $results;
+    }
+
+    private function getTestcaseResultsJudgingId(Submission $submission, bool $external): ?int
+    {
+        if ($external) {
+            /** @var ExternalJudgement|false $externalJudgement */
+            $externalJudgement = $submission->getExternalJudgements()->first();
+            return $externalJudgement ? $externalJudgement->getExtjudgementid() : null;
+        }
+
+        /** @var Judging|false $judging */
+        $judging = $submission->getJudgings()->first();
+        return $judging ? $judging->getJudgingid() : null;
     }
 
     /**

--- a/webapp/src/Twig/TwigExtension.php
+++ b/webapp/src/Twig/TwigExtension.php
@@ -313,41 +313,40 @@ class TwigExtension
         return '';
     }
 
+    /**
+     * Testcase results per submission ID as fetched by prefetchTestcaseResults(), keyed by
+     * whether they are the external results.
+     *
+     * @var array<int, array<int, list<array<string, mixed>>>>
+     */
+    private array $testcaseResults = [];
+
+    /**
+     * Fetch the testcase results for all given submissions in one go, so the testcaseResults
+     * filter does not need to query per submission.
+     *
+     * @param iterable<Submission> $submissions
+     */
+    #[AsTwigFunction('prefetchTestcaseResults')]
+    public function prefetchTestcaseResults(iterable $submissions, bool $showExternal = false): void
+    {
+        $this->testcaseResults[(int)$showExternal] =
+            $this->submissionService->getTestcaseResults($submissions, $showExternal)
+            + ($this->testcaseResults[(int)$showExternal] ?? []);
+    }
+
     #[AsTwigFilter('testcaseResults', isSafe: ['html'])]
     public function testcaseResults(Submission $submission, ?bool $showExternal = false): string
     {
-        // We use a direct SQL query here for performance reasons
-        if ($showExternal) {
-            /** @var ExternalJudgement|null $externalJudgement */
-            $externalJudgement   = $submission->getExternalJudgements()->first() ?: null;
-            $externalJudgementId = $externalJudgement?->getExtjudgementid();
-            $probId              = $submission->getProblem()->getProbid();
-            $testcases           = $this->em->getConnection()->fetchAllAssociative(
-                'SELECT er.result as runresult, t.ranknumber, t.description, t.sample
-                  FROM testcase t
-                  LEFT JOIN external_run er ON (er.testcaseid = t.testcaseid
-                                              AND er.extjudgementid = :extjudgementid)
-                  WHERE t.probid = :probid ORDER BY ranknumber',
-                ['extjudgementid' => $externalJudgementId, 'probid' => $probId]);
-
-            $submissionDone = $externalJudgement && !empty($externalJudgement->getEndtime());
-        } else {
-            /** @var Judging|bool $judging */
-            $judging   = $submission->getJudgings()->first();
-            $judgingId = $judging ? $judging->getJudgingid() : null;
-            $probId    = $submission->getProblem()->getProbid();
-            $testcases = $this->em->getConnection()->fetchAllAssociative(
-                'SELECT r.runresult, jh.hostname, jt.valid, t.ranknumber, t.description, t.sample
-                  FROM testcase t
-                  LEFT JOIN judging_run r ON (r.testcaseid = t.testcaseid
-                                              AND r.judgingid = :judgingid)
-                  LEFT JOIN judgetask jt ON (r.judgetaskid = jt.judgetaskid)
-                  LEFT JOIN judgehost jh on (jt.judgehostid = jh.judgehostid)
-                  WHERE t.probid = :probid ORDER BY ranknumber',
-                ['judgingid' => $judgingId, 'probid' => $probId]);
-
-            $submissionDone = $judging && !empty($judging->getEndtime());
+        $showExternal = (bool)$showExternal;
+        if (!isset($this->testcaseResults[(int)$showExternal][$submission->getSubmitid()])) {
+            $this->prefetchTestcaseResults([$submission], $showExternal);
         }
+        $testcases = $this->testcaseResults[(int)$showExternal][$submission->getSubmitid()];
+
+        /** @var Judging|ExternalJudgement|false $judging */
+        $judging        = $showExternal ? $submission->getExternalJudgements()->first() : $submission->getJudgings()->first();
+        $submissionDone = $judging && !empty($judging->getEndtime());
 
         $total = count($testcases);
         $separator = '<span class="tc-sep"></span>';

--- a/webapp/templates/jury/partials/submission_list.html.twig
+++ b/webapp/templates/jury/partials/submission_list.html.twig
@@ -97,6 +97,12 @@
         </tr>
         </thead>
         <tbody>
+        {%- if showTestcases is defined and showTestcases %}
+            {%- do prefetchTestcaseResults(submissions) %}
+        {%- endif %}
+        {%- if showExternalResult and showExternalTestcases %}
+            {%- do prefetchTestcaseResults(submissions, showExternal=true) %}
+        {%- endif %}
         {%- for submission in submissions %}
             {%- if rejudging is defined %}
                 {%- set link = path('jury_submission', {contestId: submission.contest.externalid, submitId: submission.externalid, rejudgingid: rejudging.rejudgingid}) %}
@@ -296,7 +302,7 @@
                         </td>
                     {% endif %}
                     <td class="testcase-results">
-                        {{- submission | testcaseResults(true) -}}
+                        {{- submission | testcaseResults(showExternal=true) -}}
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
The testcaseResults twig filter ran one query per submission row, so the jury submissions page issued 50 queries on every refresh (twice with shadow differences/external results enabled).

Each query also returned one row per testcase of the problem, so most of the time went into shipping the same testcase rows over and over.

Fetch the testcases per problem and the runs per judging for the whole page at once, before the loop, and let the filter read from that.

This also moves the SQL out of the Twig extension into the submission service.

Speeds up submission page by ~2x.