### PR TITLE
Don't require yarn license generation for in-place installs

### DIFF
--- a/.github/jobs/configure-checks/setup_configure_image.sh
+++ b/.github/jobs/configure-checks/setup_configure_image.sh
@@ -7,12 +7,12 @@ distro_id=$(grep "^ID=" /etc/os-release)
 # Install everything for configure and testing
 case $distro_id in
     "ID=fedora")
-        dnf install pkg-config make bats autoconf automake util-linux -y ;;
+        dnf install pkg-config make bats autoconf automake util-linux zip -y ;;
     *)
         apt-get update; apt-get full-upgrade -y
         # Install g++-12 to make sure we can use -std=c++20
         version=$(g++ -dumpversion 2>/dev/null | awk -F'.' '{print $1}' 2>/dev/null || echo 0); [ "${version}" -lt 12 ] && apt-get install -y g++-12
-        apt-get install pkg-config make bats autoconf php -y ;;
+        apt-get install pkg-config make bats autoconf php zip -y ;;
 esac
 
 # Build the configure file

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,10 @@ paths.mk:
 # Configure for running in source tree, not meant for normal use:
 maintainer-conf: inplace-conf-common dependencies-dev
 inplace-conf: inplace-conf-common dependencies
-inplace-conf-common: dist
+# In-place installs are not distributions: they install their own (dev)
+# dependencies above, and 'make domserver' builds the default data
+# archives. Only the configure script is needed here.
+inplace-conf-common: configure
 	./configure $(subst 1,-q,$(QUIET)) --prefix=$(CURDIR) \
 	            --with-domserver_root=$(CURDIR) \
 	            --with-judgehost_root=$(CURDIR) \

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/Makefile.global
 EXECDIRS=$(shell find files -mindepth 2 -maxdepth 2 -type d)
 ZIPFILES=$(EXECDIRS:=.zip)
 
-domserver: dj_setup_database
+domserver: dj_setup_database $(ZIPFILES)
 
 build-scripts:
 	@for d in $(EXECDIRS) ; do \


### PR DESCRIPTION
Commit 9e3481ae6 made dependencies-dist fail when LICENSES.txt cannot be generated, and pointed inplace-conf-common at dist. That check was silently skipped until 0878e086f fixed the recipe grouping, so maintainer-conf and inplace-conf now fail on systems whose yarn has no licenses command, such as Debian's yarnpkg 4.

These targets already install their own dependencies with the lenient check, so pass LICENSES_OPTIONAL down the in-place path and keep the strict check for release tarballs.