### PR TITLE
Refresh the jury user page every 15 seconds, like the team page

### DIFF
--- a/webapp/src/Controller/Jury/UserController.php
+++ b/webapp/src/Controller/Jury/UserController.php
@@ -201,7 +201,7 @@ class UserController extends BaseController
             'showContest' => count($this->dj->getCurrentContests(honorCookie: true)) > 1,
             'showExternalResult' => $this->dj->shadowMode(),
             'refresh' => [
-                'after' => 3,
+                'after' => 15,
                 'url' => $this->generateUrl('jury_user', ['userId' => $userId]),
                 'ajax' => true,
             ],


### PR DESCRIPTION
The 3 second interval was added together with the submissions list on this page; every sibling page refreshes every 15 seconds and the page did so before the Symfony port. It is most likely a typo.