### PR TITLE
Skip CI jobs that the changed files cannot affect.

### DIFF
--- a/.github/paths-filters.yml
+++ b/.github/paths-filters.yml
@@ -1,0 +1,110 @@
+# Which files matter to which CI jobs.
+#
+# Each heavy workflow starts with the reusable job in
+# .github/workflows/changes.yml, which runs dorny/paths-filter with these
+# filters. The expensive jobs then carry
+#
+#     needs: changes
+#     if: ${{ !cancelled() && needs.changes.outputs.<filter> != 'false' }}
+#
+# so a PR that only touches the manual does not build runguard, and a
+# PR that only touches the judgedaemon does not run the web tests. A job
+# skipped this way still counts as a passed required status check.
+#
+# Every filter includes the CI definitions themselves, so a change to a
+# workflow or to the scripts under .github/jobs always runs everything.
+#
+# Keep the lists generous: a job that runs needlessly costs minutes, a
+# job that is skipped wrongly lets a regression through.
+
+# The CI definitions.
+ci: &ci
+  - '.github/**'
+
+# The autotools and make plumbing that every install goes through, plus
+# the C++ library linked into the judge binaries.
+build: &build
+  - 'configure.ac'
+  - 'bootstrap'
+  - 'config.guess'
+  - 'config.sub'
+  - 'install-sh'
+  - 'm4/**'
+  - 'paths.mk.in'
+  - 'Makefile.global'
+  - '**/Makefile'
+  - 'etc/**'
+  - 'lib/**'
+
+# The judgehost: runguard, runpipe, the judgedaemon and the chroot
+# tooling, and the default executables the judgedaemon runs.
+judge: &judge
+  - *ci
+  - *build
+  - 'judge/**'
+  - 'misc-tools/**'
+  - 'sql/files/**'
+
+# The judgedaemon's PHP unit tests load its config from etc/ and the PHP
+# libraries from lib/, and install composer dependencies from webapp.
+judge-unit:
+  - *ci
+  - 'judge/**'
+  - 'etc/**'
+  - 'lib/**'
+  - 'webapp/composer.json'
+  - 'webapp/composer.lock'
+
+# Building the chroot needs the judgehost build, dj_make_chroot and the
+# bats assertion helper from submit/.
+chroot:
+  - *ci
+  - *build
+  - 'misc-tools/**'
+  - 'submit/**'
+
+# The configure checks build a judgehost and a domserver. The latter
+# only reaches into webapp for its Makefile and composer autoloader,
+# and the bats suites load the assertion helper from submit/.
+autoconf:
+  - *judge
+  - 'submit/**'
+  - 'webapp/Makefile'
+  - 'webapp/composer.json'
+  - 'webapp/composer.lock'
+
+# Everything phpstan.dist.neon analyses, and the configuration itself.
+phpstan:
+  - *ci
+  - 'etc/**'
+  - 'judge/**'
+  - 'lib/**'
+  - 'webapp/**'
+  - 'phpstan*.neon'
+
+# The default compare script and its test.
+compare:
+  - *ci
+  - 'misc-tests/**'
+  - 'sql/files/defaultdata/compare/**'
+
+# The web application and everything a domserver install ships,
+# including the import scripts in misc-tools that load the example
+# problems the tests run against.
+webapp: &webapp
+  - *ci
+  - *build
+  - 'webapp/**'
+  - 'sql/**'
+  - 'submit/**'
+  - 'misc-tools/**'
+  - 'example_problems/**'
+  - 'example_scoring_problems/**'
+  - 'doc/examples/**'
+
+# Anything that ends up in a domserver or judgehost install, for the
+# integration test that exercises both.
+code:
+  - *judge
+  - *webapp
+  - 'misc-tests/**'

