### PR TITLE
Clean build artifacts between configure-check tests.

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -66,8 +66,13 @@ LIBOBJECTS = $(addsuffix $(OBJEXT),$(LIBSBASE))
 CFLAGS   += -I$(TOPDIR)/lib -I$(TOPDIR)/etc
 CXXFLAGS += -I$(TOPDIR)/lib -I$(TOPDIR)/etc
 
-$(LIBOBJECTS):
+# Always delegate to lib/Makefile, which knows the real dependencies of
+# these objects; this Makefile does not, so without FORCE an existing
+# object file would never be rebuilt from here.
+$(LIBOBJECTS): FORCE
 	$(MAKE) -C $(TOPDIR)/lib $(notdir $@)
+
+FORCE:
 
 # Default recursive targets; these should always at least call the
 # TARGET-l variant:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -8,8 +8,10 @@ OBJECTS = $(addsuffix $(OBJEXT),lib.error lib.misc)
 
 build: $(OBJECTS)
 
-lib.error$(OBJEXT): lib.error.cc lib.error.hpp
-lib.misc$(OBJEXT): lib.misc.cc lib.misc.h
+# paths.mk holds the compiler and flags chosen by configure, so a
+# reconfigure with a different compiler must rebuild these.
+lib.error$(OBJEXT): lib.error.cc lib.error.hpp $(TOPDIR)/paths.mk
+lib.misc$(OBJEXT): lib.misc.cc lib.misc.h $(TOPDIR)/paths.mk
 
 clean-l:
 	rm -f $(OBJECTS)


### PR DESCRIPTION
Commit 9b3abc2c8a split configure-checks into separate containers started from a base image. However, because all containers bind-mount the host workspace ($(pwd)), compiled artifacts leak between steps.

This broke the autoconf check on Debian testing (seen in PR #3742 and the merge queue) following Debian's transition to GCC 16 (more details below):
1. "Check G++" compiles lib/lib.error.o using GCC 16 into $(pwd).
2. "Check Clang" runs next; Clang-21 on Debian testing links against libstdc++-15-dev, but reuses the stale lib.error.o from the host.
3. Linking runguard fails with undefined references to GCC 16's internal C++20 std::format symbols missing in GCC 15 libstdc++.

More debug info, on Debian testing we have since earlier today:
  • Installing g++ gets you GCC 16.
  • Installing clang pulls in libstdc++-15-dev.

This results in the following chain reaction

    [ Container 2: gpp ]
        │
        ├─► apt installs g++ (GCC 16)
        ├─► make judgehost compiles lib/lib.error.cc using GCC 16 headers
        └─► writes lib/lib.error.o to the mounted host directory $(pwd)
             │
             ▼  (lib.error.o remains on the host disk)
    [ Container 3: clang ]
        │
        ├─► apt removes g++ (GCC 16 and libstdc++-16-dev are purged)
        ├─► apt installs clang (pulls in libstdc++-15-dev)
        ├─► make judgehost runs:
        │     - Sees lib/lib.error.o already exists on disk
        │     - Skips compiling lib.error.o!
        │     - Invokes clang++ to link runguard:
        │       clang++ -o runguard runguard.cc lib/lib.error.o ... -lstdc++
        │
        └─► Clang links against GCC 15's libstdc++.so:
              lib.error.o (compiled with GCC 16) asks for GCC 16 <format> symbols:
                - std::basic_format_arg<...>::_M_handle_unrecognized()
                - std::__format::__do_vformat_to<char, 1u>(...)
              GCC 15 libstdc++.so says: "I don't have those symbols."
              💥 LINKER ERROR