--- a/.github/workflows/autoconf-check.yml
+++ b/.github/workflows/autoconf-check.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   mainstream:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.autoconf != 'false' }}
     strategy:
       matrix:
         version: [noble, rolling]

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,52 @@
+# Reusable job that tells the other workflows which parts of the tree a
+# change touches, so they can skip the jobs it cannot affect. The filters
+# live in .github/paths-filters.yml.
+name: Detect changed paths
+on:
+  workflow_call:
+    outputs:
+      judge:
+        value: ${{ jobs.changes.outputs.judge }}
+      judge-unit:
+        value: ${{ jobs.changes.outputs.judge-unit }}
+      chroot:
+        value: ${{ jobs.changes.outputs.chroot }}
+      compare:
+        value: ${{ jobs.changes.outputs.compare }}
+      phpstan:
+        value: ${{ jobs.changes.outputs.phpstan }}
+      autoconf:
+        value: ${{ jobs.changes.outputs.autoconf }}
+      webapp:
+        value: ${{ jobs.changes.outputs.webapp }}
+      code:
+        value: ${{ jobs.changes.outputs.code }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      judge: ${{ steps.filter.outputs.judge }}
+      judge-unit: ${{ steps.filter.outputs.judge-unit }}
+      chroot: ${{ steps.filter.outputs.chroot }}
+      compare: ${{ steps.filter.outputs.compare }}
+      phpstan: ${{ steps.filter.outputs.phpstan }}
+      autoconf: ${{ steps.filter.outputs.autoconf }}
+      webapp: ${{ steps.filter.outputs.webapp }}
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      # paths-filter reads the filter file from the checkout. On a pull
+      # request it lists the changed files through the API; in the merge
+      # queue it diffs the group's base and head, fetching the base commit
+      # itself, so a shallow checkout is enough.
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/paths-filters.yml
+          # Without this the merge queue would be compared against the
+          # default branch, which is wrong for release branches.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}

--- a/.github/workflows/chroot-checks.yml
+++ b/.github/workflows/chroot-checks.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   check-chroot-arch:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.chroot != 'false' }}
     runs-on: ubuntu-24.04
     container:
       image: domjudge/gitlabci:24.04

--- a/.github/workflows/compare-tests.yml
+++ b/.github/workflows/compare-tests.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   compare:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.compare != 'false' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     container:

--- a/.github/workflows/database-upgrade.yml
+++ b/.github/workflows/database-upgrade.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   upgrade_test:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.webapp != 'false' }}
     runs-on: ubuntu-latest
     env:
       ADMIN_PASSWORD: admin_password

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   integration:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/judge-unit-tests.yml
+++ b/.github/workflows/judge-unit-tests.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   judge-unit-tests:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.judge-unit != 'false' }}
     runs-on: ubuntu-latest
     container:
       image: domjudge/gitlabci:24.04

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   phpstan:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.phpstan != 'false' }}
     runs-on: ubuntu-latest
     container:
       image: domjudge/gitlabci:24.04

--- a/.github/workflows/runpipe.yml
+++ b/.github/workflows/runpipe.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   runpipe:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.judge != 'false' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     container:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   unit-tests:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.webapp != 'false' }}
     permissions:
       checks: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/webstandard.yml
+++ b/.github/workflows/webstandard.yml
@@ -11,7 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   standards:
+    needs: changes
+    # Skip only when change detection ran and said so: a skipped job counts
+    # as a passed required check, so if detection failed we must run.
+    if: ${{ !cancelled() && needs.changes.outputs.webapp != 'false' }}
     runs-on: ubuntu-latest
     env:
       ADMIN_PASSWORD: admin_password


### PR DESCRIPTION
Every workflow ran on every push, so a manual fix built runguard on three distributions and a judgedaemon fix ran the web accessibility suite, and the merge queue then ran it all again.

Gate the expensive jobs on a shared `paths-filter` job.

This has to be a job-level condition: a job skipped that way reports success and satisfies its required check, whereas a workflow skipped by a paths filter leaves the check pending and blocks the merge.

Since a skip counts as a pass, skip only when detection ran and found no match.

Gemini guesses from previous runs that a webapp-only PR saves about 170 job-minutes.